### PR TITLE
feat: add ephemeral setup verification

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -624,12 +624,10 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
             prompt_flag: None,
             interactive_prompt_flag: None,
             interactive_prompt_prefix_args: Vec::new(),
-            non_interactive_prompt_prefix_args: vec![
-                "exec".to_string(),
-                "--skip-git-repo-check".to_string(),
-                "--color".to_string(),
-                "never".to_string(),
-            ],
+            non_interactive_prompt_prefix_args: crate::setup::codex::NON_INTERACTIVE_PREFIX_ARGS
+                .iter()
+                .map(|argument| (*argument).to_owned())
+                .collect(),
             install_hint: crate::setup::codex::INSTALL_GUIDANCE.to_string(),
             source: "bundled".to_string(),
             manifest_path: None,
@@ -678,7 +676,10 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
             prompt_flag: None,
             interactive_prompt_flag: None,
             interactive_prompt_prefix_args: Vec::new(),
-            non_interactive_prompt_prefix_args: vec!["--print".to_string()],
+            non_interactive_prompt_prefix_args: crate::setup::claude::NON_INTERACTIVE_PREFIX_ARGS
+                .iter()
+                .map(|argument| (*argument).to_owned())
+                .collect(),
             install_hint: crate::setup::claude::INSTALL_GUIDANCE.to_string(),
             source: "bundled".to_string(),
             manifest_path: None,
@@ -787,13 +788,16 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
             // one-shots are `--prompt <text>` and interactive-with-prompt is
             // `--interactive <text>`. Both ride the `=` form via
             // `prompt_args`. Verified against the installed copilot CLI.
-            prompt_flag: Some("--prompt".to_string()),
+            prompt_flag: Some(crate::setup::copilot::PROMPT_FLAG.to_string()),
             interactive_prompt_flag: Some("--interactive".to_string()),
             interactive_prompt_prefix_args: Vec::new(),
             // Copilot colorizes whenever it sees a TTY, and Coven runs
             // non-interactive launches under a PTY — mirror codex's
             // `--color never` hygiene. Interactive launches keep color.
-            non_interactive_prompt_prefix_args: vec!["--no-color".to_string()],
+            non_interactive_prompt_prefix_args: crate::setup::copilot::NON_INTERACTIVE_PREFIX_ARGS
+                .iter()
+                .map(|argument| (*argument).to_owned())
+                .collect(),
             install_hint: crate::setup::copilot::INSTALL_GUIDANCE.to_string(),
             source: "bundled".to_string(),
             manifest_path: None,

--- a/crates/coven-cli/src/setup/claude.rs
+++ b/crates/coven-cli/src/setup/claude.rs
@@ -1,9 +1,11 @@
-use super::{CommandSpec, ProviderDescriptor, ProviderId};
+use super::{verify, CommandSpec, ProviderDescriptor, ProviderId};
 
 pub const EXECUTABLE: &str = "claude";
 pub const INSTALL_GUIDANCE: &str = "Install Claude Code with `npm install -g @anthropic-ai/claude-code`; if it is already installed, make sure `claude` is on PATH and run `claude auth login` to authenticate, then retry `coven doctor`.";
+pub const NON_INTERACTIVE_PREFIX_ARGS: &[&str] = &["--print"];
 
 pub fn descriptor() -> ProviderDescriptor {
     ProviderDescriptor::new(ProviderId::Claude, EXECUTABLE, INSTALL_GUIDANCE)
         .with_login(CommandSpec::new(["auth", "login"]))
+        .with_verification(verify::command(ProviderId::Claude))
 }

--- a/crates/coven-cli/src/setup/codex.rs
+++ b/crates/coven-cli/src/setup/codex.rs
@@ -1,9 +1,12 @@
-use super::{CommandSpec, ProviderDescriptor, ProviderId};
+use super::{verify, CommandSpec, ProviderDescriptor, ProviderId};
 
 pub const EXECUTABLE: &str = "codex";
 pub const INSTALL_GUIDANCE: &str = "Install Codex with `npm install -g @openai/codex` or `brew install --cask codex`; if it is already installed, make sure `codex` is on PATH and run `codex login` or `codex` once to authenticate, then retry `coven doctor`.";
+pub const NON_INTERACTIVE_PREFIX_ARGS: &[&str] =
+    &["exec", "--skip-git-repo-check", "--color", "never"];
 
 pub fn descriptor() -> ProviderDescriptor {
     ProviderDescriptor::new(ProviderId::Codex, EXECUTABLE, INSTALL_GUIDANCE)
         .with_login(CommandSpec::new(["login"]))
+        .with_verification(verify::command(ProviderId::Codex))
 }

--- a/crates/coven-cli/src/setup/copilot.rs
+++ b/crates/coven-cli/src/setup/copilot.rs
@@ -1,9 +1,16 @@
-use super::{CommandSpec, ProviderDescriptor, ProviderId};
+use super::{verify, CommandSpec, ProviderDescriptor, ProviderId};
 
 pub const EXECUTABLE: &str = "copilot";
 pub const INSTALL_GUIDANCE: &str = "Install GitHub Copilot CLI with `npm install -g @github/copilot` or `brew install --cask copilot-cli`; if it is already installed, make sure `copilot` is on PATH and run `copilot login` to authenticate, then retry `coven doctor`.";
+pub const NON_INTERACTIVE_PREFIX_ARGS: &[&str] = &["--no-color"];
+pub const PROMPT_FLAG: &str = "--prompt";
+
+pub fn verification_prompt_arg(prompt: &str) -> String {
+    format!("{PROMPT_FLAG}={prompt}")
+}
 
 pub fn descriptor() -> ProviderDescriptor {
     ProviderDescriptor::new(ProviderId::Copilot, EXECUTABLE, INSTALL_GUIDANCE)
         .with_login(CommandSpec::new(["login"]))
+        .with_verification(verify::command(ProviderId::Copilot))
 }

--- a/crates/coven-cli/src/setup/mod.rs
+++ b/crates/coven-cli/src/setup/mod.rs
@@ -2,6 +2,7 @@ pub mod claude;
 pub mod codex;
 pub mod copilot;
 mod process;
+mod verify;
 
 use std::ffi::{OsStr, OsString};
 use std::fmt;
@@ -96,6 +97,7 @@ pub struct ProviderDescriptor {
     pub official_install_guidance: String,
     login: Option<CommandSpec>,
     verification: Option<CommandSpec>,
+    version: CommandSpec,
 }
 
 impl ProviderDescriptor {
@@ -110,6 +112,7 @@ impl ProviderDescriptor {
             official_install_guidance: official_install_guidance.into(),
             login: None,
             verification: None,
+            version: CommandSpec::new(["--version"]),
         }
     }
 
@@ -154,12 +157,19 @@ impl ExecutableDiscovery for SystemExecutableDiscovery {
     fn discover(&self, provider: &ProviderDescriptor) -> io::Result<Option<ResolvedExecutable>> {
         let executable = Path::new(&provider.executable);
         if executable.components().count() > 1 {
-            return Ok(
-                executable_is_runnable(executable).then(|| ResolvedExecutable {
+            return Ok(executable_is_runnable(executable).then(|| {
+                let version = process::probe_version(
+                    executable,
+                    &provider.version.args,
+                    Duration::from_secs(2),
+                )
+                .ok()
+                .flatten();
+                ResolvedExecutable {
                     path: executable.to_path_buf(),
-                    version: None,
-                }),
-            );
+                    version,
+                }
+            }));
         }
         let Some(path) = self.path.as_deref() else {
             return Ok(None);
@@ -168,9 +178,16 @@ impl ExecutableDiscovery for SystemExecutableDiscovery {
             for name in executable_names(&provider.executable, self.pathext.as_deref()) {
                 let candidate = directory.join(name);
                 if executable_is_runnable(&candidate) {
+                    let version = process::probe_version(
+                        &candidate,
+                        &provider.version.args,
+                        Duration::from_secs(2),
+                    )
+                    .ok()
+                    .flatten();
                     return Ok(Some(ResolvedExecutable {
                         path: candidate,
-                        version: None,
+                        version,
                     }));
                 }
             }
@@ -322,6 +339,7 @@ pub enum SetupError {
     RequiresVerification,
     Rejected,
     PublicationFailed,
+    ReportRequiresSingleProvider,
     UnsupportedProvider,
 }
 
@@ -332,6 +350,9 @@ impl fmt::Display for SetupError {
             Self::RequiresVerification => "setup reports are available only for verification modes",
             Self::Rejected => "setup report failed privacy validation",
             Self::PublicationFailed => "setup report could not be published",
+            Self::ReportRequiresSingleProvider => {
+                "setup reports require selecting exactly one provider"
+            }
             Self::UnsupportedProvider => {
                 "the selected setup provider is not available in this build"
             }
@@ -356,6 +377,9 @@ pub fn run_setup(
     }
 
     let provider_ids = options.selector.providers();
+    if options.report_json.is_some() && provider_ids.len() != 1 {
+        return Err(SetupError::ReportRequiresSingleProvider);
+    }
     if provider_ids
         .iter()
         .any(|provider_id| !providers.iter().any(|provider| provider.id == *provider_id))
@@ -517,21 +541,43 @@ fn run_action(
         Ok(ConsentDecision::Cancelled) => return Outcome::Cancelled,
         Err(_) => return Outcome::Cancelled,
     }
+    let ephemeral_state = if action == SetupAction::Verification {
+        match verify::EphemeralState::create() {
+            Ok(state) => Some(state),
+            Err(_) => return failure_outcome(action),
+        }
+    } else {
+        None
+    };
     let request = LaunchRequest {
         executable: executable.to_path_buf(),
         args: command.args.clone(),
+        current_dir: ephemeral_state
+            .as_ref()
+            .map(|state| state.current_dir().to_path_buf()),
+        env_overrides: ephemeral_state
+            .as_ref()
+            .map(verify::EphemeralState::env_overrides)
+            .unwrap_or_default(),
     };
     let mut process = match runtime.launcher.launch(&request) {
         Ok(process) => process,
         Err(_) => return failure_outcome(action),
     };
-    match wait_bounded(process.as_mut(), runtime.clock, timeout) {
+    let outcome = match wait_bounded(process.as_mut(), runtime.clock, timeout) {
         Ok(BoundedProcessResult::TimedOut) => Outcome::TimedOut,
         Ok(BoundedProcessResult::Exited(ProcessExit::Exited(0))) => Outcome::Completed,
         Ok(BoundedProcessResult::Exited(ProcessExit::Exited(_))) => failure_outcome(action),
         Ok(BoundedProcessResult::Exited(ProcessExit::Signalled)) => Outcome::Cancelled,
         Err(_) => failure_outcome(action),
+    };
+    drop(process);
+    if let Some(state) = ephemeral_state {
+        if state.cleanup().is_err() {
+            return failure_outcome(action);
+        }
     }
+    outcome
 }
 
 fn failure_outcome(action: SetupAction) -> Outcome {
@@ -591,13 +637,12 @@ fn executable_names(executable: &str, pathext: Option<&OsStr>) -> Vec<OsString> 
         let extensions = pathext
             .and_then(OsStr::to_str)
             .unwrap_or(".COM;.EXE;.BAT;.CMD");
-        let mut names = vec![OsString::from(executable)];
-        names.extend(
-            extensions
-                .split(';')
-                .filter(|extension| !extension.is_empty())
-                .map(|extension| OsString::from(format!("{executable}{extension}"))),
-        );
+        let mut names = extensions
+            .split(';')
+            .filter(|extension| !extension.is_empty())
+            .map(|extension| OsString::from(format!("{executable}{extension}")))
+            .collect::<Vec<_>>();
+        names.push(OsString::from(executable));
         names
     }
 
@@ -625,20 +670,13 @@ fn executable_is_runnable(path: &Path) -> bool {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct SetupReport {
-    schema_version: u32,
-    results: Vec<ReportResult>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-struct ReportResult {
     harness: ProviderId,
-    version: String,
+    cli_version: String,
     platform: String,
     candidate_commit: String,
-    duration_ms: u64,
+    duration: u64,
     exit_class: Outcome,
-    completion: bool,
+    completed: bool,
 }
 
 fn publish_report(
@@ -646,24 +684,19 @@ fn publish_report(
     summary: &SetupSummary,
     candidate_commit: &str,
 ) -> Result<(), SetupError> {
+    let result = summary
+        .results
+        .first()
+        .filter(|_| summary.results.len() == 1)
+        .ok_or(SetupError::ReportRequiresSingleProvider)?;
     let report = SetupReport {
-        schema_version: 1,
-        results: summary
-            .results
-            .iter()
-            .map(|result| ReportResult {
-                harness: result.provider,
-                version: result
-                    .version
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
-                candidate_commit: candidate_commit.to_owned(),
-                duration_ms: result.duration.as_millis().try_into().unwrap_or(u64::MAX),
-                exit_class: result.outcome,
-                completion: result.outcome == Outcome::Completed,
-            })
-            .collect(),
+        harness: result.provider,
+        cli_version: result.version.clone().ok_or(SetupError::Rejected)?,
+        platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+        candidate_commit: candidate_commit.to_owned(),
+        duration: result.duration.as_millis().try_into().unwrap_or(u64::MAX),
+        exit_class: result.outcome,
+        completed: result.outcome == Outcome::Completed,
     };
     validate_report(&report)?;
     let bytes = serde_json::to_vec_pretty(&report).map_err(|_| SetupError::Rejected)?;
@@ -710,17 +743,12 @@ fn publish_report(
 }
 
 fn validate_report(report: &SetupReport) -> Result<(), SetupError> {
-    if report.schema_version != 1 || report.results.is_empty() {
+    if !safe_report_value(&report.cli_version)
+        || !safe_report_value(&report.platform)
+        || !valid_commit(&report.candidate_commit)
+        || report.completed != (report.exit_class == Outcome::Completed)
+    {
         return Err(SetupError::Rejected);
-    }
-    for result in &report.results {
-        if !safe_report_value(&result.version)
-            || !safe_report_value(&result.platform)
-            || !valid_commit(&result.candidate_commit)
-            || result.completion != (result.exit_class == Outcome::Completed)
-        {
-            return Err(SetupError::Rejected);
-        }
     }
     Ok(())
 }

--- a/crates/coven-cli/src/setup/mod.rs
+++ b/crates/coven-cli/src/setup/mod.rs
@@ -157,19 +157,14 @@ impl ExecutableDiscovery for SystemExecutableDiscovery {
     fn discover(&self, provider: &ProviderDescriptor) -> io::Result<Option<ResolvedExecutable>> {
         let executable = Path::new(&provider.executable);
         if executable.components().count() > 1 {
-            return Ok(executable_is_runnable(executable).then(|| {
-                let version = process::probe_version(
-                    executable,
-                    &provider.version.args,
-                    Duration::from_secs(2),
-                )
-                .ok()
-                .flatten();
-                ResolvedExecutable {
-                    path: executable.to_path_buf(),
-                    version,
-                }
-            }));
+            return executable_is_runnable(executable)
+                .then(|| {
+                    fs::canonicalize(executable).map(|path| ResolvedExecutable {
+                        path,
+                        version: None,
+                    })
+                })
+                .transpose();
         }
         let Some(path) = self.path.as_deref() else {
             return Ok(None);
@@ -178,17 +173,12 @@ impl ExecutableDiscovery for SystemExecutableDiscovery {
             for name in executable_names(&provider.executable, self.pathext.as_deref()) {
                 let candidate = directory.join(name);
                 if executable_is_runnable(&candidate) {
-                    let version = process::probe_version(
-                        &candidate,
-                        &provider.version.args,
-                        Duration::from_secs(2),
-                    )
-                    .ok()
-                    .flatten();
-                    return Ok(Some(ResolvedExecutable {
-                        path: candidate,
-                        version,
-                    }));
+                    return fs::canonicalize(candidate).map(|path| {
+                        Some(ResolvedExecutable {
+                            path,
+                            version: None,
+                        })
+                    });
                 }
             }
         }
@@ -459,11 +449,12 @@ fn run_provider(
         }
     };
 
-    let outcome = match options.mode {
+    let action_result = match options.mode {
         SetupMode::Login => run_action(
             provider,
             executable.path.as_path(),
             provider.login.as_ref(),
+            None,
             SetupAction::Login,
             options.timeout,
             runtime,
@@ -472,6 +463,10 @@ fn run_provider(
             provider,
             executable.path.as_path(),
             provider.verification.as_ref(),
+            options.report_json.as_ref().map(|_| VersionResolution {
+                command: &provider.version,
+                cached: executable.version.as_deref(),
+            }),
             SetupAction::Verification,
             options.timeout,
             runtime,
@@ -481,15 +476,20 @@ fn run_provider(
                 provider,
                 executable.path.as_path(),
                 provider.login.as_ref(),
+                None,
                 SetupAction::Login,
                 options.timeout,
                 runtime,
             );
-            if login == Outcome::Completed {
+            if login.outcome == Outcome::Completed {
                 run_action(
                     provider,
                     executable.path.as_path(),
                     provider.verification.as_ref(),
+                    options.report_json.as_ref().map(|_| VersionResolution {
+                        command: &provider.version,
+                        cached: executable.version.as_deref(),
+                    }),
                     SetupAction::Verification,
                     options.timeout,
                     runtime,
@@ -501,24 +501,35 @@ fn run_provider(
     };
     result(
         provider.id,
-        outcome,
+        action_result.outcome,
         provider_started,
-        executable.version,
+        action_result.version,
         None,
         runtime.clock,
     )
+}
+
+struct ActionResult {
+    outcome: Outcome,
+    version: Option<String>,
+}
+
+struct VersionResolution<'a> {
+    command: &'a CommandSpec,
+    cached: Option<&'a str>,
 }
 
 fn run_action(
     provider: &ProviderDescriptor,
     executable: &Path,
     command: Option<&CommandSpec>,
+    version_resolution: Option<VersionResolution<'_>>,
     action: SetupAction,
     timeout: Duration,
     runtime: &mut SetupRuntime<'_>,
-) -> Outcome {
+) -> ActionResult {
     let Some(command) = command else {
-        return failure_outcome(action);
+        return action_result(failure_outcome(action));
     };
     let consent = ConsentRequest {
         provider: provider.id,
@@ -537,14 +548,14 @@ fn run_action(
     };
     match runtime.confirmer.confirm(&consent) {
         Ok(ConsentDecision::Accepted) => {}
-        Ok(ConsentDecision::Declined) => return Outcome::Declined,
-        Ok(ConsentDecision::Cancelled) => return Outcome::Cancelled,
-        Err(_) => return Outcome::Cancelled,
+        Ok(ConsentDecision::Declined) => return action_result(Outcome::Declined),
+        Ok(ConsentDecision::Cancelled) => return action_result(Outcome::Cancelled),
+        Err(_) => return action_result(Outcome::Cancelled),
     }
     let ephemeral_state = if action == SetupAction::Verification {
         match verify::EphemeralState::create() {
             Ok(state) => Some(state),
-            Err(_) => return failure_outcome(action),
+            Err(_) => return action_result(failure_outcome(action)),
         }
     } else {
         None
@@ -562,9 +573,9 @@ fn run_action(
     };
     let mut process = match runtime.launcher.launch(&request) {
         Ok(process) => process,
-        Err(_) => return failure_outcome(action),
+        Err(_) => return action_result(failure_outcome(action)),
     };
-    let outcome = match wait_bounded(process.as_mut(), runtime.clock, timeout) {
+    let mut outcome = match wait_bounded(process.as_mut(), runtime.clock, timeout) {
         Ok(BoundedProcessResult::TimedOut) => Outcome::TimedOut,
         Ok(BoundedProcessResult::Exited(ProcessExit::Exited(0))) => Outcome::Completed,
         Ok(BoundedProcessResult::Exited(ProcessExit::Exited(_))) => failure_outcome(action),
@@ -572,12 +583,43 @@ fn run_action(
         Err(_) => failure_outcome(action),
     };
     drop(process);
-    if let Some(state) = ephemeral_state {
-        if state.cleanup().is_err() {
-            return failure_outcome(action);
+    let mut version = None;
+    if outcome == Outcome::Completed {
+        if let Some(version_resolution) = version_resolution {
+            version = version_resolution.cached.map(str::to_owned).or_else(|| {
+                let request = LaunchRequest {
+                    executable: executable.to_path_buf(),
+                    args: version_resolution.command.args.clone(),
+                    current_dir: ephemeral_state
+                        .as_ref()
+                        .map(|state| state.current_dir().to_path_buf()),
+                    env_overrides: ephemeral_state
+                        .as_ref()
+                        .map(verify::EphemeralState::env_overrides)
+                        .unwrap_or_default(),
+                };
+                process::probe_version(&request, timeout.min(Duration::from_secs(2)))
+                    .ok()
+                    .flatten()
+            });
+            if version.is_none() {
+                outcome = failure_outcome(action);
+            }
         }
     }
-    outcome
+    if let Some(state) = ephemeral_state {
+        if state.cleanup().is_err() {
+            return action_result(failure_outcome(action));
+        }
+    }
+    ActionResult { outcome, version }
+}
+
+fn action_result(outcome: Outcome) -> ActionResult {
+    ActionResult {
+        outcome,
+        version: None,
+    }
 }
 
 fn failure_outcome(action: SetupAction) -> Outcome {
@@ -743,7 +785,8 @@ fn publish_report(
 }
 
 fn validate_report(report: &SetupReport) -> Result<(), SetupError> {
-    if !safe_report_value(&report.cli_version)
+    if !process::valid_version(&report.cli_version)
+        || !safe_report_value(&report.cli_version)
         || !safe_report_value(&report.platform)
         || !valid_commit(&report.candidate_commit)
         || report.completed != (report.exit_class == Outcome::Completed)
@@ -790,16 +833,63 @@ fn atomic_publish_noclobber(staged: &Path, destination: &Path) -> Result<(), Set
     })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn atomic_publish_noclobber(staged: &Path, destination: &Path) -> Result<(), SetupError> {
-    if destination.exists() {
-        return Err(SetupError::Exists);
-    }
-    fs::rename(staged, destination).map_err(|error| {
-        if error.kind() == io::ErrorKind::AlreadyExists {
-            SetupError::Exists
-        } else {
-            SetupError::PublicationFailed
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS};
+    use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_WRITE_THROUGH};
+
+    fn wide_path(path: &Path) -> Result<Vec<u16>, SetupError> {
+        let mut wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        if wide.contains(&0) {
+            return Err(SetupError::Rejected);
         }
-    })
+        wide.push(0);
+        Ok(wide)
+    }
+
+    let staged = wide_path(staged)?;
+    let destination = wide_path(destination)?;
+    if unsafe {
+        MoveFileExW(
+            staged.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_WRITE_THROUGH,
+        )
+    } != 0
+    {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    match error.raw_os_error().map(|code| code as u32) {
+        Some(ERROR_ALREADY_EXISTS | ERROR_FILE_EXISTS) => Err(SetupError::Exists),
+        _ => Err(SetupError::PublicationFailed),
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn atomic_publish_noclobber(_staged: &Path, _destination: &Path) -> Result<(), SetupError> {
+    Err(SetupError::PublicationFailed)
+}
+
+#[cfg(all(test, windows))]
+mod windows_atomic_publish_tests {
+    use super::{atomic_publish_noclobber, SetupError};
+    use std::fs;
+
+    #[test]
+    fn atomic_publish_never_replaces_an_existing_destination() {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let staged = temp.path().join("staged.json");
+        let destination = temp.path().join("report.json");
+        fs::write(&staged, b"new").expect("staged report");
+        fs::write(&destination, b"existing").expect("existing report");
+
+        let error = atomic_publish_noclobber(&staged, &destination)
+            .expect_err("existing destination must be preserved");
+
+        assert!(matches!(error, SetupError::Exists));
+        assert_eq!(fs::read(&destination).expect("destination"), b"existing");
+        assert_eq!(fs::read(&staged).expect("staged"), b"new");
+    }
 }

--- a/crates/coven-cli/src/setup/process.rs
+++ b/crates/coven-cli/src/setup/process.rs
@@ -76,34 +76,19 @@ impl ProcessLauncher for SystemProcessLauncher {
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
-        if let Some(current_dir) = request.current_dir.as_deref() {
-            command.current_dir(current_dir);
-        }
-        for (name, value) in &request.env_overrides {
-            match value {
-                Some(value) => {
-                    command.env(name, value);
-                }
-                None => {
-                    command.env_remove(name);
-                }
-            }
-        }
+        apply_launch_context(&mut command, request);
         Ok(Box::new(spawn_managed(&mut command)?))
     }
 }
 
-pub fn probe_version(
-    executable: &std::path::Path,
-    args: &[OsString],
-    timeout: Duration,
-) -> io::Result<Option<String>> {
-    let mut command = Command::new(executable);
+pub fn probe_version(request: &LaunchRequest, timeout: Duration) -> io::Result<Option<String>> {
+    let mut command = Command::new(&request.executable);
     command
-        .args(args)
+        .args(&request.args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
+    apply_launch_context(&mut command, request);
     let mut process = spawn_managed(&mut command)?;
     let stdout = process
         .child
@@ -143,29 +128,110 @@ pub fn probe_version(
             return Err(io::Error::other("version probe output reader stopped"));
         }
     };
+    process.terminate_tree()?;
+    let _ = process.wait()?;
     if exit != ProcessExit::Exited(0) {
         return Ok(None);
     }
-    Ok(extract_version(&String::from_utf8_lossy(&output)))
+    Ok(extract_version(
+        &String::from_utf8_lossy(&output),
+        request
+            .executable
+            .file_stem()
+            .and_then(std::ffi::OsStr::to_str),
+    ))
 }
 
-fn extract_version(output: &str) -> Option<String> {
-    output
+fn apply_launch_context(command: &mut Command, request: &LaunchRequest) {
+    if let Some(current_dir) = request.current_dir.as_deref() {
+        command.current_dir(current_dir);
+    }
+    for (name, value) in &request.env_overrides {
+        match value {
+            Some(value) => {
+                command.env(name, value);
+            }
+            None => {
+                command.env_remove(name);
+            }
+        }
+    }
+}
+
+fn extract_version(output: &str, expected_program: Option<&str>) -> Option<String> {
+    let tokens = output
         .split_whitespace()
-        .map(|token| {
-            token.trim_matches(|character: char| {
+        .map(|raw| {
+            let normalized = raw.trim_matches(|character: char| {
                 !character.is_ascii_alphanumeric() && !matches!(character, '.' | '_' | '+' | '-')
-            })
+            });
+            (raw, normalized)
         })
-        .find(|token| {
-            !token.is_empty()
-                && token.len() <= 128
-                && token.bytes().any(|byte| byte.is_ascii_digit())
-                && token.bytes().all(|byte| {
-                    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'+' | b'-')
-                })
+        .collect::<Vec<_>>();
+    let candidates = tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, normalized))| valid_version(normalized))
+        .collect::<Vec<_>>();
+    let labeled = candidates
+        .iter()
+        .copied()
+        .filter(|(index, _)| {
+            index
+                .checked_sub(1)
+                .and_then(|previous| tokens.get(previous))
+                .is_some_and(|(_, normalized)| normalized.eq_ignore_ascii_case("version"))
         })
-        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if let [(_, (_, normalized))] = labeled.as_slice() {
+        return Some((*normalized).to_owned());
+    }
+    let [(_, (_, normalized))] = candidates.as_slice() else {
+        return None;
+    };
+    if tokens.len() == 1 {
+        return Some((*normalized).to_owned());
+    }
+    let expected_program = expected_program?.to_ascii_lowercase();
+    if tokens.iter().any(|(_, marker)| {
+        let marker = marker.to_ascii_lowercase();
+        marker == expected_program
+            || marker
+                .strip_prefix(&expected_program)
+                .is_some_and(|suffix| suffix.starts_with('-') || suffix.starts_with('_'))
+    }) {
+        Some((*normalized).to_owned())
+    } else {
+        None
+    }
+}
+
+pub(crate) fn valid_version(value: &str) -> bool {
+    if value.is_empty() || value.len() > 128 {
+        return false;
+    }
+    let value = value
+        .strip_prefix('v')
+        .or_else(|| value.strip_prefix('V'))
+        .unwrap_or(value);
+    let suffix_start = value
+        .bytes()
+        .position(|byte| matches!(byte, b'-' | b'+'))
+        .unwrap_or(value.len());
+    let (core, suffix) = value.split_at(suffix_start);
+    let mut component_count = 0;
+    for component in core.split('.') {
+        if component.is_empty() || !component.bytes().all(|byte| byte.is_ascii_digit()) {
+            return false;
+        }
+        component_count += 1;
+    }
+    component_count >= 2
+        && (suffix.is_empty()
+            || (suffix.len() > 1
+                && suffix.bytes().all(|byte| {
+                    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'+' | b'-')
+                })))
 }
 
 pub(crate) enum BoundedProcessResult {
@@ -181,6 +247,8 @@ pub(crate) fn wait_bounded(
     let deadline = clock.now().saturating_add(timeout);
     loop {
         if let Some(exit) = process.try_wait()? {
+            process.terminate_tree()?;
+            let _ = process.wait()?;
             return Ok(BoundedProcessResult::Exited(exit));
         }
         let now = clock.now();
@@ -230,7 +298,7 @@ fn spawn_managed(command: &mut Command) -> io::Result<SystemRunningProcess> {
         };
         if !windows_job::resume_suspended_child(&child) {
             let _ = job.terminate();
-            let _ = child.wait();
+            let _ = child.kill();
             return Err(io::Error::other("could not resume managed Windows process"));
         }
         (child, job)
@@ -243,6 +311,13 @@ fn spawn_managed(command: &mut Command) -> io::Result<SystemRunningProcess> {
         #[cfg(windows)]
         job,
     })
+}
+
+impl Drop for SystemRunningProcess {
+    fn drop(&mut self) {
+        let _ = terminate_system_tree(self);
+        let _ = self.child.try_wait();
+    }
 }
 
 impl RunningProcess for SystemRunningProcess {

--- a/crates/coven-cli/src/setup/process.rs
+++ b/crates/coven-cli/src/setup/process.rs
@@ -1,7 +1,9 @@
 use std::ffi::OsString;
-use std::io;
+use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc;
+use std::thread;
 use std::time::{Duration, Instant};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -10,6 +12,8 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 pub struct LaunchRequest {
     pub executable: PathBuf,
     pub args: Vec<OsString>,
+    pub current_dir: Option<PathBuf>,
+    pub env_overrides: Vec<(OsString, Option<OsString>)>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -72,37 +76,96 @@ impl ProcessLauncher for SystemProcessLauncher {
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            command.process_group(0);
+        if let Some(current_dir) = request.current_dir.as_deref() {
+            command.current_dir(current_dir);
         }
-
-        let child = command.spawn()?;
-
-        #[cfg(windows)]
-        let (child, job) = {
-            let mut child = child;
-            let job = match windows_job::assign_kill_on_close_job(&child) {
-                Ok(job) => job,
-                Err(error) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(error);
+        for (name, value) in &request.env_overrides {
+            match value {
+                Some(value) => {
+                    command.env(name, value);
                 }
-            };
-            (child, job)
-        };
-
-        Ok(Box::new(SystemRunningProcess {
-            #[cfg(unix)]
-            process_group: child.id() as libc::pid_t,
-            child,
-            #[cfg(windows)]
-            job,
-        }))
+                None => {
+                    command.env_remove(name);
+                }
+            }
+        }
+        Ok(Box::new(spawn_managed(&mut command)?))
     }
+}
+
+pub fn probe_version(
+    executable: &std::path::Path,
+    args: &[OsString],
+    timeout: Duration,
+) -> io::Result<Option<String>> {
+    let mut command = Command::new(executable);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let mut process = spawn_managed(&mut command)?;
+    let stdout = process
+        .child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("version probe stdout was not piped"))?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stdout.take(4097).read_to_end(&mut bytes).map(|_| bytes);
+        let _ = sender.send(result);
+    });
+
+    let deadline = Instant::now() + timeout;
+    let exit = loop {
+        if let Some(exit) = process.try_wait()? {
+            break exit;
+        }
+        if Instant::now() >= deadline {
+            process.terminate_tree()?;
+            let _ = process.wait()?;
+            return Ok(None);
+        }
+        thread::sleep(POLL_INTERVAL);
+    };
+    let output = match receiver.recv_timeout(Duration::from_millis(100)) {
+        Ok(output) => output?,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            process.terminate_tree()?;
+            receiver
+                .recv_timeout(Duration::from_millis(150))
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::TimedOut, "version probe output timed out")
+                })??
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            return Err(io::Error::other("version probe output reader stopped"));
+        }
+    };
+    if exit != ProcessExit::Exited(0) {
+        return Ok(None);
+    }
+    Ok(extract_version(&String::from_utf8_lossy(&output)))
+}
+
+fn extract_version(output: &str) -> Option<String> {
+    output
+        .split_whitespace()
+        .map(|token| {
+            token.trim_matches(|character: char| {
+                !character.is_ascii_alphanumeric() && !matches!(character, '.' | '_' | '+' | '-')
+            })
+        })
+        .find(|token| {
+            !token.is_empty()
+                && token.len() <= 128
+                && token.bytes().any(|byte| byte.is_ascii_digit())
+                && token.bytes().all(|byte| {
+                    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'+' | b'-')
+                })
+        })
+        .map(str::to_owned)
 }
 
 pub(crate) enum BoundedProcessResult {
@@ -136,6 +199,50 @@ struct SystemRunningProcess {
     process_group: libc::pid_t,
     #[cfg(windows)]
     job: windows_job::Job,
+}
+
+fn spawn_managed(command: &mut Command) -> io::Result<SystemRunningProcess> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
+
+        command.creation_flags(CREATE_SUSPENDED);
+    }
+
+    let child = command.spawn()?;
+
+    #[cfg(windows)]
+    let (child, job) = {
+        let mut child = child;
+        let job = match windows_job::assign_kill_on_close_job(&child) {
+            Ok(job) => job,
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+        };
+        if !windows_job::resume_suspended_child(&child) {
+            let _ = job.terminate();
+            let _ = child.wait();
+            return Err(io::Error::other("could not resume managed Windows process"));
+        }
+        (child, job)
+    };
+
+    Ok(SystemRunningProcess {
+        #[cfg(unix)]
+        process_group: child.id() as libc::pid_t,
+        child,
+        #[cfg(windows)]
+        job,
+    })
 }
 
 impl RunningProcess for SystemRunningProcess {
@@ -217,11 +324,19 @@ mod windows_job {
     use std::process::Child;
     use std::ptr;
 
-    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
-    use windows_sys::Win32::System::JobObjects::{
-        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
-        SetInformationJobObject, TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
-        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::System::{
+        Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+        },
+        JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        },
+        Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME},
     };
 
     pub(super) struct Job(HANDLE);
@@ -269,5 +384,44 @@ mod windows_job {
             return Err(io::Error::last_os_error());
         }
         Ok(job)
+    }
+
+    pub(super) fn resume_suspended_child(child: &Child) -> bool {
+        let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+        if snapshot == INVALID_HANDLE_VALUE {
+            return false;
+        }
+
+        let mut entry = THREADENTRY32 {
+            dwSize: size_of::<THREADENTRY32>() as u32,
+            ..Default::default()
+        };
+        let mut thread_ids = Vec::new();
+        let mut has_entry = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+        let mut enumeration_complete = false;
+        while has_entry {
+            if entry.th32OwnerProcessID == child.id() {
+                thread_ids.push(entry.th32ThreadID);
+            }
+            has_entry = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+            if !has_entry {
+                enumeration_complete = unsafe { GetLastError() } == ERROR_NO_MORE_FILES;
+            }
+        }
+        unsafe { CloseHandle(snapshot) };
+
+        if !enumeration_complete {
+            return false;
+        }
+        let [thread_id] = thread_ids.as_slice() else {
+            return false;
+        };
+        let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, *thread_id) };
+        if thread.is_null() {
+            return false;
+        }
+        let previous_suspend_count = unsafe { ResumeThread(thread) };
+        unsafe { CloseHandle(thread) };
+        previous_suspend_count == 1
     }
 }

--- a/crates/coven-cli/src/setup/verify.rs
+++ b/crates/coven-cli/src/setup/verify.rs
@@ -1,0 +1,111 @@
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use super::{claude, codex, copilot, CommandSpec, ProviderId};
+
+pub const PROMPT: &str = "Reply with OK.";
+
+pub fn command(provider: ProviderId) -> CommandSpec {
+    match provider {
+        ProviderId::Codex => CommandSpec::new(
+            codex::NON_INTERACTIVE_PREFIX_ARGS
+                .iter()
+                .copied()
+                .chain(["--", PROMPT]),
+        ),
+        ProviderId::Claude => CommandSpec::new(
+            claude::NON_INTERACTIVE_PREFIX_ARGS
+                .iter()
+                .copied()
+                .chain(["--", PROMPT]),
+        ),
+        ProviderId::Copilot => CommandSpec::new(
+            copilot::NON_INTERACTIVE_PREFIX_ARGS
+                .iter()
+                .map(|argument| (*argument).to_owned())
+                .chain([copilot::verification_prompt_arg(PROMPT)]),
+        ),
+    }
+}
+
+pub struct EphemeralState {
+    root: PathBuf,
+    coven_home: PathBuf,
+    cleaned: bool,
+}
+
+impl EphemeralState {
+    pub fn create() -> io::Result<Self> {
+        let temporary_root = std::env::temp_dir();
+        for _ in 0..4 {
+            let root = temporary_root.join(format!("coven-verify-{}", Uuid::new_v4()));
+            let builder = {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::DirBuilderExt;
+                    let mut builder = fs::DirBuilder::new();
+                    builder.mode(0o700);
+                    builder
+                }
+                #[cfg(not(unix))]
+                {
+                    fs::DirBuilder::new()
+                }
+            };
+            match builder.create(&root) {
+                Ok(()) => {
+                    let coven_home = root.join("coven-home");
+                    if let Err(error) = fs::create_dir(&coven_home) {
+                        let _ = fs::remove_dir(&root);
+                        return Err(error);
+                    }
+                    return Ok(Self {
+                        root,
+                        coven_home,
+                        cleaned: false,
+                    });
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate unique verification state",
+        ))
+    }
+
+    pub fn current_dir(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn env_overrides(&self) -> Vec<(OsString, Option<OsString>)> {
+        vec![(
+            OsString::from("COVEN_HOME"),
+            Some(self.coven_home.as_os_str().to_owned()),
+        )]
+    }
+
+    pub fn cleanup(mut self) -> io::Result<()> {
+        fs::remove_dir_all(&self.root)?;
+        if self.root.exists() {
+            return Err(io::Error::other(
+                "verification state still exists after cleanup",
+            ));
+        }
+        self.cleaned = true;
+        Ok(())
+    }
+}
+
+impl Drop for EphemeralState {
+    fn drop(&mut self) {
+        if !self.cleaned {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+}

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -1546,7 +1546,7 @@ fn executable_discovery_is_injectable_and_rejects_non_executables() -> Result<()
     assert!(resolved
         .path
         .to_string_lossy()
-        .eq_ignore_ascii_case(&executable.to_string_lossy()));
+        .eq_ignore_ascii_case(&fs::canonicalize(&executable)?.to_string_lossy()));
     #[cfg(not(windows))]
     assert_eq!(resolved.path, fs::canonicalize(&executable)?);
     assert_eq!(resolved.version, None);

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -1016,6 +1016,7 @@ fn verify_ephemeral_state_reaches_provider_then_is_removed() -> Result<()> {
     let temp = test_tempdir()?;
     let fake_codex = temp.path().join("codex");
     let observation_path = temp.path().join("verification-state.txt");
+    let version_observation_path = temp.path().join("version-state.txt");
     let args_path = temp.path().join("verification-args.txt");
     let report_path = temp.path().join("verification-report.json");
     let stdout_path = temp.path().join("verification.stdout");
@@ -1024,6 +1025,11 @@ fn verify_ephemeral_state_reaches_provider_then_is_removed() -> Result<()> {
         &fake_codex,
         concat!(
             "#!/bin/sh\n",
+            "if [ \"$1\" = \"--version\" ]; then\n",
+            "  printf '%s\\n%s\\n' \"$PWD\" \"$COVEN_HOME\" > \"$COVEN_SETUP_VERSION_STATE_PATH\"\n",
+            "  printf 'Authenticated alice123 account 123.456.789 sk-proj-123 version 1.2.3\\n'\n",
+            "  exit 0\n",
+            "fi\n",
             "printf '%s\\n%s\\n' \"$PWD\" \"$COVEN_HOME\" > \"$COVEN_SETUP_STATE_PATH\"\n",
             "printf '%s\\n' \"$@\" > \"$COVEN_SETUP_ARGS_PATH\"\n",
             "printf 'provider-stdout:oauth token private-path=%s\\n' \"$COVEN_SETUP_STATE_PATH\"\n",
@@ -1044,6 +1050,7 @@ fn verify_ephemeral_state_reaches_provider_then_is_removed() -> Result<()> {
         .env("COVEN_SETUP_VERIFY_HELPER", "1")
         .env("COVEN_SETUP_VERIFY_EXECUTABLE", &fake_codex)
         .env("COVEN_SETUP_STATE_PATH", &observation_path)
+        .env("COVEN_SETUP_VERSION_STATE_PATH", &version_observation_path)
         .env("COVEN_SETUP_ARGS_PATH", &args_path)
         .env("COVEN_SETUP_REPORT_PATH", &report_path)
         .stdin(Stdio::null())
@@ -1074,6 +1081,11 @@ fn verify_ephemeral_state_reaches_provider_then_is_removed() -> Result<()> {
         "ephemeral verification state should be removed: {current_dir:?}"
     );
     assert_eq!(
+        fs::read_to_string(version_observation_path)?,
+        observation,
+        "version probing must use the same ephemeral cwd and COVEN_HOME"
+    );
+    assert_eq!(
         fs::read_to_string(args_path)?,
         concat!(
             "exec\n",
@@ -1090,6 +1102,10 @@ fn verify_ephemeral_state_reaches_provider_then_is_removed() -> Result<()> {
     assert!(stdout.contains("provider-stdout:oauth token private-path="));
     assert!(stderr.contains("provider-stderr:account model bearer="));
     let report = fs::read_to_string(report_path)?;
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&report)?["cli_version"],
+        "1.2.3"
+    );
     for forbidden in [
         "provider-stdout",
         "provider-stderr",
@@ -1106,6 +1122,111 @@ fn verify_ephemeral_state_reaches_provider_then_is_removed() -> Result<()> {
             "verification report leaked {forbidden:?}: {report}"
         );
     }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn version_probe_reaps_detached_provider_descendants() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = test_tempdir()?;
+    let fake_codex = temp.path().join("codex");
+    let pid_path = temp.path().join("version-descendant.pid");
+    let report_path = temp.path().join("report.json");
+    fs::write(
+        &fake_codex,
+        concat!(
+            "#!/usr/bin/env python3\n",
+            "import os, sys, time\n",
+            "if sys.argv[1:] == ['--version']:\n",
+            "    child = os.fork()\n",
+            "    if child == 0:\n",
+            "        os.close(1)\n",
+            "        os.close(2)\n",
+            "        time.sleep(30)\n",
+            "        os._exit(0)\n",
+            "    path = os.path.join(os.path.dirname(__file__), 'version-descendant.pid')\n",
+            "    with open(path, 'w') as output:\n",
+            "        output.write(str(child))\n",
+            "    print('1.2.3', flush=True)\n",
+            "    os._exit(0)\n",
+        ),
+    )?;
+    fs::set_permissions(&fake_codex, fs::Permissions::from_mode(0o755))?;
+    let providers = [codex::descriptor()];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: fake_codex,
+        version: None,
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = SystemClock::new();
+    let mut launcher = SystemProcessLauncher;
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::VerifyOnly;
+    setup_options.report_json = Some(report_path);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    let pid = fs::read_to_string(pid_path)?
+        .parse::<u32>()
+        .context("version descendant pid")?;
+    wait_for_process_exit(pid)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn version_probe_rejects_contextual_account_identifier() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = test_tempdir()?;
+    let fake_codex = temp.path().join("codex");
+    let report_path = temp.path().join("report.json");
+    fs::write(
+        &fake_codex,
+        concat!(
+            "#!/bin/sh\n",
+            "if [ \"$1\" = \"--version\" ]; then\n",
+            "  printf 'Authenticated account 123.456.789\\n'\n",
+            "fi\n",
+        ),
+    )?;
+    fs::set_permissions(&fake_codex, fs::Permissions::from_mode(0o755))?;
+    let providers = [codex::descriptor()];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: fake_codex,
+        version: None,
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = SystemClock::new();
+    let mut launcher = SystemProcessLauncher;
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::VerifyOnly;
+    setup_options.report_json = Some(report_path.clone());
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let error = run_setup(&setup_options, &providers, &mut runtime)
+        .expect_err("contextual account identifier must not become a CLI version");
+
+    assert!(matches!(error, SetupError::Rejected));
+    assert!(!report_path.exists());
     Ok(())
 }
 
@@ -1162,7 +1283,7 @@ fn verify_ephemeral_state_helper() -> Result<()> {
     let providers = [codex::descriptor()];
     let discovery = FixedDiscovery(Some(ResolvedExecutable {
         path: executable,
-        version: Some("1.2.3".to_owned()),
+        version: None,
     }));
     let terminal = FixedTerminal(true);
     let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
@@ -1182,6 +1303,95 @@ fn verify_ephemeral_state_helper() -> Result<()> {
     let summary = run_setup(&setup_options, &providers, &mut runtime)?;
 
     assert!(summary.completed());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn declining_setup_does_not_execute_provider_version_command() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = test_tempdir()?;
+    let bin = temp.path().join("bin");
+    fs::create_dir_all(&bin)?;
+    let marker = temp.path().join("version-ran");
+    let executable = bin.join("fake-codex");
+    fs::write(
+        &executable,
+        format!(
+            "#!/bin/sh\nprintf ran > '{}'\nprintf 'fake-codex 1.2.3\\n'\n",
+            marker.display()
+        ),
+    )?;
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))?;
+
+    let provider = descriptor(ProviderId::Codex);
+    let providers = [provider];
+    let discovery = SystemExecutableDiscovery::from_path(Some(std::env::join_paths([bin])?), None);
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Declined]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&options(Selector::Codex), &providers, &mut runtime)?;
+
+    assert_eq!(summary.results[0].outcome, Outcome::Declined);
+    assert!(
+        !marker.exists(),
+        "provider code ran before explicit setup consent"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn completed_verification_reaps_detached_provider_descendants() -> Result<()> {
+    let temp = test_tempdir()?;
+    let pid_file = temp.path().join("descendant.pid");
+    let provider = ProviderDescriptor::new(
+        ProviderId::Codex,
+        "sh",
+        "Install the shell from its official source.",
+    )
+    .with_verification(CommandSpec::new([
+        "-c",
+        "sleep 30 >/dev/null 2>&1 & printf '%s' \"$!\" > \"$1\"",
+        "setup-completed",
+        pid_file.to_str().context("test path must be valid UTF-8")?,
+    ]));
+    let providers = [provider];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: PathBuf::from("/bin/sh"),
+        version: None,
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = SystemClock::new();
+    let mut launcher = SystemProcessLauncher;
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::VerifyOnly;
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    let pid = fs::read_to_string(pid_file)?
+        .parse::<u32>()
+        .context("descendant pid")?;
+    wait_for_process_exit(pid)?;
     Ok(())
 }
 
@@ -1338,9 +1548,8 @@ fn executable_discovery_is_injectable_and_rejects_non_executables() -> Result<()
         .to_string_lossy()
         .eq_ignore_ascii_case(&executable.to_string_lossy()));
     #[cfg(not(windows))]
-    assert_eq!(resolved.path, executable);
-    #[cfg(unix)]
-    assert_eq!(resolved.version.as_deref(), Some("1.2.3"));
+    assert_eq!(resolved.path, fs::canonicalize(&executable)?);
+    assert_eq!(resolved.version, None);
 
     #[cfg(unix)]
     {
@@ -1348,6 +1557,32 @@ fn executable_discovery_is_injectable_and_rejects_non_executables() -> Result<()
         fs::set_permissions(&resolved.path, fs::Permissions::from_mode(0o644))?;
         assert!(discovery.discover(&provider)?.is_none());
     }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn executable_discovery_normalizes_explicit_relative_paths() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = test_tempdir()?;
+    let executable = temp.path().join("relative-cli");
+    fs::write(&executable, b"#!/bin/sh\nprintf 'relative-cli 1.2.3\\n'\n")?;
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))?;
+    let relative = executable.strip_prefix(std::env::current_dir()?)?;
+    let provider = ProviderDescriptor::new(
+        ProviderId::Codex,
+        relative.to_string_lossy(),
+        "Official install guidance.",
+    );
+    let discovery = SystemExecutableDiscovery::from_path(None, None);
+
+    let resolved = discovery
+        .discover(&provider)?
+        .context("relative executable should be discovered")?;
+
+    assert!(resolved.path.is_absolute(), "{:?}", resolved.path);
+    assert_eq!(resolved.path, fs::canonicalize(executable)?);
     Ok(())
 }
 

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -514,6 +514,71 @@ fn verification_after_login_requires_a_second_explicit_consent() -> Result<()> {
 }
 
 #[test]
+fn verify_only_uses_adapter_commands_and_ephemeral_coven_state() -> Result<()> {
+    let providers = [
+        codex::descriptor(),
+        claude::descriptor(),
+        copilot::descriptor(),
+    ];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([
+        ConsentDecision::Accepted,
+        ConsentDecision::Accepted,
+        ConsentDecision::Accepted,
+    ]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([
+        LaunchBehavior::exit(0),
+        LaunchBehavior::exit(0),
+        LaunchBehavior::exit(0),
+    ]);
+    let mut setup_options = options(Selector::All);
+    setup_options.mode = SetupMode::VerifyOnly;
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    assert_eq!(
+        confirmer
+            .requests
+            .iter()
+            .map(|request| request.command.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "codex exec --skip-git-repo-check --color never -- Reply with OK.",
+            "claude --print -- Reply with OK.",
+            "copilot --no-color --prompt=Reply with OK.",
+        ]
+    );
+    assert_eq!(launcher.launches.len(), 3);
+    for launch in &launcher.launches {
+        let cwd = launch
+            .current_dir
+            .as_deref()
+            .context("verification must use an ephemeral working directory")?;
+        let coven_home = launch
+            .env_overrides
+            .iter()
+            .find_map(|(name, value)| (name == "COVEN_HOME").then_some(value.as_deref()).flatten())
+            .context("verification must isolate COVEN_HOME")?;
+        assert!(PathBuf::from(coven_home).starts_with(cwd));
+        assert!(
+            !cwd.exists(),
+            "ephemeral verification state should be removed after the provider exits: {cwd:?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn missing_executable_prints_only_the_descriptor_official_guidance() -> Result<()> {
     let provider = descriptor(ProviderId::Codex);
     let providers = [provider.clone()];
@@ -779,10 +844,9 @@ fn inherited_terminal_io_stays_separate_from_the_redacted_report() -> Result<()>
 
     let report_bytes = fs::read(&report_path)?;
     let report: serde_json::Value = serde_json::from_slice(&report_bytes)?;
-    assert_eq!(report["schema_version"], 1);
-    assert_eq!(report["results"][0]["harness"], "codex");
-    assert_eq!(report["results"][0]["exit_class"], "completed");
-    assert_eq!(report["results"][0]["completion"], true);
+    assert_eq!(report["harness"], "codex");
+    assert_eq!(report["exit_class"], "completed");
+    assert_eq!(report["completed"], true);
     let report_text = String::from_utf8(report_bytes)?;
     for forbidden in [
         "provider-stdout",
@@ -944,6 +1008,183 @@ fn copilot_inherited_terminal_helper() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn verify_ephemeral_state_reaches_provider_then_is_removed() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = test_tempdir()?;
+    let fake_codex = temp.path().join("codex");
+    let observation_path = temp.path().join("verification-state.txt");
+    let args_path = temp.path().join("verification-args.txt");
+    let report_path = temp.path().join("verification-report.json");
+    let stdout_path = temp.path().join("verification.stdout");
+    let stderr_path = temp.path().join("verification.stderr");
+    fs::write(
+        &fake_codex,
+        concat!(
+            "#!/bin/sh\n",
+            "printf '%s\\n%s\\n' \"$PWD\" \"$COVEN_HOME\" > \"$COVEN_SETUP_STATE_PATH\"\n",
+            "printf '%s\\n' \"$@\" > \"$COVEN_SETUP_ARGS_PATH\"\n",
+            "printf 'provider-stdout:oauth token private-path=%s\\n' \"$COVEN_SETUP_STATE_PATH\"\n",
+            "printf 'provider-stderr:account model bearer=%s\\n' \"$COVEN_SETUP_STATE_PATH\" >&2\n",
+        ),
+    )?;
+    let mut permissions = fs::metadata(&fake_codex)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions)?;
+
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "--exact",
+            "verify_ephemeral_state_helper",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("COVEN_SETUP_VERIFY_HELPER", "1")
+        .env("COVEN_SETUP_VERIFY_EXECUTABLE", &fake_codex)
+        .env("COVEN_SETUP_STATE_PATH", &observation_path)
+        .env("COVEN_SETUP_ARGS_PATH", &args_path)
+        .env("COVEN_SETUP_REPORT_PATH", &report_path)
+        .stdin(Stdio::null())
+        .stdout(fs::File::create(&stdout_path)?)
+        .stderr(fs::File::create(&stderr_path)?)
+        .status()?;
+    assert!(
+        status.success(),
+        "verification helper failed with {status}\nstdout:\n{}\nstderr:\n{}",
+        fs::read_to_string(&stdout_path).unwrap_or_default(),
+        fs::read_to_string(&stderr_path).unwrap_or_default(),
+    );
+
+    let observation = fs::read_to_string(&observation_path)?;
+    let mut lines = observation.lines();
+    let current_dir = PathBuf::from(lines.next().context("recorded working directory")?);
+    let coven_home = PathBuf::from(lines.next().context("recorded COVEN_HOME")?);
+    let expected_coven_home = current_dir.join("coven-home");
+    let expected_coven_home = expected_coven_home.to_string_lossy();
+    assert_eq!(
+        coven_home.to_string_lossy(),
+        expected_coven_home
+            .strip_prefix("/private")
+            .unwrap_or(&expected_coven_home),
+    );
+    assert!(
+        !current_dir.exists(),
+        "ephemeral verification state should be removed: {current_dir:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(args_path)?,
+        concat!(
+            "exec\n",
+            "--skip-git-repo-check\n",
+            "--color\n",
+            "never\n",
+            "--\n",
+            "Reply with OK.\n"
+        )
+    );
+
+    let stdout = fs::read_to_string(stdout_path)?;
+    let stderr = fs::read_to_string(stderr_path)?;
+    assert!(stdout.contains("provider-stdout:oauth token private-path="));
+    assert!(stderr.contains("provider-stderr:account model bearer="));
+    let report = fs::read_to_string(report_path)?;
+    for forbidden in [
+        "provider-stdout",
+        "provider-stderr",
+        "oauth",
+        "account",
+        "token",
+        "model",
+        "bearer",
+        &observation_path.to_string_lossy(),
+        &current_dir.to_string_lossy(),
+    ] {
+        assert!(
+            !report.contains(forbidden),
+            "verification report leaked {forbidden:?}: {report}"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn verification_fails_when_ephemeral_state_cannot_be_removed() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let provider = codex::descriptor();
+    let providers = [provider];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = FakeClock::default();
+    let blocked_root = Rc::new(RefCell::new(None));
+    let mut launcher = CleanupBlockingLauncher {
+        blocked_root: Rc::clone(&blocked_root),
+    };
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::VerifyOnly;
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+
+    assert_eq!(summary.results[0].outcome, Outcome::VerificationFailed);
+    let root = blocked_root
+        .borrow()
+        .clone()
+        .context("verification working directory")?;
+    let mut permissions = fs::metadata(&root)?.permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&root, permissions)?;
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn verify_ephemeral_state_helper() -> Result<()> {
+    if std::env::var_os("COVEN_SETUP_VERIFY_HELPER").is_none() {
+        return Ok(());
+    }
+    let executable = PathBuf::from(
+        std::env::var_os("COVEN_SETUP_VERIFY_EXECUTABLE").context("verification executable")?,
+    );
+    let report_path =
+        PathBuf::from(std::env::var_os("COVEN_SETUP_REPORT_PATH").context("report path")?);
+    let providers = [codex::descriptor()];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: executable,
+        version: Some("1.2.3".to_owned()),
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = SystemClock::new();
+    let mut launcher = SystemProcessLauncher;
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::VerifyOnly;
+    setup_options.report_json = Some(report_path);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    Ok(())
+}
+
 #[test]
 fn report_publication_is_fail_if_exists_atomic_and_redaction_closed() -> Result<()> {
     let temp = test_tempdir()?;
@@ -994,6 +1235,26 @@ fn report_publication_is_fail_if_exists_atomic_and_redaction_closed() -> Result<
     assert!(matches!(error, SetupError::Rejected));
     assert!(!rejected.exists());
 
+    let unresolved = temp.path().join("unresolved.json");
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: PathBuf::from("fake-codex"),
+        version: None,
+    }));
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let mut launcher = FakeLauncher::new([LaunchBehavior::exit(0)]);
+    setup_options.report_json = Some(unresolved.clone());
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let error = run_setup(&setup_options, &providers, &mut runtime)
+        .expect_err("certification requires a resolved CLI version");
+    assert!(matches!(error, SetupError::Rejected));
+    assert!(!unresolved.exists());
+
     let published = temp.path().join("published.json");
     let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
     let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
@@ -1009,7 +1270,26 @@ fn report_publication_is_fail_if_exists_atomic_and_redaction_closed() -> Result<
     let summary = run_setup(&setup_options, &providers, &mut runtime)?;
     assert!(summary.completed());
     let parsed: serde_json::Value = serde_json::from_slice(&fs::read(&published)?)?;
-    assert_eq!(parsed["results"][0]["version"], "1.2.3");
+    assert_eq!(parsed["cli_version"], "1.2.3");
+    let mut result_fields = parsed
+        .as_object()
+        .context("flat report result object")?
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    result_fields.sort_unstable();
+    assert_eq!(
+        result_fields,
+        [
+            "candidate_commit",
+            "cli_version",
+            "completed",
+            "duration",
+            "exit_class",
+            "harness",
+            "platform",
+        ]
+    );
     let entries = fs::read_dir(temp.path())?
         .map(|entry| entry.map(|entry| entry.file_name()))
         .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -1032,12 +1312,16 @@ fn executable_discovery_is_injectable_and_rejects_non_executables() -> Result<()
     } else {
         "fake-cli"
     });
-    fs::write(&executable, b"fixture")?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
+        fs::write(&executable, b"#!/bin/sh\nprintf 'fake-cli 1.2.3\\n'\n")?;
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))?;
     }
+    #[cfg(not(unix))]
+    fs::write(&executable, b"fixture")?;
+    #[cfg(windows)]
+    fs::write(bin.join("fake-cli"), b"npm shell shim")?;
     let path = std::env::join_paths([&bin])?;
     let discovery = SystemExecutableDiscovery::from_path(Some(path), Some(OsString::from(".EXE")));
     let _environment_discovery = SystemExecutableDiscovery::from_environment();
@@ -1055,6 +1339,8 @@ fn executable_discovery_is_injectable_and_rejects_non_executables() -> Result<()
         .eq_ignore_ascii_case(&executable.to_string_lossy()));
     #[cfg(not(windows))]
     assert_eq!(resolved.path, executable);
+    #[cfg(unix)]
+    assert_eq!(resolved.version.as_deref(), Some("1.2.3"));
 
     #[cfg(unix)]
     {
@@ -1364,6 +1650,32 @@ impl FakeLauncher {
             behaviors: behaviors.into_iter().collect(),
             launches: Vec::new(),
         }
+    }
+}
+
+#[cfg(unix)]
+struct CleanupBlockingLauncher {
+    blocked_root: Rc<RefCell<Option<PathBuf>>>,
+}
+
+#[cfg(unix)]
+impl ProcessLauncher for CleanupBlockingLauncher {
+    fn launch(&mut self, request: &LaunchRequest) -> io::Result<Box<dyn RunningProcess>> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = request
+            .current_dir
+            .clone()
+            .ok_or_else(|| io::Error::other("verification working directory was not set"))?;
+        let mut permissions = fs::metadata(&root)?.permissions();
+        permissions.set_mode(0o500);
+        fs::set_permissions(&root, permissions)?;
+        self.blocked_root.replace(Some(root));
+        Ok(Box::new(FakeProcess {
+            polls_before_exit: 0,
+            exit: ProcessExit::Exited(0),
+            terminated: Rc::new(Cell::new(false)),
+        }))
     }
 }
 


### PR DESCRIPTION
## Context

- Summary: Add explicitly consented, ephemeral provider verification with minimal redacted certification reports for Codex, Claude Code, and GitHub Copilot CLI.
- Files changed: setup provider descriptors, process supervision, verification state, report publication, shared harness argv, and setup integration tests.
- Bead: `coven-v041-verify`

## Implementation

- Approach: Derive fixed verification probes from provider-owned adapter argv, run each provider with inherited terminal streams inside a unique temporary cwd and `COVEN_HOME`, clean that state before certifying completion, and resolve bounded CLI versions for the flat release report.
- User-visible behavior: `coven setup <provider> --verify` and `--verify-only` require explicit network/cost consent; `--report-json` publishes one provider minimum certification facts without provider output, credentials, account data, or private paths.
- Compatibility notes: Windows processes start suspended, enter a kill-on-close Job Object, then resume; executable discovery prefers PATHEXT launchers over extensionless npm shell shims.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy -p coven-cli --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] setup suite (30 passed), Doctor boundary, smoke suite (31 passed)
- [x] Windows GNU target compile check

## Risk and Rollback

- Risk level: Medium; this adds process lifecycle and report-publication behavior across three provider CLIs.
- Rollback plan: Revert this commit to restore provider login-only setup behavior.

## Agent Handoff

- Current state: Implementation, privacy review, package gates, Windows cross-compile, and full workspace tests pass.
- Follow-ups: Unblocks setup privacy/parity tests, certification, and onboarding documentation Beads.
- Known gaps: None in this change.