### PR TITLE
docs: reconcile setup and Doctor guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ verbs:
 | --- | --- | --- |
 | `coven` / `coven chat` | Open the interactive Coven UI (engine auto-installed on first run); `coven "<task>"` plans and runs a free-text task | [Interactive UI](https://docs.opencoven.ai/docs/cli/interactive) |
 | `coven doctor` | Detect supported harness CLIs and print install hints | [Doctor](https://docs.opencoven.ai/docs/cli/doctor) |
-| `coven setup <codex\|claude\|copilot\|all>` | Run provider-owned login and optional explicitly consented verification | [Setup](docs/reference/cli-setup.md) |
+| `coven setup [<codex\|claude\|copilot\|all>]` | Run provider-owned login and optional explicitly consented verification | [Setup](docs/reference/cli-setup.md) |
 | `coven daemon start/status/restart/stop` | Manage the local daemon | [Daemon commands](https://docs.opencoven.ai/docs/cli/daemon) |
 | `coven run <harness> <prompt>` | Launch a project-scoped harness session (`--cwd`, `--title`, `--model`, `--continue`, `--stream-json`, …) | [Run](https://docs.opencoven.ai/docs/cli/run) |
 | `coven sessions` | Browse, search, and inspect sessions (`--plain`, `--json`, `--all`, `search`, `show`, `events`, `log`) | [Sessions](https://docs.opencoven.ai/docs/cli/sessions) |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ The Rust daemon is the authority boundary. All clients — including the CLI its
 
 ### Installing harness CLIs
 
-Run `coven doctor` first — it prints specific install hints for any missing harness.
+Run `coven doctor` first — it reports local readiness and points missing
+harnesses to `coven setup`. Doctor stays offline and does not verify provider
+authentication.
 
 **Codex (OpenAI):**
 
@@ -126,7 +128,7 @@ codex login
 
 ```bash
 npm install -g @anthropic-ai/claude-code
-claude doctor
+claude auth login
 ```
 
 **GitHub Copilot CLI (GitHub):**
@@ -134,11 +136,17 @@ claude doctor
 ```bash
 npm install -g @github/copilot
 # or: brew install --cask copilot-cli
+copilot login
 ```
 
-Per-harness setup detail lives in [`docs/harnesses/`](docs/harnesses/index.md).
+The recommended guided path is `coven setup codex`, `coven setup claude`, or
+`coven setup copilot`; `coven setup all` processes all three in order. Add
+`--verify` for a separately consented provider turn, or use `--verify-only`
+after an existing login. See the
+[`coven setup` reference](docs/reference/cli-setup.md).
 
-After installing and authenticating, run `coven doctor` again to confirm the harness is detected. If `doctor` still reports missing, ensure the harness binary is on your `PATH`.
+After setup, run `coven doctor` again to confirm the harness is detected. If
+Doctor still reports it missing, ensure the harness binary is on your `PATH`.
 
 ---
 
@@ -221,21 +229,24 @@ a recorded session.
 ```bash
 cd /path/to/your/project
 
-# 1. Verify setup
+# 1. Complete provider-owned login
+coven setup codex
+
+# 2. Check local readiness
 coven doctor
 
-# 2. Start the daemon
+# 3. Start the daemon
 coven daemon start
 
-# 3. Launch a session
+# 4. Launch a session
 coven run codex "fix the failing tests"
 # or with Claude Code:
 coven run claude "polish this UI"
 
-# 4. Browse and manage sessions
+# 5. Browse and manage sessions
 coven sessions
 
-# 5. Stop the daemon when done
+# 6. Stop the daemon when done
 coven daemon stop
 ```
 
@@ -261,6 +272,7 @@ verbs:
 | --- | --- | --- |
 | `coven` / `coven chat` | Open the interactive Coven UI (engine auto-installed on first run); `coven "<task>"` plans and runs a free-text task | [Interactive UI](https://docs.opencoven.ai/docs/cli/interactive) |
 | `coven doctor` | Detect supported harness CLIs and print install hints | [Doctor](https://docs.opencoven.ai/docs/cli/doctor) |
+| `coven setup <codex\|claude\|copilot\|all>` | Run provider-owned login and optional explicitly consented verification | [Setup](docs/reference/cli-setup.md) |
 | `coven daemon start/status/restart/stop` | Manage the local daemon | [Daemon commands](https://docs.opencoven.ai/docs/cli/daemon) |
 | `coven run <harness> <prompt>` | Launch a project-scoped harness session (`--cwd`, `--title`, `--model`, `--continue`, `--stream-json`, …) | [Run](https://docs.opencoven.ai/docs/cli/run) |
 | `coven sessions` | Browse, search, and inspect sessions (`--plain`, `--json`, `--all`, `search`, `show`, `events`, `log`) | [Sessions](https://docs.opencoven.ai/docs/cli/sessions) |
@@ -564,7 +576,10 @@ No. Coven wraps them. You still use the harness CLI for its AI capabilities — 
 
 **Q: Does Coven require an internet connection or an account?**
 
-No. Coven itself is fully local. Your harness CLIs (Codex, Claude Code) require their own provider authentication, but Coven stores no credentials and makes no outbound network calls.
+Core Coven operation and `coven doctor` are local. Your harness CLIs require
+their own provider authentication and network access. Coven stores no provider
+credentials; only an explicitly consented `coven setup --verify` or a harness
+session launches a provider turn.
 
 **Q: Is Windows supported?**
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -2421,9 +2421,10 @@ fn doctor_next_steps(default_harness: Option<&str>) -> Vec<String> {
             "coven sessions".to_string(),
         ],
         None => vec![
-            "Install and authenticate at least one harness in this same shell.".to_string(),
-            "Codex: npm install -g @openai/codex && codex login".to_string(),
-            "Claude Code: npm install -g @anthropic-ai/claude-code && claude doctor".to_string(),
+            "Set up at least one harness in this same shell.".to_string(),
+            "Codex: coven setup codex".to_string(),
+            "Claude Code: coven setup claude".to_string(),
+            "GitHub Copilot CLI: coven setup copilot".to_string(),
             "If PATH changed, open a new terminal and run `coven doctor` again.".to_string(),
             "Then run: coven daemon start".to_string(),
             "Install docs: https://github.com/OpenCoven/coven/blob/main/docs/install/index.md"
@@ -3692,9 +3693,9 @@ fn credentials_lines(
 /// adapter's own install/authentication hint.
 fn auth_setup_hint_for_harness(harness_id: &str) -> String {
     match harness_id {
-        "codex" => "codex login".to_string(),
-        "claude" => "claude doctor".to_string(),
-        "copilot" => "copilot login".to_string(),
+        "codex" => "coven setup codex".to_string(),
+        "claude" => "coven setup claude".to_string(),
+        "copilot" => "coven setup copilot".to_string(),
         other => format!("coven adapter doctor {other}"),
     }
 }
@@ -7777,9 +7778,12 @@ mod tests {
         // doctor renders this hint inside backticks. Adapter harnesses used to
         // land on the prose fallback "see harness docs", which reads as a
         // command that does not exist.
-        assert_eq!(auth_setup_hint_for_harness("codex"), "codex login");
-        assert_eq!(auth_setup_hint_for_harness("claude"), "claude doctor");
-        assert_eq!(auth_setup_hint_for_harness("copilot"), "copilot login");
+        assert_eq!(auth_setup_hint_for_harness("codex"), "coven setup codex");
+        assert_eq!(auth_setup_hint_for_harness("claude"), "coven setup claude");
+        assert_eq!(
+            auth_setup_hint_for_harness("copilot"),
+            "coven setup copilot"
+        );
         for id in ["grok", "hermes", "opencode", "some-local-adapter"] {
             let hint = auth_setup_hint_for_harness(id);
             assert_eq!(hint, format!("coven adapter doctor {id}"));
@@ -7788,6 +7792,25 @@ mod tests {
                 "hint must be runnable, got: {hint}"
             );
         }
+    }
+
+    #[test]
+    fn missing_harness_next_steps_use_guided_setup() {
+        let steps = doctor_next_steps(None);
+        for command in [
+            "Codex: coven setup codex",
+            "Claude Code: coven setup claude",
+            "GitHub Copilot CLI: coven setup copilot",
+        ] {
+            assert!(
+                steps.iter().any(|step| step == command),
+                "missing {command}"
+            );
+        }
+        let rendered = steps.join("\n");
+        assert!(!rendered.contains("codex login"));
+        assert!(!rendered.contains("claude auth login"));
+        assert!(!rendered.contains("copilot login"));
     }
 
     #[test]
@@ -8300,7 +8323,10 @@ mod tests {
             codex_line.contains("authentication not verified"),
             "got: {codex_line}"
         );
-        assert!(codex_line.contains("codex login"), "got: {codex_line}");
+        assert!(
+            codex_line.contains("coven setup codex"),
+            "got: {codex_line}"
+        );
         assert!(
             codex_line.contains("explicitly authorized test turn"),
             "got: {codex_line}"
@@ -8311,7 +8337,10 @@ mod tests {
             claude_line.contains("authentication not verified"),
             "got: {claude_line}"
         );
-        assert!(claude_line.contains("claude doctor"), "got: {claude_line}");
+        assert!(
+            claude_line.contains("coven setup claude"),
+            "got: {claude_line}"
+        );
         assert!(
             claude_line.contains("explicitly authorized test turn"),
             "got: {claude_line}"

--- a/crates/coven-cli/tests/doctor_auth_boundary.rs
+++ b/crates/coven-cli/tests/doctor_auth_boundary.rs
@@ -130,10 +130,18 @@ fn doctor_auth_boundary_is_offline_hermetic_and_failure_bounded() -> Result<()> 
         assert_eq!(harness_status(&configured_json, harness), "pass");
         assert_eq!(credential_status(&configured_json, harness), "warn");
     }
-    assert_eq!(
-        credential_hint(&configured_json, "codex"),
-        "authenticate or inspect local setup with: codex login; verify provider access with an explicitly authorized test turn"
-    );
+    for (harness, setup_command) in [
+        ("codex", "coven setup codex"),
+        ("claude", "coven setup claude"),
+        ("copilot", "coven setup copilot"),
+    ] {
+        assert_eq!(
+            credential_hint(&configured_json, harness),
+            format!(
+                "authenticate or inspect local setup with: {setup_command}; verify provider access with an explicitly authorized test turn"
+            )
+        );
+    }
     assert_only_local_engine_probes(&configured.invocations);
 
     let unconfigured = fixture.run("unconfigured", "unconfigured", false)?;

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -1110,8 +1110,16 @@ fn doctor_missing_harness_prints_cross_platform_setup_loop() -> anyhow::Result<(
     assert_stdout_contains(
         "doctor without harnesses",
         &output,
-        "Install and authenticate at least one harness in this same shell.",
+        "Set up at least one harness in this same shell.",
     );
+    for command in [
+        "Codex: coven setup codex",
+        "Claude Code: coven setup claude",
+        "GitHub Copilot CLI: coven setup copilot",
+    ] {
+        assert_stdout_contains("doctor without harnesses", &output, command);
+    }
+    assert_stdout_not_contains("doctor without harnesses", &output, "claude doctor");
     assert_stdout_contains(
         "doctor without harnesses",
         &output,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,6 +88,9 @@ Shipped:
 - Local daemon lifecycle: `coven daemon start/status/restart/stop`.
 - Project-root and cwd boundary guard.
 - Built-in Codex, Claude Code, and GitHub Copilot CLI harness adapters.
+- Provider-owned `coven setup` login for those three harnesses, with optional
+  explicitly consented ephemeral verification and redacted certification
+  reports.
 - Trusted opt-in recipes for Hermes 1.0.3 and OpenCode 0.1.1; experimental opt-in recipe for Grok Build 1.0.0.
 - PTY-backed `coven run codex|claude|copilot <prompt>` sessions.
 - SQLite-backed session metadata and event log.

--- a/docs/harnesses/claude-code.md
+++ b/docs/harnesses/claude-code.md
@@ -14,8 +14,9 @@ Claude Code is Anthropic's coding-agent CLI. Coven wraps it in a project-rooted 
 |---|---|
 | Harness id | `claude` |
 | Install | `npm install -g @anthropic-ai/claude-code` |
-| Auth | `claude doctor` (one-time, Anthropic side) |
-| Doctor check | `coven doctor` reports the resolved Claude path and version. |
+| Auth | `claude auth login` (one-time, Anthropic side) |
+| Guided setup | `coven setup claude` |
+| Doctor check | `coven doctor` reports local availability; it does not verify auth. |
 
 ## Setup
 
@@ -25,17 +26,26 @@ Claude Code is Anthropic's coding-agent CLI. Coven wraps it in a project-rooted 
     npm install -g @anthropic-ai/claude-code
     ```
   </Step>
-  <Step title="Run Claude's own doctor">
+  <Step title="Run guided provider login">
     ```bash
-    claude doctor
+    coven setup claude
     ```
-    Provider credentials stay with Claude Code. Coven never reads them.
+    After explicit consent, Coven hands the terminal to `claude auth login`.
+    Provider credentials stay with Claude Code; Coven never reads them.
+  </Step>
+  <Step title="Optionally verify provider access">
+    ```bash
+    coven setup claude --verify-only
+    ```
+    Verification requires separate consent, network access, and may incur
+    provider usage or cost. It runs in ephemeral state.
   </Step>
   <Step title="Confirm with Coven">
     ```bash
     coven doctor
     ```
-    The output should include `claude: ok (/usr/local/bin/claude)`.
+    Doctor confirms only that Claude Code is locally available. It remains
+    offline and does not verify provider authentication.
   </Step>
   <Step title="Launch">
     ```bash
@@ -58,12 +68,15 @@ coven run claude "refactor for clarity" --cwd packages/web --title "Web refactor
 
 Claude Code owns its own OAuth flow and token cache. Coven never reads Anthropic keys or session cookies.
 
+For the complete TTY, consent, timeout, verification, and redacted report
+contract, see [`coven setup`](/reference/cli-setup).
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `coven doctor` reports `claude` missing | Claude Code not on `PATH` | `npm install -g @anthropic-ai/claude-code`, then re-run doctor. |
-| Claude prompts for login | Auth not finished | `claude doctor`. |
+| Claude prompts for login | Auth not finished | `claude auth login` or `coven setup claude`. |
 | Session shows long pre-flight pause | Claude resolving config | First run only; subsequent launches are fast. |
 
 ## How Coven supervises Claude Code
@@ -95,4 +108,5 @@ Claude Code's tool calls run inside the Claude process — Coven does not arbitr
 
 - [Installing harness CLIs](/harnesses/installing)
 - [Provider auth boundary](/harnesses/provider-auth)
+- [`coven setup`](/reference/cli-setup)
 - [Troubleshooting](https://docs.opencoven.ai/docs/harnesses/troubleshooting)

--- a/docs/harnesses/codex.md
+++ b/docs/harnesses/codex.md
@@ -18,7 +18,8 @@ harness.
 | Harness id | `codex` |
 | Install | `npm install -g @openai/codex` |
 | Auth | `codex login` (one-time, OpenAI side) |
-| Doctor check | `coven doctor` reports the resolved Codex path and version. |
+| Guided setup | `coven setup codex` |
+| Doctor check | `coven doctor` reports local availability; it does not verify auth. |
 
 ## Setup
 
@@ -29,17 +30,26 @@ harness.
     ```
     Other install methods (Homebrew cask, package managers) are listed at the [Codex repo](https://github.com/openai/codex).
   </Step>
-  <Step title="Log in to OpenAI">
+  <Step title="Run guided provider login">
     ```bash
-    codex login
+    coven setup codex
     ```
-    Provider credentials stay with Codex. Coven never reads them.
+    After explicit consent, Coven hands the terminal to `codex login`.
+    Provider credentials stay with Codex; Coven never reads them.
+  </Step>
+  <Step title="Optionally verify provider access">
+    ```bash
+    coven setup codex --verify-only
+    ```
+    Verification requires separate consent, network access, and may incur
+    provider usage or cost. It runs in ephemeral state.
   </Step>
   <Step title="Confirm with Coven">
     ```bash
     coven doctor
     ```
-    The output should include a line like `codex: ok (/usr/local/bin/codex)`.
+    Doctor confirms only that Codex is locally available. It remains offline
+    and does not verify provider authentication.
   </Step>
   <Step title="Launch">
     ```bash
@@ -61,6 +71,9 @@ coven run codex "audit this repo" --cwd packages/cli --title "CLI audit"
 ## Provider auth boundary
 
 Codex owns its own OAuth flow and token cache. If you see `Invalidated OAuth token`, run `codex login` again. Coven will keep the existing session record so you can re-launch with the same title.
+
+For the complete TTY, consent, timeout, verification, and redacted report
+contract, see [`coven setup`](/reference/cli-setup).
 
 For the local rescue path:
 
@@ -117,4 +130,5 @@ available; otherwise Coven's timeout/error cleanup uses `taskkill /T /F`.
 
 - [Installing harness CLIs](/harnesses/installing)
 - [Provider auth boundary](/harnesses/provider-auth)
+- [`coven setup`](/reference/cli-setup)
 - [Troubleshooting](https://docs.opencoven.ai/docs/harnesses/troubleshooting)

--- a/docs/harnesses/copilot-cli.md
+++ b/docs/harnesses/copilot-cli.md
@@ -17,7 +17,8 @@ rituals work the same as for any other harness.
 | Harness id | `copilot` |
 | Install | `npm install -g @github/copilot` or `brew install --cask copilot-cli` |
 | Auth | `copilot login` (one-time, GitHub side) |
-| Doctor check | `coven doctor` reports Copilot CLI availability and the install hint when missing. |
+| Guided setup | `coven setup copilot` |
+| Doctor check | `coven doctor` reports local availability; it does not verify auth. |
 
 ## Setup
 
@@ -30,17 +31,27 @@ rituals work the same as for any other harness.
     ```
     Other install methods are listed in the [Copilot CLI docs](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
   </Step>
-  <Step title="Log in to GitHub">
+  <Step title="Run guided provider login">
     ```bash
-    copilot login
+    coven setup copilot
     ```
-    GitHub credentials stay with Copilot. Coven never reads them.
+    After explicit consent, Coven hands the terminal to `copilot login`.
+    GitHub credentials stay with Copilot; Coven never reads them.
+  </Step>
+  <Step title="Optionally verify provider access">
+    ```bash
+    coven setup copilot --verify-only
+    ```
+    Verification requires separate consent, network access, and may incur
+    provider usage or cost. It runs in ephemeral state.
   </Step>
   <Step title="Confirm with Coven">
     ```bash
     coven doctor
     ```
-    The Harnesses section should include `[OK] Copilot CLI` with the resolved `copilot` executable.
+    The Harnesses section should include `[OK] Copilot CLI` with the resolved
+    `copilot` executable. Doctor remains offline and does not verify provider
+    authentication.
   </Step>
   <Step title="Launch">
     ```bash
@@ -118,9 +129,13 @@ Copilot owns its GitHub auth flow and token cache (under `~/.copilot/`).
 Coven never reads, proxies, or stores those credentials — see the
 [provider auth boundary](/harnesses/provider-auth).
 
+For the complete TTY, consent, timeout, verification, and redacted report
+contract, see [`coven setup`](/reference/cli-setup).
+
 ## Related
 
 - [Installing harness CLIs](/harnesses/installing)
 - [Provider auth boundary](/harnesses/provider-auth)
+- [`coven setup`](/reference/cli-setup)
 - [Harness adapter guide](/HARNESS-ADAPTERS)
 - [Troubleshooting](https://docs.opencoven.ai/docs/harnesses/troubleshooting)

--- a/docs/harnesses/installing.md
+++ b/docs/harnesses/installing.md
@@ -30,7 +30,7 @@ The daemon revalidates the harness id on every launch request. Clients cannot wi
 | Harness id | Executable | Install command | Provider login | Detail page |
 |---|---|---|---|---|
 | `codex` | `codex` | `npm install -g @openai/codex` | `codex login` | [Codex harness](/harnesses/codex) |
-| `claude` | `claude` | `npm install -g @anthropic-ai/claude-code` | `claude doctor` | [Claude Code harness](/harnesses/claude-code) |
+| `claude` | `claude` | `npm install -g @anthropic-ai/claude-code` | `claude auth login` | [Claude Code harness](/harnesses/claude-code) |
 | `copilot` | `copilot` | `npm install -g @github/copilot` | `copilot login` | [Copilot CLI harness](/harnesses/copilot-cli) |
 
 Other CLIs (Aider, Gemini CLI, Cline, custom commands) are **not** bundled in
@@ -67,15 +67,19 @@ bundled. Install and set up Hermes Agent first, then run
   </Step>
 
   <Step title="Finish provider auth in the harness CLI">
-    Coven never touches provider credentials. Run each CLI's own login flow once.
+    Coven never touches provider credentials. Use guided setup to run each
+    provider-owned login flow after explicit consent.
 
     ```bash
-    codex login
-    claude doctor
-    copilot login
+    coven setup codex
+    coven setup claude
+    coven setup copilot
     ```
 
-    See [Provider auth boundary](/harnesses/provider-auth) for the rationale.
+    These invoke `codex login`, `claude auth login`, and `copilot login`
+    respectively. See [Provider auth boundary](/harnesses/provider-auth) for
+    the rationale and [`coven setup`](/reference/cli-setup) for optional
+    verification.
   </Step>
 
   <Step title="Verify Coven sees the harness">
@@ -135,7 +139,7 @@ coven doctor
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `coven doctor` reports a harness as `missing` even after install | New shell `PATH` not picked up by the daemon | `coven daemon restart`, then `coven doctor`. |
-| Doctor finds the binary but `coven run` fails immediately | Provider auth incomplete | Re-run `codex login` / `claude doctor` / `copilot login`. See [provider auth](/harnesses/provider-auth). |
+| Doctor finds the binary but `coven run` fails immediately | Provider auth incomplete | Re-run `coven setup codex`, `coven setup claude`, or `coven setup copilot`. See [provider auth](/harnesses/provider-auth). |
 | Doctor shows a stale version | Older binary earlier on `PATH` | `which -a codex` (or `claude`, `copilot`) and remove the duplicate. |
 | Doctor reports `unsupported harness` | Typo in harness id | Use one of the ids in the table above. |
 
@@ -146,6 +150,7 @@ coven doctor
 - [Codex harness](/harnesses/codex)
 - [Claude Code harness](/harnesses/claude-code)
 - [Copilot CLI harness](/harnesses/copilot-cli)
+- [`coven setup`](/reference/cli-setup)
 - [Grok Build adapter](/harnesses/grok-build)
 - [Harness adapters](/HARNESS-ADAPTERS)
 - [Future harness notes](/FUTURE-HARNESSES)

--- a/docs/harnesses/provider-auth.md
+++ b/docs/harnesses/provider-auth.md
@@ -21,7 +21,8 @@ Coven supervises harness PTYs. It never reads, proxies, persists, or mints provi
 
 ```mermaid
 flowchart LR
-  User[Developer] -->|once| HarnessLogin["harness login (codex login / claude doctor)"]
+  User[Developer] -->|once| CovenSetup["coven setup codex / claude / copilot"]
+  CovenSetup --> HarnessLogin["provider login (codex login / claude auth login / copilot login)"]
   HarnessLogin --> HarnessStore[("Provider credential store\n~/.codex, keychain, etc.")]
 
   User -->|every run| CovenRun["coven run codex prompt"]
@@ -42,7 +43,11 @@ The arrow that matters is the missing one: the daemon has no dotted line into th
 
 ### CLI
 
-`coven run codex|claude <prompt>` launches the harness with an empty argument vector apart from the validated prompt and adapter prefix args. It does not inject `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or any token-bearing env var. If the harness needs a credential, it reads it the same way it would when launched directly from your shell.
+`coven run codex|claude|copilot <prompt>` launches the harness with the
+validated prompt and adapter prefix args. It does not inject
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or any token-bearing env var. If the
+harness needs a credential, it reads it the same way it would when launched
+directly from your shell.
 
 ### Coven Code engine
 
@@ -85,7 +90,7 @@ Clients (CastCodes, comux, the OpenClaw plugin) connect to the local socket. The
 | Harness | Login command | Where credentials live | Notes |
 |---|---|---|---|
 | `codex` | `codex login` | `~/.codex/auth.json` (or platform keychain, depending on Codex version) | Use `codex logout` to revoke. Coven does not need to be restarted. |
-| `claude` | `claude doctor` then follow prompts | `~/.config/anthropic/` and/or system keychain | `claude doctor` is also a general health check; Coven only relies on the binary being present. |
+| `claude` | `claude auth login` | `~/.config/anthropic/` and/or system keychain | Coven only relies on the binary being present unless you explicitly request setup verification. |
 | `copilot` | `copilot login` | `~/.copilot/` (GitHub device-flow token managed by the CLI) | Use `copilot logout` to revoke. GitHub-side Copilot access is governed by your GitHub plan. |
 | `grok` (experimental recipe) | `grok login` or `grok login --device-code` | `~/.grok/` and/or provider-managed local auth | `XAI_API_KEY` is also supported for headless use; Coven inherits it but never reads or stores it. |
 
@@ -104,7 +109,10 @@ The daemon's responsibility is to **stay out of the credential path**. Concretel
 
 Because Coven refuses to own credentials, **the user** is responsible for:
 
-- Running each harness's own `login` / `doctor` flow at least once before expecting `coven run` to succeed.
+- Running each harness's own login flow at least once before expecting
+  `coven run` to succeed. `coven setup codex`, `coven setup claude`, and
+  `coven setup copilot` hand the terminal to the exact commands in the table
+  after explicit consent.
 - Rotating provider tokens through the harness CLI when needed.
 - Treating any harness output that prints a credential (because you asked it to) as ledger-recorded. Rotate or revoke the credential immediately. An eligible non-running session without adoption evidence may be removed with [`coven sacrifice`](/SESSION-LIFECYCLE#sacrifice); adopted/reserved sessions are retained and O3 provides no sacrifice release, so do not rely on deletion as the containment plan.
 
@@ -114,6 +122,7 @@ Because Coven refuses to own credentials, **the user** is responsible for:
 - [Authentication and local access](/AUTH)
 - [Safety model](/SAFETY-MODEL)
 - [Install harness CLIs](/harnesses/installing)
+- [`coven setup`](/reference/cli-setup)
 - [Harness adapters](/HARNESS-ADAPTERS)
 - [Codex harness](/harnesses/codex)
 - [Claude Code harness](/harnesses/claude-code)

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -16,7 +16,7 @@ limited to the bundled harness CLI login paths.
     Install `@openai/codex`, run `codex login`, then launch with harness id `codex`.
   </Card>
   <Card title="Claude Code" href="/harnesses/claude-code" icon="brain">
-    Install `@anthropic-ai/claude-code`, run `claude doctor`, then launch with harness id `claude`.
+    Install `@anthropic-ai/claude-code`, run `claude auth login`, then launch with harness id `claude`.
   </Card>
   <Card title="Copilot CLI" href="/harnesses/copilot-cli" icon="github">
     Install `@github/copilot`, run `copilot login`, then launch with harness id `copilot`.
@@ -30,13 +30,16 @@ npm install -g @openai/codex
 codex login
 
 npm install -g @anthropic-ai/claude-code
-claude doctor
+claude auth login
 
 npm install -g @github/copilot
 copilot login
 
 coven doctor
 ```
+
+For a guided provider-owned login, use `coven setup codex`,
+`coven setup claude`, or `coven setup copilot`.
 
 ## What this means for clients
 

--- a/docs/reference/cli-coven.md
+++ b/docs/reference/cli-coven.md
@@ -49,7 +49,7 @@ an explicit ANSI-color policy.
 | Goal | Start with |
 | --- | --- |
 | Check whether the local runtime is usable | `coven doctor` |
-| Complete provider login or optional verification | `coven setup <codex\|claude\|copilot\|all>` |
+| Complete provider login or optional verification | `coven setup [<codex\|claude\|copilot\|all>]` |
 | Control the local daemon | `coven daemon status` |
 | Launch an explicit harness task | `coven run <harness> "<prompt>"` |
 | Browse or manage history | `coven sessions` |

--- a/docs/reference/cli-coven.md
+++ b/docs/reference/cli-coven.md
@@ -49,6 +49,7 @@ an explicit ANSI-color policy.
 | Goal | Start with |
 | --- | --- |
 | Check whether the local runtime is usable | `coven doctor` |
+| Complete provider login or optional verification | `coven setup <codex\|claude\|copilot\|all>` |
 | Control the local daemon | `coven daemon status` |
 | Launch an explicit harness task | `coven run <harness> "<prompt>"` |
 | Browse or manage history | `coven sessions` |
@@ -62,6 +63,7 @@ authority layer, and harness credentials remain owned by the selected harness.
 ## Related
 
 - [CLI reference](/reference/cli)
+- [`coven setup`](/reference/cli-setup)
 - [Core access guide](/guides/core-access)
 - [Coven TUI](/start/coven-tui)
 - [Engine contract](/ENGINE-CONTRACT)

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -39,7 +39,7 @@ found):
     { "id": "harnesses", "status": "pass", "message": "2 of 4 configured harness executables available" },
     { "id": "engine", "status": "pass", "message": "<engine> (managed install), version 0.6.1 (pin 0.6.1)" },
     { "id": "credentials:engine", "status": "warn", "message": "authentication configured; provider turn not verified", "hint": "run an explicitly authorized test turn to verify provider access" },
-    { "id": "credentials:codex", "status": "warn", "message": "executable available; authentication not verified", "hint": "authenticate or inspect local setup with: codex login; verify provider access with an explicitly authorized test turn" }
+    { "id": "credentials:codex", "status": "warn", "message": "executable available; authentication not verified", "hint": "authenticate or inspect local setup with: coven setup codex; verify provider access with an explicitly authorized test turn" }
   ],
   "nextSteps": ["coven run codex \"explain this repo in 5 bullets\"", "coven sessions"]
 }
@@ -76,7 +76,7 @@ availability, where any missing adapter is a `fail`.
 | `Harnesses` | Supported harness executables that are visible on this shell's `PATH`. |
 | `Engine` | Whether the Coven engine is installed and meets the minimum supported version. |
 | `Familiars` | Configured familiar identities from `familiars.toml`, if present. |
-| `Credentials` | Advisory local engine auth configuration and explicit `authentication not verified` rows for external harnesses. Doctor calls only the engine's contractually offline `auth status --json`; it never launches a provider harness, starts a provider turn, contacts a provider, or reads harness credentials. |
+| `Credentials` | Advisory local engine auth configuration and explicit `authentication not verified` rows for external harnesses. Doctor calls only the engine's contractually offline `auth status --json`; it launches no provider CLI process, performs no provider network request, does not inspect provider tokens or credential stores, and does not verify authentication. |
 | `Next steps` | The safest next command based on the detected state. |
 
 ## Expected first-run loop
@@ -84,6 +84,7 @@ availability, where any missing adapter is a `fail`.
 ```sh
 coven --version
 coven doctor
+coven setup codex
 coven daemon start
 coven daemon status
 cd /path/to/project
@@ -98,18 +99,19 @@ coven run claude "explain this repo in 5 bullets"
 
 ## Missing harness output
 
-When no supported harness is visible, `doctor` prints a per-harness install
-hint. For Codex, Claude Code, and GitHub Copilot CLI those hints boil down to:
+When no supported harness is visible, Doctor points each built-in harness to
+the guided setup path:
 
 ```sh
-npm install -g @openai/codex
-codex login
-npm install -g @anthropic-ai/claude-code
-claude doctor
-npm install -g @github/copilot
-copilot login
+coven setup codex
+coven setup claude
+coven setup copilot
 coven doctor
 ```
+
+Setup prints official install guidance when the selected executable is missing.
+When present, those commands hand the terminal to `codex login`,
+`claude auth login`, or `copilot login` only after explicit consent.
 
 If you installed a harness in another shell, open a new terminal and run
 `coven doctor` again. Coven can only launch CLIs that are visible from the
@@ -164,9 +166,14 @@ Each missing harness prints an advisory `[--]` line with an install hint. When
 none is available, Doctor adds a blocking `[!!] No supported harness is
 available` line and exits 1; one working harness keeps the aggregate usable.
 Executable discovery does not prove provider authentication. A harness's own
-login/status command can configure or inspect local authentication, while only
-an explicitly authorized test turn verifies provider access.
+`coven setup` can configure local authentication, while only its separately
+consented `--verify` or `--verify-only` turn verifies provider access.
 
 `coven adapter doctor` is stricter about its own subject: it exits `1` if any
 listed adapter is unavailable. `coven wt --doctor` exits `1` when managed hooks
 are missing or a worktree sits outside the protocol layout.
+
+## Related
+
+- [`coven setup`](/reference/cli-setup)
+- [Provider auth boundary](/harnesses/provider-auth)

--- a/docs/reference/cli-setup.md
+++ b/docs/reference/cli-setup.md
@@ -1,0 +1,176 @@
+---
+summary: "Provider-owned login and explicitly consented verification for Codex, Claude Code, and GitHub Copilot CLI."
+read_when:
+  - Installing or authenticating a supported harness
+  - Verifying provider access before a release
+  - Producing a redacted setup certification report
+title: "coven setup"
+description: "Reference for coven setup: provider-owned login, optional bounded verification, terminal and privacy boundaries, outcomes, and redacted certification reports."
+---
+
+`coven setup` is the interactive setup path for Coven's three supported
+built-in harnesses. It discovers the provider CLI on `PATH`, shows the exact
+provider-owned command, asks for explicit consent, and then hands the terminal
+to that CLI.
+
+```sh
+coven setup <codex|claude|copilot|all>
+```
+
+The default selector is `all`, so bare `coven setup` is equivalent to
+`coven setup all`.
+
+## Provider commands
+
+| Harness | Install | Login command run by `coven setup` |
+| --- | --- | --- |
+| Codex | `npm install -g @openai/codex` or `brew install --cask codex` | `codex login` |
+| Claude Code | `npm install -g @anthropic-ai/claude-code` | `claude auth login` |
+| GitHub Copilot CLI | `npm install -g @github/copilot` or `brew install --cask copilot-cli` | `copilot login` |
+
+The provider owns the login UI and credential store. Coven does not read,
+proxy, copy, persist, or redact provider credentials. If a CLI is missing,
+setup prints its official install and login guidance instead of trying another
+executable.
+
+## Modes
+
+Login only is the default:
+
+```sh
+coven setup codex
+coven setup claude
+coven setup copilot
+coven setup all
+```
+
+Add a verification turn after a successful login:
+
+```sh
+coven setup codex --verify
+```
+
+Skip login and run only the verification turn:
+
+```sh
+coven setup codex --verify-only
+```
+
+`--verify` and `--verify-only` conflict. Verification sends the fixed prompt
+`Reply with OK.` through the provider's non-interactive command:
+
+| Harness | Verification command |
+| --- | --- |
+| Codex | `codex exec --skip-git-repo-check --color never -- Reply with OK.` |
+| Claude Code | `claude --print -- Reply with OK.` |
+| GitHub Copilot CLI | `copilot --no-color --prompt=Reply with OK.` |
+
+Login consent does not imply verification consent. With `--verify`, Coven asks
+again before the provider turn and warns that it requires network access and
+may incur provider usage or cost.
+
+## Terminal and automation boundary
+
+Setup is deliberately interactive:
+
+- It refuses provider execution in a non-TTY environment and reports
+  `non_tty`.
+- After explicit consent, the provider process inherits stdin, stdout, and
+  stderr directly. Coven does not capture, parse, or replay the provider's
+  login UI or verification response.
+- Coven prints the human outcome summary only after the provider exits. There
+  is no machine JSON on stdout while a provider runs.
+- Each selected provider receives an independent ordered result. `all` keeps
+  processing the remaining providers after a decline, cancellation, missing
+  executable, provider failure, or timeout.
+- Each provider action is bounded to five minutes. Timeout cleanup terminates
+  the owned provider process tree.
+
+The command exits successfully only when every selected provider completes.
+Outside report mode, human outcomes are `completed`, `not_installed`,
+`declined`, `cancelled`, `provider_failed`, `timed_out`, `non_tty`, or
+`verification_failed`.
+
+Do not redirect stdout or stderr to create a report. Those streams belong to
+the provider process and may contain its login UI, verification response, or
+other provider-owned data. Use only `--report-json <path>` for a redacted
+machine-readable artifact.
+
+## Ephemeral verification
+
+Verification runs from a unique temporary working directory with a temporary
+`COVEN_HOME`. That state is removed before Coven reports completion. Existing
+provider credentials remain owned by the provider CLI; Coven does not copy
+them into the temporary directory.
+
+This verifies only that the selected provider CLI completed the fixed turn at
+that moment. It is not a durable claim about account identity, billing,
+authorization, model selection, or future availability.
+
+## Redacted certification report
+
+`--report-json <path>` creates a machine-readable certification artifact for
+one provider:
+
+```sh
+coven setup codex --verify-only --report-json <path>
+```
+
+The flag requires `--verify` or `--verify-only` and cannot be used with
+`all`. The destination must not exist. Publication is atomic and
+fail-if-exists, so Coven never replaces an earlier report or exposes a partial
+file.
+
+Report mode is success-only. If verification does not complete, the CLI version
+cannot be established, ephemeral cleanup fails, or privacy validation rejects
+the artifact, Coven publishes no report and exits nonzero. Run the same
+verification without `--report-json` when you need its human outcome
+classification.
+
+The redacted JSON schema contains exactly:
+
+```json
+{
+  "harness": "codex",
+  "cli_version": "1.2.3",
+  "platform": "macos-aarch64",
+  "candidate_commit": "0123456789abcdef",
+  "duration": 1234,
+  "exit_class": "completed",
+  "completed": true
+}
+```
+
+The fields are `harness`, `cli_version`, `platform`, `candidate_commit`,
+`duration` in milliseconds, `exit_class`, and `completed`. The report excludes
+prompts, responses, stdout, stderr, paths, usernames, account identifiers,
+tokens, cookies, authorization data, and model identifiers. A successful
+verification, strict CLI version, valid build commit, completed ephemeral-state
+cleanup, and privacy validation are all required before publication.
+
+## CI and real certification
+
+Automated CI uses fake harness executables to prove command arguments, terminal
+ownership, ordering, failure handling, timeout cleanup, and report privacy. CI
+receives no real provider credentials and does not certify provider access.
+
+Real provider verification is an operator-run ceremony on the frozen candidate
+commit, from an interactive terminal with an authenticated provider account.
+The operator grants explicit verification consent and preserves the resulting
+redacted report outside provider stdout and stderr.
+
+## Doctor is separate
+
+`coven doctor` is an offline, hermetic readiness check. It launches no provider
+CLI process, performs no provider network request, does not inspect provider
+tokens or credential stores, and does not verify authentication. Doctor can
+report whether a supported executable is visible and point to `coven setup`;
+only the explicitly consented verification mode runs a provider turn.
+
+## Related
+
+- [Doctor](/reference/cli-doctor)
+- [Provider auth boundary](/harnesses/provider-auth)
+- [Codex harness](/harnesses/codex)
+- [Claude Code harness](/harnesses/claude-code)
+- [Copilot CLI harness](/harnesses/copilot-cli)

--- a/docs/reference/cli-setup.md
+++ b/docs/reference/cli-setup.md
@@ -14,7 +14,7 @@ provider-owned command, asks for explicit consent, and then hands the terminal
 to that CLI.
 
 ```sh
-coven setup <codex|claude|copilot|all>
+coven setup [<codex|claude|copilot|all>]
 ```
 
 The default selector is `all`, so bare `coven setup` is equivalent to

--- a/docs/start/doctor.md
+++ b/docs/start/doctor.md
@@ -3,14 +3,22 @@ summary: "What coven doctor checks and how to read its output."
 read_when:
   - Diagnosing a fresh install or a broken environment
 title: "Doctor"
-description: "Run coven doctor first after install. It reports COVEN_HOME writability, socket bind, harness CLIs on PATH, and SQLite store health."
+description: "Run coven doctor after install. It reports local readiness without launching providers, contacting provider networks, or verifying provider authentication."
 ---
 
 `coven doctor` is the first command to run after install. It reports:
 
 - Whether `$COVEN_HOME` is writable.
 - Whether the daemon socket can bind.
-- Whether `codex` and `claude` are on `PATH` and what version they are.
+- Whether `codex`, `claude`, and `copilot` are on `PATH`.
 - Whether the SQLite store is reachable.
 
-Each finding includes a remediation hint. Re-run `coven doctor` after fixing any line marked `needs attention`.
+Doctor is offline and hermetic: it launches no provider CLI process, performs
+no provider network request, does not inspect provider tokens or credential
+stores, and does not verify authentication. External harness credential rows
+are advisory even when an executable is present.
+
+Each finding includes a remediation hint. Missing or unverified harnesses point
+to `coven setup`, where provider-owned login and optional verification require
+explicit consent. Re-run `coven doctor` after fixing any line marked
+`needs attention`.

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -13,9 +13,52 @@ install the pinned engine if it is missing. The onboarding flow:
 1. Confirms `$COVEN_HOME` and creates it if missing.
 2. Runs `coven doctor` and surfaces install hints.
 3. Asks for the project root and validates it.
-4. Picks a harness (`codex`, `claude`, or `copilot`) and verifies its CLI.
+4. Picks a harness (`codex`, `claude`, or `copilot`) and checks that its CLI is
+   visible.
 5. Suggests the safest first command.
+
+Doctor does not log in to a provider or verify provider access. Complete the
+provider-owned login in the same terminal:
+
+```sh
+coven setup codex
+# or
+coven setup claude
+# or
+coven setup copilot
+```
+
+These run `codex login`, `claude auth login`, and `copilot login`
+respectively, after explicit consent. Use `coven setup all` to process all
+three providers in order.
+
+Provider verification is optional and separately consented because it uses the
+network and may incur provider usage or cost:
+
+```sh
+coven setup codex --verify
+# or, when login is already complete:
+coven setup codex --verify-only
+```
+
+Setup requires a TTY and hands stdin, stdout, and stderr directly to the
+provider. It does not capture provider output or emit machine JSON while the
+provider runs. Release operators can write an atomic, redacted, fail-if-exists
+report for one provider with `--report-json <path>`. See
+[`coven setup`](/reference/cli-setup) for the full privacy and report contract.
 
 The older in-process TUI is available only as the deprecated temporary
 compatibility fallback `COVEN_LEGACY_TUI=1`; see [Coven TUI](/start/coven-tui)
 for its legacy behavior.
+
+## First session
+
+After setup:
+
+```sh
+coven doctor
+coven daemon start
+cd /path/to/project
+coven run codex "explain this repo in 5 bullets"
+coven sessions
+```

--- a/scripts/cli-docs-test.mjs
+++ b/scripts/cli-docs-test.mjs
@@ -113,7 +113,7 @@ test('canonical CLI docs are discoverable and local guide contracts remain concr
   assert.match(topLevelCli, /## Usage/);
   assert.match(topLevelCli, /## Related/);
   assert.match(topLevelCli, /coven chat/);
-  assert.match(topLevelCli, /coven setup <codex\\\|claude\\\|copilot\\\|all>/);
+  assert.match(topLevelCli, /coven setup \[<codex\\\|claude\\\|copilot\\\|all>\]/);
 
   for (const { path, required } of coreGuideDocs) {
     const text = readRepoFile(path);
@@ -129,7 +129,7 @@ test('setup reference documents verification consent, terminal ownership, and re
   const setupReference = readRepoFile('docs/reference/cli-setup.md');
 
   for (const token of [
-    'coven setup <codex|claude|copilot|all>',
+    'coven setup [<codex|claude|copilot|all>]',
     '--verify',
     '--verify-only',
     '--report-json <path>',

--- a/scripts/cli-docs-test.mjs
+++ b/scripts/cli-docs-test.mjs
@@ -113,6 +113,7 @@ test('canonical CLI docs are discoverable and local guide contracts remain concr
   assert.match(topLevelCli, /## Usage/);
   assert.match(topLevelCli, /## Related/);
   assert.match(topLevelCli, /coven chat/);
+  assert.match(topLevelCli, /coven setup <codex\\\|claude\\\|copilot\\\|all>/);
 
   for (const { path, required } of coreGuideDocs) {
     const text = readRepoFile(path);
@@ -122,4 +123,40 @@ test('canonical CLI docs are discoverable and local guide contracts remain concr
       assert.match(text, new RegExp(escaped(phrase), 'i'), `${path} must mention ${phrase}`);
     }
   }
+});
+
+test('setup reference documents verification consent, terminal ownership, and reports', () => {
+  const setupReference = readRepoFile('docs/reference/cli-setup.md');
+
+  for (const token of [
+    'coven setup <codex|claude|copilot|all>',
+    '--verify',
+    '--verify-only',
+    '--report-json <path>',
+    'codex login',
+    'claude auth login',
+    'copilot login',
+    'harness',
+    'cli_version',
+    'platform',
+    'candidate_commit',
+    'duration',
+    'exit_class',
+    'completed'
+  ]) {
+    assert.ok(setupReference.includes(token), `setup reference must include ${JSON.stringify(token)}`);
+  }
+
+  assert.match(setupReference, /explicit consent/i);
+  assert.match(setupReference, /inherits stdin,\s+stdout, and\s+stderr/i);
+  assert.match(setupReference, /non-TTY/i);
+  assert.match(setupReference, /no machine JSON.*stdout/is);
+  assert.match(setupReference, /fail-if-exists/i);
+  assert.match(setupReference, /atomic/i);
+  assert.match(setupReference, /redacted/i);
+  assert.match(setupReference, /report mode is success-only/i);
+  assert.match(setupReference, /do not redirect stdout or stderr/i);
+  assert.match(setupReference, /fake harness/i);
+  assert.match(setupReference, /CI\s+receives no real provider credentials/i);
+  assert.match(setupReference, /operator-run ceremony/i);
 });

--- a/scripts/onboarding-docs-test.mjs
+++ b/scripts/onboarding-docs-test.mjs
@@ -141,7 +141,7 @@ test('model selection only offers CLI-login harness choices', () => {
   assert.match(text, /Codex CLI/i);
   assert.match(text, /Claude Code/i);
   assert.match(text, /codex login/);
-  assert.match(text, /claude doctor/);
+  assert.match(text, /claude auth login/);
   assert.match(text, /\/harnesses\/codex/);
   assert.match(text, /\/harnesses\/claude-code/);
   assert.doesNotMatch(text, /Per-provider setup/i);
@@ -166,7 +166,7 @@ test('ci runs npm onboarding smoke on every published platform', () => {
   assert.doesNotMatch(workflow, /os:\s+macos-latest/);
   assert.match(workflow, /windows-latest/);
   assert.match(workflow, /node scripts\/test-cli-prepublish\.mjs --target=\$\{\{ matrix\.npm-target \}\} --skip-build --skip-secrets-scan/);
-  assert.match(workflow, /COVEN_NPM_DRY_RUN_VERSION:\s+999\.0\.0\s*(?:\n|$)/);
+  assert.match(workflow, /COVEN_NPM_DRY_RUN_VERSION:\s+9{3}\.0\.0\s*(?:\n|$)/);
 });
 
 test('npm onboarding smoke exercises daemon lifecycle with isolated state', () => {
@@ -197,9 +197,74 @@ test('npm onboarding smoke verifies first-run missing-harness guidance determini
   assert.match(script, /PATH:\s*firstRunSmokePath\(wrapperBin,\s*tempDir\)/);
   assert.match(script, /node-shim-bin/);
   assert.doesNotMatch(script, /path\.dirname\(process\.execPath\)/);
-  assert.match(script, /Install and authenticate at least one harness in this same shell/);
-  assert.match(script, /npm install -g @openai\/codex && codex login/);
-  assert.match(script, /npm install -g @anthropic-ai\/claude-code && claude doctor/);
+  assert.match(script, /Set up at least one harness in this same shell/);
+  assert.match(script, /Codex: coven setup codex/);
+  assert.match(script, /Claude Code: coven setup claude/);
+  assert.match(script, /GitHub Copilot CLI: coven setup copilot/);
+  assert.doesNotMatch(script, /claude doctor/);
+});
+
+test('canonical setup docs cover the complete three-provider workflow', () => {
+  const setupReference = readRepoFile('docs/reference/cli-setup.md');
+  for (const command of [
+    'coven setup codex',
+    'coven setup claude',
+    'coven setup copilot',
+    'coven setup all'
+  ]) {
+    assert.match(setupReference, new RegExp(command.replaceAll(' ', '\\s+')));
+  }
+
+  for (const token of [
+    '--verify',
+    '--verify-only',
+    '--report-json <path>',
+    'codex login',
+    'claude auth login',
+    'copilot login',
+    'candidate_commit',
+    'exit_class'
+  ]) {
+    assert.ok(setupReference.includes(token), `setup reference must include ${JSON.stringify(token)}`);
+  }
+  assert.doesNotMatch(setupReference, /\b(?:Hermes|Grok|OpenCode)\b/);
+
+  const setupDocs = [
+    readRepoFile('README.md'),
+    readRepoFile('docs/start/onboarding.md'),
+    readRepoFile('docs/harnesses/provider-auth.md'),
+    readRepoFile('docs/harnesses/codex.md'),
+    readRepoFile('docs/harnesses/claude-code.md'),
+    readRepoFile('docs/harnesses/copilot-cli.md'),
+    setupReference
+  ].join('\n');
+  assert.match(setupDocs, /explicit consent/i);
+  assert.match(setupDocs, /stdin/i);
+  assert.match(setupDocs, /stdout/i);
+  assert.match(setupDocs, /stderr/i);
+  assert.match(setupDocs, /non-TTY/i);
+  assert.match(setupDocs, /fail-if-exists/i);
+  assert.match(setupDocs, /atomic/i);
+  assert.match(setupDocs, /redacted/i);
+  assert.match(setupDocs, /no machine JSON/i);
+  assert.match(setupDocs, /do not redirect stdout or stderr/i);
+  assert.match(setupDocs, /fake harness/i);
+  assert.match(setupDocs, /no real provider credentials/i);
+  assert.match(setupDocs, /operator-run ceremony/i);
+  assert.doesNotMatch(setupDocs, /claude doctor/);
+});
+
+test('Doctor docs preserve the offline no-auth-verification boundary', () => {
+  const doctorDocs = [
+    readRepoFile('docs/start/doctor.md'),
+    readRepoFile('docs/reference/cli-doctor.md')
+  ].join('\n');
+  assert.match(doctorDocs, /offline/i);
+  assert.match(doctorDocs, /no provider (?:CLI )?process/i);
+  assert.match(doctorDocs, /no provider network request/i);
+  assert.match(doctorDocs, /does not inspect.*(?:token|credential)/is);
+  assert.match(doctorDocs, /does not verify authentication/i);
+  assert.match(doctorDocs, /coven setup/);
 });
 
 test('npm onboarding smoke runs onboarding guardrails before packaging', () => {

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -240,9 +240,10 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
     );
   }
   for (const expected of [
-    'Install and authenticate at least one harness in this same shell',
-    'npm install -g @openai/codex && codex login',
-    'npm install -g @anthropic-ai/claude-code && claude doctor',
+    'Set up at least one harness in this same shell',
+    'Codex: coven setup codex',
+    'Claude Code: coven setup claude',
+    'GitHub Copilot CLI: coven setup copilot',
     'Doctor found problems; review the failing checks above.'
   ]) {
     if (!doctorOutput.stdout.includes(expected)) {


### PR DESCRIPTION
## Context

- Summary: Document the complete three-provider `coven setup` workflow and align Doctor guidance with its offline, setup-pointer-only boundary.
- Files changed: setup/onboarding/Doctor/provider docs, documentation guards, packaged smoke expectations, and the tightly coupled Doctor hint tests/runtime strings.
- Bead: `coven-v041-docs`

## Implementation

- Approach: Add a canonical `coven setup` reference covering exact login/verification commands, TTY ownership, consent, ephemeral state, success-only fail-if-exists reports, and fake-CI versus operator certification. Route stale `claude doctor` and direct Doctor hints to `coven setup`.
- User-visible behavior: Doctor now points Codex, Claude Code, and Copilot users to `coven setup`; canonical docs use `claude auth login`.
- Compatibility notes: No command syntax or report schema changed.

## Verification

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` (pre-existing Rust 1.95 `clippy::nonminimal_bool` in `crates/coven-relay/src/ws.rs:117`)
- [x] `cargo clippy -p coven-cli --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `node --test scripts/onboarding-docs-test.mjs scripts/cli-docs-test.mjs`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] Required pre-merge code review; no remaining Critical or Important findings

## Risk and Rollback

- Risk level: Low. Runtime changes only replace stale Doctor remediation text with existing setup commands.
- Rollback plan: Revert commit `e0cebd0`.

## Agent Handoff

- Current state: Ready for CI and merge.
- Follow-ups: Real-provider certification remains an operator-run post-freeze Bead.
- Known gaps: Workspace Clippy has the unrelated pre-existing relay lint noted above.