### PR TITLE
fix: bound relay queued memory and timeout slow WebSocket peers

### DIFF
--- a/crates/coven-relay/README.md
+++ b/crates/coven-relay/README.md
@@ -21,7 +21,7 @@ The first peer creates an in-memory room. Exactly one `host` and one `client` ma
 - text frames are rejected;
 - ping/pong remains transport-local;
 - no offline buffering or message persistence occurs;
-- bounded channels apply backpressure instead of allowing unbounded memory growth;
+- bounded channels and a relay-wide byte budget apply backpressure instead of allowing unbounded memory growth;
 - a peer disconnect closes the remaining peer;
 - idle connections expire;
 - the room is destroyed after both peers disconnect.
@@ -37,6 +37,8 @@ The current server bounds:
 - WebSocket message size: 4 MiB;
 - WebSocket frame size: 64 KiB;
 - queued live frames per peer: 32;
+- queued and in-flight application data across the relay: 16 MiB;
+- outbound send lifetime: 10 seconds;
 - idle lifetime: 120 seconds.
 
 These defaults are deliberately conservative and may become explicit deployment configuration after production measurements. The relay never logs room credentials or application frames.

--- a/crates/coven-relay/src/ws.rs
+++ b/crates/coven-relay/src/ws.rs
@@ -16,20 +16,23 @@ use axum::extract::{RawQuery, State};
 use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use tokio::sync::mpsc::error::TrySendError;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::time::Instant;
 
 const RELAY_PROTOCOL_VERSION: &str = "1";
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_FRAME_BYTES: usize = 64 * 1024;
 const IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+const SEND_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_MAX_ROOMS: usize = 1_024;
 const DEFAULT_CHANNEL_CAPACITY: usize = 32;
+const DEFAULT_MAX_QUEUED_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct RelayState {
     inner: Arc<Mutex<RelayRegistry>>,
     next_peer_id: Arc<AtomicU64>,
+    queued_bytes: Arc<Semaphore>,
     limits: RelayLimits,
 }
 
@@ -38,6 +41,7 @@ impl Default for RelayState {
         Self::with_limits(RelayLimits {
             max_rooms: DEFAULT_MAX_ROOMS,
             channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            max_queued_bytes: DEFAULT_MAX_QUEUED_BYTES,
         })
     }
 }
@@ -46,9 +50,11 @@ impl RelayState {
     fn with_limits(limits: RelayLimits) -> Self {
         assert!(limits.max_rooms > 0);
         assert!(limits.channel_capacity > 0);
+        assert!(limits.max_queued_bytes > 0);
         Self {
             inner: Arc::new(Mutex::new(RelayRegistry::default())),
             next_peer_id: Arc::new(AtomicU64::new(1)),
+            queued_bytes: Arc::new(Semaphore::new(limits.max_queued_bytes)),
             limits,
         }
     }
@@ -97,7 +103,11 @@ impl RelayState {
         })
     }
 
-    async fn peer_sender(&self, room_id: &str, role: PeerRole) -> Option<mpsc::Sender<Message>> {
+    async fn peer_sender(
+        &self,
+        room_id: &str,
+        role: PeerRole,
+    ) -> Option<mpsc::Sender<QueuedMessage>> {
         let registry = self.inner.lock().await;
         registry
             .rooms
@@ -129,7 +139,10 @@ impl RelayState {
             peer_to_notify
         };
         if let Some(peer) = peer_to_notify {
-            let _ = peer.try_send(close_message(1001, "relay peer disconnected"));
+            let _ = peer.try_send(QueuedMessage::control(close_message(
+                1001,
+                "relay peer disconnected",
+            )));
         }
     }
 
@@ -143,6 +156,7 @@ impl RelayState {
 struct RelayLimits {
     max_rooms: usize,
     channel_capacity: usize,
+    max_queued_bytes: usize,
 }
 
 #[derive(Default)]
@@ -174,14 +188,28 @@ impl RelayRoom {
 
 struct ConnectedPeer {
     id: u64,
-    sender: mpsc::Sender<Message>,
+    sender: mpsc::Sender<QueuedMessage>,
+}
+
+struct QueuedMessage {
+    message: Message,
+    _byte_budget: Option<OwnedSemaphorePermit>,
+}
+
+impl QueuedMessage {
+    fn control(message: Message) -> Self {
+        Self {
+            message,
+            _byte_budget: None,
+        }
+    }
 }
 
 struct Registration {
     room_id: String,
     role: PeerRole,
     peer_id: u64,
-    inbox: mpsc::Receiver<Message>,
+    inbox: mpsc::Receiver<QueuedMessage>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,7 +338,7 @@ async fn serve(mut socket: WebSocket, state: RelayState, request: RelayRequest) 
         Ok(registration) => registration,
         Err(error) => {
             let (code, reason) = error.close();
-            let _ = socket.send(close_message(code, reason)).await;
+            let _ = send_with_timeout(&mut socket, close_message(code, reason)).await;
             return;
         }
     };
@@ -329,7 +357,7 @@ async fn relay_loop(
     state: &RelayState,
     room_id: &str,
     role: PeerRole,
-    inbox: &mut mpsc::Receiver<Message>,
+    inbox: &mut mpsc::Receiver<QueuedMessage>,
 ) {
     let idle = tokio::time::sleep(IDLE_TIMEOUT);
     tokio::pin!(idle);
@@ -343,18 +371,22 @@ async fn relay_loop(
                         if let Err(close) = forward_to_peer(
                             state, room_id, role, Message::Binary(payload),
                         ).await {
-                            let _ = socket.send(close).await;
+                            let _ = send_with_timeout(socket, close).await;
                             break;
                         }
                     }
                     Message::Text(_) => {
-                        let _ = socket.send(close_message(1003, "binary frames required")).await;
+                        let _ = send_with_timeout(
+                            socket,
+                            close_message(1003, "binary frames required"),
+                        )
+                        .await;
                         break;
                     }
                     Message::Ping(_) | Message::Pong(_) => {}
                     Message::Close(frame) => {
                         if let Some(peer) = state.peer_sender(room_id, role).await {
-                            let _ = peer.try_send(Message::Close(frame));
+                            let _ = peer.try_send(QueuedMessage::control(Message::Close(frame)));
                         }
                         break;
                     }
@@ -363,16 +395,23 @@ async fn relay_loop(
             outgoing = inbox.recv() => {
                 idle.as_mut().reset(Instant::now() + IDLE_TIMEOUT);
                 let Some(outgoing) = outgoing else { break; };
-                let is_close = matches!(outgoing, Message::Close(_));
-                if socket.send(outgoing).await.is_err() || is_close {
+                let is_close = matches!(outgoing.message, Message::Close(_));
+                if send_with_timeout(socket, outgoing.message).await.is_err() || is_close {
                     break;
                 }
             }
             () = &mut idle => {
-                let _ = socket.send(close_message(1001, "relay idle timeout")).await;
+                let _ = send_with_timeout(socket, close_message(1001, "relay idle timeout")).await;
                 break;
             }
         }
+    }
+}
+
+async fn send_with_timeout(socket: &mut WebSocket, message: Message) -> Result<(), ()> {
+    match tokio::time::timeout(SEND_TIMEOUT, socket.send(message)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_)) | Err(_) => Err(()),
     }
 }
 
@@ -386,7 +425,25 @@ async fn forward_to_peer(
         .peer_sender(room_id, role)
         .await
         .ok_or_else(|| close_message(1013, "relay peer unavailable"))?;
-    match peer.try_send(message) {
+    let message_bytes = match &message {
+        Message::Binary(payload) => payload.len(),
+        _ => 0,
+    };
+    let byte_budget = if message_bytes == 0 {
+        None
+    } else {
+        Some(
+            state
+                .queued_bytes
+                .clone()
+                .try_acquire_many_owned(message_bytes as u32)
+                .map_err(|_| close_message(1013, "relay byte budget exhausted"))?,
+        )
+    };
+    match peer.try_send(QueuedMessage {
+        message,
+        _byte_budget: byte_budget,
+    }) {
         Ok(()) => Ok(()),
         Err(TrySendError::Full(_)) => Err(close_message(1013, "relay backpressure")),
         Err(TrySendError::Closed(_)) => Err(close_message(1001, "relay peer disconnected")),

--- a/crates/coven-relay/src/ws.rs
+++ b/crates/coven-relay/src/ws.rs
@@ -7,6 +7,7 @@
 //! interpret them and is not an authentication or authorization authority.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -51,6 +52,10 @@ impl RelayState {
         assert!(limits.max_rooms > 0);
         assert!(limits.channel_capacity > 0);
         assert!(limits.max_queued_bytes > 0);
+        assert!(
+            u32::try_from(limits.max_queued_bytes).is_ok(),
+            "max_queued_bytes must fit in u32"
+        );
         Self {
             inner: Arc::new(Mutex::new(RelayRegistry::default())),
             next_peer_id: Arc::new(AtomicU64::new(1)),
@@ -395,8 +400,11 @@ async fn relay_loop(
             outgoing = inbox.recv() => {
                 idle.as_mut().reset(Instant::now() + IDLE_TIMEOUT);
                 let Some(outgoing) = outgoing else { break; };
-                let is_close = matches!(outgoing.message, Message::Close(_));
-                if send_with_timeout(socket, outgoing.message).await.is_err() || is_close {
+                let (send_result, is_close) = deliver_queued_message(
+                    outgoing,
+                    |message| send_with_timeout(socket, message),
+                ).await;
+                if send_result.is_err() || is_close {
                     break;
                 }
             }
@@ -406,6 +414,21 @@ async fn relay_loop(
             }
         }
     }
+}
+
+async fn deliver_queued_message<F, Fut>(outgoing: QueuedMessage, send: F) -> (Result<(), ()>, bool)
+where
+    F: FnOnce(Message) -> Fut,
+    Fut: Future<Output = Result<(), ()>>,
+{
+    let QueuedMessage {
+        message,
+        _byte_budget: byte_budget,
+    } = outgoing;
+    let is_close = matches!(message, Message::Close(_));
+    let result = send(message).await;
+    drop(byte_budget);
+    (result, is_close)
 }
 
 async fn send_with_timeout(socket: &mut WebSocket, message: Message) -> Result<(), ()> {
@@ -432,11 +455,13 @@ async fn forward_to_peer(
     let byte_budget = if message_bytes == 0 {
         None
     } else {
+        let permit_count = u32::try_from(message_bytes)
+            .map_err(|_| close_message(1009, "relay message too large"))?;
         Some(
             state
                 .queued_bytes
                 .clone()
-                .try_acquire_many_owned(message_bytes as u32)
+                .try_acquire_many_owned(permit_count)
                 .map_err(|_| close_message(1013, "relay byte budget exhausted"))?,
         )
     };

--- a/crates/coven-relay/src/ws/tests.rs
+++ b/crates/coven-relay/src/ws/tests.rs
@@ -256,6 +256,61 @@ async fn relay_enforces_and_releases_the_global_queued_byte_budget() {
     state.unregister(&room, PeerRole::Host, host.peer_id).await;
 }
 
+#[test]
+#[cfg(target_pointer_width = "64")]
+#[should_panic(expected = "max_queued_bytes must fit in u32")]
+fn relay_rejects_a_byte_budget_larger_than_per_message_permits_can_represent() {
+    RelayState::with_limits(RelayLimits {
+        max_rooms: 1,
+        channel_capacity: 1,
+        max_queued_bytes: u32::MAX as usize + 1,
+    });
+}
+
+#[tokio::test]
+async fn relay_holds_the_byte_budget_until_the_socket_send_finishes() {
+    let state = RelayState::with_limits(RelayLimits {
+        max_rooms: 1,
+        channel_capacity: 1,
+        max_queued_bytes: 5,
+    });
+    let room = canonical('T');
+    let credential = canonical('U');
+    let host = state
+        .register(&room, &credential, PeerRole::Host)
+        .await
+        .unwrap();
+    let mut client = state
+        .register(&room, &credential, PeerRole::Client)
+        .await
+        .unwrap();
+
+    forward_to_peer(
+        &state,
+        &room,
+        PeerRole::Host,
+        Message::binary(&b"12345"[..]),
+    )
+    .await
+    .unwrap();
+    let outgoing = client.inbox.recv().await.unwrap();
+    let queued_bytes = state.queued_bytes.clone();
+    let (result, is_close) = deliver_queued_message(outgoing, |message| async move {
+        assert_eq!(message, Message::binary(&b"12345"[..]));
+        assert_eq!(queued_bytes.available_permits(), 0);
+        Ok(())
+    })
+    .await;
+    assert!(result.is_ok());
+    assert!(!is_close);
+    assert_eq!(state.queued_bytes.available_permits(), 5);
+
+    state
+        .unregister(&room, PeerRole::Client, client.peer_id)
+        .await;
+    state.unregister(&room, PeerRole::Host, host.peer_id).await;
+}
+
 #[tokio::test]
 async fn disconnect_notifies_the_remaining_peer() {
     let state = RelayState::with_limits(RelayLimits {

--- a/crates/coven-relay/src/ws/tests.rs
+++ b/crates/coven-relay/src/ws/tests.rs
@@ -86,6 +86,7 @@ async fn room_accepts_one_peer_per_role_with_the_same_credential() {
     let state = RelayState::with_limits(RelayLimits {
         max_rooms: 2,
         channel_capacity: 2,
+        max_queued_bytes: 1024,
     });
     let room = canonical('H');
     let credential = canonical('I');
@@ -128,6 +129,7 @@ async fn room_capacity_is_bounded_and_released_after_disconnect() {
     let state = RelayState::with_limits(RelayLimits {
         max_rooms: 1,
         channel_capacity: 1,
+        max_queued_bytes: 1024,
     });
     let first_room = canonical('K');
     let second_room = canonical('L');
@@ -162,6 +164,7 @@ async fn binary_frames_forward_and_backpressure_fails_closed() {
     let state = RelayState::with_limits(RelayLimits {
         max_rooms: 1,
         channel_capacity: 1,
+        max_queued_bytes: 1024,
     });
     let room = canonical('N');
     let credential = canonical('O');
@@ -182,10 +185,10 @@ async fn binary_frames_forward_and_backpressure_fails_closed() {
     )
     .await
     .unwrap();
-    assert_eq!(
+    assert!(matches!(
         client.inbox.recv().await,
-        Some(Message::binary(b"ciphertext".to_vec()))
-    );
+        Some(message) if message.message == Message::binary(b"ciphertext".to_vec())
+    ));
 
     forward_to_peer(
         &state,
@@ -211,10 +214,54 @@ async fn binary_frames_forward_and_backpressure_fails_closed() {
 }
 
 #[tokio::test]
+async fn relay_enforces_and_releases_the_global_queued_byte_budget() {
+    let state = RelayState::with_limits(RelayLimits {
+        max_rooms: 1,
+        channel_capacity: 4,
+        max_queued_bytes: 5,
+    });
+    let room = canonical('R');
+    let credential = canonical('S');
+    let host = state
+        .register(&room, &credential, PeerRole::Host)
+        .await
+        .unwrap();
+    let mut client = state
+        .register(&room, &credential, PeerRole::Client)
+        .await
+        .unwrap();
+
+    forward_to_peer(
+        &state,
+        &room,
+        PeerRole::Host,
+        Message::binary(&b"12345"[..]),
+    )
+    .await
+    .unwrap();
+    assert!(
+        forward_to_peer(&state, &room, PeerRole::Host, Message::binary(&b"6"[..]))
+            .await
+            .is_err()
+    );
+
+    drop(client.inbox.recv().await.unwrap());
+    forward_to_peer(&state, &room, PeerRole::Host, Message::binary(&b"6"[..]))
+        .await
+        .unwrap();
+
+    state
+        .unregister(&room, PeerRole::Client, client.peer_id)
+        .await;
+    state.unregister(&room, PeerRole::Host, host.peer_id).await;
+}
+
+#[tokio::test]
 async fn disconnect_notifies_the_remaining_peer() {
     let state = RelayState::with_limits(RelayLimits {
         max_rooms: 1,
         channel_capacity: 2,
+        max_queued_bytes: 1024,
     });
     let room = canonical('P');
     let credential = canonical('Q');
@@ -230,6 +277,12 @@ async fn disconnect_notifies_the_remaining_peer() {
     state
         .unregister(&room, PeerRole::Client, client.peer_id)
         .await;
-    assert!(matches!(host.inbox.recv().await, Some(Message::Close(_))));
+    assert!(matches!(
+        host.inbox.recv().await,
+        Some(QueuedMessage {
+            message: Message::Close(_),
+            ..
+        })
+    ));
     state.unregister(&room, PeerRole::Host, host.peer_id).await;
 }


### PR DESCRIPTION
### Motivation

- The relay previously queued full `Message::Binary` frames up to a per-peer count limit, allowing cheap memory exhaustion when many large messages were enqueued.  
- Outbound sends awaited `socket.send(...).await` with no upper bound, allowing a slow or non-reading peer to indefinitely stall the relay task and retain allocated buffers.

### Description

- Introduce a relay-wide queued-byte budget enforced by a semaphore with a default of `16 MiB`, exposed via `RelayLimits::max_queued_bytes`, to limit total queued/in-flight application data across all rooms; messages acquire permits when forwarded and hold them until delivery or drop.  
- Change peer channels to carry `QueuedMessage { message: Message, _byte_budget: Option<OwnedSemaphorePermit> }` instead of raw `Message` so the byte-budget permit is tied to the queued item.  
- Enforce fail-closed behavior in `forward_to_peer`: attempts to forward binary payloads try to acquire the required byte permits and return a close when the budget is exhausted or the recipient channel is full.  
- Add a `SEND_TIMEOUT` (default 10s) and central `send_with_timeout` helper so outbound `socket.send` operations time out and the relay can reclaim stalled peers.  
- Update the relay README to document the new queued-byte budget and outbound send lifetime.  
- Add a unit test `relay_enforces_and_releases_the_global_queued_byte_budget` that verifies budget rejection and permit release when queued data is consumed, and update existing relay tests to the new `QueuedMessage` envelope.

Files changed: `crates/coven-relay/src/ws.rs`, `crates/coven-relay/src/ws/tests.rs`, `crates/coven-relay/README.md`.

### Testing

- Ran `cargo fmt --check` and formatting checks passed.  
- Ran `cargo test -p coven-relay --locked` and all relay unit tests passed (9 tests).  
- Ran `python scripts/check-secrets.py` and `python3 scripts/check-coven-privacy.py --staged`, both checks passed for the staged changes.  
- Full workspace `cargo clippy` / `cargo test --workspace` could not be completed in this environment because an external crate (`ort-sys`) attempted to download prebuilt artifacts and the proxy returned HTTP 403; additionally, a pre-existing `clippy::nonminimal_bool` suggestion was flagged in `crates/coven-relay/src/ws.rs` and should be trivially addressable with a small refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8a5c5a90ec8327888e26dced528f74)