### PR TITLE
fix: require accepted mobile listener address

### DIFF
--- a/crates/coven-cli/src/mobile_memory/gateway.rs
+++ b/crates/coven-cli/src/mobile_memory/gateway.rs
@@ -1184,10 +1184,22 @@ mod tests {
                 return None;
             }
             let probe = TcpListener::bind(SocketAddr::new(ip, 0)).ok()?;
+            probe.set_nonblocking(true).ok()?;
             let address = probe.local_addr().ok()?;
-            TcpStream::connect_timeout(&address, Duration::from_millis(200))
-                .ok()
-                .map(|_| ip)
+            let _client = TcpStream::connect_timeout(&address, Duration::from_millis(200)).ok()?;
+            let deadline = std::time::Instant::now() + Duration::from_millis(200);
+            loop {
+                match probe.accept() {
+                    Ok(_) => return Some(ip),
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if std::time::Instant::now() >= deadline {
+                            return None;
+                        }
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(_) => return None,
+                }
+            }
         })?;
         let reserved = TcpListener::bind(SocketAddr::new(ip, 0)).ok()?;
         let port = reserved.local_addr().ok()?.port();

--- a/crates/coven-cli/src/mobile_memory/gateway.rs
+++ b/crates/coven-cli/src/mobile_memory/gateway.rs
@@ -1186,16 +1186,22 @@ mod tests {
             let probe = TcpListener::bind(SocketAddr::new(ip, 0)).ok()?;
             probe.set_nonblocking(true).ok()?;
             let address = probe.local_addr().ok()?;
-            let _client = TcpStream::connect_timeout(&address, Duration::from_millis(200)).ok()?;
             let deadline = std::time::Instant::now() + Duration::from_millis(200);
+            let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
+            if remaining.is_zero() {
+                return None;
+            }
+            let _client = TcpStream::connect_timeout(&address, remaining).ok()?;
             loop {
+                let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
+                if remaining.is_zero() {
+                    return None;
+                }
                 match probe.accept() {
                     Ok(_) => return Some(ip),
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
                     Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        if std::time::Instant::now() >= deadline {
-                            return None;
-                        }
-                        std::thread::sleep(Duration::from_millis(5));
+                        std::thread::sleep(remaining.min(Duration::from_millis(5)));
                     }
                     Err(_) => return None,
                 }


### PR DESCRIPTION
## Context

- Summary: Harden the mobile TLS test fixture so it selects a private address only after the exact bound listener accepts a probe connection.
- Files changed: `crates/coven-cli/src/mobile_memory/gateway.rs`
- Bead: `coven-v041.1`

## Implementation

- Approach: Keep the probe client alive, poll the nonblocking listener for a bounded 200 ms, and reject overlay/intercepted addresses that connect without reaching the local listener.
- User-visible behavior: None; test fixture only.
- Compatibility notes: Production gateway behavior is unchanged.

## Verification

- [x] `cargo +1.98.0 fmt --check`
- [x] `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +1.98.0 test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] Focused mobile gateway tests pass on macOS where the old fixture selected a Tailscale `100.66.x.x` address and timed out.

## Risk and Rollback

- Risk level: Low; test-only address selection.
- Rollback plan: Revert this commit.

## Agent Handoff

- Current state: Ready for review.
- Follow-ups: Unblocks final validation of `coven-v041-gh-release`.
- Known gaps: None.