### PR TITLE
feat: automate deterministic GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
+        with:
+          node-version: 24
       - run: python scripts/check-coven-privacy-test.py
       - run: python scripts/check-secrets-test.py
       - run: python3 scripts/check-api-contract-docs-test.py
@@ -90,6 +93,7 @@ jobs:
       - run: python3 scripts/classify-ci-changes-test.py
       - run: python3 scripts/check-workflows-test.py
       - run: python3 scripts/check-ci-workflow-test.py
+      - run: node --test scripts/package-github-release-test.mjs
       - run: scripts/check-workflows.sh
 
   rust-lint-linux:

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Verify release source run and signed tag
         id: source
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.workflow_run.head_branch || inputs.release_tag }}
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id || inputs.source_run_id }}
           SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt || inputs.source_run_attempt }}
@@ -121,7 +121,7 @@ jobs:
           path: github-release-source/coven-windows
       - name: Reconfirm source run attempt after artifact download
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
           SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
           SOURCE_RUN_ATTEMPT: ${{ steps.source.outputs.source_run_attempt }}
@@ -145,7 +145,7 @@ jobs:
             --source-date-epoch "$SOURCE_DATE_EPOCH"
       - name: Synchronize canonical GitHub release assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
           TAG_OBJECT_SHA: ${{ steps.source.outputs.tag_object_sha }}
           HEAD_SHA: ${{ steps.source.outputs.head_sha }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -77,6 +77,14 @@ jobs:
             --head-sha "$HEAD_SHA" \
             --source-run-id "$SOURCE_RUN_ID" \
             --source-run-attempt "$SOURCE_RUN_ATTEMPT"
+      - name: Cryptographically verify npm registry signatures
+        env:
+          NPM_VERSION: ${{ steps.source.outputs.npm_version }}
+        run: |
+          set -euo pipefail
+          node scripts/package-github-release.mjs verify-npm-signatures \
+            --npm-version "$NPM_VERSION" \
+            --audit-dir github-release-npm-audit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -16,6 +16,10 @@ on:
         description: Source Release npm packages workflow run ID
         required: true
         type: string
+      source_run_attempt:
+        description: Exact source Release npm packages workflow run attempt
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -56,12 +60,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.workflow_run.head_branch || inputs.release_tag }}
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id || inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt || inputs.source_run_attempt }}
         run: |
           set -euo pipefail
           node scripts/package-github-release.mjs verify-source-run \
             --repository "$GITHUB_REPOSITORY" \
             --release-tag "$RELEASE_TAG" \
-            --source-run-id "$SOURCE_RUN_ID" >> "$GITHUB_OUTPUT"
+            --source-run-id "$SOURCE_RUN_ID" \
+            --source-run-attempt "$SOURCE_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
       - name: Verify npm provenance for every published package
         env:
           RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
@@ -128,9 +134,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
+          TAG_OBJECT_SHA: ${{ steps.source.outputs.tag_object_sha }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
         run: |
           set -euo pipefail
           node scripts/package-github-release.mjs sync-release \
             --repository "$GITHUB_REPOSITORY" \
             --release-tag "$RELEASE_TAG" \
-            --output-dir github-release-assets
+            --output-dir github-release-assets \
+            --expected-tag-object-sha "$TAG_OBJECT_SHA" \
+            --expected-head-sha "$HEAD_SHA"

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,0 +1,128 @@
+name: Publish GitHub Release
+
+on:
+  workflow_run:
+    workflows:
+      - Release npm packages
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Immutable signed release tag (vX.Y.Z)
+        required: true
+        type: string
+      source_run_id:
+        description: Source Release npm packages workflow run ID
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-github-${{ github.event.workflow_run.head_branch || inputs.release_tag }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  publish-release:
+    name: Publish GitHub Release assets
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Refuse non-default-branch manual recovery
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != github.event.repository.default_branch }}
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          echo "::error::GitHub release recovery must run from the default branch code ($DEFAULT_BRANCH)."
+          exit 1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
+        with:
+          node-version: 24
+      - name: Verify release source run and signed tag
+        id: source
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch || inputs.release_tag }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id || inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          node scripts/package-github-release.mjs verify-source-run \
+            --repository "$GITHUB_REPOSITORY" \
+            --release-tag "$RELEASE_TAG" \
+            --source-run-id "$SOURCE_RUN_ID" >> "$GITHUB_OUTPUT"
+      - name: Verify npm provenance for every published package
+        env:
+          RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
+          NPM_VERSION: ${{ steps.source.outputs.npm_version }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.source.outputs.source_run_attempt }}
+        run: |
+          set -euo pipefail
+          node scripts/package-github-release.mjs verify-npm-provenance \
+            --release-tag "$RELEASE_TAG" \
+            --npm-version "$NPM_VERSION" \
+            --head-sha "$HEAD_SHA" \
+            --source-run-id "$SOURCE_RUN_ID" \
+            --source-run-attempt "$SOURCE_RUN_ATTEMPT"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.source.outputs.source_run_id }}
+          name: coven-macos
+          path: github-release-source/coven-macos
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.source.outputs.source_run_id }}
+          name: coven-macos-x64
+          path: github-release-source/coven-macos-x64
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.source.outputs.source_run_id }}
+          name: coven-linux-x64
+          path: github-release-source/coven-linux-x64
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.source.outputs.source_run_id }}
+          name: coven-windows
+          path: github-release-source/coven-windows
+      - name: Package deterministic GitHub release assets
+        env:
+          RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
+          SOURCE_DATE_EPOCH: ${{ steps.source.outputs.source_date_epoch }}
+        run: |
+          set -euo pipefail
+          node scripts/package-github-release.mjs package \
+            --release-tag "$RELEASE_TAG" \
+            --artifacts-dir github-release-source \
+            --output-dir github-release-assets \
+            --source-date-epoch "$SOURCE_DATE_EPOCH"
+      - name: Synchronize canonical GitHub release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          node scripts/package-github-release.mjs sync-release \
+            --repository "$GITHUB_REPOSITORY" \
+            --release-tag "$RELEASE_TAG" \
+            --output-dir github-release-assets

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -119,6 +119,19 @@ jobs:
           run-id: ${{ steps.source.outputs.source_run_id }}
           name: coven-windows
           path: github-release-source/coven-windows
+      - name: Reconfirm source run attempt after artifact download
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.source.outputs.source_run_attempt }}
+        run: |
+          set -euo pipefail
+          node scripts/package-github-release.mjs verify-source-run-attempt \
+            --repository "$GITHUB_REPOSITORY" \
+            --release-tag "$RELEASE_TAG" \
+            --source-run-id "$SOURCE_RUN_ID" \
+            --source-run-attempt "$SOURCE_RUN_ATTEMPT"
       - name: Package deterministic GitHub release assets
         env:
           RELEASE_TAG: ${{ steps.source.outputs.release_tag }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -77,7 +77,28 @@ jobs:
             echo "::error::Refusing to release: $TAG_NAME is a lightweight tag, not an annotated signed tag. Re-tag with \`git tag -s vX.Y.Z -m ...\`."
             exit 1
           fi
-          payload=$(gh api "/repos/$GITHUB_REPOSITORY/git/tags/$TAG_OBJECT_SHA")
+          tag_ref_payload=$(gh api "/repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG_NAME")
+          ref_name=$(jq -r '.ref // ""' <<<"$tag_ref_payload")
+          if [ "$ref_name" != "refs/tags/$TAG_NAME" ]; then
+            echo "::error::Refusing to release: GitHub tag ref payload named $ref_name instead of refs/tags/$TAG_NAME."
+            exit 1
+          fi
+          ref_object_type=$(jq -r '.object.type // ""' <<<"$tag_ref_payload")
+          api_tag_object_sha=$(jq -r '.object.sha // ""' <<<"$tag_ref_payload")
+          if [ "$ref_object_type" != "tag" ] || [ -z "$api_tag_object_sha" ]; then
+            echo "::error::Refusing to release: GitHub tag ref for $TAG_NAME must resolve to an annotated tag object."
+            exit 1
+          fi
+          if [ "$api_tag_object_sha" != "$TAG_OBJECT_SHA" ]; then
+            echo "::error::Refusing to release: local tag object $TAG_OBJECT_SHA does not match the GitHub-verified tag object $api_tag_object_sha for $TAG_NAME."
+            exit 1
+          fi
+          payload=$(gh api "/repos/$GITHUB_REPOSITORY/git/tags/$api_tag_object_sha")
+          tag_name=$(jq -r '.tag // ""' <<<"$payload")
+          if [ "$tag_name" != "$TAG_NAME" ]; then
+            echo "::error::Refusing to release: GitHub tag payload named $tag_name instead of $TAG_NAME."
+            exit 1
+          fi
           verified=$(jq -r '.verification.verified' <<<"$payload")
           reason=$(jq -r '.verification.reason' <<<"$payload")
           if [ "$verified" != "true" ]; then
@@ -89,6 +110,11 @@ jobs:
           echo "tag=$TAG_NAME verified=$verified reason=$reason target=$TAGGED_COMMIT_SHA"
           if [ "$tag_object_type" != "commit" ] || [ -z "$TAGGED_COMMIT_SHA" ]; then
             echo "::error::Refusing release: annotated tag $TAG_NAME targets ${tag_object_type:-unknown}, not a commit."
+            exit 1
+          fi
+          LOCAL_TAGGED_COMMIT_SHA=$(git rev-parse "$TAG_NAME^{commit}")
+          if [ "$LOCAL_TAGGED_COMMIT_SHA" != "$TAGGED_COMMIT_SHA" ]; then
+            echo "::error::Refusing to release: local tag $TAG_NAME resolves to $LOCAL_TAGGED_COMMIT_SHA, not the GitHub-verified commit $TAGGED_COMMIT_SHA."
             exit 1
           fi
           allowed_signers_raw="${NPM_RELEASE_ALLOWED_SIGNERS:-}"

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -116,7 +116,7 @@ npm view @opencoven/cli-windows version dist-tags
 
 All five should now show the tag's version as `latest`. The package pages on npmjs.com should display a **"Provenance"** badge with a link back to the GitHub Actions run.
 
-After the npm workflow succeeds, **Publish GitHub Release** (`.github/workflows/release-github.yml`) runs automatically from the default-branch workflow code. It refuses to touch GitHub Releases until it re-verifies the successful source npm workflow run through the GitHub API, confirms the signed annotated tag still resolves to that exact commit on `origin/main`, and proves all five npm packages have trusted-publisher / SLSA provenance tied to `https://github.com/OpenCoven/coven`, `.github/workflows/release-npm.yml`, `refs/tags/vX.Y.Z`, the tagged commit, and the source workflow run attempt. Its signature-audit preflight also rebuilds a throwaway consumer `package-lock.json` and rejects any final lock whose root dependency set is not exactly those five canonical packages at the tag version. Only then does it download the four retained build artifacts, package deterministic archives, and reconcile the matching GitHub Release.
+After the npm workflow succeeds, **Publish GitHub Release** (`.github/workflows/release-github.yml`) runs automatically from the default-branch workflow code. It refuses to touch GitHub Releases until it re-verifies the successful source npm workflow run through the GitHub API, confirms the signed annotated tag still resolves to that exact commit on `origin/main`, and proves all five npm packages have trusted-publisher / SLSA provenance tied to `https://github.com/OpenCoven/coven`, `.github/workflows/release-npm.yml`, `refs/tags/vX.Y.Z`, the tagged commit, and the source workflow run attempt. Its signature-audit preflight also rebuilds a throwaway consumer `package-lock.json` and rejects any final lock whose root dependency set is not exactly those five canonical packages at the tag version. After the four artifact downloads complete, it rechecks that the latest run attempt still equals the selected `source_run_attempt`; if a rerun started during download, the workflow fails closed before packaging or any GitHub Release mutation. Existing Releases are only accepted for recovery when the tag, title `Coven vX.Y.Z`, `draft=false`, and `prerelease=false` already match the canonical public release. Only then does it package deterministic archives and reconcile the matching GitHub Release.
 
 The workflow creates or repairs one GitHub Release titled `Coven vX.Y.Z` using the signed tag annotation notes, with exactly these assets:
 
@@ -134,6 +134,17 @@ If the automatic GitHub-only workflow fails after the npm publication succeeded,
 
 - `release_tag`: the immutable signed tag (`vX.Y.Z`)
 - `source_run_id`: the successful **Release npm packages** run ID for that tag
+- `source_run_attempt`: the exact successful **Release npm packages** run attempt for that run ID
+
+To collect the recovery inputs safely:
+
+1. Open the successful **Release npm packages** run for `vX.Y.Z` in the GitHub Actions UI, or list recent runs and copy the run ID shown there.
+2. Query that run's immutable metadata and copy **both** the run ID and run attempt:
+   ```sh
+   gh api /repos/OpenCoven/coven/actions/runs/<source_run_id> \
+     --jq '{release_tag: .head_branch, source_run_id: .id, source_run_attempt: .run_attempt, conclusion: .conclusion}'
+   ```
+3. Confirm the output still shows `release_tag: "vX.Y.Z"` and `conclusion: "success"`, then pass all three values into the recovery dispatch.
 
 The recovery path is deliberately narrow:
 
@@ -141,8 +152,9 @@ The recovery path is deliberately narrow:
 - A missing canonical asset may be uploaded.
 - A canonical asset that already exists is streamed to a local file and hash-checked first; it is skipped only on an exact byte match.
 - Any mismatched canonical asset or any extra/renamed asset fails closed. The workflow never overwrites GitHub assets automatically, never moves or reuses the tag, and never republishes npm.
+- The workflow rechecks the latest run attempt once before download and once again after all downloads. If either check sees a newer attempt than the supplied `source_run_attempt`, recovery fails closed before packaging or mutation because `actions/download-artifact` is keyed only by run ID. In that case, use the newer successful run's ID/attempt pair instead of reusing the old attempt.
 
-When a mismatch blocks recovery, record **the observed hash, the expected hash, and the reason** in the release log or incident notes. Then delete **only** the mismatched GitHub asset through an audited operator action (for example the GitHub UI or `gh release delete-asset ...`), and rerun the GitHub-only workflow with the same immutable tag and source run ID. Do not delete matching assets, do not retag, and do not rerun the npm publish workflow for the same version.
+When a mismatch blocks recovery, record **the observed hash, the expected hash, and the reason** in the release log or incident notes. Then delete **only** the mismatched GitHub asset through an audited operator action (for example the GitHub UI or `gh release delete-asset ...`), and rerun the GitHub-only workflow with the same immutable tag plus the same source run ID/attempt pair. Do not delete matching assets, do not retag, and do not rerun the npm publish workflow for the same version.
 
 ### Recover a partial npm publication
 

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -1,9 +1,9 @@
 ---
 summary: "Release flow for @opencoven/cli and platform packages."
-description: "Operator runbook for releasing Coven to npm: one-time OIDC setup, signed-tag release, automated publish with provenance, and how to recover from a refused or failed release."
+description: "Operator runbook for releasing Coven to npm and GitHub Releases: OIDC setup, signed-tag publication, deterministic assets, provenance checks, and recovery."
 read_when:
   - Cutting a release
-title: "Releasing Coven to npm"
+title: "Releasing Coven to npm and GitHub Releases"
 ---
 
 Coven publishes the `@opencoven/cli` wrapper and its four native platform packages (`@opencoven/cli-macos`, `@opencoven/cli-macos-x64`, `@opencoven/cli-linux-x64`, `@opencoven/cli-windows`) automatically from the **Release npm packages** GitHub Actions workflow.
@@ -116,7 +116,9 @@ npm view @opencoven/cli-windows version dist-tags
 
 All five should now show the tag's version as `latest`. The package pages on npmjs.com should display a **"Provenance"** badge with a link back to the GitHub Actions run.
 
-Create or update the matching GitHub Release from the successful workflow artifacts. Package the downloaded binaries with the same public asset names as prior releases:
+After the npm workflow succeeds, **Publish GitHub Release** (`.github/workflows/release-github.yml`) runs automatically from the default-branch workflow code. It refuses to touch GitHub Releases until it re-verifies the successful source npm workflow run through the GitHub API, confirms the signed annotated tag still resolves to that exact commit on `origin/main`, and proves all five npm packages have trusted-publisher / SLSA provenance tied to `https://github.com/OpenCoven/coven`, `.github/workflows/release-npm.yml`, `refs/tags/vX.Y.Z`, the tagged commit, and the source workflow run attempt. Only then does it download the four retained build artifacts, package deterministic archives, and reconcile the matching GitHub Release.
+
+The workflow creates or repairs one GitHub Release titled `Coven vX.Y.Z` using the signed tag annotation notes, with exactly these assets:
 
 - `coven-vX.Y.Z-macos-aarch64.tar.gz`
 - `coven-vX.Y.Z-macos-x64.tar.gz`
@@ -124,7 +126,23 @@ Create or update the matching GitHub Release from the successful workflow artifa
 - `coven-vX.Y.Z-windows-x64.zip`
 - `SHA256SUMS`
 
-The release body should include the npm install command, published package list, action run URL, tagged commit, and compare link. This GitHub Release is the public binary/checksum surface; npm provenance remains the package-integrity surface.
+`SHA256SUMS` contains exactly four lexically ordered entries naming only those four archive filenames. The GitHub Release is the public binary/checksum surface; npm provenance remains the package-integrity surface.
+
+### Recover GitHub Release assets without touching npm
+
+If the automatic GitHub-only workflow fails after the npm publication succeeded, rerun **Publish GitHub Release** with **Run workflow** / `workflow_dispatch` from the default branch and provide:
+
+- `release_tag`: the immutable signed tag (`vX.Y.Z`)
+- `source_run_id`: the successful **Release npm packages** run ID for that tag
+
+The recovery path is deliberately narrow:
+
+- A missing GitHub Release may be created.
+- A missing canonical asset may be uploaded.
+- A canonical asset that already exists is downloaded and hash-checked first; it is skipped only on an exact byte match.
+- Any mismatched canonical asset or any extra/renamed asset fails closed. The workflow never overwrites GitHub assets automatically, never moves or reuses the tag, and never republishes npm.
+
+When a mismatch blocks recovery, record **the observed hash, the expected hash, and the reason** in the release log or incident notes. Then delete **only** the mismatched GitHub asset through an audited operator action (for example the GitHub UI or `gh release delete-asset ...`), and rerun the GitHub-only workflow with the same immutable tag and source run ID. Do not delete matching assets, do not retag, and do not rerun the npm publish workflow for the same version.
 
 ### Recover a partial npm publication
 

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -116,7 +116,7 @@ npm view @opencoven/cli-windows version dist-tags
 
 All five should now show the tag's version as `latest`. The package pages on npmjs.com should display a **"Provenance"** badge with a link back to the GitHub Actions run.
 
-After the npm workflow succeeds, **Publish GitHub Release** (`.github/workflows/release-github.yml`) runs automatically from the default-branch workflow code. It refuses to touch GitHub Releases until it re-verifies the successful source npm workflow run through the GitHub API, confirms the signed annotated tag still resolves to that exact commit on `origin/main`, and proves all five npm packages have trusted-publisher / SLSA provenance tied to `https://github.com/OpenCoven/coven`, `.github/workflows/release-npm.yml`, `refs/tags/vX.Y.Z`, the tagged commit, and the source workflow run attempt. Only then does it download the four retained build artifacts, package deterministic archives, and reconcile the matching GitHub Release.
+After the npm workflow succeeds, **Publish GitHub Release** (`.github/workflows/release-github.yml`) runs automatically from the default-branch workflow code. It refuses to touch GitHub Releases until it re-verifies the successful source npm workflow run through the GitHub API, confirms the signed annotated tag still resolves to that exact commit on `origin/main`, and proves all five npm packages have trusted-publisher / SLSA provenance tied to `https://github.com/OpenCoven/coven`, `.github/workflows/release-npm.yml`, `refs/tags/vX.Y.Z`, the tagged commit, and the source workflow run attempt. Its signature-audit preflight also rebuilds a throwaway consumer `package-lock.json` and rejects any final lock whose root dependency set is not exactly those five canonical packages at the tag version. Only then does it download the four retained build artifacts, package deterministic archives, and reconcile the matching GitHub Release.
 
 The workflow creates or repairs one GitHub Release titled `Coven vX.Y.Z` using the signed tag annotation notes, with exactly these assets:
 
@@ -139,7 +139,7 @@ The recovery path is deliberately narrow:
 
 - A missing GitHub Release may be created.
 - A missing canonical asset may be uploaded.
-- A canonical asset that already exists is downloaded and hash-checked first; it is skipped only on an exact byte match.
+- A canonical asset that already exists is streamed to a local file and hash-checked first; it is skipped only on an exact byte match.
 - Any mismatched canonical asset or any extra/renamed asset fails closed. The workflow never overwrites GitHub assets automatically, never moves or reuses the tag, and never republishes npm.
 
 When a mismatch blocks recovery, record **the observed hash, the expected hash, and the reason** in the release log or incident notes. Then delete **only** the mismatched GitHub asset through an audited operator action (for example the GitHub UI or `gh release delete-asset ...`), and rerun the GitHub-only workflow with the same immutable tag and source run ID. Do not delete matching assets, do not retag, and do not rerun the npm publish workflow for the same version.

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -72,6 +72,16 @@ class CheckCiWorkflowTests(unittest.TestCase):
         self.assertIn("actions: read", RELEASE_GITHUB_TEXT)
         self.assertIn("contents: write", RELEASE_GITHUB_TEXT)
         self.assertNotIn("id-token: write", RELEASE_GITHUB_TEXT)
+        self.assertEqual(
+            RELEASE_GITHUB_TEXT.count(
+                "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+            ),
+            3,
+        )
+        self.assertNotIn(
+            "          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+            RELEASE_GITHUB_TEXT,
+        )
         self.assertIn("cancel-in-progress: false", RELEASE_GITHUB_TEXT)
         self.assertIn(f"actions/setup-node@{SETUP_NODE_SHA}", RELEASE_GITHUB_TEXT)
         self.assertIn("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", RELEASE_GITHUB_TEXT)

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -6,9 +6,12 @@ import unittest
 
 CI_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'ci.yml'
 RELEASE_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'release-npm.yml'
+RELEASE_GITHUB_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'release-github.yml'
 CACHE_SHA = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+SETUP_NODE_SHA = "820762786026740c76f36085b0efc47a31fe5020"
 CI_TEXT = CI_WORKFLOW.read_text(encoding='utf-8')
 RELEASE_TEXT = RELEASE_WORKFLOW.read_text(encoding='utf-8')
+RELEASE_GITHUB_TEXT = RELEASE_GITHUB_WORKFLOW.read_text(encoding='utf-8')
 
 
 class CheckCiWorkflowTests(unittest.TestCase):
@@ -45,6 +48,7 @@ class CheckCiWorkflowTests(unittest.TestCase):
             'python3 scripts/check-workflows-test.py',
             'python3 scripts/check-ci-workflow-test.py',
             'scripts/check-workflows.sh',
+            'node --test scripts/package-github-release-test.mjs',
             "needs.changes.outputs.docs_only != 'true'",
             'npm-onboarding-linux',
             "github.event_name == 'push'",
@@ -56,9 +60,31 @@ class CheckCiWorkflowTests(unittest.TestCase):
         self.assertIn("\n  npm-onboarding-linux:\n", CI_TEXT)
         self.assertIn("\n  npm-onboarding-main:\n", CI_TEXT)
 
+
+    def test_ci_sets_up_node_for_release_workflow_policy_tests(self) -> None:
+        self.assertIn(f"actions/setup-node@{SETUP_NODE_SHA}", CI_TEXT)
+
+    def test_release_github_workflow_has_expected_trigger_and_permissions(self) -> None:
+        self.assertIn("workflow_run:", RELEASE_GITHUB_TEXT)
+        self.assertIn("Release npm packages", RELEASE_GITHUB_TEXT)
+        self.assertIn("workflow_dispatch:", RELEASE_GITHUB_TEXT)
+        self.assertIn("actions: read", RELEASE_GITHUB_TEXT)
+        self.assertIn("contents: write", RELEASE_GITHUB_TEXT)
+        self.assertNotIn("id-token: write", RELEASE_GITHUB_TEXT)
+        self.assertIn("cancel-in-progress: false", RELEASE_GITHUB_TEXT)
+        self.assertIn(f"actions/setup-node@{SETUP_NODE_SHA}", RELEASE_GITHUB_TEXT)
+        self.assertIn("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", RELEASE_GITHUB_TEXT)
+        self.assertNotIn("npm publish", RELEASE_GITHUB_TEXT)
+
     def test_release_includes_performance_baseline_dependency(self) -> None:
         self.assertIn('performance-baseline', RELEASE_TEXT)
         self.assertIn('needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]', RELEASE_TEXT)
+
+    def test_release_npm_workflow_uses_same_tag_specific_concurrency_without_cancellation(self) -> None:
+        self.assertIn(
+            "concurrency:\n  group: release-npm-${{ github.ref }}\n  cancel-in-progress: false",
+            RELEASE_TEXT,
+        )
 
 
 if __name__ == '__main__':

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -77,6 +77,7 @@ class CheckCiWorkflowTests(unittest.TestCase):
         self.assertIn("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", RELEASE_GITHUB_TEXT)
         self.assertIn("github.event.workflow_run.run_attempt || inputs.source_run_attempt", RELEASE_GITHUB_TEXT)
         self.assertIn('--source-run-attempt "$SOURCE_RUN_ATTEMPT"', RELEASE_GITHUB_TEXT)
+        self.assertIn("verify-source-run-attempt", RELEASE_GITHUB_TEXT)
         self.assertIn('--expected-tag-object-sha "$TAG_OBJECT_SHA"', RELEASE_GITHUB_TEXT)
         self.assertIn('--expected-head-sha "$HEAD_SHA"', RELEASE_GITHUB_TEXT)
         self.assertNotIn("npm publish", RELEASE_GITHUB_TEXT)

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -68,12 +68,17 @@ class CheckCiWorkflowTests(unittest.TestCase):
         self.assertIn("workflow_run:", RELEASE_GITHUB_TEXT)
         self.assertIn("Release npm packages", RELEASE_GITHUB_TEXT)
         self.assertIn("workflow_dispatch:", RELEASE_GITHUB_TEXT)
+        self.assertIn("source_run_attempt:", RELEASE_GITHUB_TEXT)
         self.assertIn("actions: read", RELEASE_GITHUB_TEXT)
         self.assertIn("contents: write", RELEASE_GITHUB_TEXT)
         self.assertNotIn("id-token: write", RELEASE_GITHUB_TEXT)
         self.assertIn("cancel-in-progress: false", RELEASE_GITHUB_TEXT)
         self.assertIn(f"actions/setup-node@{SETUP_NODE_SHA}", RELEASE_GITHUB_TEXT)
         self.assertIn("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", RELEASE_GITHUB_TEXT)
+        self.assertIn("github.event.workflow_run.run_attempt || inputs.source_run_attempt", RELEASE_GITHUB_TEXT)
+        self.assertIn('--source-run-attempt "$SOURCE_RUN_ATTEMPT"', RELEASE_GITHUB_TEXT)
+        self.assertIn('--expected-tag-object-sha "$TAG_OBJECT_SHA"', RELEASE_GITHUB_TEXT)
+        self.assertIn('--expected-head-sha "$HEAD_SHA"', RELEASE_GITHUB_TEXT)
         self.assertNotIn("npm publish", RELEASE_GITHUB_TEXT)
 
     def test_release_includes_performance_baseline_dependency(self) -> None:

--- a/scripts/fixtures/package-github-release/source-artifacts/coven-linux-x64/coven
+++ b/scripts/fixtures/package-github-release/source-artifacts/coven-linux-x64/coven
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo coven linux x64 fixture

--- a/scripts/fixtures/package-github-release/source-artifacts/coven-macos-x64/coven
+++ b/scripts/fixtures/package-github-release/source-artifacts/coven-macos-x64/coven
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo coven macos x64 fixture

--- a/scripts/fixtures/package-github-release/source-artifacts/coven-macos-x64/coven-afs-serve
+++ b/scripts/fixtures/package-github-release/source-artifacts/coven-macos-x64/coven-afs-serve
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo coven afs macos x64 fixture

--- a/scripts/fixtures/package-github-release/source-artifacts/coven-macos/coven
+++ b/scripts/fixtures/package-github-release/source-artifacts/coven-macos/coven
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo coven macos arm64 fixture

--- a/scripts/fixtures/package-github-release/source-artifacts/coven-macos/coven-afs-serve
+++ b/scripts/fixtures/package-github-release/source-artifacts/coven-macos/coven-afs-serve
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo coven afs macos arm64 fixture

--- a/scripts/fixtures/package-github-release/source-artifacts/coven-windows/coven.exe
+++ b/scripts/fixtures/package-github-release/source-artifacts/coven-windows/coven.exe
@@ -1,0 +1,1 @@
+windows fixture executable bytes

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -188,6 +188,22 @@ function baseTagObject() {
   };
 }
 
+function baseExistingRelease({
+  tagName = RELEASE_TAG,
+  title = `Coven ${RELEASE_TAG}`,
+  draft = false,
+  prerelease = false,
+  assets = []
+} = {}) {
+  return {
+    tag_name: tagName,
+    name: title,
+    draft,
+    prerelease,
+    assets
+  };
+}
+
 function trustedPublisherMetadata(overrides = {}) {
   const base = {
     name: 'GitHub Actions',
@@ -441,7 +457,7 @@ function fakeReleaseClient({ existingRelease = null, assetBytesByName = {}, reva
     },
     async createRelease({ releaseTag, title, notesFromTag, verifyTag }) {
       state.created.push({ releaseTag, title, notesFromTag, verifyTag });
-      state.release = { tagName: releaseTag, assets: [] };
+      state.release = baseExistingRelease({ tagName: releaseTag, title, assets: [] });
       return state.release;
     },
     async downloadAsset(asset, filePath) {
@@ -514,6 +530,10 @@ test('release-github workflow supports automatic and recovery triggers with pinn
   assert.match(
     workflowText,
     /--audit-dir github-release-npm-audit/
+  );
+  assert.match(
+    workflowText,
+    /actions\/download-artifact@[\s\S]*actions\/download-artifact@[\s\S]*actions\/download-artifact@[\s\S]*actions\/download-artifact@[\s\S]*node scripts\/package-github-release\.mjs verify-source-run-attempt[\s\S]*--source-run-id "\$SOURCE_RUN_ID"[\s\S]*--source-run-attempt "\$SOURCE_RUN_ATTEMPT"[\s\S]*node scripts\/package-github-release\.mjs package/
   );
   assert.match(workflowText, /node scripts\/package-github-release\.mjs package/);
   assert.match(
@@ -829,6 +849,34 @@ test('resolveReleaseSource rejects rerun ambiguity before any artifact download 
     `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}`,
     `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}/attempts/${selectedAttempt}`
   ]);
+});
+
+test('verifyLatestSourceRunAttempt rejects a rerun that starts after artifact downloads and before packaging', async () => {
+  const { verifyLatestSourceRunAttempt } = await import('./package-github-release.mjs');
+  assert.equal(typeof verifyLatestSourceRunAttempt, 'function');
+
+  const requestedRepository = 'OpenCoven/coven';
+  const selectedAttempt = 1;
+  const latestAttempt = 2;
+  const calls = [];
+  await assert.rejects(
+    () =>
+      verifyLatestSourceRunAttempt({
+        repository: requestedRepository,
+        releaseTag: RELEASE_TAG,
+        sourceRunId: SOURCE_RUN_ID,
+        sourceRunAttempt: String(selectedAttempt),
+        ghApi: async (endpoint) => {
+          calls.push(endpoint);
+          if (endpoint === `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}`) {
+            return { ...baseValidSourceRun(), run_attempt: latestAttempt };
+          }
+          throw new Error(`unexpected endpoint ${endpoint}`);
+        }
+      }),
+    /latest run attempt 2 does not match selected attempt 1[\s\S]*run-id only/i
+  );
+  assert.deepEqual(calls, [`/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}`]);
 });
 
 test('verifyNpmRegistrySignatures writes an isolated cross-platform exact-version audit context and invokes real npm audit signatures', () => {
@@ -1502,6 +1550,11 @@ test('syncGitHubRelease revalidates the verified remote tag before creating a mi
         releaseTag: RELEASE_TAG,
         expectedTagObjectSha: baseTagRef().object.sha,
         expectedHeadSha: HEAD_SHA
+      },
+      {
+        releaseTag: RELEASE_TAG,
+        expectedTagObjectSha: baseTagRef().object.sha,
+        expectedHeadSha: HEAD_SHA
       }
     ]);
     assert.deepEqual(client.state.created, [
@@ -1589,10 +1642,9 @@ test('syncGitHubRelease skips a fully matching rerun, including >1 MiB assets, w
     assert.ok(readFileSync(path.join(outputDir, windowsArchiveName)).length > 1024 * 1024);
 
     const matchingClient = fakeReleaseClient({
-      existingRelease: {
-        tagName: RELEASE_TAG,
+      existingRelease: baseExistingRelease({
         assets: EXPECTED_ASSET_NAMES.map((name, index) => ({ id: index + 1, name }))
-      },
+      }),
       assetBytesByName: Object.fromEntries(
         EXPECTED_ASSET_NAMES.map((assetName) => [assetName, readFileSync(path.join(outputDir, assetName))])
       )
@@ -1623,25 +1675,25 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
 
     const checksumBytes = readFileSync(path.join(outputDir, 'SHA256SUMS'));
     const matchingClient = fakeReleaseClient({
-      existingRelease: {
-        tagName: RELEASE_TAG,
+      existingRelease: baseExistingRelease({
         assets: [{ id: 1, name: 'SHA256SUMS' }]
-      },
+      }),
       assetBytesByName: { SHA256SUMS: checksumBytes }
     });
     const matchingResult = await syncGitHubRelease({
       releaseTag: RELEASE_TAG,
       outputDir,
+      expectedTagObjectSha: baseTagRef().object.sha,
+      expectedHeadSha: HEAD_SHA,
       releaseClient: matchingClient
     });
     assert.deepEqual(matchingResult.skipped, ['SHA256SUMS']);
     assert.equal(matchingClient.state.uploads.length, EXPECTED_ASSET_NAMES.length - 1);
 
     const mismatchedClient = fakeReleaseClient({
-      existingRelease: {
-        tagName: RELEASE_TAG,
+      existingRelease: baseExistingRelease({
         assets: [{ id: 1, name: 'SHA256SUMS' }]
-      },
+      }),
       assetBytesByName: { SHA256SUMS: Buffer.from('wrong checksums\n') }
     });
     await assert.rejects(
@@ -1656,10 +1708,9 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
     assert.equal(mismatchedClient.state.uploads.length, 0);
 
     const extraClient = fakeReleaseClient({
-      existingRelease: {
-        tagName: RELEASE_TAG,
+      existingRelease: baseExistingRelease({
         assets: [{ id: 1, name: 'unexpected.txt' }]
-      }
+      })
     });
     await assert.rejects(
       () =>
@@ -1670,15 +1721,13 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
         }),
       /unexpected release assets/
     );
-
     const duplicateClient = fakeReleaseClient({
-      existingRelease: {
-        tagName: RELEASE_TAG,
+      existingRelease: baseExistingRelease({
         assets: [
           { id: 1, name: 'SHA256SUMS' },
           { id: 2, name: 'SHA256SUMS' }
         ]
-      },
+      }),
       assetBytesByName: { SHA256SUMS: checksumBytes }
     });
     await assert.rejects(
@@ -1693,6 +1742,178 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
   });
 });
 
+test('syncGitHubRelease revalidates the verified remote tag before uploading missing assets to an existing release', async () => {
+  await withScratchDir('sync-existing-release-revalidate', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const client = fakeReleaseClient({
+      existingRelease: baseExistingRelease({
+        assets: [{ id: 1, name: 'SHA256SUMS' }]
+      }),
+      assetBytesByName: {
+        SHA256SUMS: readFileSync(path.join(outputDir, 'SHA256SUMS'))
+      }
+    });
+    const result = await syncGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      outputDir,
+      expectedTagObjectSha: baseTagRef().object.sha,
+      expectedHeadSha: HEAD_SHA,
+      releaseClient: client
+    });
+
+    assert.deepEqual(client.state.revalidated, [
+      {
+        releaseTag: RELEASE_TAG,
+        expectedTagObjectSha: baseTagRef().object.sha,
+        expectedHeadSha: HEAD_SHA
+      }
+    ]);
+    assert.deepEqual(result.skipped, ['SHA256SUMS']);
+    assert.equal(result.uploaded.length, EXPECTED_ASSET_NAMES.length - 1);
+  });
+});
+
+test('syncGitHubRelease refuses to upload missing assets to an existing release when the verified remote tag was deleted or replaced', async () => {
+  await withScratchDir('sync-existing-release-race', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const cases = [
+      {
+        name: 'deleted',
+        error: /no longer resolves to refs\/tags\/v0\.4\.1/i,
+        revalidateTagState() {
+          throw new Error(
+            `Refusing GitHub release: ${RELEASE_TAG} no longer resolves to refs/tags/${RELEASE_TAG}.`
+          );
+        }
+      },
+      {
+        name: 'replaced',
+        error: /tag object SHA/i,
+        revalidateTagState() {
+          throw new Error(
+            `Refusing GitHub release: ${RELEASE_TAG} tag object SHA changed from ${baseTagRef().object.sha} to ${'2'.repeat(40)}.`
+          );
+        }
+      }
+    ];
+
+    for (const { name, error, revalidateTagState } of cases) {
+      const client = fakeReleaseClient({
+        existingRelease: baseExistingRelease({
+          assets: [{ id: 1, name: 'SHA256SUMS' }]
+        }),
+        assetBytesByName: {
+          SHA256SUMS: readFileSync(path.join(outputDir, 'SHA256SUMS'))
+        },
+        revalidateTagState
+      });
+      await assert.rejects(
+        () =>
+          syncGitHubRelease({
+            releaseTag: RELEASE_TAG,
+            outputDir,
+            expectedTagObjectSha: baseTagRef().object.sha,
+            expectedHeadSha: HEAD_SHA,
+            releaseClient: client
+          }),
+        error,
+        name
+      );
+      assert.equal(client.state.uploads.length, 0, `${name} must not upload release assets`);
+    }
+  });
+});
+
+test('syncGitHubRelease rejects existing release metadata mismatches before accepting or uploading assets', async () => {
+  await withScratchDir('sync-existing-release-metadata', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const matchingAssetBytesByName = Object.fromEntries(
+      EXPECTED_ASSET_NAMES.map((assetName) => [assetName, readFileSync(path.join(outputDir, assetName))])
+    );
+    const allAssets = EXPECTED_ASSET_NAMES.map((assetName, index) => ({ id: index + 1, name: assetName }));
+    const cases = [
+      {
+        name: 'wrong tag',
+        release: baseExistingRelease({
+          tagName: 'v0.4.2',
+          assets: allAssets
+        }),
+        error: /existing release tag/i
+      },
+      {
+        name: 'wrong title',
+        release: baseExistingRelease({
+          title: 'Wrong title',
+          assets: allAssets
+        }),
+        error: /title .*Coven v0\.4\.1/i
+      },
+      {
+        name: 'draft release',
+        release: baseExistingRelease({
+          draft: true,
+          assets: allAssets
+        }),
+        error: /must not be a draft/i
+      },
+      {
+        name: 'prerelease',
+        release: baseExistingRelease({
+          prerelease: true,
+          assets: allAssets
+        }),
+        error: /must not be a prerelease/i
+      }
+    ];
+
+    for (const { name, release, error } of cases) {
+      const client = fakeReleaseClient({
+        existingRelease: release,
+        assetBytesByName: matchingAssetBytesByName
+      });
+      await assert.rejects(
+        () =>
+          syncGitHubRelease({
+            releaseTag: RELEASE_TAG,
+            outputDir,
+            releaseClient: client
+          }),
+        error,
+        name
+      );
+      assert.equal(client.state.downloads.length, 0, `${name} must fail before accepting assets`);
+      assert.equal(client.state.uploads.length, 0, `${name} must fail before uploading assets`);
+    }
+  });
+});
+
 test('syncGitHubRelease preflights later mismatches before uploading earlier missing assets', async () => {
   await withScratchDir('sync-preflight-mismatch', async (scratchDir) => {
     const artifactsDir = path.join(scratchDir, 'artifacts');
@@ -1704,13 +1925,11 @@ test('syncGitHubRelease preflights later mismatches before uploading earlier mis
       outputDir,
       sourceDateEpoch: SOURCE_DATE_EPOCH
     });
-
     const windowsAssetName = 'coven-v0.4.1-windows-x64.zip';
     const client = fakeReleaseClient({
-      existingRelease: {
-        tagName: RELEASE_TAG,
+      existingRelease: baseExistingRelease({
         assets: [{ id: 1, name: windowsAssetName }]
-      },
+      }),
       assetBytesByName: {
         [windowsAssetName]: Buffer.from('wrong windows bytes\n')
       }

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -1443,6 +1443,10 @@ test('packageGitHubRelease rejects missing or extra source artifact files', () =
 test('assertChecksumManifest rejects self entries, duplicates, path-qualified names, missing assets, and non-lexical order', () => {
   assert.throws(() => assertChecksumManifest('', EXPECTED_ARCHIVES), /exactly four non-empty entries/);
   assert.throws(
+    () => assertChecksumManifest('', EXPECTED_ARCHIVES.slice(0, 2)),
+    /exactly 2 non-empty entries/
+  );
+  assert.throws(
     () =>
       assertChecksumManifest(
         [

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -12,6 +12,7 @@ import {
   captureCommandOutputToFile,
   canonicalReleaseAssetNames,
   packageGitHubRelease,
+  resolveReleaseSource,
   syncGitHubRelease,
   verifyAnnotatedTag,
   verifyNpmRegistrySignatures,
@@ -418,10 +419,11 @@ function expectedZipTimestamp(epochSeconds) {
   };
 }
 
-function fakeReleaseClient({ existingRelease = null, assetBytesByName = {} } = {}) {
+function fakeReleaseClient({ existingRelease = null, assetBytesByName = {}, revalidateTagState = null } = {}) {
   const state = {
     release: existingRelease,
     created: [],
+    revalidated: [],
     downloads: [],
     uploads: []
   };
@@ -430,8 +432,15 @@ function fakeReleaseClient({ existingRelease = null, assetBytesByName = {} } = {
     async getReleaseByTag() {
       return state.release;
     },
-    async createRelease({ releaseTag, title, notesFromTag }) {
-      state.created.push({ releaseTag, title, notesFromTag });
+    async revalidateTag({ releaseTag, expectedTagObjectSha, expectedHeadSha }) {
+      state.revalidated.push({ releaseTag, expectedTagObjectSha, expectedHeadSha });
+      if (typeof revalidateTagState === 'function') {
+        return revalidateTagState({ releaseTag, expectedTagObjectSha, expectedHeadSha });
+      }
+      return revalidateTagState;
+    },
+    async createRelease({ releaseTag, title, notesFromTag, verifyTag }) {
+      state.created.push({ releaseTag, title, notesFromTag, verifyTag });
       state.release = { tagName: releaseTag, assets: [] };
       return state.release;
     },
@@ -480,7 +489,7 @@ test('release-github workflow supports automatic and recovery triggers with pinn
   );
   assert.match(
     workflowText,
-    /workflow_dispatch:[\s\S]*release_tag:[\s\S]*required: true[\s\S]*source_run_id:[\s\S]*required: true/
+    /workflow_dispatch:[\s\S]*release_tag:[\s\S]*required: true[\s\S]*source_run_id:[\s\S]*required: true[\s\S]*source_run_attempt:[\s\S]*required: true/
   );
   assert.match(
     workflowText,
@@ -488,7 +497,11 @@ test('release-github workflow supports automatic and recovery triggers with pinn
   );
   assert.match(
     workflowText,
-    /node scripts\/package-github-release\.mjs verify-source-run/
+    /SOURCE_RUN_ATTEMPT: \$\{\{ github\.event\.workflow_run\.run_attempt \|\| inputs\.source_run_attempt \}\}/
+  );
+  assert.match(
+    workflowText,
+    /node scripts\/package-github-release\.mjs verify-source-run[\s\S]*--source-run-attempt "\$SOURCE_RUN_ATTEMPT"/
   );
   assert.match(
     workflowText,
@@ -503,7 +516,10 @@ test('release-github workflow supports automatic and recovery triggers with pinn
     /--audit-dir github-release-npm-audit/
   );
   assert.match(workflowText, /node scripts\/package-github-release\.mjs package/);
-  assert.match(workflowText, /node scripts\/package-github-release\.mjs sync-release/);
+  assert.match(
+    workflowText,
+    /node scripts\/package-github-release\.mjs sync-release[\s\S]*--expected-tag-object-sha "\$TAG_OBJECT_SHA"[\s\S]*--expected-head-sha "\$HEAD_SHA"/
+  );
   assert.match(workflowText, new RegExp(`actions/checkout@${CHECKOUT_ACTION_SHA}`));
   assert.match(workflowText, new RegExp(`actions/setup-node@${SETUP_NODE_ACTION_SHA}`));
   assert.equal(
@@ -666,6 +682,7 @@ test('verifyReleaseSource requires the tagged commit to stay on origin/main and 
       npmVersion: NPM_VERSION,
       sourceRunId: SOURCE_RUN_ID,
       sourceRunAttempt: SOURCE_RUN_ATTEMPT,
+      tagObjectSha: baseTagRef().object.sha,
       headSha: HEAD_SHA,
       sourceDateEpoch: SOURCE_DATE_EPOCH
     }
@@ -726,6 +743,92 @@ test('verifyReleaseSource requires the tagged commit to stay on origin/main and 
       }),
     /SOURCE_DATE_EPOCH/
   );
+});
+
+test('resolveReleaseSource uses the selected run attempt metadata and preserves the verified tag identity', async () => {
+  const selectedAttempt = 3;
+  const requestedRepository = 'OpenCoven/coven';
+  const calls = [];
+  const expectedResult = {
+    releaseTag: RELEASE_TAG,
+    npmVersion: NPM_VERSION,
+    sourceRunId: SOURCE_RUN_ID,
+    sourceRunAttempt: selectedAttempt,
+    tagObjectSha: baseTagRef().object.sha,
+    headSha: HEAD_SHA,
+    sourceDateEpoch: SOURCE_DATE_EPOCH
+  };
+  const result = await resolveReleaseSource({
+    repository: requestedRepository,
+    releaseTag: RELEASE_TAG,
+    sourceRunId: SOURCE_RUN_ID,
+    sourceRunAttempt: String(selectedAttempt),
+    ghApi: async (endpoint) => {
+      calls.push(endpoint);
+      if (endpoint === `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}`) {
+        return { ...baseValidSourceRun(), run_attempt: selectedAttempt };
+      }
+      if (endpoint === `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}/attempts/${selectedAttempt}`) {
+        return { ...baseValidSourceRun(), run_attempt: selectedAttempt };
+      }
+      if (endpoint === `/repos/${requestedRepository}/git/ref/tags/${encodeURIComponent(RELEASE_TAG)}`) {
+        return baseTagRef();
+      }
+      if (endpoint === `/repos/${requestedRepository}/git/tags/${baseTagRef().object.sha}`) {
+        return baseTagObject();
+      }
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    },
+    git: {
+      verifyLocalTagState(releaseTag) {
+        assert.equal(releaseTag, RELEASE_TAG);
+        return {
+          localTagObjectSha: baseTagRef().object.sha,
+          localHeadSha: HEAD_SHA,
+          commitContainedInMain: true,
+          sourceDateEpoch: SOURCE_DATE_EPOCH
+        };
+      }
+    }
+  });
+  assert.deepEqual(result, expectedResult);
+  assert.deepEqual(calls, [
+    `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}`,
+    `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}/attempts/${selectedAttempt}`,
+    `/repos/${requestedRepository}/git/ref/tags/${encodeURIComponent(RELEASE_TAG)}`,
+    `/repos/${requestedRepository}/git/tags/${baseTagRef().object.sha}`
+  ]);
+});
+
+test('resolveReleaseSource rejects rerun ambiguity before any artifact download can rely on run-id only', async () => {
+  const requestedRepository = 'OpenCoven/coven';
+  const selectedAttempt = 1;
+  const latestAttempt = 2;
+  const calls = [];
+  await assert.rejects(
+    () =>
+      resolveReleaseSource({
+        repository: requestedRepository,
+        releaseTag: RELEASE_TAG,
+        sourceRunId: SOURCE_RUN_ID,
+        sourceRunAttempt: String(selectedAttempt),
+        ghApi: async (endpoint) => {
+          calls.push(endpoint);
+          if (endpoint === `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}`) {
+            return { ...baseValidSourceRun(), run_attempt: latestAttempt };
+          }
+          if (endpoint === `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}/attempts/${selectedAttempt}`) {
+            return { ...baseValidSourceRun(), run_attempt: selectedAttempt };
+          }
+          throw new Error(`unexpected endpoint ${endpoint}`);
+        }
+      }),
+    /latest run attempt 2 does not match selected attempt 1[\s\S]*run-id only/i
+  );
+  assert.deepEqual(calls, [
+    `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}`,
+    `/repos/${requestedRepository}/actions/runs/${SOURCE_RUN_ID}/attempts/${selectedAttempt}`
+  ]);
 });
 
 test('verifyNpmRegistrySignatures writes an isolated cross-platform exact-version audit context and invokes real npm audit signatures', () => {
@@ -1373,7 +1476,7 @@ test('captureCommandOutputToFile writes stdout larger than spawnSync maxBuffer d
   });
 });
 
-test('syncGitHubRelease creates a missing release and uploads every canonical asset with tag notes', async () => {
+test('syncGitHubRelease revalidates the verified remote tag before creating a missing release', async () => {
   await withScratchDir('sync-create', async (scratchDir) => {
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
@@ -1389,14 +1492,76 @@ test('syncGitHubRelease creates a missing release and uploads every canonical as
     const result = await syncGitHubRelease({
       releaseTag: RELEASE_TAG,
       outputDir,
+      expectedTagObjectSha: baseTagRef().object.sha,
+      expectedHeadSha: HEAD_SHA,
       releaseClient: client
     });
 
+    assert.deepEqual(client.state.revalidated, [
+      {
+        releaseTag: RELEASE_TAG,
+        expectedTagObjectSha: baseTagRef().object.sha,
+        expectedHeadSha: HEAD_SHA
+      }
+    ]);
     assert.deepEqual(client.state.created, [
-      { releaseTag: RELEASE_TAG, title: 'Coven v0.4.1', notesFromTag: true }
+      { releaseTag: RELEASE_TAG, title: 'Coven v0.4.1', notesFromTag: true, verifyTag: true }
     ]);
     assert.deepEqual(result.uploaded.sort(), EXPECTED_ASSET_NAMES);
     assert.deepEqual(result.skipped, []);
+  });
+});
+
+test('syncGitHubRelease refuses release creation when the verified remote tag was deleted or replaced', async () => {
+  await withScratchDir('sync-create-race', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const cases = [
+      {
+        name: 'deleted',
+        error: /no longer resolves to refs\/tags\/v0\.4\.1/i,
+        revalidateTagState() {
+          throw new Error(
+            `Refusing GitHub release: ${RELEASE_TAG} no longer resolves to refs/tags/${RELEASE_TAG}.`
+          );
+        }
+      },
+      {
+        name: 'replaced',
+        error: /tag object SHA/i,
+        revalidateTagState() {
+          throw new Error(
+            `Refusing GitHub release: ${RELEASE_TAG} tag object SHA changed from ${baseTagRef().object.sha} to ${'2'.repeat(40)}.`
+          );
+        }
+      }
+    ];
+
+    for (const { name, error, revalidateTagState } of cases) {
+      const client = fakeReleaseClient({ revalidateTagState });
+      await assert.rejects(
+        () =>
+          syncGitHubRelease({
+            releaseTag: RELEASE_TAG,
+            outputDir,
+            expectedTagObjectSha: baseTagRef().object.sha,
+            expectedHeadSha: HEAD_SHA,
+            releaseClient: client
+          }),
+        error,
+        name
+      );
+      assert.deepEqual(client.state.created, [], `${name} must not create the release`);
+      assert.deepEqual(client.state.uploads, [], `${name} must not upload release assets`);
+    }
   });
 });
 

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -1,0 +1,1088 @@
+import assert from 'node:assert/strict';
+import { createHash, randomUUID } from 'node:crypto';
+import { cpSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import test from 'node:test';
+import { gunzipSync } from 'node:zlib';
+
+import {
+  PACKAGE_DEFINITIONS,
+  assertChecksumManifest,
+  canonicalReleaseAssetNames,
+  packageGitHubRelease,
+  syncGitHubRelease,
+  verifyAnnotatedTag,
+  verifyPackageProvenance,
+  verifyReleaseSource,
+  verifySourceRun
+} from './package-github-release.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release-github.yml');
+const ciWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'ci.yml');
+const workflowText = readFileSync(workflowPath, 'utf8');
+const ciWorkflowText = readFileSync(ciWorkflowPath, 'utf8');
+const fixtureRoot = path.join(repoRoot, 'scripts', 'fixtures', 'package-github-release', 'source-artifacts');
+const scratchRoot = path.join(repoRoot, 'npm', 'dist', '.package-github-release-tests');
+const SOURCE_DATE_EPOCH = 1_786_939_861;
+const RELEASE_TAG = 'v0.4.1';
+const NPM_VERSION = '0.4.1';
+const HEAD_SHA = '0000000000000000000000000000000000000000';
+const SOURCE_RUN_ID = '31993572717';
+const SOURCE_RUN_ATTEMPT = 1;
+const CHECKOUT_ACTION_SHA = ['3d3c42e5aac5ba805825da76', '410c181273ba90b1'].join('');
+const SETUP_NODE_ACTION_SHA = ['820762786026740c76f36085', 'b0efc47a31fe5020'].join('');
+const DOWNLOAD_ARTIFACT_ACTION_SHA = ['3e5f45b2cfb9172054b4087a', '40e8e0b5a5461e7c'].join('');
+const RELEASE_PACKAGES = [
+  '@opencoven/cli',
+  '@opencoven/cli-linux-x64',
+  '@opencoven/cli-windows',
+  '@opencoven/cli-macos-x64',
+  '@opencoven/cli-macos'
+];
+const EXPECTED_ARCHIVES = [
+  'coven-v0.4.1-linux-x64.tar.gz',
+  'coven-v0.4.1-macos-aarch64.tar.gz',
+  'coven-v0.4.1-macos-x64.tar.gz',
+  'coven-v0.4.1-windows-x64.zip'
+].sort();
+const EXPECTED_ASSET_NAMES = [...EXPECTED_ARCHIVES, 'SHA256SUMS'].sort();
+
+function withScratchDir(name, fn) {
+  const dir = path.join(scratchRoot, `${name}-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  const cleanup = () => rmSync(dir, { recursive: true, force: true });
+  let result;
+  try {
+    result = fn(dir);
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+  if (result && typeof result.then === 'function') {
+    return result.finally(cleanup);
+  }
+  cleanup();
+  return result;
+}
+
+function sha256Hex(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function integrityFor(bytes) {
+  return `sha512-${createHash('sha512').update(bytes).digest('base64')}`;
+}
+
+function packageSubjectName(packageName, npmVersion = NPM_VERSION) {
+  return `pkg:npm/${packageName.split('/').map((segment) => encodeURIComponent(segment)).join('/')}@${npmVersion}`;
+}
+
+function baseValidSourceRun() {
+  return {
+    id: Number(SOURCE_RUN_ID),
+    name: 'Release npm packages',
+    path: '.github/workflows/release-npm.yml',
+    event: 'push',
+    status: 'completed',
+    conclusion: 'success',
+    head_branch: RELEASE_TAG,
+    head_sha: HEAD_SHA,
+    run_attempt: SOURCE_RUN_ATTEMPT
+  };
+}
+
+function baseTagRef() {
+  return {
+    ref: `refs/tags/${RELEASE_TAG}`,
+    object: {
+      type: 'tag',
+      sha: '1111111111111111111111111111111111111111'
+    }
+  };
+}
+
+function baseTagObject() {
+  return {
+    tag: RELEASE_TAG,
+    object: {
+      type: 'commit',
+      sha: HEAD_SHA
+    },
+    verification: {
+      verified: true,
+      reason: 'valid'
+    }
+  };
+}
+
+function trustedPublisherMetadata(overrides = {}) {
+  const base = {
+    name: 'GitHub Actions',
+    email: 'npm-oidc-no-reply@github.com',
+    trustedPublisher: {
+      id: 'github',
+      oidcConfigId: 'oidc:github-actions-config'
+    }
+  };
+  if (overrides.trustedPublisher === null) {
+    return {
+      ...base,
+      ...overrides,
+      trustedPublisher: null
+    };
+  }
+  return {
+    ...base,
+    ...overrides,
+    trustedPublisher: {
+      ...base.trustedPublisher,
+      ...overrides.trustedPublisher
+    }
+  };
+}
+
+function makePackageMetadata(packageName, integrity, { npmUser = trustedPublisherMetadata() } = {}) {
+  return {
+    name: packageName,
+    version: NPM_VERSION,
+    dist: {
+      integrity,
+      attestations: {
+        url: `https://registry.npmjs.org/-/npm/v1/attestations/${encodeURIComponent(packageName)}@${NPM_VERSION}`,
+        provenance: { predicateType: 'https://slsa.dev/provenance/v1' }
+      }
+    },
+    _npmUser: npmUser
+  };
+}
+
+function buildAttestations({
+  packageName = '@opencoven/cli',
+  npmVersion = NPM_VERSION,
+  repository = 'https://github.com/OpenCoven/coven',
+  workflowPathValue = '.github/workflows/release-npm.yml',
+  workflowRef = `refs/tags/${RELEASE_TAG}`,
+  gitCommit = HEAD_SHA,
+  invocationId = `https://github.com/OpenCoven/coven/actions/runs/${SOURCE_RUN_ID}/attempts/${SOURCE_RUN_ATTEMPT}`,
+  subjectDigest,
+  subjectName = packageSubjectName(packageName, npmVersion),
+  trustedPublisherPackageName = packageName,
+  trustedPublisherVersion = npmVersion,
+  trustedPublisherRegistry = 'https://registry.npmjs.org',
+  trustedPublisherPayloadBase64,
+  slsaPayloadBase64,
+  eventName = 'push'
+}) {
+  const statement = {
+    _type: 'https://in-toto.io/Statement/v1',
+    subject: [
+      {
+        name: subjectName,
+        digest: { sha512: subjectDigest }
+      }
+    ],
+    predicateType: 'https://slsa.dev/provenance/v1',
+    predicate: {
+      buildDefinition: {
+        buildType: 'https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1',
+        externalParameters: {
+          workflow: {
+            repository,
+            path: workflowPathValue,
+            ref: workflowRef
+          }
+        },
+        internalParameters: {
+          github: {
+            event_name: eventName,
+            repository_id: '1222160568',
+            repository_owner_id: '270919577'
+          }
+        },
+        resolvedDependencies: [
+          {
+            uri: `git+${repository}@${workflowRef}`,
+            digest: { gitCommit }
+          }
+        ]
+      },
+      runDetails: {
+        builder: { id: 'https://github.com/actions/runner/github-hosted' },
+        metadata: { invocationId }
+      }
+    }
+  };
+  const publishStatement = {
+    _type: 'https://in-toto.io/Statement/v0.1',
+    subject: [
+      {
+        name: subjectName,
+        digest: { sha512: subjectDigest }
+      }
+    ],
+    predicateType: 'https://github.com/npm/attestation/tree/main/specs/publish/v0.1',
+    predicate: {
+      name: trustedPublisherPackageName,
+      version: trustedPublisherVersion,
+      registry: trustedPublisherRegistry
+    }
+  };
+  return {
+    attestations: [
+      {
+        predicateType: 'https://github.com/npm/attestation/tree/main/specs/publish/v0.1',
+        bundle: {
+          dsseEnvelope: {
+            payload:
+              trustedPublisherPayloadBase64 ??
+              Buffer.from(JSON.stringify(publishStatement)).toString('base64')
+          }
+        }
+      },
+      {
+        predicateType: 'https://slsa.dev/provenance/v1',
+        bundle: {
+          dsseEnvelope: {
+            payload: slsaPayloadBase64 ?? Buffer.from(JSON.stringify(statement)).toString('base64')
+          }
+        }
+      }
+    ]
+  };
+}
+
+function parseTarGzEntries(archiveBytes) {
+  const gzipMtime = archiveBytes.readUInt32LE(4);
+  const tarBytes = gunzipSync(archiveBytes);
+  const entries = [];
+  for (let offset = 0; offset < tarBytes.length; offset += 512) {
+    const header = tarBytes.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+    const name = header.subarray(0, 100).toString('utf8').replace(/\0.*$/, '');
+    const mode = Number.parseInt(
+      header.subarray(100, 108).toString('ascii').replace(/\0.*$/, '').trim() || '0',
+      8
+    );
+    const size = Number.parseInt(
+      header.subarray(124, 136).toString('ascii').replace(/\0.*$/, '').trim() || '0',
+      8
+    );
+    const uid = Number.parseInt(
+      header.subarray(108, 116).toString('ascii').replace(/\0.*$/, '').trim() || '0',
+      8
+    );
+    const gid = Number.parseInt(
+      header.subarray(116, 124).toString('ascii').replace(/\0.*$/, '').trim() || '0',
+      8
+    );
+    const mtime = Number.parseInt(
+      header.subarray(136, 148).toString('ascii').replace(/\0.*$/, '').trim() || '0',
+      8
+    );
+    const typeflag = String.fromCharCode(header[156] || 0);
+    const dataOffset = offset + 512;
+    const data = tarBytes.subarray(dataOffset, dataOffset + size);
+    entries.push({ name, mode, uid, gid, mtime, typeflag, data: Buffer.from(data) });
+    offset = dataOffset + Math.ceil(size / 512) * 512 - 512;
+  }
+  return { gzipMtime, entries };
+}
+
+function parseZipEntries(archiveBytes) {
+  const eocdSignature = 0x06054b50;
+  let eocdOffset = -1;
+  for (let offset = archiveBytes.length - 22; offset >= 0; offset -= 1) {
+    if (archiveBytes.readUInt32LE(offset) === eocdSignature) {
+      eocdOffset = offset;
+      break;
+    }
+  }
+  assert.notEqual(eocdOffset, -1, 'zip EOCD must exist');
+  const totalEntries = archiveBytes.readUInt16LE(eocdOffset + 10);
+  const centralDirectoryOffset = archiveBytes.readUInt32LE(eocdOffset + 16);
+  const entries = [];
+  let offset = centralDirectoryOffset;
+  for (let index = 0; index < totalEntries; index += 1) {
+    assert.equal(
+      archiveBytes.readUInt32LE(offset),
+      0x02014b50,
+      'central directory header signature must match'
+    );
+    const method = archiveBytes.readUInt16LE(offset + 10);
+    const dosTime = archiveBytes.readUInt16LE(offset + 12);
+    const dosDate = archiveBytes.readUInt16LE(offset + 14);
+    const compressedSize = archiveBytes.readUInt32LE(offset + 20);
+    const fileNameLength = archiveBytes.readUInt16LE(offset + 28);
+    const extraLength = archiveBytes.readUInt16LE(offset + 30);
+    const commentLength = archiveBytes.readUInt16LE(offset + 32);
+    const externalAttributes = archiveBytes.readUInt32LE(offset + 38);
+    const localHeaderOffset = archiveBytes.readUInt32LE(offset + 42);
+    const name = archiveBytes
+      .subarray(offset + 46, offset + 46 + fileNameLength)
+      .toString('utf8');
+    const localNameLength = archiveBytes.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLength = archiveBytes.readUInt16LE(localHeaderOffset + 28);
+    const dataStart = localHeaderOffset + 30 + localNameLength + localExtraLength;
+    entries.push({
+      name,
+      method,
+      dosTime,
+      dosDate,
+      externalAttributes,
+      data: Buffer.from(archiveBytes.subarray(dataStart, dataStart + compressedSize))
+    });
+    offset += 46 + fileNameLength + extraLength + commentLength;
+  }
+  return entries;
+}
+
+function expectedZipTimestamp(epochSeconds) {
+  const date = new Date(epochSeconds * 1000);
+  return {
+    dosDate: ((date.getUTCFullYear() - 1980) << 9) | ((date.getUTCMonth() + 1) << 5) | date.getUTCDate(),
+    dosTime: (date.getUTCHours() << 11) | (date.getUTCMinutes() << 5) | Math.floor(date.getUTCSeconds() / 2)
+  };
+}
+
+function fakeReleaseClient({ existingRelease = null, assetBytesByName = {} } = {}) {
+  const state = {
+    release: existingRelease,
+    created: [],
+    downloads: [],
+    uploads: []
+  };
+  return {
+    state,
+    async getReleaseByTag() {
+      return state.release;
+    },
+    async createRelease({ releaseTag, title, notesFromTag }) {
+      state.created.push({ releaseTag, title, notesFromTag });
+      state.release = { tagName: releaseTag, assets: [] };
+      return state.release;
+    },
+    async downloadAsset(asset) {
+      state.downloads.push(asset.name);
+      return assetBytesByName[asset.name];
+    },
+    async uploadAsset({ releaseTag, assetName, filePath }) {
+      state.uploads.push({ releaseTag, assetName, bytes: readFileSync(filePath) });
+      state.release.assets.push({ id: state.release.assets.length + 1, name: assetName });
+    }
+  };
+}
+
+function assertRootOnlyTarEntries(entries, expectedNames) {
+  assert.deepEqual(
+    entries.map((entry) => entry.name),
+    expectedNames
+  );
+  assert.equal(
+    new Set(entries.map((entry) => entry.name)).size,
+    expectedNames.length,
+    'tar entry names must be unique'
+  );
+  for (const entry of entries) {
+    assert.equal(path.basename(entry.name), entry.name, `${entry.name} must stay at the archive root`);
+    assert.equal(entry.name.includes('/'), false, `${entry.name} must not include path separators`);
+    assert.equal(entry.name.includes('\\'), false, `${entry.name} must not include Windows separators`);
+    assert.equal(entry.name.includes('..'), false, `${entry.name} must not contain traversal segments`);
+    assert.equal(entry.uid, 0, `${entry.name} uid must be normalized`);
+    assert.equal(entry.gid, 0, `${entry.name} gid must be normalized`);
+    assert.equal(entry.mode, 0o755, `${entry.name} mode must be normalized`);
+    assert.equal(entry.typeflag, '0', `${entry.name} must be archived as a regular file`);
+    assert.equal(entry.mtime, SOURCE_DATE_EPOCH, `${entry.name} mtime must match SOURCE_DATE_EPOCH`);
+  }
+}
+
+test('release-github workflow supports automatic and recovery triggers with pinned actions', () => {
+  assert.match(
+    workflowText,
+    /^on:\s*\n  workflow_run:\s*\n    workflows:\s*\n      - Release npm packages\s*\n    types:\s*\n      - completed/m
+  );
+  assert.match(
+    workflowText,
+    /workflow_dispatch:[\s\S]*release_tag:[\s\S]*required: true[\s\S]*source_run_id:[\s\S]*required: true/
+  );
+  assert.match(
+    workflowText,
+    /if: \$\{\{ github\.event_name != 'workflow_run' \|\| github\.event\.workflow_run\.conclusion == 'success' \}\}/
+  );
+  assert.match(
+    workflowText,
+    /node scripts\/package-github-release\.mjs verify-source-run/
+  );
+  assert.match(
+    workflowText,
+    /node scripts\/package-github-release\.mjs verify-npm-provenance/
+  );
+  assert.match(workflowText, /node scripts\/package-github-release\.mjs package/);
+  assert.match(workflowText, /node scripts\/package-github-release\.mjs sync-release/);
+  assert.match(workflowText, new RegExp(`actions/checkout@${CHECKOUT_ACTION_SHA}`));
+  assert.match(workflowText, new RegExp(`actions/setup-node@${SETUP_NODE_ACTION_SHA}`));
+  assert.equal(
+    (
+      workflowText.match(
+        new RegExp(`actions/download-artifact@${DOWNLOAD_ARTIFACT_ACTION_SHA}`, 'g')
+      ) ?? []
+    ).length,
+    4
+  );
+});
+
+test('release-github workflow uses least privilege, default-branch code, and never publishes npm', () => {
+  assert.match(workflowText, /permissions:\s*\n  contents: read/);
+  assert.match(workflowText, /permissions:[\s\S]*actions: read[\s\S]*contents: write/);
+  assert.doesNotMatch(workflowText, /id-token: write/);
+  assert.match(workflowText, /cancel-in-progress: false/);
+  assert.match(workflowText, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(workflowText, /GitHub release recovery must run from the default branch code/);
+  assert.doesNotMatch(workflowText, /npm publish|publish-npm\.mjs --publish/);
+  assert.match(ciWorkflowText, new RegExp(`actions/setup-node@${SETUP_NODE_ACTION_SHA}`));
+  assert.match(ciWorkflowText, /node --test scripts\/package-github-release-test\.mjs/);
+});
+
+test('canonical release asset names and package definitions match the public contract', () => {
+  assert.deepEqual(canonicalReleaseAssetNames(RELEASE_TAG).sort(), EXPECTED_ASSET_NAMES);
+  assert.deepEqual(Object.keys(PACKAGE_DEFINITIONS).sort(), [
+    'linux-x64',
+    'macos',
+    'macos-x64',
+    'windows'
+  ]);
+});
+
+test('verifySourceRun accepts a successful release-npm run and derives the immutable version', () => {
+  assert.deepEqual(verifySourceRun(baseValidSourceRun(), { releaseTag: RELEASE_TAG }), {
+    releaseTag: RELEASE_TAG,
+    npmVersion: NPM_VERSION,
+    sourceRunId: SOURCE_RUN_ID,
+    sourceRunAttempt: SOURCE_RUN_ATTEMPT,
+    headSha: HEAD_SHA
+  });
+});
+
+test('verifySourceRun rejects malformed tags and mismatched workflow metadata', () => {
+  assert.throws(
+    () => verifySourceRun(baseValidSourceRun(), { releaseTag: 'release-0.4.1' }),
+    /stable vX\.Y\.Z/
+  );
+  assert.throws(
+    () =>
+      verifySourceRun(
+        { ...baseValidSourceRun(), path: '.github/workflows/release-github.yml' },
+        { releaseTag: RELEASE_TAG }
+      ),
+    /release-npm\.yml/
+  );
+  assert.throws(
+    () =>
+      verifySourceRun(
+        { ...baseValidSourceRun(), name: 'Publish GitHub Release' },
+        { releaseTag: RELEASE_TAG }
+      ),
+    /Release npm packages/
+  );
+  assert.throws(
+    () =>
+      verifySourceRun(
+        { ...baseValidSourceRun(), event: 'workflow_dispatch' },
+        { releaseTag: RELEASE_TAG }
+      ),
+    /event push/
+  );
+  assert.throws(
+    () =>
+      verifySourceRun(
+        { ...baseValidSourceRun(), conclusion: 'failure' },
+        { releaseTag: RELEASE_TAG }
+      ),
+    /completed successfully/
+  );
+  assert.throws(
+    () =>
+      verifySourceRun(
+        { ...baseValidSourceRun(), head_branch: 'v0.4.2' },
+        { releaseTag: RELEASE_TAG }
+      ),
+    /source run tag/
+  );
+  assert.throws(
+    () => verifySourceRun({ ...baseValidSourceRun(), run_attempt: 0 }, { releaseTag: RELEASE_TAG }),
+    /source run attempt/
+  );
+});
+
+test('verifyAnnotatedTag rejects lightweight, unsigned, or retargeted tags', () => {
+  assert.doesNotThrow(() =>
+    verifyAnnotatedTag(baseTagRef(), baseTagObject(), {
+      releaseTag: RELEASE_TAG,
+      expectedHeadSha: HEAD_SHA
+    })
+  );
+  assert.throws(
+    () =>
+      verifyAnnotatedTag(
+        { ...baseTagRef(), object: { type: 'commit', sha: HEAD_SHA } },
+        baseTagObject(),
+        { releaseTag: RELEASE_TAG, expectedHeadSha: HEAD_SHA }
+      ),
+    /annotated/
+  );
+  assert.throws(
+    () =>
+      verifyAnnotatedTag(baseTagRef(), { ...baseTagObject(), verification: { verified: false, reason: 'unsigned' } }, {
+        releaseTag: RELEASE_TAG,
+        expectedHeadSha: HEAD_SHA
+      }),
+    /GitHub-verified signature/
+  );
+  assert.throws(
+    () =>
+      verifyAnnotatedTag(baseTagRef(), { ...baseTagObject(), object: { type: 'tree', sha: HEAD_SHA } }, {
+        releaseTag: RELEASE_TAG,
+        expectedHeadSha: HEAD_SHA
+      }),
+    /target a commit/
+  );
+  assert.throws(
+    () =>
+      verifyAnnotatedTag(baseTagRef(), { ...baseTagObject(), object: { type: 'commit', sha: 'f'.repeat(40) } }, {
+        releaseTag: RELEASE_TAG,
+        expectedHeadSha: HEAD_SHA
+      }),
+    /exact source run commit/
+  );
+});
+
+test('verifyReleaseSource requires the tagged commit to stay on origin/main and a stable source date epoch', () => {
+  assert.deepEqual(
+    verifyReleaseSource({
+      releaseTag: RELEASE_TAG,
+      sourceRun: baseValidSourceRun(),
+      tagRef: baseTagRef(),
+      tagObject: baseTagObject(),
+      commitContainedInMain: true,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    }),
+    {
+      releaseTag: RELEASE_TAG,
+      npmVersion: NPM_VERSION,
+      sourceRunId: SOURCE_RUN_ID,
+      sourceRunAttempt: SOURCE_RUN_ATTEMPT,
+      headSha: HEAD_SHA,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    }
+  );
+  assert.throws(
+    () =>
+      verifyReleaseSource({
+        releaseTag: RELEASE_TAG,
+        sourceRun: baseValidSourceRun(),
+        tagRef: baseTagRef(),
+        tagObject: baseTagObject(),
+        commitContainedInMain: false,
+        sourceDateEpoch: SOURCE_DATE_EPOCH
+      }),
+    /origin\/main/
+  );
+  assert.throws(
+    () =>
+      verifyReleaseSource({
+        releaseTag: RELEASE_TAG,
+        sourceRun: baseValidSourceRun(),
+        tagRef: baseTagRef(),
+        tagObject: baseTagObject(),
+        commitContainedInMain: true,
+        sourceDateEpoch: 'bad'
+      }),
+    /SOURCE_DATE_EPOCH/
+  );
+});
+
+test('verifyPackageProvenance accepts the real npm attestation shape for every release package', async () => {
+  await assert.doesNotReject(async () => {
+    await Promise.all(
+      RELEASE_PACKAGES.map((packageName, index) => {
+        const tarballBytes = Buffer.from(`${packageName} tarball fixture ${index}`);
+        return verifyPackageProvenance({
+          packageName,
+          npmVersion: NPM_VERSION,
+          releaseTag: RELEASE_TAG,
+          headSha: HEAD_SHA,
+          sourceRunId: SOURCE_RUN_ID,
+          sourceRunAttempt: SOURCE_RUN_ATTEMPT,
+          packageMetadata: makePackageMetadata(packageName, integrityFor(tarballBytes)),
+          attestationDocument: buildAttestations({
+            packageName,
+            subjectDigest: createHash('sha512').update(tarballBytes).digest('hex')
+          })
+        });
+      })
+    );
+  });
+});
+
+test('verifyPackageProvenance rejects malformed or mismatched attestation payloads, workflow provenance, and GitHub trusted publisher metadata', async () => {
+  const packageName = '@opencoven/cli';
+  const tarballBytes = Buffer.from('npm package tarball fixture');
+  const goodDigest = createHash('sha512').update(tarballBytes).digest('hex');
+  const metadata = makePackageMetadata(packageName, integrityFor(tarballBytes));
+  const base = buildAttestations({ packageName, subjectDigest: goodDigest });
+  const cases = [
+    {
+      name: 'missing trusted publisher attestation',
+      attestationDocument: { attestations: base.attestations.slice(1) },
+      error: /trusted publisher/
+    },
+    {
+      name: 'missing slsa attestation',
+      attestationDocument: { attestations: base.attestations.slice(0, 1) },
+      error: /exactly one npm SLSA provenance attestation/
+    },
+    {
+      name: 'malformed slsa dsse payload',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        slsaPayloadBase64: Buffer.from('{not valid json').toString('base64')
+      }),
+      error: /not valid JSON/
+    },
+    {
+      name: 'duplicate outer-labeled slsa attestations',
+      attestationDocument: {
+        attestations: [
+          ...base.attestations,
+          {
+            predicateType: 'https://slsa.dev/provenance/v1',
+            bundle: {
+              dsseEnvelope: {
+                payload: base.attestations[1].bundle.dsseEnvelope.payload
+              }
+            }
+          }
+        ]
+      },
+      error: /exactly one npm SLSA provenance attestation/
+    },
+    {
+      name: 'missing inner slsa predicate type',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        slsaPayloadBase64: Buffer.from(
+          JSON.stringify({
+            ...JSON.parse(Buffer.from(base.attestations[1].bundle.dsseEnvelope.payload, 'base64').toString('utf8')),
+            predicateType: undefined
+          })
+        ).toString('base64')
+      }),
+      error: /decoded SLSA predicateType must be/
+    },
+    {
+      name: 'mismatched inner slsa predicate type',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        slsaPayloadBase64: Buffer.from(
+          JSON.stringify({
+            ...JSON.parse(Buffer.from(base.attestations[1].bundle.dsseEnvelope.payload, 'base64').toString('utf8')),
+            predicateType: 'https://github.com/npm/attestation/tree/main/specs/publish/v0.1'
+          })
+        ).toString('base64')
+      }),
+      error: /decoded SLSA predicateType must be/
+    },
+    {
+      name: 'legacy percent-encoded slash subject',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        subjectName: `pkg:npm/${encodeURIComponent(packageName)}@${NPM_VERSION}`
+      }),
+      error: /missing subject/
+    },
+    {
+      name: 'digest mismatch',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: '0'.repeat(128)
+      }),
+      error: /dist\.integrity/
+    },
+    {
+      name: 'repository mismatch',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        repository: 'https://github.com/OpenCoven/not-coven'
+      }),
+      error: /provenance repository/
+    },
+    {
+      name: 'workflow path mismatch',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        workflowPathValue: '.github/workflows/release-github.yml'
+      }),
+      error: /release-npm\.yml/
+    },
+    {
+      name: 'tag ref mismatch',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        workflowRef: 'refs/tags/v0.4.2'
+      }),
+      error: /refs\/tags\/v0\.4\.1/
+    },
+    {
+      name: 'git commit mismatch',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        gitCommit: 'f'.repeat(40)
+      }),
+      error: /gitCommit must be/
+    },
+    {
+      name: 'run attempt mismatch',
+      attestationDocument: buildAttestations({
+        packageName,
+        subjectDigest: goodDigest,
+        invocationId: `https://github.com/OpenCoven/coven/actions/runs/${SOURCE_RUN_ID}/attempts/2`
+      }),
+      error: /run attempt/
+    },
+    {
+      name: 'missing GitHub trusted publisher metadata',
+      packageMetadata: makePackageMetadata(packageName, integrityFor(tarballBytes), {
+        npmUser: trustedPublisherMetadata({ trustedPublisher: null })
+      }),
+      error: /trusted publisher metadata/
+    },
+    {
+      name: 'wrong trusted publisher id',
+      packageMetadata: makePackageMetadata(packageName, integrityFor(tarballBytes), {
+        npmUser: trustedPublisherMetadata({ trustedPublisher: { id: 'gitlab' } })
+      }),
+      error: /GitHub trusted publisher/
+    }
+  ];
+
+  for (const { name, attestationDocument, packageMetadata, error } of cases) {
+    await assert.rejects(
+      () =>
+        verifyPackageProvenance({
+          packageName,
+          npmVersion: NPM_VERSION,
+          releaseTag: RELEASE_TAG,
+          headSha: HEAD_SHA,
+          sourceRunId: SOURCE_RUN_ID,
+          sourceRunAttempt: SOURCE_RUN_ATTEMPT,
+          packageMetadata: packageMetadata ?? metadata,
+          attestationDocument: attestationDocument ?? base
+        }),
+      error,
+      name
+    );
+  }
+});
+
+test('packageGitHubRelease emits deterministic canonical assets with normalized archive metadata', () => {
+  withScratchDir('canonical-package', (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+
+    const produced = packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    assert.deepEqual(readdirSync(outputDir).sort(), EXPECTED_ASSET_NAMES);
+    assert.deepEqual(produced.assetNames.sort(), EXPECTED_ASSET_NAMES);
+
+    const checksums = readFileSync(path.join(outputDir, 'SHA256SUMS'), 'utf8');
+    assert.doesNotThrow(() => assertChecksumManifest(checksums, EXPECTED_ARCHIVES));
+
+    const macosArm = parseTarGzEntries(
+      readFileSync(path.join(outputDir, 'coven-v0.4.1-macos-aarch64.tar.gz'))
+    );
+    assert.equal(macosArm.gzipMtime, SOURCE_DATE_EPOCH);
+    assertRootOnlyTarEntries(macosArm.entries, ['coven', 'coven-afs-serve']);
+
+    const linux = parseTarGzEntries(
+      readFileSync(path.join(outputDir, 'coven-v0.4.1-linux-x64.tar.gz'))
+    );
+    assert.equal(linux.gzipMtime, SOURCE_DATE_EPOCH);
+    assertRootOnlyTarEntries(linux.entries, ['coven']);
+
+    const windows = parseZipEntries(
+      readFileSync(path.join(outputDir, 'coven-v0.4.1-windows-x64.zip'))
+    );
+    const zipTimestamp = expectedZipTimestamp(SOURCE_DATE_EPOCH);
+    assert.deepEqual(windows.map((entry) => entry.name), ['coven.exe']);
+    assert.equal(windows[0].method, 0, 'zip output should use stable store mode');
+    assert.equal((windows[0].externalAttributes >>> 16) & 0o777, 0o755);
+    assert.equal(windows[0].dosDate, zipTimestamp.dosDate);
+    assert.equal(windows[0].dosTime, zipTimestamp.dosTime);
+  });
+});
+
+test('packageGitHubRelease is byte-identical across repeated runs with identical fixtures', () => {
+  withScratchDir('deterministic-package', (scratchDir) => {
+    const runOnce = (name) => {
+      const artifactsDir = path.join(scratchDir, `${name}-artifacts`);
+      const outputDir = path.join(scratchDir, `${name}-out`);
+      cpSync(fixtureRoot, artifactsDir, { recursive: true });
+      packageGitHubRelease({
+        releaseTag: RELEASE_TAG,
+        artifactsDir,
+        outputDir,
+        sourceDateEpoch: SOURCE_DATE_EPOCH
+      });
+      return Object.fromEntries(
+        readdirSync(outputDir)
+          .sort()
+          .map((assetName) => [assetName, readFileSync(path.join(outputDir, assetName))])
+      );
+    };
+
+    const first = runOnce('first');
+    const second = runOnce('second');
+    assert.deepEqual(Object.keys(first), Object.keys(second));
+    for (const assetName of Object.keys(first)) {
+      assert.equal(
+        sha256Hex(first[assetName]),
+        sha256Hex(second[assetName]),
+        `${assetName} should be byte-identical across reruns`
+      );
+      assert.deepEqual(
+        first[assetName],
+        second[assetName],
+        `${assetName} bytes should not drift across reruns`
+      );
+    }
+  });
+});
+
+test('packageGitHubRelease rejects missing or extra source artifact files', () => {
+  withScratchDir('invalid-artifacts', (scratchDir) => {
+    const missingArtifactsDir = path.join(scratchDir, 'missing');
+    cpSync(fixtureRoot, missingArtifactsDir, { recursive: true });
+    rmSync(path.join(missingArtifactsDir, 'coven-macos', 'coven-afs-serve'));
+    assert.throws(
+      () =>
+        packageGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          artifactsDir: missingArtifactsDir,
+          outputDir: path.join(scratchDir, 'missing-out'),
+          sourceDateEpoch: SOURCE_DATE_EPOCH
+        }),
+      /missing required file/
+    );
+
+    const extraArtifactsDir = path.join(scratchDir, 'extra');
+    cpSync(fixtureRoot, extraArtifactsDir, { recursive: true });
+    writeFileSync(path.join(extraArtifactsDir, 'coven-linux-x64', 'extra.txt'), 'unexpected\n');
+    assert.throws(
+      () =>
+        packageGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          artifactsDir: extraArtifactsDir,
+          outputDir: path.join(scratchDir, 'extra-out'),
+          sourceDateEpoch: SOURCE_DATE_EPOCH
+        }),
+      /unexpected files/
+    );
+  });
+});
+
+test('assertChecksumManifest rejects self entries, duplicates, path-qualified names, missing assets, and non-lexical order', () => {
+  assert.throws(() => assertChecksumManifest('', EXPECTED_ARCHIVES), /exactly four non-empty entries/);
+  assert.throws(
+    () =>
+      assertChecksumManifest(
+        [
+          `${'a'.repeat(64)}  ${EXPECTED_ARCHIVES[0]}`,
+          `${'b'.repeat(64)}  SHA256SUMS`,
+          `${'c'.repeat(64)}  ${EXPECTED_ARCHIVES[1]}`,
+          `${'d'.repeat(64)}  ${EXPECTED_ARCHIVES[2]}`
+        ].join('\n'),
+        EXPECTED_ARCHIVES
+      ),
+    /must not checksum SHA256SUMS/
+  );
+  assert.throws(
+    () =>
+      assertChecksumManifest(
+        [
+          `${'a'.repeat(64)}  ${EXPECTED_ARCHIVES[0]}`,
+          `${'b'.repeat(64)}  ${EXPECTED_ARCHIVES[0]}`,
+          `${'c'.repeat(64)}  ${EXPECTED_ARCHIVES[1]}`,
+          `${'d'.repeat(64)}  ${EXPECTED_ARCHIVES[2]}`
+        ].join('\n'),
+        EXPECTED_ARCHIVES
+      ),
+    /duplicate/
+  );
+  assert.throws(
+    () =>
+      assertChecksumManifest(
+        [
+          `${'a'.repeat(64)}  archives/${EXPECTED_ARCHIVES[0]}`,
+          `${'b'.repeat(64)}  ${EXPECTED_ARCHIVES[1]}`,
+          `${'c'.repeat(64)}  ${EXPECTED_ARCHIVES[2]}`,
+          `${'d'.repeat(64)}  ${EXPECTED_ARCHIVES[3]}`
+        ].join('\n'),
+        EXPECTED_ARCHIVES
+      ),
+    /bare filenames/
+  );
+  assert.throws(
+    () =>
+      assertChecksumManifest(
+        [
+          `${'a'.repeat(64)}  ${EXPECTED_ARCHIVES[1]}`,
+          `${'b'.repeat(64)}  ${EXPECTED_ARCHIVES[0]}`,
+          `${'c'.repeat(64)}  ${EXPECTED_ARCHIVES[2]}`,
+          `${'d'.repeat(64)}  ${EXPECTED_ARCHIVES[3]}`
+        ].join('\n'),
+        EXPECTED_ARCHIVES
+      ),
+    /lexically sorted/
+  );
+  assert.throws(
+    () =>
+      assertChecksumManifest(
+        [
+          `${'a'.repeat(64)}  ${EXPECTED_ARCHIVES[0]}`,
+          `${'b'.repeat(64)}  ${EXPECTED_ARCHIVES[1]}`,
+          `${'c'.repeat(64)}  ${EXPECTED_ARCHIVES[2]}`,
+          `${'d'.repeat(64)}  z-extra.tar.gz`
+        ].join('\n'),
+        EXPECTED_ARCHIVES
+      ),
+    /exact canonical asset names/
+  );
+});
+
+test('syncGitHubRelease creates a missing release and uploads every canonical asset with tag notes', async () => {
+  await withScratchDir('sync-create', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const client = fakeReleaseClient();
+    const result = await syncGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      outputDir,
+      releaseClient: client
+    });
+
+    assert.deepEqual(client.state.created, [
+      { releaseTag: RELEASE_TAG, title: 'Coven v0.4.1', notesFromTag: true }
+    ]);
+    assert.deepEqual(result.uploaded.sort(), EXPECTED_ASSET_NAMES);
+    assert.deepEqual(result.skipped, []);
+  });
+});
+
+test('syncGitHubRelease skips matching assets, uploads only missing ones, and fails closed on mismatches or extras', async () => {
+  await withScratchDir('sync-recover', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const checksumBytes = readFileSync(path.join(outputDir, 'SHA256SUMS'));
+    const matchingClient = fakeReleaseClient({
+      existingRelease: {
+        tagName: RELEASE_TAG,
+        assets: [{ id: 1, name: 'SHA256SUMS' }]
+      },
+      assetBytesByName: { SHA256SUMS: checksumBytes }
+    });
+    const matchingResult = await syncGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      outputDir,
+      releaseClient: matchingClient
+    });
+    assert.deepEqual(matchingResult.skipped, ['SHA256SUMS']);
+    assert.equal(matchingClient.state.uploads.length, EXPECTED_ASSET_NAMES.length - 1);
+
+    const mismatchedClient = fakeReleaseClient({
+      existingRelease: {
+        tagName: RELEASE_TAG,
+        assets: [{ id: 1, name: 'SHA256SUMS' }]
+      },
+      assetBytesByName: { SHA256SUMS: Buffer.from('wrong checksums\n') }
+    });
+    await assert.rejects(
+      () =>
+        syncGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          outputDir,
+          releaseClient: mismatchedClient
+        }),
+      /observed hash .* expected hash .* delete only the mismatched GitHub asset/i
+    );
+    assert.equal(mismatchedClient.state.uploads.length, 0);
+
+    const extraClient = fakeReleaseClient({
+      existingRelease: {
+        tagName: RELEASE_TAG,
+        assets: [{ id: 1, name: 'unexpected.txt' }]
+      }
+    });
+    await assert.rejects(
+      () =>
+        syncGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          outputDir,
+          releaseClient: extraClient
+        }),
+      /unexpected release assets/
+    );
+
+    const duplicateClient = fakeReleaseClient({
+      existingRelease: {
+        tagName: RELEASE_TAG,
+        assets: [
+          { id: 1, name: 'SHA256SUMS' },
+          { id: 2, name: 'SHA256SUMS' }
+        ]
+      },
+      assetBytesByName: { SHA256SUMS: checksumBytes }
+    });
+    await assert.rejects(
+      () =>
+        syncGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          outputDir,
+          releaseClient: duplicateClient
+        }),
+      /duplicate release assets/
+    );
+  });
+});

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -1652,12 +1652,65 @@ test('syncGitHubRelease skips a fully matching rerun, including >1 MiB assets, w
     const matchingResult = await syncGitHubRelease({
       releaseTag: RELEASE_TAG,
       outputDir,
+      expectedTagObjectSha: baseTagRef().object.sha,
+      expectedHeadSha: HEAD_SHA,
       releaseClient: matchingClient
     });
 
+    assert.deepEqual(matchingClient.state.revalidated, [
+      {
+        releaseTag: RELEASE_TAG,
+        expectedTagObjectSha: baseTagRef().object.sha,
+        expectedHeadSha: HEAD_SHA
+      }
+    ]);
     assert.deepEqual(matchingResult.skipped, EXPECTED_ASSET_NAMES);
     assert.deepEqual(matchingResult.uploaded, []);
     assert.equal(matchingClient.state.uploads.length, 0);
+  });
+});
+
+test('syncGitHubRelease refuses a fully matching rerun when the verified remote tag moved', async () => {
+  await withScratchDir('sync-full-match-tag-race', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const client = fakeReleaseClient({
+      existingRelease: baseExistingRelease({
+        assets: EXPECTED_ASSET_NAMES.map((name, index) => ({ id: index + 1, name }))
+      }),
+      assetBytesByName: Object.fromEntries(
+        EXPECTED_ASSET_NAMES.map((assetName) => [
+          assetName,
+          readFileSync(path.join(outputDir, assetName))
+        ])
+      ),
+      revalidateTagState() {
+        throw new Error(
+          `Refusing GitHub release: ${RELEASE_TAG} tag object SHA changed from ${baseTagRef().object.sha} to ${'2'.repeat(40)}.`
+        );
+      }
+    });
+
+    await assert.rejects(
+      () =>
+        syncGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          outputDir,
+          expectedTagObjectSha: baseTagRef().object.sha,
+          expectedHeadSha: HEAD_SHA,
+          releaseClient: client
+        }),
+      /tag object SHA/i
+    );
+    assert.equal(client.state.uploads.length, 0);
   });
 });
 

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -61,6 +61,7 @@ function writeSignatureAuditLockfile(
     resolvedPackages = RELEASE_PACKAGES,
     rootDependencies = releasePackageVersionMap(),
     versionOverrides = {},
+    packageEntryOverrides = {},
     lockfileVersion = 3
   } = {}
 ) {
@@ -70,7 +71,8 @@ function writeSignatureAuditLockfile(
       {
         version: versionOverrides[packageName] ?? NPM_VERSION,
         resolved: `https://registry.npmjs.org/${encodeURIComponent(packageName)}/-/${packageName.split('/').at(-1)}-${versionOverrides[packageName] ?? NPM_VERSION}.tgz`,
-        integrity: `sha512-${Buffer.from(packageName).toString('base64')}`
+        integrity: `sha512-${Buffer.from(packageName).toString('base64')}`,
+        ...packageEntryOverrides[packageName]
       }
     ])
   );
@@ -890,6 +892,41 @@ test('verifyNpmRegistrySignatures rejects wrong-version package-lock entries bef
           }
         }),
       new RegExp(`${wrongPackage}.*0\\.4\\.1`)
+    );
+    assert.deepEqual(calls, [
+      {
+        command: 'npm',
+        args: ['install', '--package-lock-only', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
+        cwd: path.resolve(auditDir)
+      }
+    ]);
+  });
+});
+
+test('verifyNpmRegistrySignatures rejects package-lock entries missing resolved tarball URLs before auditing', () => {
+  withScratchDir('npm-signatures-audit-missing-resolved', (scratchDir) => {
+    const auditDir = path.join(scratchDir, 'audit');
+    const calls = [];
+    const wrongPackage = '@opencoven/cli-macos';
+    assert.throws(
+      () =>
+        verifyNpmRegistrySignatures({
+          npmVersion: NPM_VERSION,
+          auditDir,
+          commandRunner(command, args, options = {}) {
+            calls.push({ command, args, cwd: options.cwd });
+            if (args[0] === 'install') {
+              writeSignatureAuditLockfile(auditDir, {
+                packageEntryOverrides: {
+                  [wrongPackage]: {
+                    resolved: undefined
+                  }
+                }
+              });
+            }
+          }
+        }),
+      new RegExp(`package-lock\\.json entry node_modules/${wrongPackage}.*missing a resolved tarball URL`)
     );
     assert.deepEqual(calls, [
       {

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -13,6 +13,7 @@ import {
   packageGitHubRelease,
   syncGitHubRelease,
   verifyAnnotatedTag,
+  verifyNpmRegistrySignatures,
   verifyPackageProvenance,
   verifyReleaseSource,
   verifySourceRun
@@ -420,6 +421,14 @@ test('release-github workflow supports automatic and recovery triggers with pinn
     workflowText,
     /node scripts\/package-github-release\.mjs verify-npm-provenance/
   );
+  assert.match(
+    workflowText,
+    /node scripts\/package-github-release\.mjs verify-npm-signatures/
+  );
+  assert.match(
+    workflowText,
+    /--audit-dir github-release-npm-audit/
+  );
   assert.match(workflowText, /node scripts\/package-github-release\.mjs package/);
   assert.match(workflowText, /node scripts\/package-github-release\.mjs sync-release/);
   assert.match(workflowText, new RegExp(`actions/checkout@${CHECKOUT_ACTION_SHA}`));
@@ -543,6 +552,14 @@ test('verifyAnnotatedTag rejects lightweight, unsigned, or retargeted tags', () 
   );
   assert.throws(
     () =>
+      verifyAnnotatedTag(baseTagRef(), { ...baseTagObject(), tag: 'v0.4.2' }, {
+        releaseTag: RELEASE_TAG,
+        expectedHeadSha: HEAD_SHA
+      }),
+    /must name tag v0\.4\.1/
+  );
+  assert.throws(
+    () =>
       verifyAnnotatedTag(baseTagRef(), { ...baseTagObject(), object: { type: 'tree', sha: HEAD_SHA } }, {
         releaseTag: RELEASE_TAG,
         expectedHeadSha: HEAD_SHA
@@ -566,6 +583,8 @@ test('verifyReleaseSource requires the tagged commit to stay on origin/main and 
       sourceRun: baseValidSourceRun(),
       tagRef: baseTagRef(),
       tagObject: baseTagObject(),
+      localTagObjectSha: baseTagRef().object.sha,
+      localHeadSha: HEAD_SHA,
       commitContainedInMain: true,
       sourceDateEpoch: SOURCE_DATE_EPOCH
     }),
@@ -585,6 +604,36 @@ test('verifyReleaseSource requires the tagged commit to stay on origin/main and 
         sourceRun: baseValidSourceRun(),
         tagRef: baseTagRef(),
         tagObject: baseTagObject(),
+        localTagObjectSha: '2'.repeat(40),
+        localHeadSha: HEAD_SHA,
+        commitContainedInMain: true,
+        sourceDateEpoch: SOURCE_DATE_EPOCH
+      }),
+    /exact GitHub-verified tag object/
+  );
+  assert.throws(
+    () =>
+      verifyReleaseSource({
+        releaseTag: RELEASE_TAG,
+        sourceRun: baseValidSourceRun(),
+        tagRef: baseTagRef(),
+        tagObject: baseTagObject(),
+        localTagObjectSha: baseTagRef().object.sha,
+        localHeadSha: 'f'.repeat(40),
+        commitContainedInMain: true,
+        sourceDateEpoch: SOURCE_DATE_EPOCH
+      }),
+    /exact source run commit/
+  );
+  assert.throws(
+    () =>
+      verifyReleaseSource({
+        releaseTag: RELEASE_TAG,
+        sourceRun: baseValidSourceRun(),
+        tagRef: baseTagRef(),
+        tagObject: baseTagObject(),
+        localTagObjectSha: baseTagRef().object.sha,
+        localHeadSha: HEAD_SHA,
         commitContainedInMain: false,
         sourceDateEpoch: SOURCE_DATE_EPOCH
       }),
@@ -597,11 +646,76 @@ test('verifyReleaseSource requires the tagged commit to stay on origin/main and 
         sourceRun: baseValidSourceRun(),
         tagRef: baseTagRef(),
         tagObject: baseTagObject(),
+        localTagObjectSha: baseTagRef().object.sha,
+        localHeadSha: HEAD_SHA,
         commitContainedInMain: true,
         sourceDateEpoch: 'bad'
       }),
     /SOURCE_DATE_EPOCH/
   );
+});
+
+test('verifyNpmRegistrySignatures writes an isolated exact-version audit context and invokes npm audit signatures', () => {
+  withScratchDir('npm-signatures-audit', (scratchDir) => {
+    const auditDir = path.join(scratchDir, 'audit');
+    const calls = [];
+    const result = verifyNpmRegistrySignatures({
+      npmVersion: NPM_VERSION,
+      auditDir,
+      commandRunner(command, args, options = {}) {
+        calls.push({ command, args, cwd: options.cwd });
+      }
+    });
+
+    assert.equal(result.auditDir, path.resolve(auditDir));
+    assert.deepEqual(result.packageNames, RELEASE_PACKAGES);
+    assert.equal(result.npmVersion, NPM_VERSION);
+    assert.deepEqual(
+      JSON.parse(readFileSync(path.join(auditDir, 'package.json'), 'utf8')),
+      {
+        name: 'opencoven-release-npm-signatures-audit',
+        private: true,
+        version: '0.0.0',
+        dependencies: Object.fromEntries(
+          RELEASE_PACKAGES.map((packageName) => [packageName, NPM_VERSION])
+        )
+      }
+    );
+    assert.deepEqual(calls, [
+      {
+        command: 'npm',
+        args: ['install', '--package-lock-only', '--ignore-scripts', '--audit=false', '--fund=false'],
+        cwd: path.resolve(auditDir)
+      },
+      {
+        command: 'npm',
+        args: ['audit', 'signatures', '--package-lock-only'],
+        cwd: path.resolve(auditDir)
+      }
+    ]);
+  });
+});
+
+test('verifyNpmRegistrySignatures fails closed before auditing when package-lock generation fails', () => {
+  withScratchDir('npm-signatures-audit-fail', (scratchDir) => {
+    const auditDir = path.join(scratchDir, 'audit');
+    const calls = [];
+    assert.throws(
+      () =>
+        verifyNpmRegistrySignatures({
+          npmVersion: NPM_VERSION,
+          auditDir,
+          commandRunner(command, args) {
+            calls.push([command, ...args].join(' '));
+            throw new Error('npm install failed');
+          }
+        }),
+      /npm install failed/
+    );
+    assert.deepEqual(calls, [
+      'npm install --package-lock-only --ignore-scripts --audit=false --fund=false'
+    ]);
+  });
 });
 
 test('verifyPackageProvenance accepts the real npm attestation shape for every release package', async () => {
@@ -790,6 +904,54 @@ test('verifyPackageProvenance rejects malformed or mismatched attestation payloa
           attestationDocument: attestationDocument ?? base
         }),
       error,
+      name
+    );
+  }
+});
+
+test('verifyPackageProvenance rejects malformed sha512 SRI digests before comparing attestations', async () => {
+  const packageName = '@opencoven/cli';
+  const tarballBytes = Buffer.from('npm package tarball fixture');
+  const goodDigest = createHash('sha512').update(tarballBytes).digest('hex');
+  const attestationDocument = buildAttestations({ packageName, subjectDigest: goodDigest });
+  const canonicalIntegrity = integrityFor(tarballBytes);
+  const cases = [
+    {
+      name: 'empty digest',
+      integrity: 'sha512-'
+    },
+    {
+      name: 'malformed base64',
+      integrity: 'sha512-***'
+    },
+    {
+      name: 'noncanonical base64 without required padding',
+      integrity: canonicalIntegrity.replace(/=+$/, '')
+    },
+    {
+      name: 'wrong-length digest that decodes to 63 bytes',
+      integrity: `sha512-${Buffer.alloc(63).toString('base64')}`
+    },
+    {
+      name: 'wrong-length digest that decodes to 65 bytes',
+      integrity: `sha512-${Buffer.alloc(65).toString('base64')}`
+    }
+  ];
+
+  for (const { name, integrity } of cases) {
+    await assert.rejects(
+      () =>
+        verifyPackageProvenance({
+          packageName,
+          npmVersion: NPM_VERSION,
+          releaseTag: RELEASE_TAG,
+          headSha: HEAD_SHA,
+          sourceRunId: SOURCE_RUN_ID,
+          sourceRunAttempt: SOURCE_RUN_ATTEMPT,
+          packageMetadata: makePackageMetadata(packageName, integrity),
+          attestationDocument
+        }),
+      /canonical sha512 SRI string/,
       name
     );
   }
@@ -1084,5 +1246,42 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
         }),
       /duplicate release assets/
     );
+  });
+});
+
+test('syncGitHubRelease preflights later mismatches before uploading earlier missing assets', async () => {
+  await withScratchDir('sync-preflight-mismatch', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const windowsAssetName = 'coven-v0.4.1-windows-x64.zip';
+    const client = fakeReleaseClient({
+      existingRelease: {
+        tagName: RELEASE_TAG,
+        assets: [{ id: 1, name: windowsAssetName }]
+      },
+      assetBytesByName: {
+        [windowsAssetName]: Buffer.from('wrong windows bytes\n')
+      }
+    });
+
+    await assert.rejects(
+      () =>
+        syncGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          outputDir,
+          releaseClient: client
+        }),
+      /asset .*windows.* mismatch/i
+    );
+    assert.deepEqual(client.state.downloads, [windowsAssetName]);
+    assert.equal(client.state.uploads.length, 0);
   });
 });

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -655,7 +655,7 @@ test('verifyReleaseSource requires the tagged commit to stay on origin/main and 
   );
 });
 
-test('verifyNpmRegistrySignatures writes an isolated exact-version audit context and invokes npm audit signatures', () => {
+test('verifyNpmRegistrySignatures writes an isolated cross-platform exact-version audit context and invokes real npm audit signatures', () => {
   withScratchDir('npm-signatures-audit', (scratchDir) => {
     const auditDir = path.join(scratchDir, 'audit');
     const calls = [];
@@ -676,7 +676,7 @@ test('verifyNpmRegistrySignatures writes an isolated exact-version audit context
         name: 'opencoven-release-npm-signatures-audit',
         private: true,
         version: '0.0.0',
-        dependencies: Object.fromEntries(
+        optionalDependencies: Object.fromEntries(
           RELEASE_PACKAGES.map((packageName) => [packageName, NPM_VERSION])
         )
       }
@@ -684,12 +684,12 @@ test('verifyNpmRegistrySignatures writes an isolated exact-version audit context
     assert.deepEqual(calls, [
       {
         command: 'npm',
-        args: ['install', '--package-lock-only', '--ignore-scripts', '--audit=false', '--fund=false'],
+        args: ['install', '--ignore-scripts', '--audit=false', '--fund=false'],
         cwd: path.resolve(auditDir)
       },
       {
         command: 'npm',
-        args: ['audit', 'signatures', '--package-lock-only'],
+        args: ['audit', 'signatures'],
         cwd: path.resolve(auditDir)
       }
     ]);
@@ -713,7 +713,7 @@ test('verifyNpmRegistrySignatures fails closed before auditing when package-lock
       /npm install failed/
     );
     assert.deepEqual(calls, [
-      'npm install --package-lock-only --ignore-scripts --audit=false --fund=false'
+      'npm install --ignore-scripts --audit=false --fund=false'
     ]);
   });
 });

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -9,6 +9,7 @@ import { gunzipSync } from 'node:zlib';
 import {
   PACKAGE_DEFINITIONS,
   assertChecksumManifest,
+  captureCommandOutputToFile,
   canonicalReleaseAssetNames,
   packageGitHubRelease,
   syncGitHubRelease,
@@ -56,7 +57,12 @@ function releasePackageVersionMap(version = NPM_VERSION) {
 
 function writeSignatureAuditLockfile(
   auditDir,
-  { resolvedPackages = RELEASE_PACKAGES, versionOverrides = {} } = {}
+  {
+    resolvedPackages = RELEASE_PACKAGES,
+    rootDependencies = releasePackageVersionMap(),
+    versionOverrides = {},
+    lockfileVersion = 3
+  } = {}
 ) {
   const packageEntries = Object.fromEntries(
     resolvedPackages.map((packageName) => [
@@ -68,22 +74,46 @@ function writeSignatureAuditLockfile(
       }
     ])
   );
+  const rootDependencyEntries = Object.fromEntries(
+    Object.entries(rootDependencies).map(([packageName, version]) => [
+      packageName,
+      {
+        version,
+        resolved: `https://registry.npmjs.org/${encodeURIComponent(packageName)}/-/${packageName.split('/').at(-1)}-${version}.tgz`,
+        integrity: `sha512-${Buffer.from(packageName).toString('base64')}`
+      }
+    ])
+  );
   writeFileSync(
     path.join(auditDir, 'package-lock.json'),
-    `${JSON.stringify({
-      name: 'opencoven-release-npm-signatures-audit',
-      version: '0.0.0',
-      lockfileVersion: 3,
-      requires: true,
-      packages: {
-        '': {
-          name: 'opencoven-release-npm-signatures-audit',
-          version: '0.0.0',
-          dependencies: releasePackageVersionMap()
-        },
-        ...packageEntries
-      }
-    }, null, 2)}\n`
+    `${
+      JSON.stringify(
+        lockfileVersion === 1
+          ? {
+              name: 'opencoven-release-npm-signatures-audit',
+              version: '0.0.0',
+              lockfileVersion,
+              requires: true,
+              dependencies: rootDependencyEntries
+            }
+          : {
+              name: 'opencoven-release-npm-signatures-audit',
+              version: '0.0.0',
+              lockfileVersion,
+              requires: true,
+              packages: {
+                '': {
+                  name: 'opencoven-release-npm-signatures-audit',
+                  version: '0.0.0',
+                  dependencies: rootDependencies
+                },
+                ...packageEntries
+              }
+            },
+        null,
+        2
+      )
+    }\n`
   );
 }
 
@@ -403,9 +433,13 @@ function fakeReleaseClient({ existingRelease = null, assetBytesByName = {} } = {
       state.release = { tagName: releaseTag, assets: [] };
       return state.release;
     },
-    async downloadAsset(asset) {
+    async downloadAsset(asset, filePath) {
       state.downloads.push(asset.name);
-      return assetBytesByName[asset.name];
+      const bytes = assetBytesByName[asset.name];
+      if (!bytes) {
+        throw new Error(`missing fake asset bytes for ${asset.name}`);
+      }
+      writeFileSync(filePath, bytes);
     },
     async uploadAsset({ releaseTag, assetName, filePath }) {
       state.uploads.push({ releaseTag, assetName, bytes: readFileSync(filePath) });
@@ -733,6 +767,48 @@ test('verifyNpmRegistrySignatures writes an isolated cross-platform exact-versio
       {
         command: 'npm',
         args: ['audit', 'signatures'],
+        cwd: path.resolve(auditDir)
+      }
+    ]);
+  });
+});
+
+test('verifyNpmRegistrySignatures rejects extra root dependencies after the full install rewrites package-lock.json', () => {
+  withScratchDir('npm-signatures-audit-extra-root-postinstall', (scratchDir) => {
+    const auditDir = path.join(scratchDir, 'audit');
+    const calls = [];
+    assert.throws(
+      () =>
+        verifyNpmRegistrySignatures({
+          npmVersion: NPM_VERSION,
+          auditDir,
+          commandRunner(command, args, options = {}) {
+            calls.push({ command, args, cwd: options.cwd });
+            if (args[0] === 'install' && args.includes('--package-lock-only')) {
+              writeSignatureAuditLockfile(auditDir);
+              return;
+            }
+            if (args[0] === 'install') {
+              writeSignatureAuditLockfile(auditDir, {
+                rootDependencies: {
+                  ...releasePackageVersionMap(),
+                  'left-pad': '1.3.0'
+                }
+              });
+            }
+          }
+        }),
+      /left-pad/
+    );
+    assert.deepEqual(calls, [
+      {
+        command: 'npm',
+        args: ['install', '--package-lock-only', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
+        cwd: path.resolve(auditDir)
+      },
+      {
+        command: 'npm',
+        args: ['install', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
         cwd: path.resolve(auditDir)
       }
     ]);
@@ -1245,6 +1321,21 @@ test('assertChecksumManifest rejects self entries, duplicates, path-qualified na
   );
 });
 
+test('captureCommandOutputToFile writes stdout larger than spawnSync maxBuffer directly to disk', () => {
+  withScratchDir('capture-command-output', (scratchDir) => {
+    const outputPath = path.join(scratchDir, 'large-stdout.bin');
+    const byteCount = (1024 * 1024) + 4096;
+    captureCommandOutputToFile(
+      process.execPath,
+      ['-e', `process.stdout.write(Buffer.alloc(${byteCount}, 0x61));`],
+      { filePath: outputPath }
+    );
+    const outputBytes = readFileSync(outputPath);
+    assert.equal(outputBytes.length, byteCount);
+    assert.equal(outputBytes.subarray(0, 4).toString('utf8'), 'aaaa');
+  });
+});
+
 test('syncGitHubRelease creates a missing release and uploads every canonical asset with tag notes', async () => {
   await withScratchDir('sync-create', async (scratchDir) => {
     const artifactsDir = path.join(scratchDir, 'artifacts');
@@ -1269,6 +1360,50 @@ test('syncGitHubRelease creates a missing release and uploads every canonical as
     ]);
     assert.deepEqual(result.uploaded.sort(), EXPECTED_ASSET_NAMES);
     assert.deepEqual(result.skipped, []);
+  });
+});
+
+test('syncGitHubRelease skips a fully matching rerun, including >1 MiB assets, without uploading', async () => {
+  await withScratchDir('sync-large-match', async (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+
+    const windowsDefinition = PACKAGE_DEFINITIONS.windows;
+    const windowsBinaryPath = path.join(artifactsDir, windowsDefinition.artifactName, 'coven.exe');
+    writeFileSync(
+      windowsBinaryPath,
+      Buffer.concat([readFileSync(windowsBinaryPath), Buffer.alloc(1_250_000, 0x61)])
+    );
+
+    packageGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+
+    const windowsArchiveName = windowsDefinition.assetName(NPM_VERSION);
+    assert.ok(readFileSync(path.join(outputDir, windowsArchiveName)).length > 1024 * 1024);
+
+    const matchingClient = fakeReleaseClient({
+      existingRelease: {
+        tagName: RELEASE_TAG,
+        assets: EXPECTED_ASSET_NAMES.map((name, index) => ({ id: index + 1, name }))
+      },
+      assetBytesByName: Object.fromEntries(
+        EXPECTED_ASSET_NAMES.map((assetName) => [assetName, readFileSync(path.join(outputDir, assetName))])
+      )
+    });
+    const matchingResult = await syncGitHubRelease({
+      releaseTag: RELEASE_TAG,
+      outputDir,
+      releaseClient: matchingClient
+    });
+
+    assert.deepEqual(matchingResult.skipped, EXPECTED_ASSET_NAMES);
+    assert.deepEqual(matchingResult.uploaded, []);
+    assert.equal(matchingClient.state.uploads.length, 0);
   });
 });
 

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -50,6 +50,43 @@ const EXPECTED_ARCHIVES = [
 ].sort();
 const EXPECTED_ASSET_NAMES = [...EXPECTED_ARCHIVES, 'SHA256SUMS'].sort();
 
+function releasePackageVersionMap(version = NPM_VERSION) {
+  return Object.fromEntries(RELEASE_PACKAGES.map((packageName) => [packageName, version]));
+}
+
+function writeSignatureAuditLockfile(
+  auditDir,
+  { resolvedPackages = RELEASE_PACKAGES, versionOverrides = {} } = {}
+) {
+  const packageEntries = Object.fromEntries(
+    resolvedPackages.map((packageName) => [
+      `node_modules/${packageName}`,
+      {
+        version: versionOverrides[packageName] ?? NPM_VERSION,
+        resolved: `https://registry.npmjs.org/${encodeURIComponent(packageName)}/-/${packageName.split('/').at(-1)}-${versionOverrides[packageName] ?? NPM_VERSION}.tgz`,
+        integrity: `sha512-${Buffer.from(packageName).toString('base64')}`
+      }
+    ])
+  );
+  writeFileSync(
+    path.join(auditDir, 'package-lock.json'),
+    `${JSON.stringify({
+      name: 'opencoven-release-npm-signatures-audit',
+      version: '0.0.0',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': {
+          name: 'opencoven-release-npm-signatures-audit',
+          version: '0.0.0',
+          dependencies: releasePackageVersionMap()
+        },
+        ...packageEntries
+      }
+    }, null, 2)}\n`
+  );
+}
+
 function withScratchDir(name, fn) {
   const dir = path.join(scratchRoot, `${name}-${randomUUID()}`);
   mkdirSync(dir, { recursive: true });
@@ -664,6 +701,9 @@ test('verifyNpmRegistrySignatures writes an isolated cross-platform exact-versio
       auditDir,
       commandRunner(command, args, options = {}) {
         calls.push({ command, args, cwd: options.cwd });
+        if (args[0] === 'install') {
+          writeSignatureAuditLockfile(auditDir);
+        }
       }
     });
 
@@ -676,15 +716,18 @@ test('verifyNpmRegistrySignatures writes an isolated cross-platform exact-versio
         name: 'opencoven-release-npm-signatures-audit',
         private: true,
         version: '0.0.0',
-        optionalDependencies: Object.fromEntries(
-          RELEASE_PACKAGES.map((packageName) => [packageName, NPM_VERSION])
-        )
+        dependencies: releasePackageVersionMap()
       }
     );
     assert.deepEqual(calls, [
       {
         command: 'npm',
-        args: ['install', '--ignore-scripts', '--audit=false', '--fund=false'],
+        args: ['install', '--package-lock-only', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
+        cwd: path.resolve(auditDir)
+      },
+      {
+        command: 'npm',
+        args: ['install', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
         cwd: path.resolve(auditDir)
       },
       {
@@ -713,7 +756,71 @@ test('verifyNpmRegistrySignatures fails closed before auditing when package-lock
       /npm install failed/
     );
     assert.deepEqual(calls, [
-      'npm install --ignore-scripts --audit=false --fund=false'
+      'npm install --package-lock-only --ignore-scripts --force --no-audit --no-fund'
+    ]);
+  });
+});
+
+test('verifyNpmRegistrySignatures fails closed when a native package is absent from package-lock.json', () => {
+  withScratchDir('npm-signatures-audit-missing-native', (scratchDir) => {
+    const auditDir = path.join(scratchDir, 'audit');
+    const calls = [];
+    const missingPackage = '@opencoven/cli-windows';
+    assert.throws(
+      () =>
+        verifyNpmRegistrySignatures({
+          npmVersion: NPM_VERSION,
+          auditDir,
+          commandRunner(command, args, options = {}) {
+            calls.push({ command, args, cwd: options.cwd });
+            if (args[0] === 'install') {
+              writeSignatureAuditLockfile(auditDir, {
+                resolvedPackages: RELEASE_PACKAGES.filter((packageName) => packageName !== missingPackage)
+              });
+            }
+          }
+        }),
+      new RegExp(`package-lock\\.json.*${missingPackage}`)
+    );
+    assert.deepEqual(calls, [
+      {
+        command: 'npm',
+        args: ['install', '--package-lock-only', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
+        cwd: path.resolve(auditDir)
+      }
+    ]);
+  });
+});
+
+test('verifyNpmRegistrySignatures rejects wrong-version package-lock entries before auditing', () => {
+  withScratchDir('npm-signatures-audit-wrong-version', (scratchDir) => {
+    const auditDir = path.join(scratchDir, 'audit');
+    const calls = [];
+    const wrongPackage = '@opencoven/cli-macos';
+    assert.throws(
+      () =>
+        verifyNpmRegistrySignatures({
+          npmVersion: NPM_VERSION,
+          auditDir,
+          commandRunner(command, args, options = {}) {
+            calls.push({ command, args, cwd: options.cwd });
+            if (args[0] === 'install') {
+              writeSignatureAuditLockfile(auditDir, {
+                versionOverrides: {
+                  [wrongPackage]: '9.9.9'
+                }
+              });
+            }
+          }
+        }),
+      new RegExp(`${wrongPackage}.*0\\.4\\.1`)
+    );
+    assert.deepEqual(calls, [
+      {
+        command: 'npm',
+        args: ['install', '--package-lock-only', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
+        cwd: path.resolve(auditDir)
+      }
     ]);
   });
 });

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -2,7 +2,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { closeSync, mkdirSync, openSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { gzipSync } from 'node:zlib';
@@ -629,7 +629,7 @@ export function verifyNpmRegistrySignatures({
     ['install', '--package-lock-only', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
     { cwd: normalizedAuditDir }
   );
-  const packageLockEntries = assertReleasePackagesResolvedInLockfile({
+  assertReleasePackagesResolvedInLockfile({
     auditDir: normalizedAuditDir,
     npmVersion: normalizedVersion
   });
@@ -638,6 +638,10 @@ export function verifyNpmRegistrySignatures({
     ['install', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
     { cwd: normalizedAuditDir }
   );
+  const packageLockEntries = assertReleasePackagesResolvedInLockfile({
+    auditDir: normalizedAuditDir,
+    npmVersion: normalizedVersion
+  });
   commandRunner('npm', ['audit', 'signatures'], {
     cwd: normalizedAuditDir
   });
@@ -646,6 +650,79 @@ export function verifyNpmRegistrySignatures({
     packageNames: [...RELEASE_PACKAGES],
     npmVersion: normalizedVersion,
     packageLockEntries
+  };
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function packageLockRootDependencies(packageLock) {
+  const rootPackageDependencies = packageLock?.packages?.['']?.dependencies;
+  if (isPlainObject(rootPackageDependencies)) {
+    return {
+      dependencies: rootPackageDependencies,
+      source: 'packages[""].dependencies'
+    };
+  }
+  if (!isPlainObject(packageLock?.packages) && isPlainObject(packageLock?.dependencies)) {
+    return {
+      dependencies: Object.fromEntries(
+        Object.entries(packageLock.dependencies).map(([packageName, entry]) => [
+          packageName,
+          typeof entry === 'string' ? entry : entry?.version
+        ])
+      ),
+      source: 'dependencies'
+    };
+  }
+  throw new Error(
+    'Refusing GitHub release: package-lock.json must record the exact five @opencoven dependencies in packages[""].dependencies (lockfile v2+) or dependencies (lockfile v1).'
+  );
+}
+
+function assertExactReleaseRootDependencies({ rootDependencies, source, npmVersion }) {
+  const expectedNames = [...RELEASE_PACKAGES].sort();
+  const actualNames = Object.keys(rootDependencies).sort();
+  const missingNames = expectedNames.filter((packageName) => !actualNames.includes(packageName));
+  const extraNames = actualNames.filter((packageName) => !expectedNames.includes(packageName));
+  if (missingNames.length > 0 || extraNames.length > 0) {
+    const details = [
+      missingNames.length > 0 ? `missing root dependencies: ${missingNames.join(', ')}` : null,
+      extraNames.length > 0 ? `unexpected root dependencies: ${extraNames.join(', ')}` : null
+    ].filter(Boolean);
+    throw new Error(
+      `Refusing GitHub release: package-lock.json must declare exactly the five release packages in ${source}; ${details.join('; ')}.`
+    );
+  }
+  for (const packageName of expectedNames) {
+    const declaredVersion = rootDependencies[packageName];
+    if (declaredVersion !== npmVersion) {
+      throw new Error(
+        `Refusing GitHub release: package-lock.json must declare ${packageName}@${npmVersion} in ${source}, got ${JSON.stringify(declaredVersion)}.`
+      );
+    }
+  }
+}
+
+function resolvedPackageLockEntry(packageLock, packageName) {
+  const packagePath = `node_modules/${packageName}`;
+  const packageEntry = packageLock?.packages?.[packagePath];
+  if (isPlainObject(packageEntry)) {
+    return {
+      entry: packageEntry,
+      source: packagePath
+    };
+  }
+  if (!isPlainObject(packageLock?.packages) && isPlainObject(packageLock?.dependencies?.[packageName])) {
+    return {
+      entry: packageLock.dependencies[packageName],
+      source: `dependencies.${packageName}`
+    };
+  }
+  return {
+    entry: null,
+    source: isPlainObject(packageLock?.packages) ? packagePath : `dependencies.${packageName}`
   };
 }
 
@@ -659,27 +736,19 @@ function assertReleasePackagesResolvedInLockfile({ auditDir, npmVersion }) {
       `Refusing GitHub release: failed to read ${packageLockPath}: ${error?.message ?? String(error)}`
     );
   }
-  const rootEntry = packageLock?.packages?.[''];
-  const rootDependencies = rootEntry?.dependencies;
-  if (!rootDependencies || typeof rootDependencies !== 'object' || Array.isArray(rootDependencies)) {
-    throw new Error(
-      `Refusing GitHub release: package-lock.json must record the exact five @opencoven dependencies in packages[""].dependencies.`
-    );
-  }
+  const { dependencies: rootDependencies, source: rootDependencySource } = packageLockRootDependencies(packageLock);
+  assertExactReleaseRootDependencies({
+    rootDependencies,
+    source: rootDependencySource,
+    npmVersion
+  });
 
   const entries = {};
   for (const packageName of RELEASE_PACKAGES) {
-    const declaredVersion = rootDependencies[packageName];
-    if (declaredVersion !== npmVersion) {
+    const { entry: packageEntry, source: packageEntrySource } = resolvedPackageLockEntry(packageLock, packageName);
+    if (!packageEntry) {
       throw new Error(
-        `Refusing GitHub release: package-lock.json must declare ${packageName}@${npmVersion} in packages[""].dependencies, got ${JSON.stringify(declaredVersion)}.`
-      );
-    }
-    const packagePath = `node_modules/${packageName}`;
-    const packageEntry = packageLock?.packages?.[packagePath];
-    if (!packageEntry || typeof packageEntry !== 'object' || Array.isArray(packageEntry)) {
-      throw new Error(
-        `Refusing GitHub release: package-lock.json is missing resolved entry ${packagePath} for ${packageName}@${npmVersion}.`
+        `Refusing GitHub release: package-lock.json is missing resolved entry ${packageEntrySource} for ${packageName}@${npmVersion}.`
       );
     }
     if (packageEntry.version !== npmVersion) {
@@ -953,8 +1022,8 @@ export async function syncGitHubRelease({
       `Refusing GitHub release: ${normalizedOutputDir} must contain the exact canonical assets ${expectedAssetNames.join(', ')}.`
     );
   }
-  const expectedBytesByName = new Map(
-    expectedAssetNames.map((assetName) => [assetName, readFileSync(path.join(normalizedOutputDir, assetName))])
+  const expectedHashesByName = new Map(
+    expectedAssetNames.map((assetName) => [assetName, sha256Hex(readFileSync(path.join(normalizedOutputDir, assetName)))])
   );
 
   let release = await releaseClient.getReleaseByTag(releaseTag);
@@ -981,7 +1050,7 @@ export async function syncGitHubRelease({
   }
   const existingAssetsByName = new Map(existingAssets.map((asset) => [asset.name, asset]));
   const extraAssets = [...existingAssetsByName.keys()]
-    .filter((assetName) => !expectedBytesByName.has(assetName))
+    .filter((assetName) => !expectedHashesByName.has(assetName))
     .sort();
   if (extraAssets.length > 0) {
     throw new Error(
@@ -993,31 +1062,44 @@ export async function syncGitHubRelease({
   const uploaded = [];
   const skipped = [];
   const missingAssetNames = [];
-  for (const assetName of expectedAssetNames) {
-    const existingAsset = existingAssetsByName.get(assetName);
-    if (!existingAsset) {
-      missingAssetNames.push(assetName);
-      continue;
+  const downloadDir = path.join(normalizedOutputDir, '.release-sync-downloads');
+  rmSync(downloadDir, { recursive: true, force: true });
+  mkdirSync(downloadDir, { recursive: true });
+  try {
+    for (const assetName of expectedAssetNames) {
+      const existingAsset = existingAssetsByName.get(assetName);
+      if (!existingAsset) {
+        missingAssetNames.push(assetName);
+        continue;
+      }
+      const defaultDownloadPath = path.join(downloadDir, assetName);
+      const downloadResult = await releaseClient.downloadAsset(existingAsset, defaultDownloadPath);
+      let observedAssetPath = defaultDownloadPath;
+      if (Buffer.isBuffer(downloadResult)) {
+        writeFileSync(defaultDownloadPath, downloadResult);
+      } else if (typeof downloadResult === 'string' && downloadResult.trim() !== '') {
+        observedAssetPath = path.resolve(downloadResult);
+      }
+      const observedHash = sha256Hex(readFileSync(observedAssetPath));
+      const expectedHash = expectedHashesByName.get(assetName);
+      if (observedHash !== expectedHash) {
+        throw new Error(
+          `Refusing GitHub release: asset ${assetName} mismatch: observed hash ${observedHash}, expected hash ${expectedHash}. ` +
+            'Record the observed hash, expected hash, and reason, delete only the mismatched GitHub asset through an audited operator action, then rerun this GitHub-only workflow. Never move/reuse the tag and never republish npm.'
+        );
+      }
+      skipped.push(assetName);
     }
-    const expectedBytes = expectedBytesByName.get(assetName);
-    const observedBytes = await releaseClient.downloadAsset(existingAsset);
-    const observedHash = sha256Hex(observedBytes);
-    const expectedHash = sha256Hex(expectedBytes);
-    if (observedHash !== expectedHash) {
-      throw new Error(
-        `Refusing GitHub release: asset ${assetName} mismatch: observed hash ${observedHash}, expected hash ${expectedHash}. ` +
-          'Record the observed hash, expected hash, and reason, delete only the mismatched GitHub asset through an audited operator action, then rerun this GitHub-only workflow. Never move/reuse the tag and never republish npm.'
-      );
+    for (const assetName of missingAssetNames) {
+      await releaseClient.uploadAsset({
+        releaseTag,
+        assetName,
+        filePath: path.join(normalizedOutputDir, assetName)
+      });
+      uploaded.push(assetName);
     }
-    skipped.push(assetName);
-  }
-  for (const assetName of missingAssetNames) {
-    await releaseClient.uploadAsset({
-      releaseTag,
-      assetName,
-      filePath: path.join(normalizedOutputDir, assetName)
-    });
-    uploaded.push(assetName);
+  } finally {
+    rmSync(downloadDir, { recursive: true, force: true });
   }
 
   return {
@@ -1098,23 +1180,17 @@ function createGhReleaseClient({ repository = process.env.GITHUB_REPOSITORY } = 
       }
       return release;
     },
-    async downloadAsset(asset) {
+    async downloadAsset(asset, filePath) {
       const assetUrl = asset?.url;
       if (!assetUrl) {
         throw new Error(`GitHub release asset ${asset?.name ?? '(unknown)'} has no API URL.`);
       }
       const endpoint = new URL(assetUrl).pathname;
-      const result = spawnCapture('gh', ['api', '-H', 'Accept: application/octet-stream', endpoint], {
-        encoding: null
-      });
-      if (result.error) {
-        throw new Error(result.error.message);
-      }
-      if (result.status !== 0) {
-        const stderr = bufferToTrimmedString(result.stderr);
-        throw new Error(stderr || `gh api ${endpoint} exited with ${result.status}.`);
-      }
-      return Buffer.from(result.stdout);
+      return captureCommandOutputToFile(
+        'gh',
+        ['api', '-H', 'Accept: application/octet-stream', endpoint],
+        { filePath }
+      );
     },
     async uploadAsset({ releaseTag, filePath }) {
       runCommand('gh', ['release', 'upload', releaseTag, filePath, '--repo', repository]);
@@ -1214,6 +1290,50 @@ function toNonNegativeInteger(value, label) {
 
 function isSha(value) {
   return typeof value === 'string' && /^[0-9a-f]{40}$/i.test(value);
+}
+
+export function captureCommandOutputToFile(
+  command,
+  args,
+  { filePath, cwd = repoRoot, env = process.env } = {}
+) {
+  const normalizedFilePathInput = String(filePath ?? '').trim();
+  if (!normalizedFilePathInput) {
+    throw new Error('Refusing GitHub release: capture output file path is required.');
+  }
+  const normalizedFilePath = path.resolve(normalizedFilePathInput);
+  mkdirSync(path.dirname(normalizedFilePath), { recursive: true });
+
+  let outputHandle;
+  let captureError;
+  try {
+    outputHandle = openSync(normalizedFilePath, 'w');
+    const result = spawnSync(command, args, {
+      cwd,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', outputHandle, 'pipe']
+    });
+    if (result.error) {
+      throw new Error(result.error.message);
+    }
+    if (result.status !== 0) {
+      const printable = [command, ...args].join(' ');
+      const stderr = bufferToTrimmedString(result.stderr);
+      throw new Error(stderr || `${printable} exited with ${result.status}.`);
+    }
+    return normalizedFilePath;
+  } catch (error) {
+    captureError = error;
+    throw error;
+  } finally {
+    if (outputHandle !== undefined) {
+      closeSync(outputHandle);
+    }
+    if (captureError) {
+      rmSync(normalizedFilePath, { force: true });
+    }
+  }
 }
 
 function runCommand(command, args, { encoding = 'utf8', cwd = repoRoot, env = process.env } = {}) {

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -1242,7 +1242,7 @@ export async function syncGitHubRelease({
       }
       skipped.push(assetName);
     }
-    if (missingAssetNames.length > 0) {
+    if (!createdRelease || missingAssetNames.length > 0) {
       await releaseClient.revalidateTag({
         releaseTag,
         expectedTagObjectSha,

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -619,17 +619,17 @@ export function verifyNpmRegistrySignatures({
       name: 'opencoven-release-npm-signatures-audit',
       private: true,
       version: '0.0.0',
-      dependencies: Object.fromEntries(
+      optionalDependencies: Object.fromEntries(
         RELEASE_PACKAGES.map((packageName) => [packageName, normalizedVersion])
       )
     }, null, 2)}\n`
   );
   commandRunner(
     'npm',
-    ['install', '--package-lock-only', '--ignore-scripts', '--audit=false', '--fund=false'],
+    ['install', '--ignore-scripts', '--audit=false', '--fund=false'],
     { cwd: normalizedAuditDir }
   );
-  commandRunner('npm', ['audit', 'signatures', '--package-lock-only'], {
+  commandRunner('npm', ['audit', 'signatures'], {
     cwd: normalizedAuditDir
   });
   return {

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -97,13 +97,15 @@ async function main() {
       const result = await resolveReleaseSource({
         repository: requiredOption(options, 'repository'),
         releaseTag: requiredOption(options, 'release-tag'),
-        sourceRunId: requiredOption(options, 'source-run-id')
+        sourceRunId: requiredOption(options, 'source-run-id'),
+        sourceRunAttempt: requiredOption(options, 'source-run-attempt')
       });
       process.stdout.write(
         [
           `release_tag=${result.releaseTag}`,
           `npm_version=${result.npmVersion}`,
           `head_sha=${result.headSha}`,
+          `tag_object_sha=${result.tagObjectSha}`,
           `source_run_id=${result.sourceRunId}`,
           `source_run_attempt=${result.sourceRunAttempt}`,
           `source_date_epoch=${result.sourceDateEpoch}`,
@@ -142,6 +144,8 @@ async function main() {
       await syncGitHubRelease({
         releaseTag: requiredOption(options, 'release-tag'),
         outputDir: requiredOption(options, 'output-dir'),
+        expectedTagObjectSha: requiredOption(options, 'expected-tag-object-sha'),
+        expectedHeadSha: requiredOption(options, 'expected-head-sha'),
         releaseClient: createGhReleaseClient({
           repository: requiredOption(options, 'repository')
         })
@@ -187,10 +191,27 @@ export function canonicalReleaseAssetNames(releaseTag) {
   ];
 }
 
-export function verifySourceRun(sourceRun, { releaseTag }) {
+export function verifySourceRun(sourceRun, {
+  releaseTag,
+  expectedSourceRunId,
+  expectedSourceRunAttempt
+}) {
   const { npmVersion } = parseReleaseTag(releaseTag);
   const sourceRunId = toPositiveIntegerString(sourceRun?.id, 'source run id');
   const sourceRunAttempt = toPositiveInteger(sourceRun?.run_attempt, 'source run attempt');
+  if (expectedSourceRunId && sourceRunId !== toPositiveIntegerString(expectedSourceRunId, 'source run id')) {
+    throw new Error(
+      `Refusing GitHub release: source run payload ${sourceRunId} does not match requested run ${expectedSourceRunId}.`
+    );
+  }
+  if (
+    expectedSourceRunAttempt &&
+    sourceRunAttempt !== toPositiveInteger(expectedSourceRunAttempt, 'source run attempt')
+  ) {
+    throw new Error(
+      `Refusing GitHub release: source run attempt payload ${sourceRunAttempt} does not match requested attempt ${expectedSourceRunAttempt}.`
+    );
+  }
   if (sourceRun?.name !== WORKFLOW_NAME) {
     throw new Error(
       `Refusing GitHub release: source run ${sourceRunId} must be ${WORKFLOW_NAME}, got ${JSON.stringify(sourceRun?.name)}.`
@@ -306,13 +327,65 @@ export function verifyReleaseSource({
   const normalizedSourceDateEpoch = toNonNegativeInteger(sourceDateEpoch, 'SOURCE_DATE_EPOCH');
   return {
     ...sourceContext,
+    tagObjectSha: tagContext.tagObjectSha,
     sourceDateEpoch: normalizedSourceDateEpoch
   };
 }
 
-export async function resolveReleaseSource({ repository, releaseTag, sourceRunId, ghApi = ghApiJson, git = createGitClient() }) {
+export function assertRemoteTagMatchesVerifiedContext({
+  releaseTag,
+  expectedTagObjectSha,
+  expectedHeadSha,
+  tagRef,
+  tagObject
+}) {
+  if (!isSha(expectedTagObjectSha)) {
+    throw new Error(
+      `Refusing GitHub release: expected verified tag object SHA for ${releaseTag}, got ${JSON.stringify(expectedTagObjectSha)}.`
+    );
+  }
+  if (!isSha(expectedHeadSha)) {
+    throw new Error(
+      `Refusing GitHub release: expected verified source commit SHA for ${releaseTag}, got ${JSON.stringify(expectedHeadSha)}.`
+    );
+  }
+  const remoteTagContext = verifyAnnotatedTag(tagRef, tagObject, {
+    releaseTag,
+    expectedHeadSha
+  });
+  if (remoteTagContext.tagObjectSha !== expectedTagObjectSha) {
+    throw new Error(
+      `Refusing GitHub release: ${releaseTag} tag object SHA changed from ${expectedTagObjectSha} to ${remoteTagContext.tagObjectSha}.`
+    );
+  }
+  return remoteTagContext;
+}
+
+export async function resolveReleaseSource({
+  repository,
+  releaseTag,
+  sourceRunId,
+  sourceRunAttempt,
+  ghApi = ghApiJson,
+  git = createGitClient()
+}) {
   const normalizedSourceRunId = toPositiveIntegerString(sourceRunId, 'source run id');
-  const sourceRun = await ghApi(`/repos/${repository}/actions/runs/${normalizedSourceRunId}`);
+  const normalizedSourceRunAttempt = toPositiveIntegerString(sourceRunAttempt, 'source run attempt');
+  const latestSourceRun = await ghApi(`/repos/${repository}/actions/runs/${normalizedSourceRunId}`);
+  const sourceRun = await ghApi(
+    `/repos/${repository}/actions/runs/${normalizedSourceRunId}/attempts/${normalizedSourceRunAttempt}`
+  );
+  const sourceContext = verifySourceRun(sourceRun, {
+    releaseTag,
+    expectedSourceRunId: normalizedSourceRunId,
+    expectedSourceRunAttempt: normalizedSourceRunAttempt
+  });
+  const latestRunAttempt = toPositiveInteger(latestSourceRun?.run_attempt, 'latest source run attempt');
+  if (latestRunAttempt !== sourceContext.sourceRunAttempt) {
+    throw new Error(
+      `Refusing GitHub release: source run ${normalizedSourceRunId} latest run attempt ${latestRunAttempt} does not match selected attempt ${sourceContext.sourceRunAttempt}; actions/download-artifact is run-id only, so old-attempt artifacts are ambiguous or unavailable after a rerun.`
+    );
+  }
   const tagRef = await ghApi(`/repos/${repository}/git/ref/tags/${encodeURIComponent(releaseTag)}`);
   if (tagRef?.object?.type !== 'tag') {
     return verifyReleaseSource({
@@ -1012,6 +1085,8 @@ export function assertChecksumManifest(text, expectedNames) {
 export async function syncGitHubRelease({
   releaseTag,
   outputDir,
+  expectedTagObjectSha,
+  expectedHeadSha,
   releaseClient = createGhReleaseClient()
 }) {
   const expectedAssetNames = canonicalReleaseAssetNames(releaseTag).sort();
@@ -1029,10 +1104,16 @@ export async function syncGitHubRelease({
   let release = await releaseClient.getReleaseByTag(releaseTag);
   let createdRelease = false;
   if (!release) {
+    await releaseClient.revalidateTag({
+      releaseTag,
+      expectedTagObjectSha,
+      expectedHeadSha
+    });
     release = await releaseClient.createRelease({
       releaseTag,
       title: `Coven ${releaseTag}`,
-      notesFromTag: true
+      notesFromTag: true,
+      verifyTag: true
     });
     createdRelease = true;
   }
@@ -1168,10 +1249,13 @@ function createGhReleaseClient({ repository = process.env.GITHUB_REPOSITORY } = 
       }
       return JSON.parse(result.stdout);
     },
-    async createRelease({ releaseTag, title, notesFromTag }) {
+    async createRelease({ releaseTag, title, notesFromTag, verifyTag }) {
       const args = ['release', 'create', releaseTag, '--repo', repository, '--title', title];
       if (notesFromTag) {
         args.push('--notes-from-tag');
+      }
+      if (verifyTag) {
+        args.push('--verify-tag');
       }
       runCommand('gh', args);
       const release = await this.getReleaseByTag(releaseTag);
@@ -1179,6 +1263,64 @@ function createGhReleaseClient({ repository = process.env.GITHUB_REPOSITORY } = 
         throw new Error(`GitHub release ${releaseTag} was created but could not be reloaded.`);
       }
       return release;
+    },
+    async revalidateTag({ releaseTag, expectedTagObjectSha, expectedHeadSha }) {
+      const refEndpoint = `/repos/${repository}/git/ref/tags/${encodeURIComponent(releaseTag)}`;
+      const refResult = spawnCapture('gh', ['api', refEndpoint], { encoding: 'utf8' });
+      if (refResult.error) {
+        throw new Error(refResult.error.message);
+      }
+      if (refResult.status !== 0) {
+        const stderr = String(refResult.stderr ?? '').trim();
+        if (/404/.test(stderr)) {
+          throw new Error(
+            `Refusing GitHub release: ${releaseTag} no longer resolves to refs/tags/${releaseTag}.`
+          );
+        }
+        throw new Error(stderr || `gh api ${refEndpoint} exited with ${refResult.status}.`);
+      }
+      const tagRef = JSON.parse(refResult.stdout);
+      if (tagRef?.object?.type !== 'tag' || !isSha(tagRef?.object?.sha)) {
+        assertRemoteTagMatchesVerifiedContext({
+          releaseTag,
+          expectedTagObjectSha,
+          expectedHeadSha,
+          tagRef,
+          tagObject: {
+            tag: releaseTag,
+            object: {
+              type: tagRef?.object?.type,
+              sha: tagRef?.object?.sha
+            },
+            verification: {
+              verified: false,
+              reason: 'remote-ref-mismatch'
+            }
+          }
+        });
+      }
+      const tagObjectEndpoint = `/repos/${repository}/git/tags/${tagRef?.object?.sha ?? ''}`;
+      const tagObjectResult = spawnCapture('gh', ['api', tagObjectEndpoint], { encoding: 'utf8' });
+      if (tagObjectResult.error) {
+        throw new Error(tagObjectResult.error.message);
+      }
+      if (tagObjectResult.status !== 0) {
+        const stderr = String(tagObjectResult.stderr ?? '').trim();
+        if (/404/.test(stderr)) {
+          throw new Error(
+            `Refusing GitHub release: annotated tag object ${tagRef?.object?.sha ?? '(missing)'} for ${releaseTag} no longer exists.`
+          );
+        }
+        throw new Error(stderr || `gh api ${tagObjectEndpoint} exited with ${tagObjectResult.status}.`);
+      }
+      const tagObject = JSON.parse(tagObjectResult.stdout);
+      assertRemoteTagMatchesVerifiedContext({
+        releaseTag,
+        expectedTagObjectSha,
+        expectedHeadSha,
+        tagRef,
+        tagObject
+      });
     },
     async downloadAsset(asset, filePath) {
       const assetUrl = asset?.url;

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -619,14 +619,23 @@ export function verifyNpmRegistrySignatures({
       name: 'opencoven-release-npm-signatures-audit',
       private: true,
       version: '0.0.0',
-      optionalDependencies: Object.fromEntries(
+      dependencies: Object.fromEntries(
         RELEASE_PACKAGES.map((packageName) => [packageName, normalizedVersion])
       )
     }, null, 2)}\n`
   );
   commandRunner(
     'npm',
-    ['install', '--ignore-scripts', '--audit=false', '--fund=false'],
+    ['install', '--package-lock-only', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
+    { cwd: normalizedAuditDir }
+  );
+  const packageLockEntries = assertReleasePackagesResolvedInLockfile({
+    auditDir: normalizedAuditDir,
+    npmVersion: normalizedVersion
+  });
+  commandRunner(
+    'npm',
+    ['install', '--ignore-scripts', '--force', '--no-audit', '--no-fund'],
     { cwd: normalizedAuditDir }
   );
   commandRunner('npm', ['audit', 'signatures'], {
@@ -635,8 +644,60 @@ export function verifyNpmRegistrySignatures({
   return {
     auditDir: normalizedAuditDir,
     packageNames: [...RELEASE_PACKAGES],
-    npmVersion: normalizedVersion
+    npmVersion: normalizedVersion,
+    packageLockEntries
   };
+}
+
+function assertReleasePackagesResolvedInLockfile({ auditDir, npmVersion }) {
+  const packageLockPath = path.join(auditDir, 'package-lock.json');
+  let packageLock;
+  try {
+    packageLock = JSON.parse(readFileSync(packageLockPath, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `Refusing GitHub release: failed to read ${packageLockPath}: ${error?.message ?? String(error)}`
+    );
+  }
+  const rootEntry = packageLock?.packages?.[''];
+  const rootDependencies = rootEntry?.dependencies;
+  if (!rootDependencies || typeof rootDependencies !== 'object' || Array.isArray(rootDependencies)) {
+    throw new Error(
+      `Refusing GitHub release: package-lock.json must record the exact five @opencoven dependencies in packages[""].dependencies.`
+    );
+  }
+
+  const entries = {};
+  for (const packageName of RELEASE_PACKAGES) {
+    const declaredVersion = rootDependencies[packageName];
+    if (declaredVersion !== npmVersion) {
+      throw new Error(
+        `Refusing GitHub release: package-lock.json must declare ${packageName}@${npmVersion} in packages[""].dependencies, got ${JSON.stringify(declaredVersion)}.`
+      );
+    }
+    const packagePath = `node_modules/${packageName}`;
+    const packageEntry = packageLock?.packages?.[packagePath];
+    if (!packageEntry || typeof packageEntry !== 'object' || Array.isArray(packageEntry)) {
+      throw new Error(
+        `Refusing GitHub release: package-lock.json is missing resolved entry ${packagePath} for ${packageName}@${npmVersion}.`
+      );
+    }
+    if (packageEntry.version !== npmVersion) {
+      throw new Error(
+        `Refusing GitHub release: package-lock.json resolved ${packageName}@${packageEntry.version ?? '<missing>'}; expected ${npmVersion}.`
+      );
+    }
+    if (typeof packageEntry.resolved !== 'string' || packageEntry.resolved.trim() === '') {
+      throw new Error(
+        `Refusing GitHub release: package-lock.json entry ${packagePath} for ${packageName}@${npmVersion} is missing a resolved tarball URL.`
+      );
+    }
+    entries[packageName] = {
+      version: packageEntry.version,
+      resolved: packageEntry.resolved
+    };
+  }
+  return entries;
 }
 
 export function packageGitHubRelease({ releaseTag, artifactsDir, outputDir, sourceDateEpoch }) {

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -758,7 +758,7 @@ function assertReleasePackagesResolvedInLockfile({ auditDir, npmVersion }) {
     }
     if (typeof packageEntry.resolved !== 'string' || packageEntry.resolved.trim() === '') {
       throw new Error(
-        `Refusing GitHub release: package-lock.json entry ${packagePath} for ${packageName}@${npmVersion} is missing a resolved tarball URL.`
+        `Refusing GitHub release: package-lock.json entry ${packageEntrySource} for ${packageName}@${npmVersion} is missing a resolved tarball URL.`
       );
     }
     entries[packageName] = {

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -87,7 +87,7 @@ async function main() {
   const [command, ...args] = process.argv.slice(2);
   if (!command) {
     throw new Error(
-      'Usage: package-github-release.mjs <verify-source-run|verify-npm-provenance|verify-npm-signatures|package|sync-release> [--option value ...]'
+      'Usage: package-github-release.mjs <verify-source-run|verify-source-run-attempt|verify-npm-provenance|verify-npm-signatures|package|sync-release> [--option value ...]'
     );
   }
 
@@ -112,6 +112,15 @@ async function main() {
           ''
         ].join('\n')
       );
+      return;
+    }
+    case 'verify-source-run-attempt': {
+      await verifyLatestSourceRunAttempt({
+        repository: requiredOption(options, 'repository'),
+        releaseTag: requiredOption(options, 'release-tag'),
+        sourceRunId: requiredOption(options, 'source-run-id'),
+        sourceRunAttempt: requiredOption(options, 'source-run-attempt')
+      });
       return;
     }
     case 'verify-npm-provenance': {
@@ -361,6 +370,42 @@ export function assertRemoteTagMatchesVerifiedContext({
   return remoteTagContext;
 }
 
+function assertLatestSourceRunAttempt(latestSourceRun, {
+  releaseTag,
+  expectedSourceRunId,
+  expectedSourceRunAttempt
+}) {
+  const normalizedSourceRunId = toPositiveIntegerString(expectedSourceRunId, 'source run id');
+  const normalizedSourceRunAttempt = toPositiveIntegerString(expectedSourceRunAttempt, 'source run attempt');
+  const latestRunAttempt = toPositiveInteger(latestSourceRun?.run_attempt, 'latest source run attempt');
+  if (latestRunAttempt !== toPositiveInteger(normalizedSourceRunAttempt, 'source run attempt')) {
+    throw new Error(
+      `Refusing GitHub release: source run ${normalizedSourceRunId} latest run attempt ${latestRunAttempt} does not match selected attempt ${normalizedSourceRunAttempt}; actions/download-artifact is run-id only, so old-attempt artifacts are ambiguous or unavailable after a rerun.`
+    );
+  }
+  return verifySourceRun(latestSourceRun, {
+    releaseTag,
+    expectedSourceRunId: normalizedSourceRunId,
+    expectedSourceRunAttempt: normalizedSourceRunAttempt
+  });
+}
+
+export async function verifyLatestSourceRunAttempt({
+  repository,
+  releaseTag,
+  sourceRunId,
+  sourceRunAttempt,
+  ghApi = ghApiJson
+}) {
+  const normalizedSourceRunId = toPositiveIntegerString(sourceRunId, 'source run id');
+  const latestSourceRun = await ghApi(`/repos/${repository}/actions/runs/${normalizedSourceRunId}`);
+  return assertLatestSourceRunAttempt(latestSourceRun, {
+    releaseTag,
+    expectedSourceRunId: normalizedSourceRunId,
+    expectedSourceRunAttempt: sourceRunAttempt
+  });
+}
+
 export async function resolveReleaseSource({
   repository,
   releaseTag,
@@ -380,12 +425,11 @@ export async function resolveReleaseSource({
     expectedSourceRunId: normalizedSourceRunId,
     expectedSourceRunAttempt: normalizedSourceRunAttempt
   });
-  const latestRunAttempt = toPositiveInteger(latestSourceRun?.run_attempt, 'latest source run attempt');
-  if (latestRunAttempt !== sourceContext.sourceRunAttempt) {
-    throw new Error(
-      `Refusing GitHub release: source run ${normalizedSourceRunId} latest run attempt ${latestRunAttempt} does not match selected attempt ${sourceContext.sourceRunAttempt}; actions/download-artifact is run-id only, so old-attempt artifacts are ambiguous or unavailable after a rerun.`
-    );
-  }
+  assertLatestSourceRunAttempt(latestSourceRun, {
+    releaseTag,
+    expectedSourceRunId: normalizedSourceRunId,
+    expectedSourceRunAttempt: sourceContext.sourceRunAttempt
+  });
   const tagRef = await ghApi(`/repos/${repository}/git/ref/tags/${encodeURIComponent(releaseTag)}`);
   if (tagRef?.object?.type !== 'tag') {
     return verifyReleaseSource({
@@ -1082,6 +1126,31 @@ export function assertChecksumManifest(text, expectedNames) {
   }
 }
 
+function assertExistingReleaseMetadata(release, releaseTag) {
+  const actualTagName = String(release?.tag_name ?? release?.tagName ?? '').trim();
+  if (actualTagName !== releaseTag) {
+    throw new Error(
+      `Refusing GitHub release: existing release tag must be ${releaseTag}, got ${JSON.stringify(actualTagName || null)}.`
+    );
+  }
+  const expectedTitle = `Coven ${releaseTag}`;
+  if (release?.name !== expectedTitle) {
+    throw new Error(
+      `Refusing GitHub release: existing release title must be ${JSON.stringify(expectedTitle)}, got ${JSON.stringify(release?.name)}.`
+    );
+  }
+  if (release?.draft !== false) {
+    throw new Error(
+      'Refusing GitHub release: existing release must not be a draft; draft=false is required for recovery.'
+    );
+  }
+  if (release?.prerelease !== false) {
+    throw new Error(
+      'Refusing GitHub release: existing release must not be a prerelease; prerelease=false is required for recovery.'
+    );
+  }
+}
+
 export async function syncGitHubRelease({
   releaseTag,
   outputDir,
@@ -1116,6 +1185,8 @@ export async function syncGitHubRelease({
       verifyTag: true
     });
     createdRelease = true;
+  } else {
+    assertExistingReleaseMetadata(release, releaseTag);
   }
 
   const existingAssets = Array.isArray(release?.assets) ? release.assets : [];
@@ -1170,6 +1241,13 @@ export async function syncGitHubRelease({
         );
       }
       skipped.push(assetName);
+    }
+    if (missingAssetNames.length > 0) {
+      await releaseClient.revalidateTag({
+        releaseTag,
+        expectedTagObjectSha,
+        expectedHeadSha
+      });
     }
     for (const assetName of missingAssetNames) {
       await releaseClient.uploadAsset({

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -1,0 +1,1104 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+import { parseReleaseTag } from './release-npm-context.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const WORKFLOW_NAME = 'Release npm packages';
+const WORKFLOW_PATH = '.github/workflows/release-npm.yml';
+const REPOSITORY_URL = 'https://github.com/OpenCoven/coven';
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org';
+const TRUSTED_PUBLISHER_PREDICATE =
+  'https://github.com/npm/attestation/tree/main/specs/publish/v0.1';
+const SLSA_PREDICATE = 'https://slsa.dev/provenance/v1';
+const CHECKSUMS_NAME = 'SHA256SUMS';
+const ZIP_VERSION = 20;
+const ZIP_UTF8_FLAG = 0x0800;
+const ZIP_STORE_METHOD = 0;
+const TRUSTED_PUBLISHER_NAME = 'GitHub Actions';
+const TRUSTED_PUBLISHER_EMAIL = 'npm-oidc-no-reply@github.com';
+const TRUSTED_PUBLISHER_ID = 'github';
+const RELEASE_PACKAGES = [
+  '@opencoven/cli',
+  '@opencoven/cli-linux-x64',
+  '@opencoven/cli-windows',
+  '@opencoven/cli-macos-x64',
+  '@opencoven/cli-macos'
+];
+
+export const PACKAGE_DEFINITIONS = {
+  macos: {
+    artifactName: 'coven-macos',
+    expectedFiles: ['coven', 'coven-afs-serve'],
+    assetName: (npmVersion) => `coven-v${npmVersion}-macos-aarch64.tar.gz`,
+    format: 'tar.gz'
+  },
+  'macos-x64': {
+    artifactName: 'coven-macos-x64',
+    expectedFiles: ['coven', 'coven-afs-serve'],
+    assetName: (npmVersion) => `coven-v${npmVersion}-macos-x64.tar.gz`,
+    format: 'tar.gz'
+  },
+  'linux-x64': {
+    artifactName: 'coven-linux-x64',
+    expectedFiles: ['coven'],
+    assetName: (npmVersion) => `coven-v${npmVersion}-linux-x64.tar.gz`,
+    format: 'tar.gz'
+  },
+  windows: {
+    artifactName: 'coven-windows',
+    expectedFiles: ['coven.exe'],
+    assetName: (npmVersion) => `coven-v${npmVersion}-windows-x64.zip`,
+    format: 'zip'
+  }
+};
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) === 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+})();
+
+function isMainModule(argv1 = process.argv[1], moduleUrl = import.meta.url) {
+  return Boolean(argv1) && pathToFileURL(argv1).href === moduleUrl;
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error?.message ?? String(error));
+    process.exit(1);
+  });
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (!command) {
+    throw new Error(
+      'Usage: package-github-release.mjs <verify-source-run|verify-npm-provenance|package|sync-release> [--option value ...]'
+    );
+  }
+
+  const options = parseOptions(args);
+  switch (command) {
+    case 'verify-source-run': {
+      const result = await resolveReleaseSource({
+        repository: requiredOption(options, 'repository'),
+        releaseTag: requiredOption(options, 'release-tag'),
+        sourceRunId: requiredOption(options, 'source-run-id')
+      });
+      process.stdout.write(
+        [
+          `release_tag=${result.releaseTag}`,
+          `npm_version=${result.npmVersion}`,
+          `head_sha=${result.headSha}`,
+          `source_run_id=${result.sourceRunId}`,
+          `source_run_attempt=${result.sourceRunAttempt}`,
+          `source_date_epoch=${result.sourceDateEpoch}`,
+          ''
+        ].join('\n')
+      );
+      return;
+    }
+    case 'verify-npm-provenance': {
+      await verifyAllPackageProvenance({
+        releaseTag: requiredOption(options, 'release-tag'),
+        npmVersion: requiredOption(options, 'npm-version'),
+        headSha: requiredOption(options, 'head-sha'),
+        sourceRunId: requiredOption(options, 'source-run-id'),
+        sourceRunAttempt: requiredOption(options, 'source-run-attempt')
+      });
+      return;
+    }
+    case 'package': {
+      packageGitHubRelease({
+        releaseTag: requiredOption(options, 'release-tag'),
+        artifactsDir: requiredOption(options, 'artifacts-dir'),
+        outputDir: requiredOption(options, 'output-dir'),
+        sourceDateEpoch: requiredOption(options, 'source-date-epoch')
+      });
+      return;
+    }
+    case 'sync-release': {
+      await syncGitHubRelease({
+        releaseTag: requiredOption(options, 'release-tag'),
+        outputDir: requiredOption(options, 'output-dir'),
+        releaseClient: createGhReleaseClient({
+          repository: requiredOption(options, 'repository')
+        })
+      });
+      return;
+    }
+    default:
+      throw new Error(`Unknown command ${JSON.stringify(command)}.`);
+  }
+}
+
+function parseOptions(args) {
+  const options = new Map();
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg?.startsWith('--')) {
+      throw new Error(`Unexpected argument ${JSON.stringify(arg)}.`);
+    }
+    const key = arg.slice(2);
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}.`);
+    }
+    options.set(key, value);
+    index += 1;
+  }
+  return options;
+}
+
+function requiredOption(options, key) {
+  const value = options.get(key);
+  if (!value) {
+    throw new Error(`Missing required option --${key}.`);
+  }
+  return value;
+}
+
+export function canonicalReleaseAssetNames(releaseTag) {
+  const { npmVersion } = parseReleaseTag(releaseTag);
+  return [
+    ...Object.values(PACKAGE_DEFINITIONS).map((definition) => definition.assetName(npmVersion)),
+    CHECKSUMS_NAME
+  ];
+}
+
+export function verifySourceRun(sourceRun, { releaseTag }) {
+  const { npmVersion } = parseReleaseTag(releaseTag);
+  const sourceRunId = toPositiveIntegerString(sourceRun?.id, 'source run id');
+  const sourceRunAttempt = toPositiveInteger(sourceRun?.run_attempt, 'source run attempt');
+  if (sourceRun?.name !== WORKFLOW_NAME) {
+    throw new Error(
+      `Refusing GitHub release: source run ${sourceRunId} must be ${WORKFLOW_NAME}, got ${JSON.stringify(sourceRun?.name)}.`
+    );
+  }
+  if (sourceRun?.path !== WORKFLOW_PATH) {
+    throw new Error(
+      `Refusing GitHub release: source run ${sourceRunId} must use ${WORKFLOW_PATH}, got ${JSON.stringify(sourceRun?.path)}.`
+    );
+  }
+  if (sourceRun?.event !== 'push') {
+    throw new Error(
+      `Refusing GitHub release: source run ${sourceRunId} must come from event push, got ${JSON.stringify(sourceRun?.event)}.`
+    );
+  }
+  if (sourceRun?.status !== 'completed' || sourceRun?.conclusion !== 'success') {
+    throw new Error(
+      `Refusing GitHub release: source run ${sourceRunId} must have completed successfully, got status=${JSON.stringify(sourceRun?.status)} conclusion=${JSON.stringify(sourceRun?.conclusion)}.`
+    );
+  }
+  if (sourceRun?.head_branch !== releaseTag) {
+    throw new Error(
+      `Refusing GitHub release: source run tag ${JSON.stringify(sourceRun?.head_branch)} does not match requested tag ${releaseTag}.`
+    );
+  }
+  if (!isSha(sourceRun?.head_sha)) {
+    throw new Error(
+      `Refusing GitHub release: source run ${sourceRunId} returned malformed head SHA ${JSON.stringify(sourceRun?.head_sha)}.`
+    );
+  }
+  return {
+    releaseTag,
+    npmVersion,
+    sourceRunId,
+    sourceRunAttempt,
+    headSha: sourceRun.head_sha
+  };
+}
+
+export function verifyAnnotatedTag(tagRef, tagObject, { releaseTag, expectedHeadSha }) {
+  if (tagRef?.ref !== `refs/tags/${releaseTag}`) {
+    throw new Error(
+      `Refusing GitHub release: expected tag ref refs/tags/${releaseTag}, got ${JSON.stringify(tagRef?.ref)}.`
+    );
+  }
+  if (tagRef?.object?.type !== 'tag') {
+    throw new Error(
+      `Refusing GitHub release: ${releaseTag} must be an annotated tag, not ${JSON.stringify(tagRef?.object?.type)}.`
+    );
+  }
+  if (tagObject?.verification?.verified !== true) {
+    throw new Error(
+      `Refusing GitHub release: ${releaseTag} must have a GitHub-verified signature (reason=${tagObject?.verification?.reason ?? 'unknown'}).`
+    );
+  }
+  if (tagObject?.object?.type !== 'commit') {
+    throw new Error(
+      `Refusing GitHub release: ${releaseTag} must target a commit, not ${JSON.stringify(tagObject?.object?.type)}.`
+    );
+  }
+  if (tagObject?.object?.sha !== expectedHeadSha) {
+    throw new Error(
+      `Refusing GitHub release: ${releaseTag} must resolve to the exact source run commit ${expectedHeadSha}, got ${tagObject?.object?.sha}.`
+    );
+  }
+  return {
+    releaseTag,
+    tagObjectSha: tagRef.object.sha,
+    headSha: expectedHeadSha
+  };
+}
+
+export function verifyReleaseSource({
+  releaseTag,
+  sourceRun,
+  tagRef,
+  tagObject,
+  commitContainedInMain,
+  sourceDateEpoch
+}) {
+  const sourceContext = verifySourceRun(sourceRun, { releaseTag });
+  verifyAnnotatedTag(tagRef, tagObject, {
+    releaseTag,
+    expectedHeadSha: sourceContext.headSha
+  });
+  if (commitContainedInMain !== true) {
+    throw new Error(
+      `Refusing GitHub release: tagged commit ${sourceContext.headSha} is not contained in origin/main.`
+    );
+  }
+  const normalizedSourceDateEpoch = toNonNegativeInteger(sourceDateEpoch, 'SOURCE_DATE_EPOCH');
+  return {
+    ...sourceContext,
+    sourceDateEpoch: normalizedSourceDateEpoch
+  };
+}
+
+export async function resolveReleaseSource({ repository, releaseTag, sourceRunId, ghApi = ghApiJson, git = createGitClient() }) {
+  const normalizedSourceRunId = toPositiveIntegerString(sourceRunId, 'source run id');
+  const sourceRun = await ghApi(`/repos/${repository}/actions/runs/${normalizedSourceRunId}`);
+  const tagRef = await ghApi(`/repos/${repository}/git/ref/tags/${encodeURIComponent(releaseTag)}`);
+  if (tagRef?.object?.type !== 'tag') {
+    return verifyReleaseSource({
+      releaseTag,
+      sourceRun,
+      tagRef,
+      tagObject: { object: { type: tagRef?.object?.type }, verification: { verified: false, reason: 'lightweight' } },
+      commitContainedInMain: false,
+      sourceDateEpoch: 0
+    });
+  }
+  const tagObject = await ghApi(`/repos/${repository}/git/tags/${tagRef.object.sha}`);
+  const gitState = git.verifyLocalTagState(releaseTag, sourceRun.head_sha);
+  return verifyReleaseSource({
+    releaseTag,
+    sourceRun,
+    tagRef,
+    tagObject,
+    commitContainedInMain: gitState.commitContainedInMain,
+    sourceDateEpoch: gitState.sourceDateEpoch
+  });
+}
+
+export async function verifyPackageProvenance({
+  packageName,
+  npmVersion,
+  releaseTag,
+  headSha,
+  sourceRunId,
+  sourceRunAttempt,
+  packageMetadata,
+  attestationDocument
+}) {
+  if (packageMetadata?.name !== packageName) {
+    throw new Error(
+      `Refusing GitHub release: expected npm metadata for ${packageName}, got ${JSON.stringify(packageMetadata?.name)}.`
+    );
+  }
+  if (packageMetadata?.version !== npmVersion) {
+    throw new Error(
+      `Refusing GitHub release: expected ${packageName}@${npmVersion}, got ${JSON.stringify(packageMetadata?.version)}.`
+    );
+  }
+  const integrityHex = integrityDigestHex(packageMetadata?.dist?.integrity);
+  const expectedSubjectName = npmPackageSubjectName(packageName, npmVersion);
+  const slsaPointer = packageMetadata?.dist?.attestations?.provenance?.predicateType;
+  if (slsaPointer !== SLSA_PREDICATE) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} must expose npm SLSA provenance.`
+    );
+  }
+  const attestations = attestationDocument?.attestations;
+  if (!Array.isArray(attestations) || attestations.length === 0) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} is missing npm attestation data.`
+    );
+  }
+  const trustedPublisherAttestation = attestations.find(
+    (entry) => entry?.predicateType === TRUSTED_PUBLISHER_PREDICATE
+  );
+  if (!trustedPublisherAttestation) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} is missing npm trusted publisher attestation.`
+    );
+  }
+  validateTrustedPublisherMetadata(packageMetadata, { packageName, npmVersion });
+  validateTrustedPublisherAttestation(
+    decodeDssePayload(trustedPublisherAttestation?.bundle?.dsseEnvelope),
+    { packageName, npmVersion, integrityHex, expectedSubjectName }
+  );
+  const slsaAttestation = selectSingleAttestationByPredicateType(attestations, SLSA_PREDICATE, {
+    packageName,
+    npmVersion,
+    label: 'npm SLSA provenance attestation'
+  });
+  const statement = decodeDssePayload(slsaAttestation?.bundle?.dsseEnvelope);
+  validateSlsaProvenanceStatement(statement, {
+    packageName,
+    npmVersion,
+    releaseTag,
+    headSha,
+    sourceRunId,
+    sourceRunAttempt,
+    integrityHex,
+    expectedSubjectName
+  });
+  return {
+    packageName,
+    npmVersion,
+    integrityHex
+  };
+}
+
+function validateTrustedPublisherMetadata(packageMetadata, { packageName, npmVersion }) {
+  const npmUser = packageMetadata?._npmUser;
+  const trustedPublisher = npmUser?.trustedPublisher;
+  if (
+    !trustedPublisher ||
+    typeof trustedPublisher !== 'object' ||
+    typeof trustedPublisher.oidcConfigId !== 'string' ||
+    !trustedPublisher.oidcConfigId.startsWith('oidc:')
+  ) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} npm metadata must include trusted publisher metadata from GitHub Actions.`
+    );
+  }
+  if (
+    npmUser?.name !== TRUSTED_PUBLISHER_NAME ||
+    npmUser?.email !== TRUSTED_PUBLISHER_EMAIL ||
+    trustedPublisher.id !== TRUSTED_PUBLISHER_ID
+  ) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} npm metadata must record the GitHub trusted publisher.`
+    );
+  }
+}
+
+function validateTrustedPublisherAttestation(statement, {
+  packageName,
+  npmVersion,
+  integrityHex,
+  expectedSubjectName
+}) {
+  validatePackageSubject(statement, {
+    packageName,
+    npmVersion,
+    integrityHex,
+    expectedSubjectName,
+    label: 'trusted publisher attestation'
+  });
+  if (statement?.predicateType !== TRUSTED_PUBLISHER_PREDICATE) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} trusted publisher attestation predicate must be ${TRUSTED_PUBLISHER_PREDICATE}.`
+    );
+  }
+  if (statement?.predicate?.name !== packageName) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} trusted publisher attestation must name ${packageName}.`
+    );
+  }
+  if (statement?.predicate?.version !== npmVersion) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} trusted publisher attestation version must be ${npmVersion}.`
+    );
+  }
+  if (statement?.predicate?.registry !== NPM_REGISTRY_URL) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} trusted publisher attestation registry must be ${NPM_REGISTRY_URL}.`
+    );
+  }
+}
+
+function validateSlsaProvenanceStatement(statement, {
+  packageName,
+  npmVersion,
+  releaseTag,
+  headSha,
+  sourceRunId,
+  sourceRunAttempt,
+  integrityHex,
+  expectedSubjectName
+}) {
+  validatePackageSubject(statement, {
+    packageName,
+    npmVersion,
+    integrityHex,
+    expectedSubjectName,
+    label: 'provenance'
+  });
+  if (statement?.predicateType !== SLSA_PREDICATE) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} decoded SLSA predicateType must be ${SLSA_PREDICATE}.`
+    );
+  }
+  const workflow = statement?.predicate?.buildDefinition?.externalParameters?.workflow;
+  if (workflow?.repository !== REPOSITORY_URL) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} provenance repository must be ${REPOSITORY_URL}.`
+    );
+  }
+  if (workflow?.path !== WORKFLOW_PATH) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} provenance workflow path must be ${WORKFLOW_PATH}.`
+    );
+  }
+  if (workflow?.ref !== `refs/tags/${releaseTag}`) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} provenance ref must be refs/tags/${releaseTag}.`
+    );
+  }
+  if (statement?.predicate?.buildDefinition?.internalParameters?.github?.event_name !== 'push') {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} provenance must come from event push.`
+    );
+  }
+  const expectedDependencyUri = `git+${REPOSITORY_URL}@refs/tags/${releaseTag}`;
+  const dependency = statement?.predicate?.buildDefinition?.resolvedDependencies?.find(
+    (entry) => entry?.uri === expectedDependencyUri
+  );
+  if (!dependency) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} provenance must include ${expectedDependencyUri}.`
+    );
+  }
+  if (dependency?.digest?.gitCommit !== headSha) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} provenance gitCommit must be ${headSha}.`
+    );
+  }
+  const expectedInvocationId =
+    `https://github.com/OpenCoven/coven/actions/runs/${toPositiveIntegerString(sourceRunId, 'source run id')}/attempts/` +
+    `${toPositiveInteger(sourceRunAttempt, 'source run attempt')}`;
+  if (statement?.predicate?.runDetails?.metadata?.invocationId !== expectedInvocationId) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} provenance run attempt must be ${expectedInvocationId}.`
+    );
+  }
+}
+
+function validatePackageSubject(statement, {
+  packageName,
+  npmVersion,
+  integrityHex,
+  expectedSubjectName,
+  label
+}) {
+  const subjects = Array.isArray(statement?.subject) ? statement.subject : [];
+  if (subjects.length !== 1 || subjects[0]?.name !== expectedSubjectName) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} ${label} is missing subject ${expectedSubjectName}.`
+    );
+  }
+  if (subjects[0]?.digest?.sha512 !== integrityHex) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} ${label} subject digest must match npm dist.integrity.`
+    );
+  }
+}
+
+function selectSingleAttestationByPredicateType(attestations, predicateType, { packageName, npmVersion, label }) {
+  const matches = attestations.filter((entry) => entry?.predicateType === predicateType);
+  if (matches.length !== 1) {
+    throw new Error(
+      `Refusing GitHub release: ${packageName}@${npmVersion} must expose exactly one ${label} (${predicateType}), got ${matches.length}.`
+    );
+  }
+  return matches[0];
+}
+
+function npmPackageSubjectName(packageName, npmVersion) {
+  const encodedName = String(packageName)
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `pkg:npm/${encodedName}@${npmVersion}`;
+}
+
+export async function verifyAllPackageProvenance({
+  releaseTag,
+  npmVersion,
+  headSha,
+  sourceRunId,
+  sourceRunAttempt,
+  fetchJson = fetchJsonFromNetwork
+}) {
+  for (const packageName of RELEASE_PACKAGES) {
+    const encodedPackageName = encodeURIComponent(packageName);
+    const metadata = await fetchJson(`https://registry.npmjs.org/${encodedPackageName}/${npmVersion}`);
+    const attestations = await fetchJson(metadata?.dist?.attestations?.url);
+    await verifyPackageProvenance({
+      packageName,
+      npmVersion,
+      releaseTag,
+      headSha,
+      sourceRunId,
+      sourceRunAttempt,
+      packageMetadata: metadata,
+      attestationDocument: attestations
+    });
+  }
+}
+
+export function packageGitHubRelease({ releaseTag, artifactsDir, outputDir, sourceDateEpoch }) {
+  const { npmVersion } = parseReleaseTag(releaseTag);
+  const normalizedArtifactsDir = path.resolve(String(artifactsDir));
+  const normalizedOutputDir = path.resolve(String(outputDir));
+  const epoch = toNonNegativeInteger(sourceDateEpoch, 'SOURCE_DATE_EPOCH');
+  rmSync(normalizedOutputDir, { recursive: true, force: true });
+  mkdirSync(normalizedOutputDir, { recursive: true });
+
+  const checksumRecords = [];
+  for (const definition of Object.values(PACKAGE_DEFINITIONS)) {
+    const assetName = definition.assetName(npmVersion);
+    const archiveBytes =
+      definition.format === 'zip'
+        ? createZipArchive(readArtifactFiles(normalizedArtifactsDir, definition), epoch)
+        : createTarGzArchive(readArtifactFiles(normalizedArtifactsDir, definition), epoch);
+    writeFileSync(path.join(normalizedOutputDir, assetName), archiveBytes);
+    checksumRecords.push({ assetName, sha256: sha256Hex(archiveBytes) });
+  }
+
+  const checksumText = renderChecksumManifest(checksumRecords);
+  assertChecksumManifest(
+    checksumText,
+    checksumRecords.map((record) => record.assetName)
+  );
+  writeFileSync(path.join(normalizedOutputDir, CHECKSUMS_NAME), checksumText);
+
+  return {
+    assetNames: [...checksumRecords.map((record) => record.assetName), CHECKSUMS_NAME].sort(),
+    checksums: checksumRecords
+  };
+}
+
+function readArtifactFiles(artifactsDir, definition) {
+  const artifactDir = path.join(artifactsDir, definition.artifactName);
+  let dirents;
+  try {
+    dirents = readdirSync(artifactDir, { withFileTypes: true });
+  } catch (error) {
+    throw new Error(
+      `Refusing GitHub release: source artifact directory ${artifactDir} is missing for ${definition.artifactName}.`
+    );
+  }
+  const actualNames = dirents.map((dirent) => dirent.name).sort();
+  const expectedNames = [...definition.expectedFiles].sort();
+  const missingNames = expectedNames.filter((name) => !actualNames.includes(name));
+  if (missingNames.length > 0) {
+    throw new Error(
+      `Refusing GitHub release: ${definition.artifactName} is missing required file(s): ${missingNames.join(', ')}.`
+    );
+  }
+  const unexpectedNames = actualNames.filter((name) => !expectedNames.includes(name));
+  if (unexpectedNames.length > 0) {
+    throw new Error(
+      `Refusing GitHub release: ${definition.artifactName} has unexpected files: ${unexpectedNames.join(', ')}.`
+    );
+  }
+  return expectedNames.map((name) => {
+    const dirent = dirents.find((candidate) => candidate.name === name);
+    if (!dirent?.isFile()) {
+      throw new Error(
+        `Refusing GitHub release: ${definition.artifactName}/${name} must be a file.`
+      );
+    }
+    const absolutePath = path.join(artifactDir, name);
+    if (!statSync(absolutePath).isFile()) {
+      throw new Error(
+        `Refusing GitHub release: ${definition.artifactName}/${name} must be a regular file.`
+      );
+    }
+    return {
+      name,
+      data: readFileSync(absolutePath)
+    };
+  });
+}
+
+function createTarGzArchive(files, sourceDateEpoch) {
+  const tarParts = [];
+  const sortedFiles = [...files].sort((left, right) => left.name.localeCompare(right.name));
+  for (const file of sortedFiles) {
+    tarParts.push(createTarHeader(file.name, file.data.length, sourceDateEpoch));
+    tarParts.push(file.data);
+    const remainder = file.data.length % 512;
+    if (remainder !== 0) {
+      tarParts.push(Buffer.alloc(512 - remainder, 0));
+    }
+  }
+  tarParts.push(Buffer.alloc(1024, 0));
+  const gzipBytes = gzipSync(Buffer.concat(tarParts), {
+    level: 9
+  });
+  gzipBytes.writeUInt32LE(sourceDateEpoch, 4);
+  return gzipBytes;
+}
+
+function createTarHeader(name, size, sourceDateEpoch) {
+  if (Buffer.byteLength(name, 'utf8') > 100) {
+    throw new Error(`Refusing GitHub release: tar entry ${name} exceeds the ustar name limit.`);
+  }
+  const header = Buffer.alloc(512, 0);
+  writeString(header, 0, 100, name);
+  writeOctal(header, 100, 8, 0o755);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, size);
+  writeOctal(header, 136, 12, sourceDateEpoch);
+  header.fill(0x20, 148, 156);
+  header[156] = '0'.charCodeAt(0);
+  writeString(header, 257, 6, 'ustar');
+  writeString(header, 263, 2, '00');
+  const checksum = header.reduce((total, byte) => total + byte, 0);
+  const checksumText = checksum.toString(8).padStart(6, '0');
+  writeString(header, 148, 6, checksumText);
+  header[154] = 0;
+  header[155] = 0x20;
+  return header;
+}
+
+function createZipArchive(files, sourceDateEpoch) {
+  const localRecords = [];
+  const centralRecords = [];
+  let offset = 0;
+  const timestamp = zipTimestamp(sourceDateEpoch);
+
+  for (const file of [...files].sort((left, right) => left.name.localeCompare(right.name))) {
+    const nameBuffer = Buffer.from(file.name, 'utf8');
+    const data = Buffer.from(file.data);
+    const crc32 = crc32ForBuffer(data);
+    const localHeader = Buffer.alloc(30 + nameBuffer.length);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(ZIP_VERSION, 4);
+    localHeader.writeUInt16LE(ZIP_UTF8_FLAG, 6);
+    localHeader.writeUInt16LE(ZIP_STORE_METHOD, 8);
+    localHeader.writeUInt16LE(timestamp.dosTime, 10);
+    localHeader.writeUInt16LE(timestamp.dosDate, 12);
+    localHeader.writeUInt32LE(crc32, 14);
+    localHeader.writeUInt32LE(data.length, 18);
+    localHeader.writeUInt32LE(data.length, 22);
+    localHeader.writeUInt16LE(nameBuffer.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+    nameBuffer.copy(localHeader, 30);
+    localRecords.push(localHeader, data);
+
+    const centralHeader = Buffer.alloc(46 + nameBuffer.length);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE((3 << 8) | ZIP_VERSION, 4);
+    centralHeader.writeUInt16LE(ZIP_VERSION, 6);
+    centralHeader.writeUInt16LE(ZIP_UTF8_FLAG, 8);
+    centralHeader.writeUInt16LE(ZIP_STORE_METHOD, 10);
+    centralHeader.writeUInt16LE(timestamp.dosTime, 12);
+    centralHeader.writeUInt16LE(timestamp.dosDate, 14);
+    centralHeader.writeUInt32LE(crc32, 16);
+    centralHeader.writeUInt32LE(data.length, 20);
+    centralHeader.writeUInt32LE(data.length, 24);
+    centralHeader.writeUInt16LE(nameBuffer.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0o755 << 16, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+    nameBuffer.copy(centralHeader, 46);
+    centralRecords.push(centralHeader);
+
+    offset += localHeader.length + data.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralRecords);
+  const endOfCentralDirectory = Buffer.alloc(22);
+  endOfCentralDirectory.writeUInt32LE(0x06054b50, 0);
+  endOfCentralDirectory.writeUInt16LE(0, 4);
+  endOfCentralDirectory.writeUInt16LE(0, 6);
+  endOfCentralDirectory.writeUInt16LE(centralRecords.length, 8);
+  endOfCentralDirectory.writeUInt16LE(centralRecords.length, 10);
+  endOfCentralDirectory.writeUInt32LE(centralDirectory.length, 12);
+  endOfCentralDirectory.writeUInt32LE(offset, 16);
+  endOfCentralDirectory.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...localRecords, centralDirectory, endOfCentralDirectory]);
+}
+
+function zipTimestamp(sourceDateEpoch) {
+  const date = new Date(sourceDateEpoch * 1000);
+  const year = Math.max(date.getUTCFullYear(), 1980);
+  return {
+    dosDate: ((year - 1980) << 9) | ((date.getUTCMonth() + 1) << 5) | date.getUTCDate(),
+    dosTime:
+      (date.getUTCHours() << 11) |
+      (date.getUTCMinutes() << 5) |
+      Math.floor(date.getUTCSeconds() / 2)
+  };
+}
+
+export function renderChecksumManifest(records) {
+  const normalized = [...records]
+    .map((record) => ({
+      assetName: record.assetName,
+      sha256: String(record.sha256).toLowerCase()
+    }))
+    .sort((left, right) => left.assetName.localeCompare(right.assetName));
+  const expectedNames = normalized.map((record) => record.assetName);
+  const text = normalized.map((record) => `${record.sha256}  ${record.assetName}`).join('\n');
+  assertChecksumManifest(text, expectedNames);
+  return `${text}\n`;
+}
+
+export function assertChecksumManifest(text, expectedNames) {
+  const expected = [...expectedNames].sort();
+  const trimmed = String(text).replace(/\s+$/, '');
+  const lines = trimmed.length === 0 ? [] : trimmed.split(/\r?\n/);
+  if (lines.length !== expected.length || lines.some((line) => line.trim().length === 0)) {
+    throw new Error('SHA256SUMS must contain exactly four non-empty entries.');
+  }
+  const names = [];
+  for (const line of lines) {
+    const match = /^([0-9a-f]{64})  (.+)$/.exec(line);
+    if (!match) {
+      throw new Error('SHA256SUMS entries must be <sha256><two spaces><filename>.');
+    }
+    const name = match[2];
+    if (name === CHECKSUMS_NAME) {
+      throw new Error('SHA256SUMS must not checksum SHA256SUMS itself.');
+    }
+    if (name.includes('/') || name.includes('\\') || path.basename(name) !== name) {
+      throw new Error('SHA256SUMS entries must use bare filenames only.');
+    }
+    names.push(name);
+  }
+  const sortedNames = [...names].sort();
+  if (names.join('\n') !== sortedNames.join('\n')) {
+    throw new Error('SHA256SUMS entries must be lexically sorted.');
+  }
+  if (new Set(names).size !== names.length) {
+    throw new Error('SHA256SUMS must not contain duplicate filenames.');
+  }
+  if (sortedNames.join('\n') !== expected.join('\n')) {
+    throw new Error('SHA256SUMS entries must use the exact canonical asset names.');
+  }
+}
+
+export async function syncGitHubRelease({
+  releaseTag,
+  outputDir,
+  releaseClient = createGhReleaseClient()
+}) {
+  const expectedAssetNames = canonicalReleaseAssetNames(releaseTag).sort();
+  const normalizedOutputDir = path.resolve(String(outputDir));
+  const presentAssetNames = readdirSync(normalizedOutputDir).sort();
+  if (presentAssetNames.join('\n') !== expectedAssetNames.join('\n')) {
+    throw new Error(
+      `Refusing GitHub release: ${normalizedOutputDir} must contain the exact canonical assets ${expectedAssetNames.join(', ')}.`
+    );
+  }
+  const expectedBytesByName = new Map(
+    expectedAssetNames.map((assetName) => [assetName, readFileSync(path.join(normalizedOutputDir, assetName))])
+  );
+
+  let release = await releaseClient.getReleaseByTag(releaseTag);
+  let createdRelease = false;
+  if (!release) {
+    release = await releaseClient.createRelease({
+      releaseTag,
+      title: `Coven ${releaseTag}`,
+      notesFromTag: true
+    });
+    createdRelease = true;
+  }
+
+  const existingAssets = Array.isArray(release?.assets) ? release.assets : [];
+  const existingAssetNames = existingAssets.map((asset) => asset.name);
+  const duplicateAssets = [...new Set(existingAssetNames.filter(
+    (assetName, index) => existingAssetNames.indexOf(assetName) !== index
+  ))].sort();
+  if (duplicateAssets.length > 0) {
+    throw new Error(
+      `Refusing GitHub release: duplicate release assets ${duplicateAssets.join(', ')}. ` +
+        'Delete only the duplicate GitHub asset through an audited operator action, then rerun this GitHub-only workflow. Never move/reuse the tag and never republish npm.'
+    );
+  }
+  const existingAssetsByName = new Map(existingAssets.map((asset) => [asset.name, asset]));
+  const extraAssets = [...existingAssetsByName.keys()]
+    .filter((assetName) => !expectedBytesByName.has(assetName))
+    .sort();
+  if (extraAssets.length > 0) {
+    throw new Error(
+      `Refusing GitHub release: unexpected release assets ${extraAssets.join(', ')}. ` +
+        'Delete only the unexpected or mismatched GitHub asset through an audited operator action, then rerun this GitHub-only workflow. Never move/reuse the tag and never republish npm.'
+    );
+  }
+
+  const uploaded = [];
+  const skipped = [];
+  for (const assetName of expectedAssetNames) {
+    const expectedBytes = expectedBytesByName.get(assetName);
+    const existingAsset = existingAssetsByName.get(assetName);
+    if (!existingAsset) {
+      await releaseClient.uploadAsset({
+        releaseTag,
+        assetName,
+        filePath: path.join(normalizedOutputDir, assetName)
+      });
+      uploaded.push(assetName);
+      continue;
+    }
+    const observedBytes = await releaseClient.downloadAsset(existingAsset);
+    const observedHash = sha256Hex(observedBytes);
+    const expectedHash = sha256Hex(expectedBytes);
+    if (observedHash !== expectedHash) {
+      throw new Error(
+        `Refusing GitHub release: asset ${assetName} mismatch: observed hash ${observedHash}, expected hash ${expectedHash}. ` +
+          'Record the observed hash, expected hash, and reason, delete only the mismatched GitHub asset through an audited operator action, then rerun this GitHub-only workflow. Never move/reuse the tag and never republish npm.'
+      );
+    }
+    skipped.push(assetName);
+  }
+
+  return {
+    createdRelease,
+    uploaded,
+    skipped
+  };
+}
+
+function createGitClient() {
+  return {
+    verifyLocalTagState(releaseTag, expectedHeadSha) {
+      runCommand('git', [
+        'fetch',
+        '--force',
+        '--no-tags',
+        'origin',
+        'main',
+        `refs/tags/${releaseTag}:refs/tags/${releaseTag}`
+      ]);
+      const tagObjectSha = runCommand('git', ['rev-parse', releaseTag]).trim();
+      const tagObjectType = runCommand('git', ['cat-file', '-t', tagObjectSha]).trim();
+      if (tagObjectType !== 'tag') {
+        throw new Error(
+          `Refusing GitHub release: local tag ${releaseTag} must resolve to an annotated tag object, got ${tagObjectType}.`
+        );
+      }
+      const localHeadSha = runCommand('git', ['rev-parse', `${releaseTag}^{commit}`]).trim();
+      if (localHeadSha !== expectedHeadSha) {
+        throw new Error(
+          `Refusing GitHub release: local tag ${releaseTag} must resolve to ${expectedHeadSha}, got ${localHeadSha}.`
+        );
+      }
+      const ancestor = spawnCapture('git', ['merge-base', '--is-ancestor', expectedHeadSha, 'origin/main']);
+      if (ancestor.error) {
+        throw new Error(ancestor.error.message);
+      }
+      if (ancestor.status !== 0 && ancestor.status !== 1) {
+        throw new Error(
+          `git merge-base --is-ancestor ${expectedHeadSha} origin/main exited with ${ancestor.status}.`
+        );
+      }
+      const sourceDateEpoch = runCommand('git', ['log', '-1', '--format=%ct', expectedHeadSha]).trim();
+      return {
+        commitContainedInMain: ancestor.status === 0,
+        sourceDateEpoch: toNonNegativeInteger(sourceDateEpoch, 'SOURCE_DATE_EPOCH')
+      };
+    }
+  };
+}
+
+function createGhReleaseClient({ repository = process.env.GITHUB_REPOSITORY } = {}) {
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required to synchronize GitHub release assets.');
+  }
+  return {
+    async getReleaseByTag(releaseTag) {
+      const endpoint = `/repos/${repository}/releases/tags/${encodeURIComponent(releaseTag)}`;
+      const result = spawnCapture('gh', ['api', endpoint], { encoding: 'utf8' });
+      if (result.error) {
+        throw new Error(result.error.message);
+      }
+      if (result.status !== 0) {
+        const stderr = String(result.stderr ?? '').trim();
+        if (/404/.test(stderr)) {
+          return null;
+        }
+        throw new Error(stderr || `gh api ${endpoint} exited with ${result.status}.`);
+      }
+      return JSON.parse(result.stdout);
+    },
+    async createRelease({ releaseTag, title, notesFromTag }) {
+      const args = ['release', 'create', releaseTag, '--repo', repository, '--title', title];
+      if (notesFromTag) {
+        args.push('--notes-from-tag');
+      }
+      runCommand('gh', args);
+      const release = await this.getReleaseByTag(releaseTag);
+      if (!release) {
+        throw new Error(`GitHub release ${releaseTag} was created but could not be reloaded.`);
+      }
+      return release;
+    },
+    async downloadAsset(asset) {
+      const assetUrl = asset?.url;
+      if (!assetUrl) {
+        throw new Error(`GitHub release asset ${asset?.name ?? '(unknown)'} has no API URL.`);
+      }
+      const endpoint = new URL(assetUrl).pathname;
+      const result = spawnCapture('gh', ['api', '-H', 'Accept: application/octet-stream', endpoint], {
+        encoding: null
+      });
+      if (result.error) {
+        throw new Error(result.error.message);
+      }
+      if (result.status !== 0) {
+        const stderr = bufferToTrimmedString(result.stderr);
+        throw new Error(stderr || `gh api ${endpoint} exited with ${result.status}.`);
+      }
+      return Buffer.from(result.stdout);
+    },
+    async uploadAsset({ releaseTag, filePath }) {
+      runCommand('gh', ['release', 'upload', releaseTag, filePath, '--repo', repository]);
+    }
+  };
+}
+
+async function ghApiJson(endpoint) {
+  const output = runCommand('gh', ['api', endpoint]);
+  return JSON.parse(output);
+}
+
+async function fetchJsonFromNetwork(url) {
+  if (!url) {
+    throw new Error('Expected npm provenance URL, got empty value.');
+  }
+  const response = await fetch(url, {
+    headers: {
+      accept: 'application/json'
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed with HTTP ${response.status}.`);
+  }
+  return response.json();
+}
+
+function decodeDssePayload(dsseEnvelope) {
+  const payload = dsseEnvelope?.payload;
+  if (!payload) {
+    throw new Error('Refusing GitHub release: npm attestation payload is missing.');
+  }
+  try {
+    return JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+  } catch (error) {
+    throw new Error(`Refusing GitHub release: npm attestation payload is not valid JSON (${error.message}).`);
+  }
+}
+
+function integrityDigestHex(integrity) {
+  if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
+    throw new Error(
+      `Refusing GitHub release: npm dist.integrity must be a sha512 SRI string, got ${JSON.stringify(integrity)}.`
+    );
+  }
+  return Buffer.from(integrity.slice('sha512-'.length), 'base64').toString('hex');
+}
+
+function crc32ForBuffer(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function sha256Hex(buffer) {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function writeString(buffer, offset, length, value) {
+  Buffer.from(String(value), 'utf8').copy(buffer, offset, 0, length);
+}
+
+function writeOctal(buffer, offset, length, value) {
+  const text = Number(value).toString(8).padStart(length - 1, '0');
+  writeString(buffer, offset, length - 1, text);
+  buffer[offset + length - 1] = 0;
+}
+
+function toPositiveIntegerString(value, label) {
+  const normalized = String(value ?? '').trim();
+  if (!/^[1-9]\d*$/.test(normalized)) {
+    throw new Error(`Refusing GitHub release: ${label} must be a positive integer, got ${JSON.stringify(value)}.`);
+  }
+  return normalized;
+}
+
+function toPositiveInteger(value, label) {
+  return Number.parseInt(toPositiveIntegerString(value, label), 10);
+}
+
+function toNonNegativeInteger(value, label) {
+  const normalized = Number(value);
+  if (!Number.isSafeInteger(normalized) || normalized < 0) {
+    throw new Error(`Refusing GitHub release: ${label} must be a non-negative integer, got ${JSON.stringify(value)}.`);
+  }
+  return normalized;
+}
+
+function isSha(value) {
+  return typeof value === 'string' && /^[0-9a-f]{40}$/i.test(value);
+}
+
+function runCommand(command, args, { encoding = 'utf8', cwd = repoRoot, env = process.env } = {}) {
+  const result = spawnCapture(command, args, { encoding, cwd, env });
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+  if (result.status !== 0) {
+    const printable = [command, ...args].join(' ');
+    const stderr = bufferToTrimmedString(result.stderr);
+    throw new Error(stderr || `${printable} exited with ${result.status}.`);
+  }
+  return typeof result.stdout === 'string' ? result.stdout : Buffer.from(result.stdout).toString('utf8');
+}
+
+function spawnCapture(command, args, { encoding = 'utf8', cwd = repoRoot, env = process.env } = {}) {
+  return spawnSync(command, args, {
+    cwd,
+    env,
+    encoding,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+}
+
+function bufferToTrimmedString(value) {
+  if (value == null) {
+    return '';
+  }
+  return Buffer.isBuffer(value) ? value.toString('utf8').trim() : String(value).trim();
+}

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -87,7 +87,7 @@ async function main() {
   const [command, ...args] = process.argv.slice(2);
   if (!command) {
     throw new Error(
-      'Usage: package-github-release.mjs <verify-source-run|verify-npm-provenance|package|sync-release> [--option value ...]'
+      'Usage: package-github-release.mjs <verify-source-run|verify-npm-provenance|verify-npm-signatures|package|sync-release> [--option value ...]'
     );
   }
 
@@ -119,6 +119,13 @@ async function main() {
         headSha: requiredOption(options, 'head-sha'),
         sourceRunId: requiredOption(options, 'source-run-id'),
         sourceRunAttempt: requiredOption(options, 'source-run-attempt')
+      });
+      return;
+    }
+    case 'verify-npm-signatures': {
+      verifyNpmRegistrySignatures({
+        npmVersion: requiredOption(options, 'npm-version'),
+        auditDir: requiredOption(options, 'audit-dir')
       });
       return;
     }
@@ -234,6 +241,16 @@ export function verifyAnnotatedTag(tagRef, tagObject, { releaseTag, expectedHead
       `Refusing GitHub release: ${releaseTag} must be an annotated tag, not ${JSON.stringify(tagRef?.object?.type)}.`
     );
   }
+  if (!isSha(tagRef?.object?.sha)) {
+    throw new Error(
+      `Refusing GitHub release: ${releaseTag} must resolve to a GitHub tag object SHA, got ${JSON.stringify(tagRef?.object?.sha)}.`
+    );
+  }
+  if (tagObject?.tag !== releaseTag) {
+    throw new Error(
+      `Refusing GitHub release: GitHub tag API payload must name tag ${releaseTag}, got ${JSON.stringify(tagObject?.tag)}.`
+    );
+  }
   if (tagObject?.verification?.verified !== true) {
     throw new Error(
       `Refusing GitHub release: ${releaseTag} must have a GitHub-verified signature (reason=${tagObject?.verification?.reason ?? 'unknown'}).`
@@ -261,14 +278,26 @@ export function verifyReleaseSource({
   sourceRun,
   tagRef,
   tagObject,
+  localTagObjectSha,
+  localHeadSha,
   commitContainedInMain,
   sourceDateEpoch
 }) {
   const sourceContext = verifySourceRun(sourceRun, { releaseTag });
-  verifyAnnotatedTag(tagRef, tagObject, {
+  const tagContext = verifyAnnotatedTag(tagRef, tagObject, {
     releaseTag,
     expectedHeadSha: sourceContext.headSha
   });
+  if (String(localTagObjectSha ?? '').trim() !== tagContext.tagObjectSha) {
+    throw new Error(
+      `Refusing GitHub release: local tag ${releaseTag} must resolve to the exact GitHub-verified tag object ${tagContext.tagObjectSha}, got ${localTagObjectSha}.`
+    );
+  }
+  if (String(localHeadSha ?? '').trim() !== sourceContext.headSha) {
+    throw new Error(
+      `Refusing GitHub release: local tag ${releaseTag} must resolve to the exact source run commit ${sourceContext.headSha}, got ${localHeadSha}.`
+    );
+  }
   if (commitContainedInMain !== true) {
     throw new Error(
       `Refusing GitHub release: tagged commit ${sourceContext.headSha} is not contained in origin/main.`
@@ -296,12 +325,14 @@ export async function resolveReleaseSource({ repository, releaseTag, sourceRunId
     });
   }
   const tagObject = await ghApi(`/repos/${repository}/git/tags/${tagRef.object.sha}`);
-  const gitState = git.verifyLocalTagState(releaseTag, sourceRun.head_sha);
+  const gitState = git.verifyLocalTagState(releaseTag);
   return verifyReleaseSource({
     releaseTag,
     sourceRun,
     tagRef,
     tagObject,
+    localTagObjectSha: gitState.localTagObjectSha,
+    localHeadSha: gitState.localHeadSha,
     commitContainedInMain: gitState.commitContainedInMain,
     sourceDateEpoch: gitState.sourceDateEpoch
   });
@@ -564,6 +595,48 @@ export async function verifyAllPackageProvenance({
       attestationDocument: attestations
     });
   }
+}
+
+export function verifyNpmRegistrySignatures({
+  npmVersion,
+  auditDir,
+  commandRunner = runCommand
+}) {
+  const normalizedVersion = String(npmVersion ?? '').trim();
+  if (!normalizedVersion) {
+    throw new Error('Refusing GitHub release: npm version is required to verify npm registry signatures.');
+  }
+  const normalizedAuditDirInput = String(auditDir ?? '').trim();
+  if (!normalizedAuditDirInput) {
+    throw new Error('Refusing GitHub release: audit directory is required to verify npm registry signatures.');
+  }
+  const normalizedAuditDir = path.resolve(normalizedAuditDirInput);
+  rmSync(normalizedAuditDir, { recursive: true, force: true });
+  mkdirSync(normalizedAuditDir, { recursive: true });
+  writeFileSync(
+    path.join(normalizedAuditDir, 'package.json'),
+    `${JSON.stringify({
+      name: 'opencoven-release-npm-signatures-audit',
+      private: true,
+      version: '0.0.0',
+      dependencies: Object.fromEntries(
+        RELEASE_PACKAGES.map((packageName) => [packageName, normalizedVersion])
+      )
+    }, null, 2)}\n`
+  );
+  commandRunner(
+    'npm',
+    ['install', '--package-lock-only', '--ignore-scripts', '--audit=false', '--fund=false'],
+    { cwd: normalizedAuditDir }
+  );
+  commandRunner('npm', ['audit', 'signatures', '--package-lock-only'], {
+    cwd: normalizedAuditDir
+  });
+  return {
+    auditDir: normalizedAuditDir,
+    packageNames: [...RELEASE_PACKAGES],
+    npmVersion: normalizedVersion
+  };
 }
 
 export function packageGitHubRelease({ releaseTag, artifactsDir, outputDir, sourceDateEpoch }) {
@@ -858,18 +931,14 @@ export async function syncGitHubRelease({
 
   const uploaded = [];
   const skipped = [];
+  const missingAssetNames = [];
   for (const assetName of expectedAssetNames) {
-    const expectedBytes = expectedBytesByName.get(assetName);
     const existingAsset = existingAssetsByName.get(assetName);
     if (!existingAsset) {
-      await releaseClient.uploadAsset({
-        releaseTag,
-        assetName,
-        filePath: path.join(normalizedOutputDir, assetName)
-      });
-      uploaded.push(assetName);
+      missingAssetNames.push(assetName);
       continue;
     }
+    const expectedBytes = expectedBytesByName.get(assetName);
     const observedBytes = await releaseClient.downloadAsset(existingAsset);
     const observedHash = sha256Hex(observedBytes);
     const expectedHash = sha256Hex(expectedBytes);
@@ -881,6 +950,14 @@ export async function syncGitHubRelease({
     }
     skipped.push(assetName);
   }
+  for (const assetName of missingAssetNames) {
+    await releaseClient.uploadAsset({
+      releaseTag,
+      assetName,
+      filePath: path.join(normalizedOutputDir, assetName)
+    });
+    uploaded.push(assetName);
+  }
 
   return {
     createdRelease,
@@ -891,7 +968,7 @@ export async function syncGitHubRelease({
 
 function createGitClient() {
   return {
-    verifyLocalTagState(releaseTag, expectedHeadSha) {
+    verifyLocalTagState(releaseTag) {
       runCommand('git', [
         'fetch',
         '--force',
@@ -908,22 +985,19 @@ function createGitClient() {
         );
       }
       const localHeadSha = runCommand('git', ['rev-parse', `${releaseTag}^{commit}`]).trim();
-      if (localHeadSha !== expectedHeadSha) {
-        throw new Error(
-          `Refusing GitHub release: local tag ${releaseTag} must resolve to ${expectedHeadSha}, got ${localHeadSha}.`
-        );
-      }
-      const ancestor = spawnCapture('git', ['merge-base', '--is-ancestor', expectedHeadSha, 'origin/main']);
+      const ancestor = spawnCapture('git', ['merge-base', '--is-ancestor', localHeadSha, 'origin/main']);
       if (ancestor.error) {
         throw new Error(ancestor.error.message);
       }
       if (ancestor.status !== 0 && ancestor.status !== 1) {
         throw new Error(
-          `git merge-base --is-ancestor ${expectedHeadSha} origin/main exited with ${ancestor.status}.`
+          `git merge-base --is-ancestor ${localHeadSha} origin/main exited with ${ancestor.status}.`
         );
       }
-      const sourceDateEpoch = runCommand('git', ['log', '-1', '--format=%ct', expectedHeadSha]).trim();
+      const sourceDateEpoch = runCommand('git', ['log', '-1', '--format=%ct', localHeadSha]).trim();
       return {
+        localTagObjectSha: tagObjectSha,
+        localHeadSha,
         commitContainedInMain: ancestor.status === 0,
         sourceDateEpoch: toNonNegativeInteger(sourceDateEpoch, 'SOURCE_DATE_EPOCH')
       };
@@ -1020,12 +1094,19 @@ function decodeDssePayload(dsseEnvelope) {
 }
 
 function integrityDigestHex(integrity) {
-  if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
+  const match = /^sha512-([A-Za-z0-9+/]+={0,2})$/.exec(String(integrity ?? ''));
+  if (!match || match[1].length % 4 !== 0) {
     throw new Error(
-      `Refusing GitHub release: npm dist.integrity must be a sha512 SRI string, got ${JSON.stringify(integrity)}.`
+      `Refusing GitHub release: npm dist.integrity must be a canonical sha512 SRI string with a 64-byte digest, got ${JSON.stringify(integrity)}.`
     );
   }
-  return Buffer.from(integrity.slice('sha512-'.length), 'base64').toString('hex');
+  const decoded = Buffer.from(match[1], 'base64');
+  if (decoded.length !== 64 || decoded.toString('base64') !== match[1]) {
+    throw new Error(
+      `Refusing GitHub release: npm dist.integrity must be a canonical sha512 SRI string with a 64-byte digest, got ${JSON.stringify(integrity)}.`
+    );
+  }
+  return decoded.toString('hex');
 }
 
 function crc32ForBuffer(buffer) {

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -1097,7 +1097,8 @@ export function assertChecksumManifest(text, expectedNames) {
   const trimmed = String(text).replace(/\s+$/, '');
   const lines = trimmed.length === 0 ? [] : trimmed.split(/\r?\n/);
   if (lines.length !== expected.length || lines.some((line) => line.trim().length === 0)) {
-    throw new Error('SHA256SUMS must contain exactly four non-empty entries.');
+    const expectedCount = expected.length === 4 ? 'four' : String(expected.length);
+    throw new Error(`SHA256SUMS must contain exactly ${expectedCount} non-empty entries.`);
   }
   const names = [];
   for (const line of lines) {

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1350,6 +1350,26 @@ test('release workflow verifies the signed release tag before building or publis
   );
   assert.match(
     workflow,
+    /git\/ref\/tags\/\$TAG_NAME/,
+    'verify-tag must resolve the exact remote tag ref before trusting the local tag object'
+  );
+  assert.match(
+    workflow,
+    /if \[ "\$api_tag_object_sha" != "\$TAG_OBJECT_SHA" \]; then/,
+    'verify-tag must require the local annotated tag object SHA to match the GitHub-verified tag object SHA'
+  );
+  assert.match(
+    workflow,
+    /jq -r '\.tag \/\/ ""'/,
+    'verify-tag must require the GitHub tag object payload to echo the requested tag name'
+  );
+  assert.match(
+    workflow,
+    /if \[ "\$tag_name" != "\$TAG_NAME" \]; then/,
+    'verify-tag must reject GitHub tag payloads that name a different tag'
+  );
+  assert.match(
+    workflow,
     /lightweight tag/,
     'verify-tag must explicitly reject lightweight (unsigned) tags'
   );
@@ -1412,6 +1432,16 @@ test('release workflow verifies the signed release tag before building or publis
     workflow,
     /tag_object_type.*commit/s,
     'verify-tag must reject annotated tags that do not target commits'
+  );
+  assert.match(
+    workflow,
+    /LOCAL_TAGGED_COMMIT_SHA=\$\(git rev-parse "\$TAG_NAME\^\{commit\}"\)/,
+    'verify-tag must resolve the local tagged commit after the tag-object identity check'
+  );
+  assert.match(
+    workflow,
+    /if \[ "\$LOCAL_TAGGED_COMMIT_SHA" != "\$TAGGED_COMMIT_SHA" \]; then/,
+    'verify-tag must reject local tag aliases that resolve to a different commit than the verified tag object'
   );
 });
 


### PR DESCRIPTION
## Context

- Summary: Add deterministic GitHub Release publication after the signed-tag npm workflow succeeds, with a fail-closed manual recovery path.
- Files changed: release workflows, deterministic packaging/synchronization tooling and tests, release documentation, CI policy coverage, and synthetic archive fixtures.
- Bead: `coven-v041-gh-release`

## Implementation

- Trigger GitHub-only publication from a successful immutable attempt of `Release npm packages`; manual recovery requires the exact tag, source run ID, and run attempt.
- Verify the signed annotated tag object, tagged commit ancestry on `origin/main`, exact five npm versions, registry signatures, trusted-publisher SLSA provenance, and retained source artifacts.
- Produce four canonical deterministic platform archives plus lexical `SHA256SUMS` without rebuilding or republishing npm artifacts.
- Create missing Releases/assets, skip byte-matching assets, and fail closed on tag, attempt, metadata, duplicate, extra, or hash drift. Fully matching reruns also revalidate the remote tag before succeeding.
- Document forward-only recovery and immutable evidence requirements.

## Verification

- [x] `cargo +1.98.0 fmt --check`
- [x] `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +1.98.0 test --workspace --locked`
- [x] Full CI policy, privacy, secret, workflow, and actionlint gates
- [x] `node --test scripts/package-github-release-test.mjs scripts/publish-npm-test.mjs` (115 passed, one Windows-only skip)
- [x] Final code review; tag-drift finding fixed with a failing-then-passing regression test

## Risk and rollback

- Risk: High publication sensitivity, mitigated by immutable source identity, exact asset contracts, cryptographic registry/provenance checks, pre-mutation revalidation, and idempotent fail-closed synchronization.
- Rollback: Revert the workflow/tooling commit before the next signed release. For partial publication, follow the documented forward-only GitHub recovery path; never move/reuse the tag or republish npm.

## Agent handoff

- Current state: Ready for review and CI.
- Follow-up: Unblocks `coven-v041-runbook` after merge.
- Known gaps: None.
