### PR TITLE
fix(release): allow full cargo preflight gates

### DIFF
--- a/scripts/onboarding-docs-test.mjs
+++ b/scripts/onboarding-docs-test.mjs
@@ -286,6 +286,17 @@ test('npm onboarding smoke bounds subprocess hangs', () => {
   assert.match(script, /ETIMEDOUT/);
 });
 
+test('npm onboarding smoke gives full cargo gates the CI timeout budget', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /CARGO_GATE_TIMEOUT_MS\s*=\s*20\s*\*\s*60_000/);
+  assert.match(script, /run\('cargo', \['clippy', '--workspace', '--all-targets'/);
+  assert.match(script, /run\('cargo', \['test', '--workspace', '--locked'\]/);
+  assert.equal(
+    (script.match(/timeoutMs: CARGO_GATE_TIMEOUT_MS/g) ?? []).length,
+    2
+  );
+});
+
 test('npm onboarding smoke does not pipe-capture Windows daemon start', () => {
   const script = readRepoFile('scripts/test-cli-prepublish.mjs');
   assert.match(script, /function runDaemonStart\(/);

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -45,6 +45,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const distRoot = path.join(repoRoot, 'npm', 'dist');
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
+const CARGO_GATE_TIMEOUT_MS = 20 * 60_000;
 
 const PLATFORM_TARGETS = {
   macos: { packageName: '@opencoven/cli-macos', binaryName: 'coven' },
@@ -125,10 +126,14 @@ step('onboarding, PR readiness, and publish guardrails', () => {
 if (withCargoGates) {
   step('cargo fmt --check', () => run('cargo', ['fmt', '--check']));
   step('cargo clippy', () =>
-    run('cargo', ['clippy', '--workspace', '--all-targets', '--', '-D', 'warnings'])
+    run('cargo', ['clippy', '--workspace', '--all-targets', '--', '-D', 'warnings'], {
+      timeoutMs: CARGO_GATE_TIMEOUT_MS
+    })
   );
   step('cargo test --workspace --locked', () =>
-    run('cargo', ['test', '--workspace', '--locked'])
+    run('cargo', ['test', '--workspace', '--locked'], {
+      timeoutMs: CARGO_GATE_TIMEOUT_MS
+    })
   );
 }
 


### PR DESCRIPTION
## Context

- Summary: Prevent the npm prepublish preflight from timing out full workspace cargo gates at the generic two-minute subprocess limit.
- Files changed: `scripts/test-cli-prepublish.mjs`, `scripts/onboarding-docs-test.mjs`.
- Bead: `coven-v041-npm`

## Implementation

- Keep ordinary prepublish subprocesses bounded to 120 seconds.
- Give full workspace Clippy and tests the same 20-minute budget as their CI jobs when `--with-cargo-gates` is requested.
- Add a regression guard requiring both full cargo gates to use the dedicated timeout.

## Verification

- [x] Reproduced on current `main`: Rust 1.98 workspace tests exceeded 120 seconds after unit tests while finishing doc tests.
- [x] Failing regression test added before implementation.
- [x] `RUSTUP_TOOLCHAIN=1.98.0 node scripts/test-cli-prepublish.mjs --with-cargo-gates` completes end-to-end.
- [x] `node --test scripts/onboarding-docs-test.mjs scripts/publish-npm-test.mjs scripts/package-github-release-test.mjs` (131 passed, one Windows-only skip).
- [x] Secret and staged privacy guards pass.

## Risk and rollback

- Risk: Low. Only explicitly requested full cargo gates receive a longer timeout; package, install, daemon, and other smoke operations retain the strict default.
- Rollback: Revert this commit, restoring the two-minute cap for all subprocesses.

## Agent handoff

- Current state: Ready for review and CI.
- Follow-up: Complete authenticated npm Trusted Publishers settings evidence for all five packages, then close `coven-v041-npm`.
- Known gap: Local npm is 10.9.8; npm 11.16 trust-list access is authentication-gated and returned E401 without npm account credentials. Public package metadata and exact v0.4.0 OIDC/SLSA provenance otherwise pass for all five packages.
