### PR TITLE
test(release): add bounded reliability stress workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       - run: python3 scripts/check-workflows-test.py
       - run: python3 scripts/check-ci-workflow-test.py
       - run: node --test scripts/package-github-release-test.mjs
+      - run: node --test scripts/release-stress-test.mjs
       - run: scripts/check-workflows.sh
 
   rust-lint-linux:

--- a/.github/workflows/release-stress.yml
+++ b/.github/workflows/release-stress.yml
@@ -1,0 +1,84 @@
+name: Release stress
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-stress-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  unix:
+    name: Release stress (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-26
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-05-20
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-release-stress-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-release-stress-
+      - name: Install native link dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - name: Run bounded release stress
+        timeout-minutes: 42
+        run: node scripts/release-stress.mjs --suite unix --iterations 10 --command-timeout-ms 180000 --log "release-stress-${RUNNER_OS}.log"
+      - name: Upload release stress evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: release-stress-${{ runner.os }}
+          path: release-stress-${{ runner.os }}.log
+          if-no-files-found: error
+
+  windows:
+    name: Release stress (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-05-20
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-release-stress-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-release-stress-
+      - name: Run bounded release stress
+        timeout-minutes: 42
+        run: node scripts/release-stress.mjs --suite windows --iterations 10 --command-timeout-ms 180000 --log "release-stress-${env:RUNNER_OS}.log"
+      - name: Upload release stress evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: release-stress-${{ runner.os }}
+          path: release-stress-${{ runner.os }}.log
+          if-no-files-found: error

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -7,6 +7,7 @@ import unittest
 CI_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'ci.yml'
 RELEASE_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'release-npm.yml'
 RELEASE_GITHUB_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'release-github.yml'
+RELEASE_STRESS_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'release-stress.yml'
 CACHE_SHA = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
 SETUP_NODE_SHA = "820762786026740c76f36085b0efc47a31fe5020"
 CI_TEXT = CI_WORKFLOW.read_text(encoding='utf-8')
@@ -49,6 +50,7 @@ class CheckCiWorkflowTests(unittest.TestCase):
             'python3 scripts/check-ci-workflow-test.py',
             'scripts/check-workflows.sh',
             'node --test scripts/package-github-release-test.mjs',
+            'node --test scripts/release-stress-test.mjs',
             "needs.changes.outputs.docs_only != 'true'",
             'npm-onboarding-linux',
             "github.event_name == 'push'",
@@ -95,6 +97,20 @@ class CheckCiWorkflowTests(unittest.TestCase):
     def test_release_includes_performance_baseline_dependency(self) -> None:
         self.assertIn('performance-baseline', RELEASE_TEXT)
         self.assertIn('needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]', RELEASE_TEXT)
+
+    def test_release_stress_workflow_is_bounded_and_uploads_failure_evidence(self) -> None:
+        stress_text = RELEASE_STRESS_WORKFLOW.read_text(encoding='utf-8')
+        self.assertIn(
+            "name: Release stress\n\non:\n  workflow_dispatch:\n\npermissions:",
+            stress_text,
+        )
+        self.assertNotIn("schedule:", stress_text)
+        self.assertEqual(stress_text.count("timeout-minutes: 45"), 2)
+        self.assertEqual(stress_text.count("timeout-minutes: 42"), 2)
+        self.assertIn("--suite unix --iterations 10 --command-timeout-ms 180000", stress_text)
+        self.assertIn("--suite windows --iterations 10 --command-timeout-ms 180000", stress_text)
+        self.assertEqual(stress_text.count("if: ${{ always() }}"), 2)
+        self.assertEqual(stress_text.count("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"), 2)
 
     def test_release_npm_workflow_uses_same_tag_specific_concurrency_without_cancellation(self) -> None:
         self.assertIn(

--- a/scripts/release-stress-test.mjs
+++ b/scripts/release-stress-test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildStressPlan,
+  runStressPlan,
+  sanitizeOutput
+} from './release-stress.mjs';
+
+test('unix stress plan covers every release reliability surface ten times', () => {
+  const plan = buildStressPlan({ suite: 'unix', iterations: 10 });
+
+  assert.equal(plan.length, 50);
+  assert.deepEqual(
+    [...new Set(plan.map((entry) => entry.label))],
+    [
+      'claim acquisition',
+      'memory migration',
+      'process cleanup',
+      'PTY timeout',
+      'short socket homes'
+    ]
+  );
+  assert.ok(plan.every((entry) => entry.timeoutMs === 180_000));
+  assert.deepEqual(
+    plan.filter((entry) => entry.iteration === 1).map((entry) => entry.args),
+    [
+      ['test', '-p', 'coven-cli', '--test', 'parallel_protocol', '--locked'],
+      [
+        'test',
+        '-p',
+        'coven-cli',
+        '--bin',
+        'coven',
+        'cockpit_sources::tests::opened_memory_record_rechecks_logical_restore_state',
+        '--locked',
+        '--',
+        '--exact'
+      ],
+      [
+        'test',
+        '-p',
+        'coven-cli',
+        '--test',
+        'smoke',
+        'daemon_stop_terminates_live_piped_session_descendants',
+        '--locked',
+        '--',
+        '--exact'
+      ],
+      [
+        'test',
+        '-p',
+        'coven-cli',
+        '--bin',
+        'coven',
+        'pty_runner::tests::codex_json_runner_times_out_while_a_large_prompt_is_still_writing',
+        '--locked',
+        '--',
+        '--exact'
+      ],
+      ['test', '-p', 'coven-client', '--test', 'health', '--locked']
+    ]
+  );
+});
+
+test('windows stress plan repeats descendant-killing PTY timeout ten times', () => {
+  const plan = buildStressPlan({ suite: 'windows', iterations: 10 });
+
+  assert.equal(plan.length, 10);
+  assert.ok(plan.every((entry) => entry.label === 'Windows PTY timeout and process cleanup'));
+  assert.deepEqual(plan[0].args, [
+    'test',
+    '-p',
+    'coven-cli',
+    '--bin',
+    'coven',
+    'pty_runner::tests::windows_detached_pty_timeout_fails_and_kills_descendant',
+    '--locked',
+    '--',
+    '--exact'
+  ]);
+});
+
+test('stress runner stops at the first failed command and records its iteration', () => {
+  const calls = [];
+  const writes = [];
+  const plan = buildStressPlan({ suite: 'windows', iterations: 3 });
+
+  assert.throws(
+    () =>
+      runStressPlan({
+        plan,
+        repoRoot: '/private/work/coven',
+        runCommand(entry) {
+          calls.push(entry.iteration);
+          return entry.iteration === 2
+            ? { status: 17, stdout: '', stderr: '/private/work/coven failed' }
+            : { status: 0, stdout: 'ok', stderr: '' };
+        },
+        writeLog(text) {
+          writes.push(text);
+        }
+      }),
+    /iteration 2.*exit 17/
+  );
+  assert.deepEqual(calls, [1, 2]);
+  assert.match(writes.join(''), /<repo> failed/);
+  assert.doesNotMatch(writes.join(''), /\/private\/work\/coven/);
+});
+
+test('stress output redacts repository paths', () => {
+  assert.equal(
+    sanitizeOutput(
+      'failed in /private/work/coven and C:\\work\\coven',
+      ['/private/work/coven', 'C:\\work\\coven']
+    ),
+    'failed in <repo> and <repo>'
+  );
+});

--- a/scripts/release-stress.mjs
+++ b/scripts/release-stress.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_ITERATIONS = 10;
+const DEFAULT_COMMAND_TIMEOUT_MS = 180_000;
+
+const UNIX_COMMANDS = [
+  {
+    label: 'claim acquisition',
+    args: ['test', '-p', 'coven-cli', '--test', 'parallel_protocol', '--locked']
+  },
+  {
+    label: 'memory migration',
+    args: [
+      'test',
+      '-p',
+      'coven-cli',
+      '--bin',
+      'coven',
+      'cockpit_sources::tests::opened_memory_record_rechecks_logical_restore_state',
+      '--locked',
+      '--',
+      '--exact'
+    ]
+  },
+  {
+    label: 'process cleanup',
+    args: [
+      'test',
+      '-p',
+      'coven-cli',
+      '--test',
+      'smoke',
+      'daemon_stop_terminates_live_piped_session_descendants',
+      '--locked',
+      '--',
+      '--exact'
+    ]
+  },
+  {
+    label: 'PTY timeout',
+    args: [
+      'test',
+      '-p',
+      'coven-cli',
+      '--bin',
+      'coven',
+      'pty_runner::tests::codex_json_runner_times_out_while_a_large_prompt_is_still_writing',
+      '--locked',
+      '--',
+      '--exact'
+    ]
+  },
+  {
+    label: 'short socket homes',
+    args: ['test', '-p', 'coven-client', '--test', 'health', '--locked']
+  }
+];
+
+const WINDOWS_COMMANDS = [
+  {
+    label: 'Windows PTY timeout and process cleanup',
+    args: [
+      'test',
+      '-p',
+      'coven-cli',
+      '--bin',
+      'coven',
+      'pty_runner::tests::windows_detached_pty_timeout_fails_and_kills_descendant',
+      '--locked',
+      '--',
+      '--exact'
+    ]
+  }
+];
+
+export function buildStressPlan({
+  suite,
+  iterations = DEFAULT_ITERATIONS,
+  commandTimeoutMs = DEFAULT_COMMAND_TIMEOUT_MS
+}) {
+  if (!Number.isInteger(iterations) || iterations < 1 || iterations > DEFAULT_ITERATIONS) {
+    throw new Error(`iterations must be an integer from 1 through ${DEFAULT_ITERATIONS}`);
+  }
+  if (!Number.isInteger(commandTimeoutMs) || commandTimeoutMs < 1 || commandTimeoutMs > 300_000) {
+    throw new Error('command timeout must be an integer from 1 through 300000 milliseconds');
+  }
+  const commands = suite === 'unix'
+    ? UNIX_COMMANDS
+    : suite === 'windows'
+      ? WINDOWS_COMMANDS
+      : null;
+  if (!commands) {
+    throw new Error("suite must be 'unix' or 'windows'");
+  }
+
+  return Array.from({ length: iterations }, (_, index) =>
+    commands.map((command) => ({
+      ...command,
+      args: [...command.args],
+      iteration: index + 1,
+      timeoutMs: commandTimeoutMs
+    }))
+  ).flat();
+}
+
+export function sanitizeOutput(text, privatePaths) {
+  let sanitized = String(text ?? '');
+  for (const privatePath of privatePaths) {
+    if (!privatePath) {
+      continue;
+    }
+    sanitized = sanitized.split(String(privatePath)).join('<repo>');
+  }
+  return sanitized;
+}
+
+export function runStressPlan({
+  plan,
+  repoRoot: workingDirectory,
+  runCommand = runCargoCommand,
+  writeLog
+}) {
+  for (const entry of plan) {
+    const header = `iteration=${entry.iteration} surface=${entry.label}\n`;
+    writeLog(header);
+    const result = runCommand(entry, workingDirectory);
+    const output = sanitizeOutput(
+      `${result.stdout ?? ''}${result.stderr ?? ''}`,
+      [workingDirectory, process.env.HOME, process.env.USERPROFILE]
+    );
+    writeLog(output);
+    if (output && !output.endsWith('\n')) {
+      writeLog('\n');
+    }
+
+    if (result.error?.code === 'ETIMEDOUT') {
+      throw new Error(
+        `${entry.label} iteration ${entry.iteration} timed out after ${entry.timeoutMs}ms`
+      );
+    }
+    if (result.error) {
+      throw new Error(
+        `${entry.label} iteration ${entry.iteration} failed to launch: ${result.error.message}`
+      );
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `${entry.label} iteration ${entry.iteration} failed with exit ${result.status}`
+      );
+    }
+  }
+}
+
+function runCargoCommand(entry, workingDirectory) {
+  return spawnSync('cargo', entry.args, {
+    cwd: workingDirectory,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: entry.timeoutMs
+  });
+}
+
+function optionValue(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || index + 1 >= args.length) {
+    throw new Error(`${name} is required`);
+  }
+  return args[index + 1];
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const suite = optionValue(args, '--suite');
+  const iterations = Number(optionValue(args, '--iterations'));
+  const commandTimeoutMs = Number(optionValue(args, '--command-timeout-ms'));
+  const logPath = path.resolve(optionValue(args, '--log'));
+  const plan = buildStressPlan({ suite, iterations, commandTimeoutMs });
+  writeFileSync(logPath, `suite=${suite} iterations=${iterations}\n`);
+
+  runStressPlan({
+    plan,
+    repoRoot,
+    writeLog(text) {
+      appendFileSync(logPath, text);
+      process.stdout.write(text);
+    }
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a manual-only Linux/macOS/Windows release-stress workflow
- repeat the release-blocking claim, migration, cleanup, PTY, and short-socket-home surfaces ten times
- stop on first failure, bound each command to three minutes, reserve upload time within the 45-minute jobs, and sanitize artifact logs
- enforce the workflow and runner contract in the policy guard

## Verification
- `node --test scripts/release-stress-test.mjs`
- `python3 scripts/check-ci-workflow-test.py`
- `python3 scripts/check-workflows-test.py`
- `python3 scripts/classify-ci-changes-test.py`
- `scripts/check-workflows.sh`
- one complete local Unix stress iteration
- `rustup run 1.98.0 cargo clippy --workspace --all-targets -- -D warnings`
- `rustup run 1.98.0 cargo test --workspace --locked`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`

Bead: `coven-v041-stress`