### PR TITLE
fix: stabilize macOS process tests

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -6021,8 +6021,25 @@ mod tests {
         );
         // Releasing the lock lets the next daemon take it — it never wedges shut.
         drop(first);
-        let _second =
-            acquire_serve_lock(home.path()).expect("lock should be reacquirable once released");
+        // The suite forks constantly (fixtures shell out to `git`, probes, and
+        // sh). FD_CLOEXEC only takes effect at `exec`, so between `fork` and
+        // `exec` a sibling test's child inherits this descriptor and holds the
+        // flock. That is an in-process artifact — a real daemon never shares an
+        // address space with the releasing process — so retry against a
+        // deadline rather than asserting on the first attempt.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let second = loop {
+            match acquire_serve_lock(home.path()) {
+                Ok(lock) => break lock,
+                Err(error) => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(error).context("lock should be reacquirable once released");
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                }
+            }
+        };
+        drop(second);
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -6029,11 +6029,11 @@ mod tests {
         // deadline rather than asserting on the first attempt.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         let second = loop {
-            match acquire_serve_lock(home.path()) {
-                Ok(lock) => break lock,
-                Err(error) => {
+            match try_acquire_serve_lock(home.path())? {
+                Some(lock) => break lock,
+                None => {
                     if std::time::Instant::now() >= deadline {
-                        return Err(error).context("lock should be reacquirable once released");
+                        anyhow::bail!("lock should be reacquirable once released");
                     }
                     std::thread::sleep(std::time::Duration::from_millis(25));
                 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -5899,6 +5899,23 @@ mod tests {
         // fixture startup under load cannot consume the budget.
         let readiness_deadline = Instant::now() + Duration::from_secs(30);
         while !ready_marker.exists() {
+            match result_rx.try_recv() {
+                Ok(early) => {
+                    runner
+                        .join()
+                        .map_err(|_| anyhow::anyhow!("observed runner panicked"))?;
+                    anyhow::bail!(
+                        "observed runner finished before descendant readiness; result: {early:?}"
+                    );
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    runner
+                        .join()
+                        .map_err(|_| anyhow::anyhow!("observed runner panicked"))?;
+                    anyhow::bail!("observed runner disconnected before descendant readiness");
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
             if Instant::now() >= readiness_deadline {
                 let late = result_rx.recv_timeout(Duration::from_secs(5));
                 runner

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -5853,11 +5853,14 @@ mod tests {
         let pid_file = temp_dir
             .path()
             .join("observed-inherited-output-descendant.pid");
+        let ready_marker = temp_dir
+            .path()
+            .join("observed-inherited-output-descendant.ready");
         let mut command = piped_prompt_probe_command(
             temp_dir.path(),
             "root-exit-short-output-descendant",
             &pid_file.to_string_lossy(),
-            None,
+            Some(&ready_marker),
             Vec::new(),
         )?;
         command.env_overrides.push((
@@ -5891,6 +5894,22 @@ mod tests {
                 )));
             }
         };
+        // The one-second budget below measures post-exit cleanup only. Start it
+        // after the descendant has proven both inherited pipes carry output, so
+        // fixture startup under load cannot consume the budget.
+        let readiness_deadline = Instant::now() + Duration::from_secs(30);
+        while !ready_marker.exists() {
+            if Instant::now() >= readiness_deadline {
+                let late = result_rx.recv_timeout(Duration::from_secs(5));
+                runner
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("observed runner panicked"))?;
+                anyhow::bail!(
+                    "inherited-output descendant never signalled readiness; result: {late:?}"
+                );
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
         let result = match result_rx.recv_timeout(Duration::from_secs(1)) {
             Ok(result) => result,
             Err(mpsc::RecvTimeoutError::Timeout) => {

--- a/crates/coven-cli/src/state_lock.rs
+++ b/crates/coven-cli/src/state_lock.rs
@@ -195,6 +195,27 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn state_lock_descriptors_are_close_on_exec() -> Result<()> {
+        // Lock descriptors must not survive into an exec'd child, or a spawned
+        // helper would hold the flock for its entire lifetime. Note this only
+        // takes effect at `exec`: a forked-but-not-yet-exec'd child still
+        // inherits the descriptor, which is why in-process lock tests retry.
+        use std::os::fd::AsRawFd;
+
+        let home = tempfile::tempdir()?;
+        let lock = acquire_shared(home.path())?;
+        let flags = unsafe { libc::fcntl(lock.file.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(flags, -1, "F_GETFD failed on the shared lock descriptor");
+        assert_ne!(
+            flags & libc::FD_CLOEXEC,
+            0,
+            "shared state lock descriptor is not close-on-exec"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn anchored_exclusive_lock_stays_with_opened_home_after_path_replacement() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let home = temp.path().join("coven-home");

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -812,6 +812,12 @@ mod tests {
     fn read_request_path(stream: &mut std::os::unix::net::UnixStream) -> String {
         use std::io::Read;
 
+        // BSD `accept(2)` inherits O_NONBLOCK from the listener; Linux does
+        // not. Tests that poll a non-blocking listener would otherwise get
+        // EWOULDBLOCK here on macOS instead of the request.
+        stream
+            .set_nonblocking(false)
+            .expect("restore blocking mode on accepted stream");
         let mut request = String::new();
         stream
             .read_to_string(&mut request)
@@ -828,6 +834,11 @@ mod tests {
     fn write_response(stream: &mut std::os::unix::net::UnixStream, status: u16, body: &str) {
         use std::io::Write;
 
+        // See `read_request_path`: an accepted stream inherits the listener's
+        // non-blocking mode on BSD/macOS, which would short-write the response.
+        stream
+            .set_nonblocking(false)
+            .expect("restore blocking mode on accepted stream");
         write!(
             stream,
             "HTTP/1.1 {status} Test\r\nContent-Length: {}\r\n\r\n{body}",
@@ -867,6 +878,11 @@ mod tests {
     fn read_request_path_if_present(stream: &mut std::os::unix::net::UnixStream) -> Option<String> {
         use std::io::Read;
 
+        // See `read_request_path`: an accepted stream inherits the listener's
+        // non-blocking mode on BSD/macOS.
+        stream
+            .set_nonblocking(false)
+            .expect("restore blocking mode on accepted stream");
         let mut request = String::new();
         stream
             .read_to_string(&mut request)

--- a/crates/coven-cli/tests/fixtures/piped_prompt_probe.rs
+++ b/crates/coven-cli/tests/fixtures/piped_prompt_probe.rs
@@ -43,6 +43,29 @@ fn required_arg(name: &str) -> String {
         .unwrap_or_else(|| panic!("missing {name}"))
 }
 
+fn optional_arg(name: &str) -> Option<String> {
+    env::args().nth(match name {
+        "mode" => 1,
+        "first" => 2,
+        "second" => 3,
+        _ => unreachable!(),
+    })
+}
+
+/// Blocks until `path` exists. A fixed sleep standing in for "the descendant
+/// produced output" always loses the race under CPU contention, so the root
+/// waits for the descendant to prove it wrote to both inherited pipes.
+fn wait_for_marker(path: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while std::time::Instant::now() < deadline {
+        if fs::metadata(path).is_ok() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+    panic!("descendant readiness marker {path} never appeared");
+}
+
 fn main() {
     let mode = required_arg("mode");
     if !mode.starts_with("output-child") {
@@ -142,15 +165,25 @@ fn main() {
         }
         "root-exit-short-output-descendant" => {
             let pid_file = required_arg("first");
-            let child = Command::new(env::current_exe().expect("current executable"))
-                .arg("output-child-short")
+            let ready_marker = optional_arg("second");
+            let mut command = Command::new(env::current_exe().expect("current executable"));
+            command.arg("output-child-short");
+            if let Some(marker) = ready_marker.as_ref() {
+                command.arg(marker);
+            }
+            let child = command
                 .stdin(Stdio::null())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .spawn()
                 .expect("spawn short inherited-output descendant");
             fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
-            thread::sleep(Duration::from_millis(50));
+            // Exit only once the descendant has proven both inherited pipes
+            // carry real output.
+            match ready_marker.as_deref() {
+                Some(marker) => wait_for_marker(marker),
+                None => thread::sleep(Duration::from_millis(50)),
+            }
         }
         "root-exit-closed-descendant" => {
             let pid_file = required_arg("first");
@@ -173,12 +206,22 @@ fn main() {
             thread::sleep(Duration::from_millis(5));
         },
         "output-child-short" => {
+            let ready_marker = optional_arg("first");
             let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            let mut announced = false;
             while std::time::Instant::now() < deadline {
                 io::stdout().write_all(b"stdout-tick\n").expect("stdout tick");
                 io::stdout().flush().expect("flush stdout tick");
                 io::stderr().write_all(b"stderr-tick\n").expect("stderr tick");
                 io::stderr().flush().expect("flush stderr tick");
+                if !announced {
+                    // Both inherited pipes now hold real bytes; release the
+                    // root so it can exit.
+                    if let Some(marker) = ready_marker.as_ref() {
+                        fs::write(marker, b"ready").expect("write readiness marker");
+                    }
+                    announced = true;
+                }
                 thread::sleep(Duration::from_millis(5));
             }
         }


### PR DESCRIPTION
## Summary
- retry the in-process serve-lock reacquisition while forked sibling fixtures release inherited descriptors
- replace a fixed descendant startup sleep with an explicit output-readiness handshake
- normalize accepted test sockets to blocking mode on BSD/macOS and retain close-on-exec coverage

## Root cause and scope
Under deliberate CPU contention, four macOS-only failures reproduced in the `coven-cli` suite. Three were test synchronization/platform-semantics defects and are fixed here. A proposed `proc_pidinfo` guardian optimization was deliberately excluded because Apple does not document it as async-signal-safe after `fork` in a multithreaded process.

## Validation
- `cargo fmt --check` (Rust 1.98)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` (Rust 1.98)
- `cargo test --workspace --locked` (Rust 1.98)
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
