### PR TITLE
feat(cli): add progressive public help

### DIFF
--- a/crates/coven-cli/src/help.rs
+++ b/crates/coven-cli/src/help.rs
@@ -287,6 +287,9 @@ fn is_public_completion_subcommand(command: &Command) -> bool {
     !command.is_hide_set() && command.get_name() != "help"
 }
 
+// Clap requires a static command name unless its optional `string` feature is
+// enabled. Completion generation is a short-lived CLI process, and this leaks
+// only the bounded command tree once before exit.
 fn leak_command_name(name: &str) -> &'static str {
     Box::leak(name.to_owned().into_boxed_str())
 }
@@ -572,8 +575,8 @@ fn public_help_groups() -> Result<Vec<PublicHelpGroup>> {
         let mut commands = Vec::with_capacity(group.commands.len());
         for command in group.commands {
             let summary = match (summaries.remove(command.name), command.summary_override) {
-                (Some(summary), _) => summary,
-                (None, Some(summary)) => summary.to_owned(),
+                (Some(_), Some(summary)) | (None, Some(summary)) => summary.to_owned(),
+                (Some(summary), None) => summary,
                 (None, None) => {
                     return Err(anyhow!(
                         "public help metadata references unknown command `{}`",

--- a/crates/coven-cli/src/help.rs
+++ b/crates/coven-cli/src/help.rs
@@ -1,0 +1,671 @@
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::io::{self, Write};
+
+use anyhow::{anyhow, Context, Result};
+use clap::{Command, CommandFactory, Parser};
+use serde::Serialize;
+
+pub(crate) const TOP_LEVEL_HELP_TEMPLATE: &str = "\
+{about-with-newline}
+{usage-heading} {usage}
+
+Arguments:
+{positionals}
+
+Options:
+{options}
+{after-help}";
+
+pub(crate) const TOP_LEVEL_AFTER_HELP: &str = "\
+Core commands:
+  doctor    Check local setup and print next steps (exits 1 when a blocking problem is found)
+  setup     Run provider-owned login with explicit consent and direct terminal access
+  run       Launch a project-scoped harness session
+  sessions  List or search recent Coven sessions
+  attach    Replay/follow a session and forward input to live daemon sessions
+  daemon    Manage the local Coven daemon
+  status    Show what's happening across your coven: daemon, sessions, familiars, skills, research, hub
+  help      Show concise help, every public command, or help for one command
+
+Use `coven help --all` to browse every public command grouped by task.
+Use `coven help <command>` or `coven <command> --help` for command-specific help.";
+
+const DOCS_BASE_URL: &str = "https://docs.opencoven.ai/docs";
+const HELP_COMMAND_SUMMARY: &str =
+    "Show concise help, every public command, or help for one command";
+const HELP_COMMAND_AFTER_HELP: &str = "Examples:
+  coven help
+  coven help run
+  coven help sessions show
+  coven help --all
+  coven help --all --json";
+
+#[derive(Parser, Debug)]
+#[command(name = "coven help")]
+#[command(about = HELP_COMMAND_SUMMARY)]
+#[command(after_help = HELP_COMMAND_AFTER_HELP)]
+struct ProgressiveHelpArgs {
+    #[arg(
+        long,
+        value_name = "WHEN",
+        value_parser = ["auto", "always", "never"],
+        default_value = "auto",
+        help = "Control ANSI color output; auto honors NO_COLOR and CLICOLOR_FORCE"
+    )]
+    color: String,
+    #[arg(
+        long,
+        conflicts_with = "command_path",
+        help = "Show every public command grouped by task"
+    )]
+    all: bool,
+    #[arg(
+        long,
+        requires = "all",
+        help = "Print grouped public help as JSON (machine-readable)"
+    )]
+    json: bool,
+    #[arg(
+        value_name = "COMMAND",
+        num_args = 0..,
+        help = "Command path to explain, for example `run` or `sessions show`"
+    )]
+    command_path: Vec<String>,
+}
+
+const HELP_GROUPS: &[HelpGroupSpec] = &[
+    HelpGroupSpec {
+        id: "start-and-launch",
+        title: "Start and launch",
+        commands: &[
+            HelpCommandSpec::new("doctor", "/cli/doctor"),
+            HelpCommandSpec::new("setup", "/reference/cli-setup"),
+            HelpCommandSpec::new("run", "/cli/run"),
+            HelpCommandSpec::new("sessions", "/cli/sessions"),
+            HelpCommandSpec::new("attach", "/cli/sessions#attach"),
+            HelpCommandSpec::new("daemon", "/cli/daemon"),
+            HelpCommandSpec::new("status", "/cli/observe"),
+            HelpCommandSpec::new("chat", "/cli/interactive"),
+            HelpCommandSpec::new("tui", "/cli/interactive"),
+            HelpCommandSpec::synthetic("help", "/cli/interactive", HELP_COMMAND_SUMMARY),
+        ],
+    },
+    HelpGroupSpec {
+        id: "configure-and-extend",
+        title: "Configure and extend",
+        commands: &[
+            HelpCommandSpec::new("config", "/daemon/configuration"),
+            HelpCommandSpec::new("completions", "/cli"),
+            HelpCommandSpec::new("adapter", "/cli/repo-workflow"),
+            HelpCommandSpec::new("engine", "/cli/engine-auth"),
+            HelpCommandSpec::new("auth", "/cli/engine-auth"),
+            HelpCommandSpec::new("models", "/cli/engine-auth"),
+            HelpCommandSpec::new("acp", "/cli/engine-auth"),
+            HelpCommandSpec::new("code", "/cli/engine-auth"),
+        ],
+    },
+    HelpGroupSpec {
+        id: "session-lifecycle",
+        title: "Manage session lifecycle",
+        commands: &[
+            HelpCommandSpec::new("summon", "/cli/sessions#summon"),
+            HelpCommandSpec::new("archive", "/cli/sessions#archive"),
+            HelpCommandSpec::new("sacrifice", "/cli/sessions#sacrifice"),
+            HelpCommandSpec::new("kill", "/cli/sessions"),
+        ],
+    },
+    HelpGroupSpec {
+        id: "observe-your-coven",
+        title: "Observe your coven",
+        commands: &[
+            HelpCommandSpec::new("familiars", "/cli/observe"),
+            HelpCommandSpec::new("skills", "/cli/observe"),
+            HelpCommandSpec::new("memory", "/memory-models"),
+            HelpCommandSpec::new("research", "/cli/observe"),
+            HelpCommandSpec::new("calls", "/cli/observe"),
+            HelpCommandSpec::new("hub", "/cli/hub-scheduler"),
+            HelpCommandSpec::new("scheduler", "/cli/hub-scheduler"),
+            HelpCommandSpec::new("travel", "/cli/hub-scheduler"),
+        ],
+    },
+    HelpGroupSpec {
+        id: "coordinate-parallel-work",
+        title: "Coordinate parallel work",
+        commands: &[
+            HelpCommandSpec::new("wt", "/cli/repo-workflow"),
+            HelpCommandSpec::new("claim", "/cli/repo-workflow"),
+            HelpCommandSpec::new("maintenance", "/cli/repo-workflow"),
+            HelpCommandSpec::new("hooks", "/cli/repo-workflow"),
+        ],
+    },
+    HelpGroupSpec {
+        id: "repair-and-administer",
+        title: "Repair and administer",
+        commands: &[
+            HelpCommandSpec::new("logs", "/cli/observe"),
+            HelpCommandSpec::new("vacuum", "/cli/observe"),
+            HelpCommandSpec::new("reset", "/cli"),
+            HelpCommandSpec::new("patch", "/cli/patch-openclaw"),
+            HelpCommandSpec::new("pc", "/cli/pc"),
+            HelpCommandSpec::new("ward", "/cli/repo-workflow"),
+            HelpCommandSpec::new("executor", "/cli/hub-scheduler"),
+        ],
+    },
+];
+
+pub(crate) fn maybe_run_from_raw_args(raw_args: &[OsString]) -> Option<Result<()>> {
+    let (filtered_args, color_args) = split_global_color_args(raw_args)?;
+    let route = classify_help_route(&filtered_args)?;
+    Some(match route {
+        HelpRoute::Root { trailing_args } => run_root_help_route(&trailing_args, &color_args),
+        HelpRoute::Nested { command_path } => {
+            let args = parse_progressive_help_args(&[], &color_args);
+            apply_color_choice(&args.color);
+            write_command_help_with_color(&command_path, &color_args)
+        }
+    })
+}
+
+pub(crate) fn completion_command() -> Command {
+    build_public_completion_command(&crate::Cli::command(), CompletionHelpSurface::Root)
+}
+
+fn run(all: bool, json: bool, command_path: &[String], color_args: &[OsString]) -> Result<()> {
+    if all {
+        if json {
+            return write_public_help_json();
+        }
+        return write_public_help();
+    }
+    if command_path.is_empty() {
+        return render_help_for_args([OsString::from("coven"), OsString::from("--help")]);
+    }
+    if command_path.len() == 1 && command_path[0] == "help" {
+        return render_progressive_help_command(color_args);
+    }
+    write_command_help_with_color(command_path, color_args)
+}
+
+fn build_public_completion_command(
+    source: &Command,
+    help_surface: CompletionHelpSurface,
+) -> Command {
+    let mut command = clone_completion_command(source);
+    let public_subcommands = source
+        .get_subcommands()
+        .filter(|candidate| is_public_completion_subcommand(candidate))
+        .map(|candidate| build_public_completion_command(candidate, CompletionHelpSurface::Nested))
+        .collect::<Vec<_>>();
+
+    for subcommand in &public_subcommands {
+        command = command.subcommand(subcommand.clone());
+    }
+    if !public_subcommands.is_empty() {
+        command = command.subcommand(build_help_completion_subcommand(help_surface, source));
+    }
+    command
+}
+
+fn clone_completion_command(source: &Command) -> Command {
+    let about = source.get_about().map(ToString::to_string);
+    let mut command =
+        Command::new(leak_command_name(source.get_name())).disable_help_subcommand(true);
+    if let Some(about) = about {
+        command = command.about(about);
+    }
+    for arg in source.get_arguments().filter(|arg| !arg.is_hide_set()) {
+        command = command.arg(arg.clone());
+    }
+    command
+}
+
+fn build_help_completion_subcommand(
+    help_surface: CompletionHelpSurface,
+    source: &Command,
+) -> Command {
+    let mut help = match help_surface {
+        CompletionHelpSurface::Root => root_help_completion_command(),
+        CompletionHelpSurface::Nested => nested_help_completion_command(),
+    };
+    for subcommand in source
+        .get_subcommands()
+        .filter(|candidate| is_public_completion_subcommand(candidate))
+        .map(build_help_target_completion_command)
+    {
+        help = help.subcommand(subcommand);
+    }
+    help.subcommand(match help_surface {
+        CompletionHelpSurface::Root => root_help_completion_command(),
+        CompletionHelpSurface::Nested => nested_help_completion_command(),
+    })
+}
+
+fn root_help_completion_command() -> Command {
+    let mut command = Command::new("help")
+        .about(HELP_COMMAND_SUMMARY)
+        .disable_help_subcommand(true);
+    let help_command = ProgressiveHelpArgs::command();
+    for arg in help_command
+        .get_arguments()
+        .filter(|arg| !arg.is_hide_set())
+    {
+        let arg = if arg.is_positional() {
+            arg.clone().hide(true)
+        } else {
+            arg.clone()
+        };
+        command = command.arg(arg);
+    }
+    command
+}
+
+fn nested_help_completion_command() -> Command {
+    Command::new("help")
+        .about("Print this message or the help of the given subcommand(s)")
+        .disable_help_subcommand(true)
+}
+
+fn build_help_target_completion_command(source: &Command) -> Command {
+    let about = source.get_about().map(ToString::to_string);
+    let mut command =
+        Command::new(leak_command_name(source.get_name())).disable_help_subcommand(true);
+    if let Some(about) = about {
+        command = command.about(about);
+    }
+    for subcommand in source
+        .get_subcommands()
+        .filter(|candidate| is_public_completion_subcommand(candidate))
+        .map(build_help_target_completion_command)
+    {
+        command = command.subcommand(subcommand);
+    }
+    command
+}
+
+fn is_public_completion_subcommand(command: &Command) -> bool {
+    !command.is_hide_set() && command.get_name() != "help"
+}
+
+fn leak_command_name(name: &str) -> &'static str {
+    Box::leak(name.to_owned().into_boxed_str())
+}
+
+fn write_public_help() -> Result<()> {
+    let groups = public_help_groups()?;
+    let width = groups
+        .iter()
+        .flat_map(|group| group.commands.iter())
+        .map(|command| command.name.len())
+        .max()
+        .unwrap_or(0);
+    let mut stdout = io::stdout().lock();
+    ok_if_broken_pipe((|| -> Result<()> {
+        writeln!(stdout, "Coven public command guide").context("failed writing help output")?;
+        writeln!(stdout).context("failed writing help output")?;
+        writeln!(
+            stdout,
+            "`coven` with no arguments opens the interactive Coven UI."
+        )
+        .context("failed writing help output")?;
+        writeln!(
+            stdout,
+            "Run `coven help <command>` or `coven <command> --help` for flags and subcommands."
+        )
+        .context("failed writing help output")?;
+        writeln!(stdout).context("failed writing help output")?;
+        for group in groups {
+            writeln!(stdout, "{}", group.title).context("failed writing help output")?;
+            for command in group.commands {
+                writeln!(
+                    stdout,
+                    "  {:width$}  {}",
+                    command.name,
+                    command.summary,
+                    width = width
+                )
+                .context("failed writing help output")?;
+            }
+            writeln!(stdout).context("failed writing help output")?;
+        }
+        writeln!(
+            stdout,
+            "Use `coven help --all --json` for a machine-readable command catalog."
+        )
+        .context("failed writing help output")?;
+        Ok(())
+    })())
+}
+
+fn write_public_help_json() -> Result<()> {
+    let payload = PublicHelpPayload {
+        schema_version: 1,
+        groups: public_help_groups()?,
+    };
+    let mut stdout = io::stdout().lock();
+    ok_if_broken_pipe((|| -> Result<()> {
+        serde_json::to_writer_pretty(&mut stdout, &payload)
+            .context("failed writing JSON help output")?;
+        writeln!(stdout).context("failed finishing JSON help output")?;
+        Ok(())
+    })())
+}
+
+fn write_command_help_with_color(command_path: &[String], color_args: &[OsString]) -> Result<()> {
+    let canonical_path = resolve_public_command_path(command_path);
+    let args = std::iter::once(OsString::from("coven"))
+        .chain(color_args.iter().cloned())
+        .chain(canonical_path.into_iter().map(OsString::from))
+        .chain(std::iter::once(OsString::from("--help")))
+        .collect::<Vec<_>>();
+    render_help_for_args(args)
+}
+
+fn resolve_public_command_path(command_path: &[String]) -> Vec<String> {
+    let mut canonical_path = Vec::with_capacity(command_path.len());
+    resolve_public_command(crate::Cli::command(), command_path, &mut canonical_path);
+    canonical_path
+}
+
+fn resolve_public_command(
+    command: Command,
+    command_path: &[String],
+    canonical_path: &mut Vec<String>,
+) {
+    let Some((segment, remainder)) = command_path.split_first() else {
+        return;
+    };
+    let child = command
+        .get_subcommands()
+        .find(|candidate| matches_public_name(candidate, segment))
+        .cloned()
+        .unwrap_or_else(|| unknown_command(segment, &command, canonical_path));
+    canonical_path.push(child.get_name().to_owned());
+    resolve_public_command(child, remainder, canonical_path)
+}
+
+fn matches_public_name(command: &Command, requested: &str) -> bool {
+    !command.is_hide_set()
+        && (command.get_name() == requested
+            || command.get_all_aliases().any(|alias| alias == requested))
+}
+
+fn unknown_command(segment: &str, parent: &Command, canonical_path: &[String]) -> ! {
+    let mut full_path = vec!["coven".to_owned()];
+    full_path.extend(canonical_path.iter().cloned());
+    let mut parent = parent.clone().bin_name(full_path.join(" "));
+    parent
+        .error(
+            clap::error::ErrorKind::InvalidSubcommand,
+            format!("unrecognized public command `{segment}`"),
+        )
+        .exit()
+}
+
+fn render_help_for_args<I, T>(args: I) -> Result<()>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let mut command = crate::Cli::command();
+    match command.try_get_matches_from_mut(args) {
+        Ok(_) => unreachable!("help rendering should not parse into a runnable command"),
+        Err(error) if error.exit_code() == 0 => {
+            ok_if_broken_pipe(error.print().context("failed writing help output"))
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn render_progressive_help_command(color_args: &[OsString]) -> Result<()> {
+    let args = std::iter::once(OsString::from("coven help"))
+        .chain(color_args.iter().cloned())
+        .chain(std::iter::once(OsString::from("--help")))
+        .collect::<Vec<_>>();
+    let mut command = ProgressiveHelpArgs::command();
+    match command.try_get_matches_from_mut(args) {
+        Ok(_) => unreachable!("progressive help rendering should display help"),
+        Err(error) if error.exit_code() == 0 => {
+            ok_if_broken_pipe(error.print().context("failed writing help output"))
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn ok_if_broken_pipe(result: Result<()>) -> Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if is_broken_pipe(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn is_broken_pipe(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<io::Error>()
+            .is_some_and(|io_error| io_error.kind() == io::ErrorKind::BrokenPipe)
+            || cause
+                .downcast_ref::<serde_json::Error>()
+                .is_some_and(|json_error| {
+                    json_error.io_error_kind() == Some(io::ErrorKind::BrokenPipe)
+                })
+    })
+}
+
+fn split_global_color_args(raw_args: &[OsString]) -> Option<(Vec<OsString>, Vec<OsString>)> {
+    let mut filtered_args = Vec::with_capacity(raw_args.len());
+    let mut color_args = Vec::new();
+    let mut index = 0;
+    while index < raw_args.len() {
+        match raw_args[index].to_str() {
+            Some("--color") => {
+                let value = raw_args.get(index + 1)?.clone();
+                color_args.push(raw_args[index].clone());
+                color_args.push(value);
+                index += 2;
+            }
+            Some(arg) if arg.starts_with("--color=") => {
+                color_args.push(raw_args[index].clone());
+                index += 1;
+            }
+            _ => {
+                filtered_args.push(raw_args[index].clone());
+                index += 1;
+            }
+        }
+    }
+    Some((filtered_args, color_args))
+}
+
+fn run_root_help_route(trailing_args: &[OsString], color_args: &[OsString]) -> Result<()> {
+    let args = parse_progressive_help_args(trailing_args, color_args);
+    apply_color_choice(&args.color);
+    run(args.all, args.json, &args.command_path, color_args)
+}
+
+fn parse_progressive_help_args(
+    trailing_args: &[OsString],
+    color_args: &[OsString],
+) -> ProgressiveHelpArgs {
+    let args = std::iter::once(OsString::from("coven help"))
+        .chain(color_args.iter().cloned())
+        .chain(trailing_args.iter().cloned())
+        .collect::<Vec<_>>();
+    ProgressiveHelpArgs::try_parse_from(args).unwrap_or_else(|error| error.exit())
+}
+
+fn apply_color_choice(color: &str) {
+    crate::theme::set_color_choice(color_choice_from_str(color));
+}
+
+fn color_choice_from_str(value: &str) -> crate::theme::ColorChoice {
+    match value {
+        "always" => crate::theme::ColorChoice::Always,
+        "never" => crate::theme::ColorChoice::Never,
+        _ => crate::theme::ColorChoice::Auto,
+    }
+}
+
+fn classify_help_route(args: &[OsString]) -> Option<HelpRoute> {
+    let (first, trailing) = args.split_first()?;
+    if first == "help" {
+        return Some(HelpRoute::Root {
+            trailing_args: trailing.to_vec(),
+        });
+    }
+
+    let mut current = crate::Cli::command();
+    let mut prefix = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        let argument = args[index].to_str()?;
+        if argument == "help" {
+            if prefix.is_empty() || current.get_subcommands().next().is_none() {
+                return None;
+            }
+            let mut command_path = prefix;
+            for target in &args[index + 1..] {
+                let target = target.to_str()?;
+                if target.starts_with('-') {
+                    return None;
+                }
+                command_path.push(target.to_owned());
+            }
+            return Some(HelpRoute::Nested { command_path });
+        }
+        if argument.starts_with('-') {
+            return None;
+        }
+        let child = current
+            .get_subcommands()
+            .find(|candidate| matches_public_name(candidate, argument))
+            .cloned()?;
+        prefix.push(child.get_name().to_owned());
+        current = child;
+        index += 1;
+    }
+    None
+}
+
+fn public_help_groups() -> Result<Vec<PublicHelpGroup>> {
+    let root = crate::Cli::command();
+    let mut summaries = root
+        .get_subcommands()
+        .filter(|command| !command.is_hide_set())
+        .map(|command| {
+            let summary = command
+                .get_about()
+                .map(ToString::to_string)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "public command `{}` is missing an about string",
+                        command.get_name()
+                    )
+                })?;
+            Ok((command.get_name().to_owned(), summary))
+        })
+        .collect::<Result<BTreeMap<_, _>>>()?;
+
+    let mut groups = Vec::with_capacity(HELP_GROUPS.len());
+    for group in HELP_GROUPS {
+        let mut commands = Vec::with_capacity(group.commands.len());
+        for command in group.commands {
+            let summary = match (summaries.remove(command.name), command.summary_override) {
+                (Some(summary), _) => summary,
+                (None, Some(summary)) => summary.to_owned(),
+                (None, None) => {
+                    return Err(anyhow!(
+                        "public help metadata references unknown command `{}`",
+                        command.name
+                    ))
+                }
+            };
+            commands.push(PublicHelpCommand {
+                name: command.name.to_owned(),
+                summary,
+                docs_url: format!("{DOCS_BASE_URL}{}", command.docs_path),
+            });
+        }
+        groups.push(PublicHelpGroup {
+            id: group.id.to_owned(),
+            title: group.title.to_owned(),
+            commands,
+        });
+    }
+
+    if !summaries.is_empty() {
+        let missing = summaries.into_keys().collect::<Vec<_>>();
+        return Err(anyhow!(
+            "public help metadata is missing visible command(s): {}",
+            missing.join(", ")
+        ));
+    }
+
+    Ok(groups)
+}
+
+#[derive(Clone, Copy)]
+struct HelpGroupSpec {
+    id: &'static str,
+    title: &'static str,
+    commands: &'static [HelpCommandSpec],
+}
+
+#[derive(Clone, Copy)]
+struct HelpCommandSpec {
+    name: &'static str,
+    docs_path: &'static str,
+    summary_override: Option<&'static str>,
+}
+
+enum HelpRoute {
+    Root { trailing_args: Vec<OsString> },
+    Nested { command_path: Vec<String> },
+}
+
+#[derive(Clone, Copy)]
+enum CompletionHelpSurface {
+    Root,
+    Nested,
+}
+
+impl HelpCommandSpec {
+    const fn new(name: &'static str, docs_path: &'static str) -> Self {
+        Self {
+            name,
+            docs_path,
+            summary_override: None,
+        }
+    }
+
+    const fn synthetic(name: &'static str, docs_path: &'static str, summary: &'static str) -> Self {
+        Self {
+            name,
+            docs_path,
+            summary_override: Some(summary),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PublicHelpPayload {
+    schema_version: u8,
+    groups: Vec<PublicHelpGroup>,
+}
+
+#[derive(Serialize)]
+struct PublicHelpGroup {
+    id: String,
+    title: String,
+    commands: Vec<PublicHelpCommand>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PublicHelpCommand {
+    name: String,
+    summary: String,
+    docs_url: String,
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -95,6 +95,7 @@ const COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID: &str = "COVEN_CODE_ANTHROPIC_OAUTH_C
 
 #[derive(Parser, Debug)]
 #[command(name = "coven")]
+#[command(bin_name = "coven")]
 #[command(about = "Run project-scoped coding agents without memorizing harness commands")]
 #[command(
     long_about = "Coven runs Codex, Claude Code, GitHub Copilot CLI, and future harnesses inside a local, project-scoped session ledger. Run `coven` with no arguments to open the interactive Coven UI (requires the coven-code front-end), or pass a free-text task to plan and run it directly."

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -43,6 +43,7 @@ mod harness;
 /// Public at the crate root so every adapter entrypoint shares one contract
 /// vocabulary instead of re-declaring embedded runner details.
 pub mod harness_contract;
+mod help;
 mod hub;
 mod maintenance_gate;
 mod memory_dashboard;
@@ -98,11 +99,8 @@ const COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID: &str = "COVEN_CODE_ANTHROPIC_OAUTH_C
 #[command(
     long_about = "Coven runs Codex, Claude Code, GitHub Copilot CLI, and future harnesses inside a local, project-scoped session ledger. Run `coven` with no arguments to open the interactive Coven UI (requires the coven-code front-end), or pass a free-text task to plan and run it directly."
 )]
-#[command(after_help = "Common first steps:
-  coven doctor                    check your local setup and harnesses
-  coven run codex \"<task>\"        run a task in a recorded session
-  coven sessions                  browse recorded sessions
-  coven status                    see daemon, sessions, familiars, and hub at a glance")]
+#[command(help_template = help::TOP_LEVEL_HELP_TEMPLATE)]
+#[command(after_help = help::TOP_LEVEL_AFTER_HELP)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -278,7 +276,7 @@ enum Command {
     },
     #[command(about = "Manage the local Coven daemon")]
     #[command(
-        long_about = "Manage the local Coven daemon that hosts live sessions and the local socket API. `daemon start` launches the hidden `coven daemon serve` entrypoint in the background; serve is the internal foreground server process and is not meant to be run by hand."
+        long_about = "Manage the local Coven daemon that hosts live sessions and the local socket API. `daemon start` launches the background daemon process when it is not already running; the long-running foreground server process stays internal and is not meant to be run by hand."
     )]
     #[command(after_help = "Examples:
   coven daemon start     start the daemon if it is not already running
@@ -1167,6 +1165,12 @@ fn main() -> Result<()> {
         }
     }
 
+    let raw_args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    if let Some(result) = help::maybe_run_from_raw_args(&raw_args) {
+        result?;
+        return Ok(());
+    }
+
     let cli = Cli::parse().validate().unwrap_or_else(|error| error.exit());
     // This diagnostic must not create COVEN_HOME through the shared state lock
     // or read settings contents during startup. It is deliberately the one
@@ -1295,13 +1299,8 @@ fn run_cli(cli: Cli) -> Result<()> {
             config_paths::print_json()
         }
         Some(Command::Completions { shell }) => {
-            use clap::CommandFactory;
-            clap_complete::generate(
-                shell,
-                &mut Cli::command(),
-                "coven",
-                &mut io::stdout().lock(),
-            );
+            let mut command = help::completion_command();
+            clap_complete::generate(shell, &mut command, "coven", &mut io::stdout().lock());
             Ok(())
         }
         Some(Command::Adapter { command }) => run_adapter_command(command),

--- a/crates/coven-cli/tests/help_disclosure.rs
+++ b/crates/coven-cli/tests/help_disclosure.rs
@@ -1,0 +1,458 @@
+use anyhow::Context;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+const CURATED_COMMANDS: &[&str] = &[
+    "doctor", "setup", "run", "sessions", "attach", "daemon", "status", "help",
+];
+const PUBLIC_COMMANDS: &[&str] = &[
+    "doctor",
+    "setup",
+    "run",
+    "sessions",
+    "attach",
+    "daemon",
+    "status",
+    "chat",
+    "tui",
+    "help",
+    "config",
+    "completions",
+    "adapter",
+    "engine",
+    "auth",
+    "models",
+    "acp",
+    "code",
+    "summon",
+    "archive",
+    "sacrifice",
+    "kill",
+    "familiars",
+    "skills",
+    "memory",
+    "research",
+    "calls",
+    "hub",
+    "scheduler",
+    "travel",
+    "wt",
+    "claim",
+    "maintenance",
+    "hooks",
+    "logs",
+    "vacuum",
+    "reset",
+    "patch",
+    "pc",
+    "ward",
+    "executor",
+];
+const GROUP_IDS: &[&str] = &[
+    "start-and-launch",
+    "configure-and-extend",
+    "session-lifecycle",
+    "observe-your-coven",
+    "coordinate-parallel-work",
+    "repair-and-administer",
+];
+
+fn coven_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+}
+
+struct ScratchDir {
+    path: PathBuf,
+}
+
+impl ScratchDir {
+    fn new(name: &str) -> anyhow::Result<Self> {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = manifest_dir
+            .parent()
+            .expect("crate root has workspace parent")
+            .parent()
+            .expect("workspace root");
+        let unique = format!(
+            "{name}-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
+        );
+        let path = workspace_root
+            .join("target")
+            .join("help-disclosure-tests")
+            .join(unique);
+        fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn isolated_help_command(root: &Path, args: &[&str]) -> anyhow::Result<Command> {
+    let current_dir = root.join("current");
+    let user_home = root.join("user-home");
+    let xdg_config = root.join("xdg-config");
+    fs::create_dir_all(&current_dir)?;
+    fs::create_dir_all(&user_home)?;
+    fs::create_dir_all(&xdg_config)?;
+
+    let mut command = Command::new(coven_bin());
+    command
+        .args(args)
+        .current_dir(&current_dir)
+        .env("COVEN_HOME", root.join("coven-home"))
+        .env("HOME", &user_home)
+        .env("USERPROFILE", &user_home)
+        .env("XDG_CONFIG_HOME", &xdg_config)
+        .env("PATH", OsString::new())
+        .env_remove("COVEN_SETTINGS_PATH")
+        .env_remove("COVEN_HARNESS_ADAPTER_DIRS")
+        .env_remove("COVEN_HARNESS_ADAPTER_MANIFEST");
+    Ok(command)
+}
+
+fn closed_stdout_help_output(root: &Path, args: &[&str]) -> anyhow::Result<Output> {
+    let mut command = isolated_help_command(root, args)?;
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    drop(child.stdout.take());
+    child.wait_with_output().map_err(Into::into)
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected success, got {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "help should keep stderr empty: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_failure(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "expected failure, got success\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn listed_commands(help: &str) -> Vec<String> {
+    help.lines()
+        .filter_map(|line| {
+            let trimmed = line.strip_prefix("  ")?;
+            let name = trimmed.split_whitespace().next()?;
+            let separator = &trimmed[name.len()..];
+            if separator.starts_with("  ")
+                && name
+                    .chars()
+                    .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+            {
+                Some(name.to_owned())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn command_from_json<'a>(json: &'a Value, name: &str) -> Option<&'a Value> {
+    json["groups"]
+        .as_array()?
+        .iter()
+        .flat_map(|group| group["commands"].as_array().into_iter().flatten())
+        .find(|command| command["name"] == name)
+}
+
+#[test]
+fn top_level_help_is_concise_and_help_subcommand_matches() -> anyhow::Result<()> {
+    let scratch = ScratchDir::new("top-level-help")?;
+
+    let short_help = isolated_help_command(scratch.path(), &["-h"])?.output()?;
+    assert_success(&short_help);
+
+    let top_level = isolated_help_command(scratch.path(), &["--help"])?.output()?;
+    assert_success(&top_level);
+
+    let explicit_help = isolated_help_command(scratch.path(), &["help"])?.output()?;
+    assert_success(&explicit_help);
+
+    assert_eq!(explicit_help.stdout, top_level.stdout);
+    assert_eq!(
+        listed_commands(&String::from_utf8(short_help.stdout)?),
+        CURATED_COMMANDS
+    );
+    let stdout = String::from_utf8(top_level.stdout)?;
+    assert!(stdout.contains("Run `coven` with no arguments to open the interactive Coven UI"));
+    assert_eq!(listed_commands(&stdout), CURATED_COMMANDS);
+    assert!(!stdout.contains("\n  chat  "));
+    assert!(!stdout.contains("\n  config  "));
+    assert!(
+        !scratch.path().join("coven-home").exists(),
+        "help should not initialize COVEN_HOME state"
+    );
+    Ok(())
+}
+
+#[test]
+fn full_help_lists_each_public_command_once_and_hides_internal_commands() -> anyhow::Result<()> {
+    let scratch = ScratchDir::new("full-help")?;
+
+    let output = isolated_help_command(scratch.path(), &["help", "--all"])?.output()?;
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert_eq!(listed_commands(&stdout), PUBLIC_COMMANDS);
+    assert!(!stdout.contains("process-supervisor"));
+    assert!(!stdout.contains("daemon serve"));
+    Ok(())
+}
+
+#[test]
+fn help_subcommand_matches_direct_command_help() -> anyhow::Result<()> {
+    let scratch = ScratchDir::new("command-help")?;
+
+    let via_help = isolated_help_command(scratch.path(), &["help", "run"])?.output()?;
+    let direct = isolated_help_command(scratch.path(), &["run", "--help"])?.output()?;
+    assert_success(&via_help);
+    assert_success(&direct);
+    assert_eq!(via_help.stdout, direct.stdout);
+
+    let nested_via_help =
+        isolated_help_command(scratch.path(), &["help", "sessions", "show"])?.output()?;
+    let nested_direct =
+        isolated_help_command(scratch.path(), &["sessions", "show", "--help"])?.output()?;
+    assert_success(&nested_via_help);
+    assert_success(&nested_direct);
+    assert_eq!(nested_via_help.stdout, nested_direct.stdout);
+
+    let daemon_via_help = isolated_help_command(scratch.path(), &["help", "daemon"])?.output()?;
+    let daemon_direct = isolated_help_command(scratch.path(), &["daemon", "--help"])?.output()?;
+    assert_success(&daemon_via_help);
+    assert_success(&daemon_direct);
+    assert_eq!(daemon_via_help.stdout, daemon_direct.stdout);
+    let daemon_stdout = String::from_utf8_lossy(&daemon_via_help.stdout);
+    assert!(daemon_stdout.contains("background daemon process"));
+    assert!(!daemon_stdout.contains("daemon serve"));
+
+    assert!(
+        !scratch.path().join("coven-home").exists(),
+        "command-specific help should not initialize COVEN_HOME state"
+    );
+
+    let self_help = isolated_help_command(scratch.path(), &["help", "help"])?.output()?;
+    let direct_self_help = isolated_help_command(scratch.path(), &["help", "--help"])?.output()?;
+    assert_success(&self_help);
+    assert_success(&direct_self_help);
+    assert_eq!(self_help.stdout, direct_self_help.stdout);
+
+    let via_help_with_color =
+        isolated_help_command(scratch.path(), &["help", "run", "--color=always"])?.output()?;
+    let direct_with_color =
+        isolated_help_command(scratch.path(), &["run", "--help", "--color=always"])?.output()?;
+    assert_success(&via_help_with_color);
+    assert_success(&direct_with_color);
+    assert_eq!(via_help_with_color.stdout, direct_with_color.stdout);
+
+    for args in [
+        &["daemon", "help", "--color=bogus"][..],
+        &["daemon", "help", "--color", "bogus"][..],
+    ] {
+        let invalid_color = isolated_help_command(scratch.path(), args)?.output()?;
+        assert_failure(&invalid_color);
+        assert!(String::from_utf8(invalid_color.stderr)?.contains("invalid value 'bogus'"));
+    }
+    Ok(())
+}
+
+#[test]
+fn nested_help_subcommands_remain_available() -> anyhow::Result<()> {
+    let scratch = ScratchDir::new("nested-help")?;
+
+    let daemon_help = isolated_help_command(scratch.path(), &["daemon", "help"])?.output()?;
+    let daemon_direct = isolated_help_command(scratch.path(), &["daemon", "--help"])?.output()?;
+    assert_success(&daemon_help);
+    assert_success(&daemon_direct);
+    assert_eq!(daemon_help.stdout, daemon_direct.stdout);
+
+    let sessions_help =
+        isolated_help_command(scratch.path(), &["sessions", "help", "show"])?.output()?;
+    let sessions_direct =
+        isolated_help_command(scratch.path(), &["sessions", "show", "--help"])?.output()?;
+    assert_success(&sessions_help);
+    assert_success(&sessions_direct);
+    assert_eq!(sessions_help.stdout, sessions_direct.stdout);
+
+    let hidden = isolated_help_command(scratch.path(), &["daemon", "help", "serve"])?.output()?;
+    assert_failure(&hidden);
+    assert_eq!(hidden.status.code(), Some(2));
+    assert!(hidden.stdout.is_empty());
+    let hidden_stderr = String::from_utf8(hidden.stderr)?;
+    assert!(hidden_stderr.contains("unrecognized public command `serve`"));
+    assert!(hidden_stderr.contains("Usage: coven daemon"));
+    assert!(!hidden_stderr.contains("Usage: coven daemon serve"));
+
+    assert!(
+        !scratch.path().join("coven-home").exists(),
+        "nested help should not initialize COVEN_HOME state"
+    );
+    Ok(())
+}
+
+#[test]
+fn full_help_json_has_stable_schema_routes_and_no_ansi() -> anyhow::Result<()> {
+    let scratch = ScratchDir::new("json-help")?;
+
+    let first = isolated_help_command(
+        scratch.path(),
+        &["--color=always", "help", "--all", "--json"],
+    )?
+    .output()?;
+    assert_success(&first);
+    let second = isolated_help_command(scratch.path(), &["help", "--all", "--json"])?.output()?;
+    assert_success(&second);
+    assert_eq!(first.stdout, second.stdout);
+
+    let stdout = String::from_utf8(first.stdout)?;
+    assert!(!stdout.contains('\u{1b}'));
+    assert!(!stdout.contains(&scratch.path().display().to_string()));
+    assert!(!stdout.contains("process-supervisor"));
+    assert!(!stdout.contains("daemon serve"));
+
+    let json: Value = serde_json::from_str(&stdout)?;
+    assert_eq!(json["schemaVersion"], 1);
+
+    let group_ids: Vec<_> = json["groups"]
+        .as_array()
+        .expect("groups array")
+        .iter()
+        .map(|group| group["id"].as_str().expect("group id"))
+        .collect();
+    assert_eq!(group_ids, GROUP_IDS);
+
+    let commands: Vec<_> = json["groups"]
+        .as_array()
+        .expect("groups array")
+        .iter()
+        .flat_map(|group| group["commands"].as_array().into_iter().flatten())
+        .map(|command| command["name"].as_str().expect("command name"))
+        .collect();
+    assert_eq!(commands, PUBLIC_COMMANDS);
+
+    let doctor = command_from_json(&json, "doctor").expect("doctor command");
+    assert_eq!(
+        doctor["docsUrl"],
+        "https://docs.opencoven.ai/docs/cli/doctor"
+    );
+    assert_eq!(
+        doctor["summary"],
+        "Check local setup and print next steps (exits 1 when a blocking problem is found)"
+    );
+    let setup = command_from_json(&json, "setup").expect("setup command");
+    assert_eq!(
+        setup["docsUrl"],
+        "https://docs.opencoven.ai/docs/reference/cli-setup"
+    );
+
+    let status = command_from_json(&json, "status").expect("status command");
+    assert_eq!(
+        status["docsUrl"],
+        "https://docs.opencoven.ai/docs/cli/observe"
+    );
+
+    let help = command_from_json(&json, "help").expect("help command");
+    assert_eq!(
+        help["docsUrl"],
+        "https://docs.opencoven.ai/docs/cli/interactive"
+    );
+    let config = command_from_json(&json, "config").expect("config command");
+    assert_eq!(
+        config["docsUrl"],
+        "https://docs.opencoven.ai/docs/daemon/configuration"
+    );
+    let engine = command_from_json(&json, "engine").expect("engine command");
+    assert_eq!(
+        engine["docsUrl"],
+        "https://docs.opencoven.ai/docs/cli/engine-auth"
+    );
+    let adapter = command_from_json(&json, "adapter").expect("adapter command");
+    assert_eq!(
+        adapter["docsUrl"],
+        "https://docs.opencoven.ai/docs/cli/repo-workflow"
+    );
+    let memory = command_from_json(&json, "memory").expect("memory command");
+    assert_eq!(
+        memory["docsUrl"],
+        "https://docs.opencoven.ai/docs/memory-models"
+    );
+    let patch = command_from_json(&json, "patch").expect("patch command");
+    assert_eq!(
+        patch["docsUrl"],
+        "https://docs.opencoven.ai/docs/cli/patch-openclaw"
+    );
+    let pc = command_from_json(&json, "pc").expect("pc command");
+    assert_eq!(pc["docsUrl"], "https://docs.opencoven.ai/docs/cli/pc");
+    let executor = command_from_json(&json, "executor").expect("executor command");
+    assert_eq!(
+        executor["docsUrl"],
+        "https://docs.opencoven.ai/docs/cli/hub-scheduler"
+    );
+    assert!(json["groups"]
+        .as_array()
+        .expect("groups array")
+        .iter()
+        .flat_map(|group| group["commands"].as_array().into_iter().flatten())
+        .all(|command| command["summary"].is_string()
+            && command["docsUrl"].as_str().is_some_and(|url| {
+                url.starts_with("https://docs.opencoven.ai/docs/cli/")
+                    || url.starts_with("https://docs.opencoven.ai/docs/daemon/")
+                    || url.starts_with("https://docs.opencoven.ai/docs/memory-models")
+                    || url == "https://docs.opencoven.ai/docs/reference/cli-setup"
+                    || url == "https://docs.opencoven.ai/docs/reference/troubleshooting"
+                    || url == "https://docs.opencoven.ai/docs/reference/support"
+                    || url == "https://docs.opencoven.ai/docs/cli"
+            })));
+    Ok(())
+}
+
+#[test]
+fn progressive_help_treats_broken_pipe_as_success() -> anyhow::Result<()> {
+    let scratch = ScratchDir::new("broken-pipe-help")?;
+
+    for (label, args) in [
+        ("command help", vec!["help", "run"]),
+        ("full help", vec!["help", "--all"]),
+        ("json help", vec!["help", "--all", "--json"]),
+    ] {
+        let output = closed_stdout_help_output(scratch.path(), &args)
+            .with_context(|| format!("failed running {label} with closed stdout"))?;
+        assert_success(&output);
+        assert!(
+            output.stdout.is_empty(),
+            "{label} should not retain closed-pipe stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    Ok(())
+}

--- a/crates/coven-cli/tests/help_disclosure.rs
+++ b/crates/coven-cli/tests/help_disclosure.rs
@@ -204,6 +204,8 @@ fn top_level_help_is_concise_and_help_subcommand_matches() -> anyhow::Result<()>
     );
     let stdout = String::from_utf8(top_level.stdout)?;
     assert!(stdout.contains("Run `coven` with no arguments to open the interactive Coven UI"));
+    assert!(stdout.contains("Usage: coven "));
+    assert!(!stdout.contains("coven.exe"));
     assert_eq!(listed_commands(&stdout), CURATED_COMMANDS);
     assert!(!stdout.contains("\n  chat  "));
     assert!(!stdout.contains("\n  config  "));
@@ -381,6 +383,10 @@ fn full_help_json_has_stable_schema_routes_and_no_ansi() -> anyhow::Result<()> {
     );
 
     let help = command_from_json(&json, "help").expect("help command");
+    assert_eq!(
+        help["summary"],
+        "Show concise help, every public command, or help for one command"
+    );
     assert_eq!(
         help["docsUrl"],
         "https://docs.opencoven.ai/docs/cli/interactive"

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -1191,6 +1191,55 @@ fn completions_generate_for_supported_shells() -> anyhow::Result<()> {
 }
 
 #[test]
+fn completions_expose_progressive_help_flags_and_hide_internal_targets() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+
+    let bash = run_coven(&coven, &coven_home, &path, &["completions", "bash"])?;
+    assert_success("completions bash progressive help", &bash);
+    let stdout = String::from_utf8(bash.stdout)?;
+
+    let root_opts = bash_completion_opts(&stdout, "coven").context("missing root completion")?;
+    assert!(root_opts.contains(&"-h"));
+    assert!(root_opts.contains(&"--help"));
+    assert!(root_opts.contains(&"run"));
+    assert!(root_opts.contains(&"help"));
+    assert!(!root_opts.contains(&"process-supervisor"));
+
+    let daemon_opts = bash_completion_opts(&stdout, "coven__subcmd__daemon")
+        .context("missing daemon completion")?;
+    assert!(daemon_opts.contains(&"-h"));
+    assert!(daemon_opts.contains(&"--help"));
+
+    let help_opts =
+        bash_completion_opts(&stdout, "coven__subcmd__help").context("missing help completion")?;
+    assert!(help_opts.contains(&"-h"));
+    assert!(help_opts.contains(&"--help"));
+    assert!(help_opts.contains(&"--all"));
+    assert!(help_opts.contains(&"--json"));
+    assert!(help_opts.contains(&"--color"));
+    assert!(help_opts.contains(&"daemon"));
+    assert!(help_opts.contains(&"run"));
+    assert!(help_opts.contains(&"help"));
+    assert!(!help_opts.contains(&"process-supervisor"));
+
+    let daemon_help_opts = bash_completion_opts(&stdout, "coven__subcmd__daemon__subcmd__help")
+        .context("missing daemon help completion")?;
+    assert!(daemon_help_opts.contains(&"-h"));
+    assert!(daemon_help_opts.contains(&"--help"));
+    assert!(daemon_help_opts.contains(&"start"));
+    assert!(daemon_help_opts.contains(&"status"));
+    assert!(!daemon_help_opts.contains(&"serve"));
+
+    assert!(!stdout.contains("process-supervisor"));
+    assert!(!stdout.contains("daemon__subcmd__serve"));
+    Ok(())
+}
+
+#[test]
 fn color_flag_parses_and_rejects_unknown_values() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -1967,6 +2016,21 @@ fn assert_stdout_not_contains(label: &str, output: &Output, needle: &str) {
         "{label} stdout unexpectedly contained {needle:?}\nstdout:\n{stdout}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn bash_completion_opts<'a>(script: &'a str, case_label: &str) -> Option<Vec<&'a str>> {
+    let marker = format!("{case_label})");
+    let section = script.split_once(&marker)?.1;
+    let opts_line = section
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("opts=\""))?;
+    let opts = opts_line
+        .strip_prefix("opts=\"")?
+        .strip_suffix('"')?
+        .split_whitespace()
+        .collect();
+    Some(opts)
 }
 
 fn prepend_path(fake_bin: &Path) -> OsString {

--- a/docs/development/cli-core-functionality.md
+++ b/docs/development/cli-core-functionality.md
@@ -28,7 +28,7 @@ Do not call the CLI healthy merely because `--help` renders. A healthy core path
 
 | User outcome | CLI entry point | Primary Rust owner | Contract to preserve |
 | --- | --- | --- | --- |
-| Discover commands and route free-text input | `coven`, `coven chat`, `coven tui`, `coven help` | `crates/coven-cli/src/main.rs`, `tui/`, `engine.rs` | Bare Coven opens the interactive route; free-text work remains confirmable and recorded. |
+| Discover commands and route free-text input | `coven`, `coven chat`, `coven tui`, `coven help` | `crates/coven-cli/src/main.rs`, `help.rs`, `tui/`, `engine.rs` | Bare Coven opens the interactive route; default top-level help stays concise (`doctor`, `run`, `sessions`, `attach`, `daemon`, `status`, `help`); `coven help --all` exposes the full public command map without leaking internal entrypoints. |
 | Check local readiness | `coven doctor [--json]` | `main.rs`, `harness.rs`, `paths.rs`, `daemon.rs` | Human output gives repair hints; JSON stays a single machine-readable document. |
 | Control the daemon | `coven daemon start/status/restart/stop` | `daemon.rs`, `api.rs`, `paths.rs` | One same-user local daemon owns the socket and state directory. |
 | Launch work | `coven run <harness> <prompt>` | `session_launch.rs`, `harness.rs`, `pty_runner.rs`, `store.rs` | Validate project root and cwd in Rust, construct argv safely, then record session/events. |
@@ -39,13 +39,21 @@ Do not call the CLI healthy merely because `--help` renders. A healthy core path
 
 `main.rs` is the authoritative parser and dispatch map. When a command changes, start there and follow its delegated module before changing documentation.
 
+Progressive help is part of that parser contract:
+
+- `coven --help` and `coven help` stay focused on the core workflow while still documenting the bare interactive `coven` route above the command list.
+- `coven help --all` is the public inventory: every public top-level command appears once, grouped by user task, plus the machine-readable `--json` view.
+- `coven help <command>` should stay equivalent in useful content to `coven <command> --help`.
+- Hidden/internal entrypoints such as `process-supervisor` and `coven daemon serve` stay absent from the public help surfaces and JSON catalog.
+
 ## Access paths developers should exercise
 
 Run these from a clean, representative project directory. They are ordered from read-only inspection to daemon activation; the final launch is intentionally opt-in.
 
 ```sh
-# Parser and command inventory: no daemon or harness execution.
+# Concise discovery plus the grouped public inventory: no daemon or harness execution.
 coven --help
+coven help --all
 
 # Readiness envelope: succeeds only when a usable local path exists.
 coven doctor --json | jq -e '.ok'

--- a/scripts/export-cli-help-contract-test.mjs
+++ b/scripts/export-cli-help-contract-test.mjs
@@ -1,0 +1,323 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const fixturesRoot = path.join(repoRoot, 'target', 'export-cli-help-contract-tests');
+const scriptPath = path.join(repoRoot, 'scripts', 'export-cli-help-contract.mjs');
+
+const VALID_FIXTURE = {
+  schemaVersion: 1,
+  groups: [
+    {
+      id: 'start-and-launch',
+      title: 'Start and launch',
+      commands: [
+        {
+          name: 'doctor',
+          summary: 'Check local setup and print next steps',
+          docsUrl: 'https://docs.opencoven.ai/docs/cli/doctor',
+        },
+        {
+          name: 'help',
+          summary: 'Show concise help, every public command, or help for one command',
+          docsUrl: 'https://docs.opencoven.ai/docs/cli/interactive',
+        },
+      ],
+    },
+    {
+      id: 'observe-your-coven',
+      title: 'Observe your coven',
+      commands: [
+        {
+          name: 'skills',
+          summary: 'List installed skills from ~/.coven/skills/',
+          docsUrl: 'https://docs.opencoven.ai/docs/cli/observe',
+        },
+      ],
+    },
+  ],
+};
+
+let counter = 0;
+
+function testDir(name) {
+  const safeName = name.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+  const directory = path.join(fixturesRoot, `${safeName}-${process.pid}-${counter++}`);
+  rmSync(directory, { recursive: true, force: true });
+  mkdirSync(directory, { recursive: true });
+  return directory;
+}
+
+function pushFlag(args, flagName, value, form) {
+  if (form === 'equals') {
+    args.push(`${flagName}=${value}`);
+    return;
+  }
+  args.push(flagName, value);
+}
+
+function writeFakeBinary(directory) {
+  const fixtureBinary = path.join(directory, 'fake coven help.mjs');
+  writeFileSync(
+    fixtureBinary,
+    `import { readFileSync } from 'node:fs';
+
+const args = JSON.stringify(process.argv.slice(2));
+const expected = JSON.stringify(['help', '--all', '--json']);
+if (args !== expected) {
+  console.error(\`unexpected args: \${args}\`);
+  process.exit(2);
+}
+
+const fixturePath = process.env.COVEN_FAKE_HELP_FIXTURE;
+if (!fixturePath) {
+  console.error('missing COVEN_FAKE_HELP_FIXTURE');
+  process.exit(3);
+}
+
+process.stdout.write(readFileSync(fixturePath, 'utf8'));
+if (process.env.COVEN_FAKE_HELP_STDERR) {
+  process.stderr.write(process.env.COVEN_FAKE_HELP_STDERR);
+}
+process.exit(Number(process.env.COVEN_FAKE_HELP_EXIT ?? 0));
+`,
+  );
+  return fixtureBinary;
+}
+
+function runExport({
+  fixture,
+  binaryForm = 'split',
+  nodeFlagForm = 'equals',
+  scriptArgForm = 'split',
+  outputForm = 'split',
+  name,
+  env = {},
+}) {
+  const directory = testDir(name);
+  const binaryPath = writeFakeBinary(directory);
+  const fixturePath = path.join(directory, 'fixture.json');
+  const outputPath = path.join(directory, 'out dir', 'coven cli help.json');
+  writeFileSync(fixturePath, typeof fixture === 'string' ? fixture : JSON.stringify(fixture));
+
+  const args = [];
+  if (binaryForm === 'equals') {
+    args.push(`--binary=${process.execPath}`);
+  } else {
+    args.push('--binary', process.execPath);
+  }
+
+  pushFlag(args, '--binary-arg', '--no-warnings', nodeFlagForm);
+  pushFlag(args, '--binary-arg', binaryPath, scriptArgForm);
+
+  pushFlag(args, '--output', outputPath, outputForm);
+
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      COVEN_FAKE_HELP_FIXTURE: fixturePath,
+      ...env,
+    },
+  });
+
+  return { directory, outputPath, result };
+}
+
+test('exports a deterministic pretty contract with a trailing newline', () => {
+  const first = runExport({
+    fixture: {
+      groups: VALID_FIXTURE.groups,
+      schemaVersion: 1,
+    },
+    binaryForm: 'equals',
+    nodeFlagForm: 'equals',
+    scriptArgForm: 'split',
+    outputForm: 'split',
+    name: 'success first with spaces',
+  });
+  assert.equal(first.result.status, 0, first.result.stderr);
+  assert.equal(
+    readFileSync(first.outputPath, 'utf8'),
+    `${JSON.stringify(VALID_FIXTURE, null, 2)}\n`,
+  );
+
+  const second = runExport({
+    fixture: JSON.stringify({
+      schemaVersion: 1,
+      groups: VALID_FIXTURE.groups,
+    }),
+    binaryForm: 'split',
+    nodeFlagForm: 'split',
+    scriptArgForm: 'equals',
+    outputForm: 'equals',
+    name: 'success-second',
+  });
+  assert.equal(second.result.status, 0, second.result.stderr);
+  assert.equal(readFileSync(second.outputPath, 'utf8'), readFileSync(first.outputPath, 'utf8'));
+});
+
+test('rejects duplicate command names', () => {
+  const { result } = runExport({
+    fixture: {
+      schemaVersion: 1,
+      groups: [
+        {
+          id: 'one',
+          title: 'One',
+          commands: [
+            { name: 'doctor', summary: 'First', docsUrl: 'https://docs.opencoven.ai/docs/cli/doctor' },
+          ],
+        },
+        {
+          id: 'two',
+          title: 'Two',
+          commands: [
+            { name: 'doctor', summary: 'Second', docsUrl: 'https://docs.opencoven.ai/docs/cli/run' },
+          ],
+        },
+      ],
+    },
+    name: 'duplicate-command',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /duplicate command name: doctor/);
+});
+
+test('rejects unsupported schema versions', () => {
+  const { result } = runExport({
+    fixture: {
+      schemaVersion: 2,
+      groups: VALID_FIXTURE.groups,
+    },
+    name: 'invalid-schema',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /schemaVersion must be 1/);
+});
+
+test('rejects leaked internal commands', () => {
+  const { result } = runExport({
+    fixture: {
+      schemaVersion: 1,
+      groups: [
+        {
+          id: 'ops',
+          title: 'Ops',
+          commands: [
+            {
+              name: 'process-supervisor',
+              summary: 'Internal only',
+              docsUrl: 'https://docs.opencoven.ai/docs/cli/daemon',
+            },
+          ],
+        },
+      ],
+    },
+    name: 'internal-command',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /internal command leaked into public help/);
+});
+
+test('rejects unstable docs URLs', () => {
+  const { result } = runExport({
+    fixture: {
+      schemaVersion: 1,
+      groups: [
+        {
+          id: 'bad-url',
+          title: 'Bad URL',
+          commands: [
+            {
+              name: 'doctor',
+              summary: 'Check local setup',
+              docsUrl: 'https://example.com/docs/cli/doctor?preview=1',
+            },
+          ],
+        },
+      ],
+    },
+    name: 'bad-url',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /stable https:\/\/docs\.opencoven\.ai origin/);
+});
+
+test('rejects ANSI escape sequences', () => {
+  const ansiFixture = JSON.stringify({
+    schemaVersion: 1,
+    groups: [
+      {
+        id: 'ansi',
+        title: 'ANSI',
+        commands: [
+          {
+            name: 'doctor',
+            summary: '\u001b[31mCheck local setup\u001b[0m',
+            docsUrl: 'https://docs.opencoven.ai/docs/cli/doctor',
+          },
+        ],
+      },
+    ],
+  });
+  const { result } = runExport({
+    fixture: ansiFixture,
+    name: 'ansi',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /ANSI escape sequences/);
+});
+
+test('rejects machine-specific path leakage', () => {
+  const { result } = runExport({
+    fixture: {
+      schemaVersion: 1,
+      groups: [
+        {
+          id: 'paths',
+          title: 'Paths',
+          commands: [
+            {
+              name: 'doctor',
+              summary: 'Read /var/db/coven/private.sock before continuing',
+              docsUrl: 'https://docs.opencoven.ai/docs/cli/doctor',
+            },
+          ],
+        },
+      ],
+    },
+    name: 'path-leak',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /machine-specific path/);
+});
+
+test('rejects Windows machine-specific path leakage', () => {
+  const { result } = runExport({
+    fixture: {
+      schemaVersion: 1,
+      groups: [
+        {
+          id: 'windows-paths',
+          title: 'Windows paths',
+          commands: [
+            {
+              name: 'doctor',
+              summary: 'Read C:\\Users\\example\\coven\\private.sock before continuing',
+              docsUrl: 'https://docs.opencoven.ai/docs/cli/doctor',
+            },
+          ],
+        },
+      ],
+    },
+    name: 'windows-path-leak',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /machine-specific path/);
+});

--- a/scripts/export-cli-help-contract.mjs
+++ b/scripts/export-cli-help-contract.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HELP_ARGS = ['help', '--all', '--json'];
+const HELP_SCHEMA_VERSION = 1;
+const DOCS_ORIGIN = 'https://docs.opencoven.ai';
+const DOCS_PATH_PREFIX = '/docs/';
+const ANSI_ESCAPE_RE = /\u001b\[[0-?]*[ -/]*[@-~]/u;
+const POSIX_MACHINE_PATH_RE =
+  /(?:^|[\s"'`(])\/(?:Users|home|var|private|opt|etc|Volumes|mnt|srv|root)(?:\/[^\s"'`<>]+)+/u;
+const WINDOWS_MACHINE_PATH_RE =
+  /(?:^|[\s"'`(])[A-Za-z]:\\(?:[^\\\s"'`<>]+\\)*[^\\\s"'`<>]*/u;
+const INTERNAL_COMMAND_NAMES = new Set(['process-supervisor', 'serve']);
+
+function usage() {
+  return 'Usage: node scripts/export-cli-help-contract.mjs --binary <command> [--binary-arg <arg>]... --output <path>';
+}
+
+function fail(message) {
+  throw new Error(`${message}\n${usage()}`);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasAnsi(value) {
+  return ANSI_ESCAPE_RE.test(value);
+}
+
+function hasMachinePath(value) {
+  return POSIX_MACHINE_PATH_RE.test(value) || WINDOWS_MACHINE_PATH_RE.test(value);
+}
+
+function ensureExactKeys(value, expectedKeys, label) {
+  const actualKeys = Object.keys(value).sort();
+  const wantedKeys = [...expectedKeys].sort();
+  if (actualKeys.length !== wantedKeys.length || actualKeys.some((key, index) => key !== wantedKeys[index])) {
+    throw new Error(`${label} must contain exactly these keys: ${expectedKeys.join(', ')}`);
+  }
+}
+
+function ensureSafeString(value, label) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (hasAnsi(value)) {
+    throw new Error(`${label} must not contain ANSI escape sequences`);
+  }
+  if (hasMachinePath(value)) {
+    throw new Error(`${label} must not contain a machine-specific path`);
+  }
+  return value;
+}
+
+function normalizeDocsUrl(value, label) {
+  const docsUrl = ensureSafeString(value, label);
+  let parsed;
+  try {
+    parsed = new URL(docsUrl);
+  } catch (error) {
+    throw new Error(`${label} must be a valid URL: ${error.message}`);
+  }
+  if (parsed.origin !== DOCS_ORIGIN) {
+    throw new Error(`${label} must use the stable ${DOCS_ORIGIN} origin`);
+  }
+  if (!parsed.pathname.startsWith(DOCS_PATH_PREFIX)) {
+    throw new Error(`${label} must stay under ${DOCS_PATH_PREFIX}`);
+  }
+  if (parsed.search) {
+    throw new Error(`${label} must not include query parameters`);
+  }
+  if (parsed.hash && !/^#[a-z0-9-]+$/u.test(parsed.hash)) {
+    throw new Error(`${label} must use lowercase kebab-case fragment ids`);
+  }
+  return `${parsed.origin}${parsed.pathname}${parsed.hash}`;
+}
+
+export function parseArgs(argv) {
+  const options = { binaryArgs: [] };
+  let index = 0;
+
+  while (index < argv.length) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      return { help: true };
+    }
+
+    if (argument.startsWith('--binary=')) {
+      options.binary = argument.slice('--binary='.length);
+      index += 1;
+      continue;
+    }
+    if (argument === '--binary') {
+      if (argv[index + 1] === undefined) {
+        fail('missing value for --binary');
+      }
+      options.binary = argv[index + 1];
+      index += 2;
+      continue;
+    }
+    if (argument.startsWith('--binary-arg=')) {
+      options.binaryArgs.push(argument.slice('--binary-arg='.length));
+      index += 1;
+      continue;
+    }
+    if (argument === '--binary-arg') {
+      if (argv[index + 1] === undefined) {
+        fail('missing value for --binary-arg');
+      }
+      options.binaryArgs.push(argv[index + 1]);
+      index += 2;
+      continue;
+    }
+    if (argument.startsWith('--output=')) {
+      options.output = argument.slice('--output='.length);
+      index += 1;
+      continue;
+    }
+    if (argument === '--output') {
+      if (argv[index + 1] === undefined) {
+        fail('missing value for --output');
+      }
+      options.output = argv[index + 1];
+      index += 2;
+      continue;
+    }
+
+    fail(`unknown argument: ${argument}`);
+  }
+
+  if (!options.binary) {
+    fail('missing required --binary path');
+  }
+  if (!options.output) {
+    fail('missing required --output path');
+  }
+
+  return options;
+}
+
+export function normalizeCliHelpContract(payload) {
+  if (!isPlainObject(payload)) {
+    throw new Error('help contract must be a JSON object');
+  }
+  ensureExactKeys(payload, ['schemaVersion', 'groups'], 'help contract');
+
+  if (payload.schemaVersion !== HELP_SCHEMA_VERSION) {
+    throw new Error(`schemaVersion must be ${HELP_SCHEMA_VERSION}`);
+  }
+  if (!Array.isArray(payload.groups) || payload.groups.length === 0) {
+    throw new Error('groups must be a non-empty array');
+  }
+
+  const seenGroupIds = new Set();
+  const seenCommands = new Set();
+
+  const groups = payload.groups.map((group, groupIndex) => {
+    if (!isPlainObject(group)) {
+      throw new Error(`group ${groupIndex} must be an object`);
+    }
+    ensureExactKeys(group, ['id', 'title', 'commands'], `group ${groupIndex}`);
+
+    const id = ensureSafeString(group.id, `group ${groupIndex} id`);
+    if (!/^[a-z0-9-]+$/u.test(id)) {
+      throw new Error(`group ${groupIndex} id must be lowercase kebab-case`);
+    }
+    if (seenGroupIds.has(id)) {
+      throw new Error(`duplicate group id: ${id}`);
+    }
+    seenGroupIds.add(id);
+
+    const title = ensureSafeString(group.title, `group ${groupIndex} title`);
+    if (!Array.isArray(group.commands) || group.commands.length === 0) {
+      throw new Error(`group ${id} must contain at least one command`);
+    }
+
+    const commands = group.commands.map((command, commandIndex) => {
+      if (!isPlainObject(command)) {
+        throw new Error(`group ${id} command ${commandIndex} must be an object`);
+      }
+      ensureExactKeys(command, ['name', 'summary', 'docsUrl'], `group ${id} command ${commandIndex}`);
+
+      const name = ensureSafeString(command.name, `group ${id} command ${commandIndex} name`);
+      if (!/^[a-z0-9-]+$/u.test(name)) {
+        throw new Error(`command ${name} must be lowercase kebab-case`);
+      }
+      if (INTERNAL_COMMAND_NAMES.has(name)) {
+        throw new Error(`internal command leaked into public help: ${name}`);
+      }
+      if (seenCommands.has(name)) {
+        throw new Error(`duplicate command name: ${name}`);
+      }
+      seenCommands.add(name);
+
+      return {
+        name,
+        summary: ensureSafeString(command.summary, `command ${name} summary`),
+        docsUrl: normalizeDocsUrl(command.docsUrl, `command ${name} docsUrl`),
+      };
+    });
+
+    return { id, title, commands };
+  });
+
+  return {
+    schemaVersion: HELP_SCHEMA_VERSION,
+    groups,
+  };
+}
+
+export function exportCliHelpContract({ binary, binaryArgs = [], output }) {
+  const commandArgs = [...binaryArgs, ...HELP_ARGS];
+  const result = spawnSync(binary, commandArgs, {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  if (result.error) {
+    throw new Error(`failed to execute ${binary}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `${binary} ${commandArgs.join(' ')} exited with ${result.status}`,
+        result.stdout ? `stdout:\n${result.stdout}` : null,
+        result.stderr ? `stderr:\n${result.stderr}` : null,
+      ]
+        .filter(Boolean)
+        .join('\n\n'),
+    );
+  }
+  if (!result.stdout || result.stdout.trim().length === 0) {
+    throw new Error('CLI help contract command produced no stdout');
+  }
+  if (hasAnsi(result.stdout)) {
+    throw new Error('CLI help contract stdout must not contain ANSI escape sequences');
+  }
+  if (hasMachinePath(result.stdout)) {
+    throw new Error('CLI help contract stdout must not contain a machine-specific path');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`CLI help contract stdout was not valid JSON: ${error.message}`);
+  }
+
+  const normalized = normalizeCliHelpContract(parsed);
+  const pretty = `${JSON.stringify(normalized, null, 2)}\n`;
+
+  mkdirSync(path.dirname(output), { recursive: true });
+  writeFileSync(output, pretty);
+  return { normalized, pretty };
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.help) {
+    console.log(usage());
+    return;
+  }
+  exportCliHelpContract(parsed);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -118,6 +118,7 @@ step('onboarding, PR readiness, and publish guardrails', () => {
     '--test',
     'scripts/onboarding-docs-test.mjs',
     'scripts/cli-docs-test.mjs',
+    'scripts/export-cli-help-contract-test.mjs',
     'scripts/pr-readiness-test.mjs',
     'scripts/publish-npm-test.mjs'
   ]);


### PR DESCRIPTION
## Summary
- keep default `coven --help` focused on the core onboarding path while preserving every command under `coven help --all`
- add grouped human and JSON help contracts, public-only completions, nested help routing, and broken-pipe handling
- export a deterministic CLI documentation contract with portability and leakage checks

## Readiness packet
- **Issue:** contributes the repository-owned CLI/help portion of #670; it does not close the broader cross-repository program
- **Risk:** command discoverability and completion generation; internal commands remain hidden and all visible commands must have explicit metadata
- **Recovery:** revert this PR to restore Clap’s previous top-level help surface

## Validation
- `cargo fmt --check` (Rust 1.98)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` (Rust 1.98)
- `cargo test --workspace --locked` (Rust 1.98)
- `node scripts/export-cli-help-contract-test.mjs`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
