### PR TITLE
test(cli): add packaged first-session E2E journey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,15 +318,22 @@ jobs:
       - run: pnpm test
         working-directory: packages/openclaw-coven
 
-  npm-onboarding-linux:
-    name: npm onboarding smoke (linux-x64)
+  npm-onboarding-pr:
+    name: npm onboarding smoke (${{ matrix.npm-target }})
     needs: changes
     if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.npm_packaging == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
-    env:
-      NPM_TARGET: linux-x64
-      RUST_TARGET: x86_64-unknown-linux-gnu
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            npm-target: linux-x64
+            rust-target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            npm-target: windows
+            rust-target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-node@v7
@@ -334,7 +341,7 @@ jobs:
           node-version: 24
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ env.RUST_TARGET }}
+          targets: ${{ matrix.rust-target }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -345,9 +352,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-npm-
       - name: Install native link dependencies (Linux only)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
-      - run: cargo build --release --package coven-cli --target ${{ env.RUST_TARGET }}
-      - run: node scripts/test-cli-prepublish.mjs --target="$NPM_TARGET" --skip-build --skip-secrets-scan
+      - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
+      - run: node scripts/test-cli-prepublish.mjs --target=${{ matrix.npm-target }} --skip-build --skip-secrets-scan
         env:
           COVEN_NPM_DRY_RUN_VERSION: 999.0.0
 
@@ -460,7 +468,7 @@ jobs:
       - performance-baseline
       - channels
       - openclaw-bridge
-      - npm-onboarding-linux
+      - npm-onboarding-pr
       - npm-onboarding-main
       - engine-contract
       - cargo-deny

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -52,19 +52,24 @@ class CheckCiWorkflowTests(unittest.TestCase):
             'node --test scripts/package-github-release-test.mjs',
             'node --test scripts/release-stress-test.mjs',
             "needs.changes.outputs.docs_only != 'true'",
-            'npm-onboarding-linux',
+            'npm-onboarding-pr',
             "github.event_name == 'push'",
             'performance-baseline',
             'name: CLI performance baseline',
             "if: ${{ github.event_name == 'push' }}",
         ]:
             self.assertIn(needle, CI_TEXT)
-        self.assertIn("\n  npm-onboarding-linux:\n", CI_TEXT)
+        self.assertIn("\n  npm-onboarding-pr:\n", CI_TEXT)
         self.assertIn("\n  npm-onboarding-main:\n", CI_TEXT)
         self.assertIn(
             "if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.npm_packaging == 'true' }}",
             CI_TEXT,
         )
+        pull_request_job = CI_TEXT.split("\n  npm-onboarding-pr:\n", 1)[1].split(
+            "\n  npm-onboarding-main:\n", 1
+        )[0]
+        self.assertIn("npm-target: linux-x64", pull_request_job)
+        self.assertIn("npm-target: windows", pull_request_job)
 
 
     def test_ci_sets_up_node_for_release_workflow_policy_tests(self) -> None:

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -61,6 +61,10 @@ class CheckCiWorkflowTests(unittest.TestCase):
             self.assertIn(needle, CI_TEXT)
         self.assertIn("\n  npm-onboarding-linux:\n", CI_TEXT)
         self.assertIn("\n  npm-onboarding-main:\n", CI_TEXT)
+        self.assertIn(
+            "if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.npm_packaging == 'true' }}",
+            CI_TEXT,
+        )
 
 
     def test_ci_sets_up_node_for_release_workflow_policy_tests(self) -> None:

--- a/scripts/classify-ci-changes-test.py
+++ b/scripts/classify-ci-changes-test.py
@@ -63,6 +63,30 @@ class ClassifyTest(unittest.TestCase):
         self.assertTrue(result['npm_packaging'])
         self.assertFalse(result['rust'])
 
+    def test_help_surface_routes_to_npm_packaging(self):
+        for path in (
+            'docs/reference/cli-daemon.md',
+            'docs/guides/core-access.md',
+            'docs/development/cli-core-functionality.md',
+            'scripts/cli-docs-test.mjs',
+        ):
+            with self.subTest(path=path):
+                result = self.classify(path)
+                self.assertTrue(result['npm_packaging'])
+                self.assertFalse(result['workflow'])
+
+    def test_packaged_user_journey_paths_route_to_npm_packaging(self):
+        for path in (
+            'scripts/test-cli-prepublish-test.mjs',
+            'scripts/user-journey-e2e.mjs',
+            'scripts/user-journey-e2e-test.mjs',
+            'scripts/fixtures/fake-codex.mjs',
+        ):
+            with self.subTest(path=path):
+                result = self.classify(path)
+                self.assertTrue(result['npm_packaging'])
+                self.assertFalse(result['workflow'])
+
     def test_engine_install(self):
         result = self.classify('crates/coven-cli/src/engine_install.rs')
         self.assertTrue(result['rust'])

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -44,13 +44,27 @@ def classify(paths: list[str]) -> dict[str, bool]:
         is_afs = is_cargo_metadata or path.startswith('crates/coven-afs/') or path == 'crates/coven-cli/src/afs_mount.rs' or path == 'scripts/afs-mount-smoke.sh'
         is_channels = path.startswith('packages/channels/') or path.startswith('crates/coven-channels/')
         is_openclaw = path.startswith('packages/openclaw-coven/') or path.startswith('crates/coven-openclaw/')
+        is_help_surface = (
+            path.startswith('docs/reference/cli')
+            or path in {
+                'docs/development/cli-core-functionality.md',
+                'docs/guides/core-access.md',
+                'docs/guides/session-operations.md',
+                'docs/guides/automation-json.md',
+                'scripts/cli-docs-test.mjs',
+            }
+        )
         is_npm = is_cargo_metadata or path.startswith('npm/') or path.startswith('crates/coven-cli/') or path in {
             'scripts/publish-npm.mjs',
             'scripts/publish-npm-test.mjs',
             'scripts/release-npm-context.mjs',
             'scripts/release-npm-platform-matrix.mjs',
             'scripts/test-cli-prepublish.mjs',
-        }
+            'scripts/test-cli-prepublish-test.mjs',
+            'scripts/user-journey-e2e.mjs',
+            'scripts/user-journey-e2e-test.mjs',
+            'scripts/fixtures/fake-codex.mjs',
+        } or is_help_surface
         is_engine = path in {
             'crates/coven-cli/src/engine.rs',
             'crates/coven-cli/src/engine_install.rs',

--- a/scripts/cli-docs-test.mjs
+++ b/scripts/cli-docs-test.mjs
@@ -100,6 +100,9 @@ test('parallel-work guide uses issue-keyed claim tokens', () => {
 test('prepublish smoke runs the CLI docs discovery guard', () => {
   const prepublish = readRepoFile('scripts/test-cli-prepublish.mjs');
   assert.match(prepublish, /scripts\/cli-docs-test\.mjs/);
+  assert.match(prepublish, /scripts\/test-cli-prepublish-test\.mjs/);
+  assert.match(prepublish, /scripts\/user-journey-e2e-test\.mjs/);
+  assert.match(prepublish, /runPackagedUserJourney/);
 });
 
 test('canonical CLI docs are discoverable and local guide contracts remain concrete', () => {

--- a/scripts/fixtures/fake-codex.mjs
+++ b/scripts/fixtures/fake-codex.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 
 const args = process.argv.slice(2);
 const fixtureFlagIndex = args.indexOf('--fixture-kind');
@@ -15,11 +15,15 @@ const passthroughArgs = [
   ...args.slice(fixtureFlagIndex + 2),
 ];
 
-logInvocation(fixtureKind, passthroughArgs);
+const stdinPrompt =
+  fixtureKind === 'codex' && passthroughArgs.at(-1) === '-'
+    ? readFileSync(0, 'utf8').trim()
+    : undefined;
+logInvocation(fixtureKind, passthroughArgs, stdinPrompt);
 
 switch (fixtureKind) {
   case 'codex':
-    runCodexFixture(passthroughArgs);
+    runCodexFixture(passthroughArgs, stdinPrompt);
     break;
   case 'coven-code':
     runCovenCodeFixture(passthroughArgs);
@@ -29,7 +33,7 @@ switch (fixtureKind) {
     process.exit(2);
 }
 
-function runCodexFixture(argv) {
+function runCodexFixture(argv, stdinPrompt) {
   if (argv[0] === '--version') {
     process.stdout.write('codex 0.0.0-fake\n');
     return;
@@ -39,7 +43,7 @@ function runCodexFixture(argv) {
     return;
   }
 
-  const prompt = promptText(argv);
+  const prompt = promptText(argv, stdinPrompt);
   process.stdout.write('fake codex harness=codex\n');
   process.stdout.write(`fake codex complete: ${prompt}\n`);
 }
@@ -62,21 +66,24 @@ function runCovenCodeFixture(argv) {
   process.stdout.write('fake coven-code ready\n');
 }
 
-function promptText(argv) {
+function promptText(argv, stdinPrompt) {
+  if (stdinPrompt !== undefined) {
+    return stdinPrompt || '<empty prompt>';
+  }
   const separatorIndex = argv.indexOf('--');
   const promptArgs =
     separatorIndex === -1 ? argv.filter((arg) => !arg.startsWith('-')) : argv.slice(separatorIndex + 1);
   return promptArgs.join(' ').trim() || '<empty prompt>';
 }
 
-function logInvocation(kind, argv) {
+function logInvocation(kind, argv, prompt) {
   const logPath = process.env.COVEN_FAKE_FIXTURE_LOG;
   if (!logPath) {
     return;
   }
   appendFileSync(
     logPath,
-    `${JSON.stringify({ kind, argv, cwd: process.cwd() })}\n`,
+    `${JSON.stringify({ kind, argv, cwd: process.cwd(), prompt })}\n`,
     'utf8'
   );
 }

--- a/scripts/fixtures/fake-codex.mjs
+++ b/scripts/fixtures/fake-codex.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const fixtureFlagIndex = args.indexOf('--fixture-kind');
+if (fixtureFlagIndex === -1 || fixtureFlagIndex === args.length - 1) {
+  console.error('fake-codex fixture requires --fixture-kind <codex|coven-code>');
+  process.exit(2);
+}
+
+const fixtureKind = args[fixtureFlagIndex + 1];
+const passthroughArgs = [
+  ...args.slice(0, fixtureFlagIndex),
+  ...args.slice(fixtureFlagIndex + 2),
+];
+
+logInvocation(fixtureKind, passthroughArgs);
+
+switch (fixtureKind) {
+  case 'codex':
+    runCodexFixture(passthroughArgs);
+    break;
+  case 'coven-code':
+    runCovenCodeFixture(passthroughArgs);
+    break;
+  default:
+    console.error(`unsupported fake fixture kind: ${fixtureKind}`);
+    process.exit(2);
+}
+
+function runCodexFixture(argv) {
+  if (argv[0] === '--version') {
+    process.stdout.write('codex 0.0.0-fake\n');
+    return;
+  }
+  if (argv[0] === 'login') {
+    process.stdout.write('fake codex login ok\n');
+    return;
+  }
+
+  const prompt = promptText(argv);
+  process.stdout.write('fake codex harness=codex\n');
+  process.stdout.write(`fake codex complete: ${prompt}\n`);
+}
+
+function runCovenCodeFixture(argv) {
+  if (argv.length === 1 && argv[0] === '--version') {
+    process.stdout.write('coven-code 0.6.1\n');
+    return;
+  }
+  if (
+    argv.length === 3 &&
+    argv[0] === 'auth' &&
+    argv[1] === 'status' &&
+    argv[2] === '--json'
+  ) {
+    process.stdout.write('{"loggedIn":true}\n');
+    return;
+  }
+
+  process.stdout.write('fake coven-code ready\n');
+}
+
+function promptText(argv) {
+  const separatorIndex = argv.indexOf('--');
+  const promptArgs =
+    separatorIndex === -1 ? argv.filter((arg) => !arg.startsWith('-')) : argv.slice(separatorIndex + 1);
+  return promptArgs.join(' ').trim() || '<empty prompt>';
+}
+
+function logInvocation(kind, argv) {
+  const logPath = process.env.COVEN_FAKE_FIXTURE_LOG;
+  if (!logPath) {
+    return;
+  }
+  appendFileSync(
+    logPath,
+    `${JSON.stringify({ kind, argv, cwd: process.cwd() })}\n`,
+    'utf8'
+  );
+}

--- a/scripts/fixtures/fake-harness-windows.rs
+++ b/scripts/fixtures/fake-harness-windows.rs
@@ -1,0 +1,126 @@
+use std::env;
+use std::fs::OpenOptions;
+use std::io::{self, Read, Write};
+
+fn main() {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let executable = env::current_exe()
+        .ok()
+        .and_then(|path| {
+            path.file_stem()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .unwrap_or_default();
+    let kind = if executable.eq_ignore_ascii_case("coven-code") {
+        "coven-code"
+    } else {
+        "codex"
+    };
+
+    if kind == "coven-code" {
+        run_coven_code(&args);
+        log_invocation(kind, &args, None);
+        return;
+    }
+
+    let prompt = codex_prompt(&args);
+    log_invocation(kind, &args, Some(&prompt));
+    if args.first().is_some_and(|argument| argument == "--version") {
+        println!("codex 0.0.0-fake");
+    } else if args.first().is_some_and(|argument| argument == "login") {
+        println!("fake codex login ok");
+    } else {
+        println!("fake codex harness=codex");
+        println!("fake codex complete: {prompt}");
+    }
+}
+
+fn run_coven_code(args: &[String]) {
+    if args == ["--version"] {
+        println!("coven-code 0.6.1");
+    } else if args == ["auth", "status", "--json"] {
+        println!("{{\"loggedIn\":true}}");
+    } else {
+        println!("fake coven-code ready");
+    }
+}
+
+fn codex_prompt(args: &[String]) -> String {
+    if args.last().is_some_and(|argument| argument == "-") {
+        let mut input = String::new();
+        io::stdin()
+            .read_to_string(&mut input)
+            .expect("failed reading Codex fixture stdin");
+        let prompt = input.trim();
+        return if prompt.is_empty() {
+            "<empty prompt>".to_string()
+        } else {
+            prompt.to_string()
+        };
+    }
+
+    let prompt_args = args
+        .iter()
+        .position(|argument| argument == "--")
+        .map(|index| &args[index + 1..])
+        .unwrap_or(args);
+    let prompt = prompt_args
+        .iter()
+        .filter(|argument| !argument.starts_with('-'))
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if prompt.trim().is_empty() {
+        "<empty prompt>".to_string()
+    } else {
+        prompt
+    }
+}
+
+fn log_invocation(kind: &str, args: &[String], prompt: Option<&str>) {
+    let Ok(log_path) = env::var("COVEN_FAKE_FIXTURE_LOG") else {
+        return;
+    };
+    let cwd = env::current_dir()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let args_json = args
+        .iter()
+        .map(|argument| format!("\"{}\"", json_escape(argument)))
+        .collect::<Vec<_>>()
+        .join(",");
+    let prompt_json = prompt
+        .map(|value| format!("\"{}\"", json_escape(value)))
+        .unwrap_or_else(|| "null".to_string());
+    let record = format!(
+        "{{\"kind\":\"{}\",\"argv\":[{}],\"cwd\":\"{}\",\"prompt\":{}}}\n",
+        json_escape(kind),
+        args_json,
+        json_escape(&cwd),
+        prompt_json
+    );
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .expect("failed opening fixture log");
+    file.write_all(record.as_bytes())
+        .expect("failed writing fixture log");
+}
+
+fn json_escape(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| match character {
+            '"' => "\\\"".chars().collect::<Vec<_>>(),
+            '\\' => "\\\\".chars().collect(),
+            '\n' => "\\n".chars().collect(),
+            '\r' => "\\r".chars().collect(),
+            '\t' => "\\t".chars().collect(),
+            character if character.is_control() => {
+                format!("\\u{:04x}", character as u32).chars().collect()
+            }
+            character => vec![character],
+        })
+        .collect()
+}

--- a/scripts/onboarding-docs-test.mjs
+++ b/scripts/onboarding-docs-test.mjs
@@ -160,25 +160,31 @@ test('model selection only offers CLI-login harness choices', () => {
 
 test('ci runs npm onboarding smoke on every published platform', () => {
   const workflow = readRepoFile('.github/workflows/ci.yml');
+  const dryRunVersionPattern = new RegExp(
+    String.raw`COVEN_NPM_DRY_RUN_VERSION:\s+${'9'.repeat(3)}\.0\.0\s*(?:\n|$)`
+  );
   assert.match(workflow, /name:\s+npm onboarding smoke/i);
   assert.match(workflow, /ubuntu-latest/);
   assert.match(workflow, /macos-26/);
   assert.doesNotMatch(workflow, /os:\s+macos-latest/);
   assert.match(workflow, /windows-latest/);
   assert.match(workflow, /node scripts\/test-cli-prepublish\.mjs --target=\$\{\{ matrix\.npm-target \}\} --skip-build --skip-secrets-scan/);
-  assert.match(workflow, /COVEN_NPM_DRY_RUN_VERSION:\s+9{3}\.0\.0\s*(?:\n|$)/);
+  assert.match(workflow, dryRunVersionPattern);
 });
 
 test('npm onboarding smoke exercises daemon lifecycle with isolated state', () => {
-  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
-  assert.match(script, /COVEN_HOME:\s*path\.join\(tempDir,\s*'coven-home'\)/);
-  assert.match(script, /\['daemon',\s*'start'\]/);
-  assert.match(script, /\['daemon',\s*'status'\]/);
-  assert.match(script, /\['daemon',\s*'stop'\]/);
-  assert.match(script, /\['sessions',\s*'--plain'\]/);
-  assert.match(script, /Coven daemon: running/);
-  assert.match(script, /\['daemon',\s*'status',\s*'--json'\]/);
-  assert.match(script, /statusJson\.ok !== true/);
+  const prepublish = readRepoFile('scripts/test-cli-prepublish.mjs');
+  const journey = readRepoFile('scripts/user-journey-e2e.mjs');
+  assert.match(prepublish, /runPackagedUserJourney\(/);
+  assert.match(prepublish, /keepScratchDir:\s*keepTempdir/);
+  assert.match(prepublish, /packaged user journey scratch preserved at/);
+  assert.match(journey, /\['daemon',\s*'start'\]/);
+  assert.match(journey, /\['daemon',\s*'status'\]/);
+  assert.match(journey, /\['daemon',\s*'stop'\]/);
+  assert.match(journey, /\['daemon',\s*'status',\s*'--json'\]/);
+  assert.match(journey, /\['sessions',\s*'--json'\]/);
+  assert.match(journey, /Coven daemon: running/);
+  assert.match(journey, /assertDaemonStatusJson\(daemonStatusJson,\s*'running',\s*true\)/);
 });
 
 test('npm onboarding smoke launches Windows cmd shims through a shell', () => {
@@ -187,16 +193,16 @@ test('npm onboarding smoke launches Windows cmd shims through a shell', () => {
   assert.match(script, /shell:\s*platform === 'win32'/);
   assert.match(script, /spawnOptionsForCommand\(options/);
   assert.match(script, /spawnSync\(command,\s*args,\s*\{\s*\.\.\.spawnOptionsForCommand\(\)/);
-  assert.match(script, /spawnSync\('npm',\s*\['view'[\s\S]*?\.\.\.spawnOptionsForCommand\(\)/);
+  assert.match(script, /spawnSyncImpl\('npm',\s*\['view'[\s\S]*?\.\.\.spawnOptionsForCommand\(\)/);
   assert.match(script, /spawnSync\('npm',\s*\['pack'[\s\S]*?\.\.\.spawnOptionsForCommand\(\)/);
 });
 
-test('npm onboarding smoke verifies first-run missing-harness guidance deterministically', () => {
-  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
-  assert.match(script, /function firstRunSmokePath\(/);
-  assert.match(script, /PATH:\s*firstRunSmokePath\(wrapperBin,\s*tempDir\)/);
-  assert.match(script, /node-shim-bin/);
-  assert.doesNotMatch(script, /path\.dirname\(process\.execPath\)/);
+test('packaged journey isolates shims and verifies current setup guidance', () => {
+  const script = readRepoFile('scripts/user-journey-e2e.mjs');
+  assert.match(script, /function createNodeShim\(/);
+  assert.match(script, /nodeShimDir/);
+  assert.match(script, /fixtureBinDir/);
+  assert.match(script, /PATH = pathValue/);
   assert.match(script, /Set up at least one harness in this same shell/);
   assert.match(script, /Codex: coven setup codex/);
   assert.match(script, /Claude Code: coven setup claude/);
@@ -271,6 +277,7 @@ test('npm onboarding smoke runs onboarding guardrails before packaging', () => {
   const script = readRepoFile('scripts/test-cli-prepublish.mjs');
   assert.match(script, /scripts\/onboarding-docs-test\.mjs/);
   assert.match(script, /scripts\/publish-npm-test\.mjs/);
+  assert.match(script, /scripts\/test-cli-prepublish-test\.mjs/);
 });
 
 test('npm onboarding smoke avoids deprecated optional dependency install flag', () => {
@@ -284,6 +291,8 @@ test('npm onboarding smoke bounds subprocess hangs', () => {
   assert.match(script, /DEFAULT_COMMAND_TIMEOUT_MS/);
   assert.match(script, /timeout:\s*options\.timeoutMs \?\? DEFAULT_COMMAND_TIMEOUT_MS/);
   assert.match(script, /ETIMEDOUT/);
+  assert.match(script, /npm view timed out after/);
+  assert.match(script, /Set COVEN_NPM_DRY_RUN_VERSION to an unpublished higher semver and rerun/);
 });
 
 test('npm onboarding smoke gives full cargo gates the CI timeout budget', () => {
@@ -298,9 +307,9 @@ test('npm onboarding smoke gives full cargo gates the CI timeout budget', () => 
 });
 
 test('npm onboarding smoke does not pipe-capture Windows daemon start', () => {
-  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  const script = readRepoFile('scripts/user-journey-e2e.mjs');
   assert.match(script, /function runDaemonStart\(/);
-  assert.match(script, /process\.platform === 'win32'/);
+  assert.match(script, /platform === 'win32'/);
   assert.match(script, /run\(wrapperBin, \['daemon', 'start'\]/);
-  assert.match(script, /runCapture\(wrapperBin, \['daemon', 'status'\]/);
+  assert.match(script, /runCapture\(wrapperBin, \['daemon', 'start'\]/);
 });

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1755,6 +1755,7 @@ test('prepublish smoke has explicit dry-run version override and registry failur
 
   assert.match(script, /COVEN_NPM_DRY_RUN_VERSION/);
   assert.match(script, /Could not read current \$\{packageName\} version/);
+  assert.match(script, /npm view timed out after/);
 });
 
 test('prepublish smoke rejects a missing dashboard tarball before running gates', () => {

--- a/scripts/test-cli-prepublish-test.mjs
+++ b/scripts/test-cli-prepublish-test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -64,4 +65,10 @@ test('synthesizeDryRunVersion bumps the published patch version for dry-run pack
   });
 
   assert.equal(version, '1.2.4');
+});
+
+test('prepublish failures preserve finally cleanup', () => {
+  const script = readFileSync(new URL('./test-cli-prepublish.mjs', import.meta.url), 'utf8');
+  assert.match(script, /process\.exitCode = 1/);
+  assert.doesNotMatch(script, /process\.exit\(1\)/);
 });

--- a/scripts/test-cli-prepublish-test.mjs
+++ b/scripts/test-cli-prepublish-test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULT_COMMAND_TIMEOUT_MS,
+  synthesizeDryRunVersion
+} from './test-cli-prepublish.mjs';
+
+test('synthesizeDryRunVersion honors COVEN_NPM_DRY_RUN_VERSION without calling npm view', () => {
+  let called = false;
+  const version = synthesizeDryRunVersion('@opencoven/cli', {
+    env: { COVEN_NPM_DRY_RUN_VERSION: 'v999.0.0' },
+    spawnSyncImpl() {
+      called = true;
+      throw new Error('override should bypass npm view');
+    }
+  });
+
+  assert.equal(version, '999.0.0');
+  assert.equal(called, false);
+});
+
+test('synthesizeDryRunVersion bounds npm view and reports timeout override guidance', () => {
+  let request;
+  assert.throws(
+    () =>
+      synthesizeDryRunVersion('@opencoven/cli', {
+        env: {},
+        spawnSyncImpl(command, args, options) {
+          request = { command, args, options };
+          return {
+            status: null,
+            stdout: '',
+            stderr: '',
+            error: { code: 'ETIMEDOUT' }
+          };
+        }
+      }),
+    /Set COVEN_NPM_DRY_RUN_VERSION/
+  );
+
+  assert.deepEqual(request, {
+    command: 'npm',
+    args: ['view', '@opencoven/cli', 'version', '--silent'],
+    options: {
+      shell: process.platform === 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      timeout: DEFAULT_COMMAND_TIMEOUT_MS
+    }
+  });
+});
+
+test('synthesizeDryRunVersion bumps the published patch version for dry-run packaging', () => {
+  const version = synthesizeDryRunVersion('@opencoven/cli', {
+    env: {},
+    spawnSyncImpl() {
+      return {
+        status: 0,
+        stdout: '1.2.3\n',
+        stderr: ''
+      };
+    }
+  });
+
+  assert.equal(version, '1.2.4');
+});

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -247,7 +247,7 @@ export async function main() {
     console.log('Next: bump version + tag (vX.Y.Z) to trigger .github/workflows/release-npm.yml.');
   } catch (error) {
     console.error(`\n${error.message}`);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     if (tempDir && !keepTempdir) {
       rmSync(tempDir, { recursive: true, force: true });

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -9,8 +9,8 @@
 //      --skip-build is passed) and lets `npm publish --dry-run` validate the
 //      platform + wrapper tarballs.
 //   4. `npm pack`s the native and wrapper packages, installs them into a fresh
-//      temp project, and invokes the wrapper bin to confirm the native binary
-//      is resolved, executable, and can start the daemon with isolated state.
+//      temp project, then runs the full hermetic installed-wrapper user
+//      journey through scripts/user-journey-e2e.mjs.
 //
 // Flags:
 //   --target=<name>       Override the npm target (macos, macos-x64, linux-x64, windows).
@@ -28,23 +28,28 @@
 //                         local iteration; CI still runs both.
 //   --keep-tempdir        Leave the temp install dir on disk for inspection.
 //   COVEN_NPM_DRY_RUN_VERSION=vX.Y.Z
-//                         Override the synthesized dry-run version when the
+//                         Override the synthesized dry-run version to skip
+//                         npm view during hermetic verification, or when the
 //                         public npm registry cannot be reached.
 //
 // Exit code is non-zero on the first failing step.
 
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { defaultTargetName } from './publish-npm.mjs';
+import {
+  createScratchDir,
+  isMainModule,
+  runPackagedUserJourney
+} from './user-journey-e2e.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const distRoot = path.join(repoRoot, 'npm', 'dist');
-const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
+export const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 const CARGO_GATE_TIMEOUT_MS = 20 * 60_000;
 
 const PLATFORM_TARGETS = {
@@ -120,7 +125,9 @@ step('onboarding, PR readiness, and publish guardrails', () => {
     'scripts/cli-docs-test.mjs',
     'scripts/export-cli-help-contract-test.mjs',
     'scripts/pr-readiness-test.mjs',
-    'scripts/publish-npm-test.mjs'
+    'scripts/publish-npm-test.mjs',
+    'scripts/test-cli-prepublish-test.mjs',
+    'scripts/user-journey-e2e-test.mjs'
   ]);
 });
 
@@ -180,7 +187,7 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
   const platformTgz = npmPack(platformDir);
   const wrapperTgz = npmPack(wrapperDir);
 
-  tempDir = mkdtempSync(path.join(tmpdir(), 'coven-prepublish-'));
+  tempDir = createScratchDir(path.join(repoRoot, 'target', 'script-scratch'), 'coven-prepublish');
   writeFileSync(
     path.join(tempDir, 'package.json'),
     `${JSON.stringify({ name: 'coven-prepublish-test', private: true, version: '0.0.0' }, null, 2)}\n`
@@ -206,66 +213,6 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
     fail(`wrapper bin not present at ${wrapperBin} after install`);
   }
 
-  const isolatedUserHome = path.join(tempDir, 'user-home');
-  mkdirSync(isolatedUserHome, { recursive: true });
-  const smokeEnv = {
-    ...process.env,
-    COVEN_HOME: path.join(tempDir, 'coven-home'),
-    HOME: isolatedUserHome,
-    PATH: firstRunSmokePath(wrapperBin, tempDir),
-    USERPROFILE: isolatedUserHome
-  };
-  if (process.platform === 'win32') {
-    const homeRoot = path.parse(isolatedUserHome).root;
-    smokeEnv.HOMEDRIVE = homeRoot.replace(/[\\/]$/, '');
-    smokeEnv.HOMEPATH = isolatedUserHome.slice(homeRoot.length - 1);
-  }
-  mkdirSync(smokeEnv.COVEN_HOME, { recursive: true });
-
-  const versionOutput = runCapture(wrapperBin, ['--version'], { env: smokeEnv });
-  if (!versionOutput.stdout.trim()) {
-    fail('`coven --version` produced no output');
-  }
-  console.log(`coven --version => ${versionOutput.stdout.trim()}`);
-
-  // A bare runner has no harness installed, so doctor correctly reports a
-  // blocking problem and exits 1. The smoke asserts the first-run report,
-  // not a provisioned environment.
-  const doctorOutput = runCapture(wrapperBin, ['doctor'], {
-    env: smokeEnv,
-    allowedExitCodes: [1]
-  });
-  if (doctorOutput.status !== 1) {
-    fail(
-      `\`coven doctor\` on a bare runner should exit 1 (no harness available); got ${doctorOutput.status}\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`
-    );
-  }
-  if (!doctorOutput.stdout.includes('Coven doctor')) {
-    fail(
-      `\`coven doctor\` did not print the expected banner.\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`
-    );
-  }
-  for (const expected of [
-    'Set up at least one harness in this same shell',
-    'Codex: coven setup codex',
-    'Claude Code: coven setup claude',
-    'GitHub Copilot CLI: coven setup copilot',
-    'Doctor found problems; review the failing checks above.'
-  ]) {
-    if (!doctorOutput.stdout.includes(expected)) {
-      fail(`\`coven doctor\` missing first-run setup guidance "${expected}".\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`);
-    }
-  }
-  console.log('coven doctor first-run setup guidance present (exit 1 on bare runner)');
-
-  const helpOutput = runCapture(wrapperBin, ['--help'], { env: smokeEnv });
-  if (helpOutput.status !== 0) {
-    fail(`\`coven --help\` exited with ${helpOutput.status}\nstderr:\n${helpOutput.stderr}`);
-  }
-  if (!helpOutput.stdout.toLowerCase().includes('usage')) {
-    fail(`\`coven --help\` missing usage section.\nstdout:\n${helpOutput.stdout}`);
-  }
-
   if (dashboardTarball) {
     const dashboardEntry = path.join(
       tempDir,
@@ -278,55 +225,20 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
     if (!existsSync(dashboardEntry)) {
       fail(`dashboard entry not present after install: ${dashboardEntry}`);
     }
-    const memoryHelp = runCapture(wrapperBin, ['memory', 'open', '--help'], {
-      env: smokeEnv
-    });
-    if (!memoryHelp.stdout.includes('private local memory dashboard')) {
-      fail(
-        `\`coven memory open --help\` did not describe the private local dashboard.\nstdout:\n${memoryHelp.stdout}\nstderr:\n${memoryHelp.stderr}`
-      );
-    }
   }
 
-  let daemonStarted = false;
-  try {
-    const startOutput = runDaemonStart(wrapperBin, smokeEnv);
-    daemonStarted = true;
-    if (startOutput && !startOutput.stdout.includes('Coven daemon: running')) {
-      fail(`\`coven daemon start\` did not report a running daemon.\nstdout:\n${startOutput.stdout}\nstderr:\n${startOutput.stderr}`);
-    }
-
-    const statusOutput = runCapture(wrapperBin, ['daemon', 'status'], { env: smokeEnv });
-    if (!statusOutput.stdout.includes('Coven daemon: running')) {
-      fail(`\`coven daemon status\` did not report a running daemon.\nstdout:\n${statusOutput.stdout}\nstderr:\n${statusOutput.stderr}`);
-    }
-
-    // Health check goes through the machine surface: `--json` carries the
-    // `ok` flag that the human prose line intentionally no longer prints.
-    const statusJsonOutput = runCapture(wrapperBin, ['daemon', 'status', '--json'], { env: smokeEnv });
-    let statusJson;
-    try {
-      statusJson = JSON.parse(statusJsonOutput.stdout);
-    } catch {
-      fail(`\`coven daemon status --json\` did not print valid JSON.\nstdout:\n${statusJsonOutput.stdout}\nstderr:\n${statusJsonOutput.stderr}`);
-    }
-    if (statusJson.status !== 'running' || statusJson.ok !== true) {
-      fail(`\`coven daemon status --json\` did not report a healthy running daemon.\nstdout:\n${statusJsonOutput.stdout}\nstderr:\n${statusJsonOutput.stderr}`);
-    }
-
-    const sessionsOutput = runCapture(wrapperBin, ['sessions', '--plain'], { env: smokeEnv });
-    if (!sessionsOutput.stdout.includes('No active Coven sessions yet.')) {
-      fail(`\`coven sessions --plain\` did not report an empty fresh store.\nstdout:\n${sessionsOutput.stdout}\nstderr:\n${sessionsOutput.stderr}`);
-    }
-    console.log('coven daemon lifecycle verified');
-  } finally {
-    if (daemonStarted) {
-      runCapture(wrapperBin, ['daemon', 'stop'], { env: smokeEnv });
-    }
+  const result = runPackagedUserJourney({
+    dashboardExpected: Boolean(dashboardTarball),
+    keepScratchDir: keepTempdir,
+    wrapperBin
+  });
+  console.log(`packaged user journey ok (session ${result.sessionId})`);
+  if (keepTempdir) {
+    console.log(`packaged user journey scratch preserved at ${result.scratchRoot}`);
   }
 });
 
-(async () => {
+export async function main() {
   try {
     for (const run of steps) {
       await run();
@@ -343,10 +255,17 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
       console.log(`\nTemp project left at ${tempDir} (--keep-tempdir).`);
     }
   }
-})();
+}
 
-function synthesizeDryRunVersion(packageName) {
-  const override = process.env.COVEN_NPM_DRY_RUN_VERSION?.trim();
+export function synthesizeDryRunVersion(
+  packageName,
+  {
+    env = process.env,
+    spawnSyncImpl = spawnSync,
+    timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS
+  } = {}
+) {
+  const override = env.COVEN_NPM_DRY_RUN_VERSION?.trim();
   if (override) {
     const normalized = override.replace(/^v/, '');
     if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(normalized)) {
@@ -355,11 +274,24 @@ function synthesizeDryRunVersion(packageName) {
     return normalized;
   }
 
-  const view = spawnSync('npm', ['view', packageName, 'version', '--silent'], {
+  const view = spawnSyncImpl('npm', ['view', packageName, 'version', '--silent'], {
     ...spawnOptionsForCommand(),
     stdio: ['ignore', 'pipe', 'pipe'],
-    encoding: 'utf8'
+    encoding: 'utf8',
+    timeout: timeoutMs
   });
+  if (view.error?.code === 'ETIMEDOUT') {
+    fail(
+      `npm view timed out after ${timeoutMs}ms while reading current ${packageName} version. ` +
+        'Set COVEN_NPM_DRY_RUN_VERSION to an unpublished higher semver and rerun.'
+    );
+  }
+  if (view.error) {
+    fail(
+      `npm view failed while reading current ${packageName} version: ${view.error.message}. ` +
+        'Set COVEN_NPM_DRY_RUN_VERSION to an unpublished higher semver and rerun.'
+    );
+  }
   if (view.status !== 0) {
     const stderr = view.stderr.trim();
     fail(
@@ -382,6 +314,10 @@ function synthesizeDryRunVersion(packageName) {
   const baseMinor = Number(match[2]);
   const basePatch = Number(match[3]);
   return `${baseMajor}.${baseMinor}.${basePatch + 1}`;
+}
+
+if (isMainModule(import.meta.url)) {
+  void main();
 }
 
 function ensureCommand(command, args) {
@@ -470,37 +406,11 @@ function runCapture(command, commandArgs, options = {}) {
   return result;
 }
 
-function runDaemonStart(wrapperBin, smokeEnv) {
-  if (process.platform === 'win32') {
-    // Capturing stdout from npm's Windows .cmd shim can keep the pipe open
-    // while the background daemon is alive. Run start attached to this process,
-    // then verify health via a separate captured status command below.
-    run(wrapperBin, ['daemon', 'start'], { env: smokeEnv });
-    return undefined;
-  }
-  return runCapture(wrapperBin, ['daemon', 'start'], { env: smokeEnv });
-}
-
 function spawnOptionsForCommand(options = {}, platform = process.platform) {
   return {
     shell: platform === 'win32',
     ...options.spawnOptions
   };
-}
-
-function firstRunSmokePath(wrapperBin, tempProjectDir) {
-  const nodeShimDir = path.join(tempProjectDir, 'node-shim-bin');
-  mkdirSync(nodeShimDir, { recursive: true });
-
-  if (process.platform === 'win32') {
-    writeFileSync(path.join(nodeShimDir, 'node.cmd'), `@"${process.execPath}" %*\r\n`);
-  } else {
-    const nodeShim = path.join(nodeShimDir, 'node');
-    writeFileSync(nodeShim, `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$@"\n`);
-    chmodSync(nodeShim, 0o755);
-  }
-
-  return [path.dirname(wrapperBin), nodeShimDir].join(path.delimiter);
 }
 
 function fail(message) {

--- a/scripts/user-journey-e2e-test.mjs
+++ b/scripts/user-journey-e2e-test.mjs
@@ -351,9 +351,13 @@ test(
       }
 
       createNodeShim(layout.nodeShimDir, { platform: process.platform });
-      createGitShim(layout.nodeShimDir, { baseEnv, platform: process.platform });
+      const gitCommand = createGitShim(layout.nodeShimDir, {
+        baseEnv,
+        platform: process.platform
+      });
       const env = buildJourneyEnv({
         baseEnv,
+        gitBinDir: process.platform === 'win32' ? path.dirname(gitCommand) : undefined,
         layout,
         platform: process.platform,
         wrapperBin

--- a/scripts/user-journey-e2e-test.mjs
+++ b/scripts/user-journey-e2e-test.mjs
@@ -17,7 +17,7 @@ import {
   repoRoot,
   runPackagedUserJourney,
   spawnOptionsForCommand,
-  windowsCommandLine
+  windowsCommandInvocation
 } from './user-journey-e2e.mjs';
 
 function withScratch(label, fn) {
@@ -164,28 +164,54 @@ test('createFakeCodexFixture writes executable Unix shims that log deterministic
     assert.equal(entries[0].argv.at(-1), 'fixture marker');
   }));
 
+test('fake Codex fixture reads a dash prompt from stdin', { skip: process.platform === 'win32' }, () =>
+  withScratch('fixture-stdin', (scratch) => {
+    const fixture = createFakeCodexFixture(path.join(scratch, 'bin'));
+    const logPath = path.join(scratch, 'fixture-log.jsonl');
+    const runner = createCommandRunner({ platform: process.platform });
+    const result = runner.runCapture(fixture.codexCommand, ['exec', '-'], {
+      cwd: scratch,
+      env: { ...process.env, COVEN_FAKE_FIXTURE_LOG: logPath },
+      spawnOptions: { input: 'stdin marker\n' }
+    });
+
+    assert.match(result.stdout, /fake codex complete: stdin marker/);
+    const entry = JSON.parse(readFileSync(logPath, 'utf8').trim());
+    assert.equal(entry.prompt, 'stdin marker');
+  }));
+
 test('createFakeCodexFixture writes Windows cmd shims without requiring a release package', () =>
   withScratch('fixture-win', (scratch) => {
-    const fixture = createFakeCodexFixture(path.join(scratch, 'bin'), { platform: 'win32' });
+    const nativeFixture = path.join(scratch, 'fixture.exe');
+    writeFileSync(nativeFixture, 'fixture');
+    const fixture = createFakeCodexFixture(path.join(scratch, 'bin'), {
+      platform: 'win32',
+      windowsNativeFixture: nativeFixture
+    });
     assert.deepEqual(
       fixture.files.map((file) => path.basename(file)).sort(),
-      ['codex.cmd', 'coven-code.cmd']
+      ['codex.cmd', 'coven-code.exe']
     );
-    for (const file of fixture.files) {
-      const text = readFileSync(file, 'utf8');
-      assert.match(text, /fake-codex\.mjs/);
-      assert.match(text, /--fixture-kind/);
-    }
+    assert.match(
+      readFileSync(fixture.codexCommand, 'utf8'),
+      /node_modules\\@openai\\codex\\bin\\codex\.js/
+    );
+    assert.equal(readFileSync(fixture.engineCommand, 'utf8'), 'fixture');
+  }));
+
+test('createNodeShim escapes percent characters in Windows batch files', () =>
+  withScratch('node-shim-win', (scratch) => {
+    const shim = createNodeShim(scratch, {
+      nodePath: 'C:\\100% ready\\node.exe',
+      platform: 'win32'
+    });
+    assert.equal(readFileSync(shim, 'utf8'), '@"C:\\100%% ready\\node.exe" %*\r\n');
   }));
 
 test('Windows commands use an explicitly quoted cmd.exe invocation', () => {
   assert.equal(spawnOptionsForCommand({}, 'darwin').shell, false);
   assert.equal(spawnOptionsForCommand({}, 'win32').shell, false);
   assert.equal(spawnOptionsForCommand({}, 'win32').windowsHide, true);
-  assert.equal(
-    windowsCommandLine('C:\\wrapper path\\coven.cmd', ['run', 'marker & 100%']),
-    '"C:\\wrapper path\\coven.cmd" "run" "marker & 100%%"'
-  );
 
   const calls = [];
   const runner = createCommandRunner({
@@ -203,14 +229,29 @@ test('Windows commands use an explicitly quoted cmd.exe invocation', () => {
   assert.equal(result, undefined);
   assert.equal(calls.length, 1);
   assert.equal(calls[0].command, 'C:\\Windows\\cmd.exe');
-  assert.deepEqual(calls[0].args.slice(0, 3), ['/d', '/s', '/c']);
+  assert.deepEqual(calls[0].args.slice(0, 4), ['/d', '/v:off', '/s', '/c']);
   assert.equal(
-    calls[0].args[3],
-    '"C:\\wrapper path\\coven.cmd" "daemon" "start"'
+    calls[0].args[4],
+    '"%COVEN_JOURNEY_COMMAND_0%" "%COVEN_JOURNEY_COMMAND_1%" "%COVEN_JOURNEY_COMMAND_2%"'
   );
+  assert.equal(calls[0].options.env.COVEN_JOURNEY_COMMAND_0, 'C:\\wrapper path\\coven.cmd');
+  assert.equal(calls[0].options.env.COVEN_JOURNEY_COMMAND_1, 'daemon');
+  assert.equal(calls[0].options.env.COVEN_JOURNEY_COMMAND_2, 'start');
   assert.equal(calls[0].options.shell, false);
   assert.equal(calls[0].options.windowsHide, true);
   assert.equal(calls[0].options.stdio, 'inherit');
+});
+
+test('windowsCommandInvocation preserves percent characters outside shell text', () => {
+  const invocation = windowsCommandInvocation(
+    'C:\\100% ready\\coven.cmd',
+    ['run', 'marker & %TEMP%'],
+    { ComSpec: 'C:\\Windows\\cmd.exe' }
+  );
+  assert.equal(invocation.command, 'C:\\Windows\\cmd.exe');
+  assert.equal(invocation.env.COVEN_JOURNEY_COMMAND_0, 'C:\\100% ready\\coven.cmd');
+  assert.equal(invocation.env.COVEN_JOURNEY_COMMAND_2, 'marker & %TEMP%');
+  assert.doesNotMatch(invocation.commandArgs.at(-1), /100%|TEMP/);
 });
 
 test('buildJourneyEnv strips inherited npm configuration', () =>
@@ -507,6 +548,17 @@ test('runPackagedUserJourney sequences installed-wrapper commands and full lifec
         method: 'runCapture',
         command: wrapperBin,
         args: ['run', 'codex', 'E2E journey marker'],
+        assertOptions(options) {
+          writeFileSync(
+            options.env.COVEN_FAKE_FIXTURE_LOG,
+            `${JSON.stringify({
+              kind: 'codex',
+              argv: ['exec', '-'],
+              cwd: options.cwd,
+              prompt: 'E2E journey marker'
+            })}\n`
+          );
+        },
         result: makeResult({ stdout: 'fake codex complete: E2E journey marker\n' })
       },
       {
@@ -643,6 +695,21 @@ test('assertSessionInspection rejects missing terminal events after the completi
     /did not record a completed terminal payload/
   );
 });
+
+test('assertSessionInspection requires the supplied fixture log', () =>
+  withScratch('fixture-log-required', (scratch) => {
+    assert.throws(
+      () =>
+        assertSessionInspection({
+          ...makeSessionInspectionArgs([
+            { seq: 1, payload_json: '{"text":"fake codex complete: E2E journey marker"}' },
+            { seq: 2, kind: 'exit', payload_json: '{"status":"completed","exitCode":0}' }
+          ]),
+          fixtureLogPath: path.join(scratch, 'missing.jsonl')
+        }),
+      /fixture log was not created/
+    );
+  }));
 
 test('assertSessionInspection rejects terminal events that arrive before completion output', () => {
   assert.throws(

--- a/scripts/user-journey-e2e-test.mjs
+++ b/scripts/user-journey-e2e-test.mjs
@@ -225,6 +225,7 @@ test('Windows commands use an explicitly quoted cmd.exe invocation', () => {
   assert.equal(spawnOptionsForCommand({}, 'darwin').shell, false);
   assert.equal(spawnOptionsForCommand({}, 'win32').shell, false);
   assert.equal(spawnOptionsForCommand({}, 'win32').windowsHide, true);
+  assert.equal(spawnOptionsForCommand({}, 'win32').windowsVerbatimArguments, true);
 
   const calls = [];
   const runner = createCommandRunner({
@@ -245,13 +246,14 @@ test('Windows commands use an explicitly quoted cmd.exe invocation', () => {
   assert.deepEqual(calls[0].args.slice(0, 4), ['/d', '/v:off', '/s', '/c']);
   assert.equal(
     calls[0].args[4],
-    '"%COVEN_JOURNEY_COMMAND_0%" "%COVEN_JOURNEY_COMMAND_1%" "%COVEN_JOURNEY_COMMAND_2%"'
+    '""%COVEN_JOURNEY_COMMAND_0%" "%COVEN_JOURNEY_COMMAND_1%" "%COVEN_JOURNEY_COMMAND_2%""'
   );
   assert.equal(calls[0].options.env.COVEN_JOURNEY_COMMAND_0, 'C:\\wrapper path\\coven.cmd');
   assert.equal(calls[0].options.env.COVEN_JOURNEY_COMMAND_1, 'daemon');
   assert.equal(calls[0].options.env.COVEN_JOURNEY_COMMAND_2, 'start');
   assert.equal(calls[0].options.shell, false);
   assert.equal(calls[0].options.windowsHide, true);
+  assert.equal(calls[0].options.windowsVerbatimArguments, true);
   assert.equal(calls[0].options.stdio, 'inherit');
 });
 

--- a/scripts/user-journey-e2e-test.mjs
+++ b/scripts/user-journey-e2e-test.mjs
@@ -63,6 +63,19 @@ function assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome) {
   assert.notEqual(options.env.USERPROFILE, maliciousHome);
 }
 
+function scriptedJourneyBaseEnv(scratch, maliciousHome) {
+  const systemBin = path.join(scratch, 'system-bin');
+  mkdirSync(systemBin, { recursive: true });
+  writeFileSync(path.join(systemBin, 'git'), 'fixture');
+  return {
+    ...process.env,
+    HOME: maliciousHome,
+    USERPROFILE: maliciousHome,
+    GIT_CONFIG_GLOBAL: path.join(maliciousHome, '.gitconfig'),
+    PATH: [systemBin, process.env.PATH ?? process.env.Path ?? ''].join(path.delimiter)
+  };
+}
+
 function gitInitArgs(layout) {
   return [
     '-c',
@@ -665,12 +678,7 @@ test('runPackagedUserJourney sequences installed-wrapper commands and full lifec
     ]);
 
     const result = runPackagedUserJourney({
-      baseEnv: {
-        ...process.env,
-        HOME: maliciousHome,
-        USERPROFILE: maliciousHome,
-        GIT_CONFIG_GLOBAL: path.join(maliciousHome, '.gitconfig')
-      },
+      baseEnv: scriptedJourneyBaseEnv(scratch, maliciousHome),
       keepScratchDir: false,
       platform: 'darwin',
       runner: script.runner,
@@ -833,12 +841,7 @@ test('runPackagedUserJourney attempts bounded daemon stop after start failure', 
     assert.throws(
       () =>
         runPackagedUserJourney({
-          baseEnv: {
-            ...process.env,
-            HOME: maliciousHome,
-            USERPROFILE: maliciousHome,
-            GIT_CONFIG_GLOBAL: path.join(maliciousHome, '.gitconfig')
-          },
+          baseEnv: scriptedJourneyBaseEnv(scratch, maliciousHome),
           platform: 'darwin',
           runner: script.runner,
           scratchRoot: journeyRoot,
@@ -1012,12 +1015,7 @@ test('runPackagedUserJourney stops the daemon and removes scratch after mid-jour
     assert.throws(
       () =>
         runPackagedUserJourney({
-          baseEnv: {
-            ...process.env,
-            HOME: maliciousHome,
-            USERPROFILE: maliciousHome,
-            GIT_CONFIG_GLOBAL: path.join(maliciousHome, '.gitconfig')
-          },
+          baseEnv: scriptedJourneyBaseEnv(scratch, maliciousHome),
           platform: 'darwin',
           runner: script.runner,
           scratchRoot: journeyRoot,

--- a/scripts/user-journey-e2e-test.mjs
+++ b/scripts/user-journey-e2e-test.mjs
@@ -1,0 +1,983 @@
+import assert from 'node:assert/strict';
+import { chmodSync, statSync, existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  assertSessionInspection,
+  assertInvalidCwdFailure,
+  buildJourneyEnv,
+  createCommandRunner,
+  createFakeCodexFixture,
+  createGitShim,
+  createJourneyLayout,
+  createNodeShim,
+  createScratchDir,
+  initGitRepo,
+  repoRoot,
+  runPackagedUserJourney,
+  spawnOptionsForCommand,
+  windowsCommandLine
+} from './user-journey-e2e.mjs';
+
+function withScratch(label, fn) {
+  const scratch = createScratchDir(path.join(repoRoot, 'target', 'script-test-scratch'), label);
+  try {
+    return fn(scratch);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+function makeResult({ status = 0, stdout = '', stderr = '' } = {}) {
+  return { status, stdout, stderr };
+}
+
+function makeSessionInspectionArgs(events) {
+  return {
+    eventsOutput: JSON.stringify({ events }),
+    logOutput: JSON.stringify([{ message: 'fake codex complete: E2E journey marker' }]),
+    marker: 'E2E journey marker',
+    sessionListOutput: JSON.stringify({
+      sessions: [{ id: 'sess-1', harness: 'codex', status: 'completed', exit_code: 0 }]
+    }),
+    showOutput: JSON.stringify({
+      id: 'sess-1',
+      harness: 'codex',
+      status: 'completed',
+      exit_code: 0
+    })
+  };
+}
+
+function assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome) {
+  assert.equal(options.cwd, layout.projectRoot);
+  assert.equal(options.env.HOME, layout.userHome);
+  assert.equal(options.env.USERPROFILE, layout.userHome);
+  assert.equal(options.env.COVEN_HOME, layout.covenHome);
+  assert.equal(options.env.GIT_CONFIG_GLOBAL, layout.gitGlobalConfigPath);
+  assert.equal(options.env.GIT_CONFIG_NOSYSTEM, '1');
+  assert.equal(options.env.GIT_TEMPLATE_DIR, layout.gitTemplateDir);
+  assert.equal(options.env.PATH, [path.dirname(wrapperBin), layout.nodeShimDir].join(path.delimiter));
+  assert.notEqual(options.env.HOME, maliciousHome);
+  assert.notEqual(options.env.USERPROFILE, maliciousHome);
+}
+
+function gitInitArgs(layout) {
+  return [
+    '-c',
+    `core.hooksPath=${layout.gitHooksDir}`,
+    '-c',
+    `init.templateDir=${layout.gitTemplateDir}`,
+    'init',
+    '--initial-branch=main'
+  ];
+}
+
+function gitCommitArgs(layout) {
+  return [
+    '-c',
+    `core.hooksPath=${layout.gitHooksDir}`,
+    '-c',
+    'user.name=Coven User Journey',
+    '-c',
+    'user.email=user-journey@example.invalid',
+    '-c',
+    'commit.gpgsign=false',
+    'commit',
+    '--allow-empty',
+    '-m',
+    'init'
+  ];
+}
+
+function createScriptedRunner(script) {
+  const queue = [...script];
+  const calls = [];
+
+  function take(method, command, args, options = {}) {
+    const next = queue.shift();
+    assert(next, `unexpected ${method} ${command} ${args.join(' ')}`);
+    assert.equal(next.method, method, `expected ${next.method}, got ${method}`);
+    if (next.command !== undefined) {
+      assert.equal(command, next.command);
+    }
+    if (next.args !== undefined) {
+      assert.deepEqual(args, next.args);
+    }
+    if (next.assertOptions) {
+      next.assertOptions(options);
+    }
+    calls.push({ method, command, args, options });
+    if (next.error) {
+      throw next.error;
+    }
+    return next.result;
+  }
+
+  return {
+    calls,
+    runner: {
+      platform: 'darwin',
+      run() {
+        throw new Error('run() should not be used by the scripted darwin runner');
+      },
+      runCapture(command, args, options) {
+        return take('runCapture', command, args, options);
+      },
+      runDaemonStart(wrapperBin, env, options) {
+        return take('runDaemonStart', wrapperBin, ['daemon', 'start'], { ...options, env });
+      }
+    },
+    assertExhausted() {
+      assert.deepEqual(queue, []);
+    }
+  };
+}
+
+test('createFakeCodexFixture writes executable Unix shims that log deterministically', { skip: process.platform === 'win32' }, () =>
+  withScratch('fixture-unix', (scratch) => {
+    const fixture = createFakeCodexFixture(path.join(scratch, 'bin'));
+    const logPath = path.join(scratch, 'fixture-log.jsonl');
+    const runner = createCommandRunner({ platform: process.platform });
+
+    runner.runCapture(fixture.codexCommand, ['exec', '--', 'fixture marker'], {
+      cwd: scratch,
+      env: { ...process.env, COVEN_FAKE_FIXTURE_LOG: logPath }
+    });
+    const engine = runner.runCapture(fixture.engineCommand, ['auth', 'status', '--json'], {
+      cwd: scratch,
+      env: { ...process.env, COVEN_FAKE_FIXTURE_LOG: logPath }
+    });
+
+    const codexMode = statSync(fixture.codexCommand).mode & 0o777;
+    const engineMode = statSync(fixture.engineCommand).mode & 0o777;
+    assert.equal(codexMode, 0o755);
+    assert.equal(engineMode, 0o755);
+    assert.equal(engine.stdout, '{"loggedIn":true}\n');
+
+    const entries = readFileSync(logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(entries.map((entry) => entry.kind), ['codex', 'coven-code']);
+    assert.equal(entries[0].argv.at(-1), 'fixture marker');
+  }));
+
+test('createFakeCodexFixture writes Windows cmd shims without requiring a release package', () =>
+  withScratch('fixture-win', (scratch) => {
+    const fixture = createFakeCodexFixture(path.join(scratch, 'bin'), { platform: 'win32' });
+    assert.deepEqual(
+      fixture.files.map((file) => path.basename(file)).sort(),
+      ['codex.cmd', 'coven-code.cmd']
+    );
+    for (const file of fixture.files) {
+      const text = readFileSync(file, 'utf8');
+      assert.match(text, /fake-codex\.mjs/);
+      assert.match(text, /--fixture-kind/);
+    }
+  }));
+
+test('Windows commands use an explicitly quoted cmd.exe invocation', () => {
+  assert.equal(spawnOptionsForCommand({}, 'darwin').shell, false);
+  assert.equal(spawnOptionsForCommand({}, 'win32').shell, false);
+  assert.equal(spawnOptionsForCommand({}, 'win32').windowsHide, true);
+  assert.equal(
+    windowsCommandLine('C:\\wrapper path\\coven.cmd', ['run', 'marker & 100%']),
+    '"C:\\wrapper path\\coven.cmd" "run" "marker & 100%%"'
+  );
+
+  const calls = [];
+  const runner = createCommandRunner({
+    logger: { log() {} },
+    platform: 'win32',
+    spawnSyncImpl(command, args, options) {
+      calls.push({ command, args, options });
+      return makeResult();
+    }
+  });
+
+  const result = runner.runDaemonStart('C:\\wrapper path\\coven.cmd', { ComSpec: 'C:\\Windows\\cmd.exe', PATH: 'shim' }, {
+    cwd: 'C:\\repo'
+  });
+  assert.equal(result, undefined);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'C:\\Windows\\cmd.exe');
+  assert.deepEqual(calls[0].args.slice(0, 3), ['/d', '/s', '/c']);
+  assert.equal(
+    calls[0].args[3],
+    '"C:\\wrapper path\\coven.cmd" "daemon" "start"'
+  );
+  assert.equal(calls[0].options.shell, false);
+  assert.equal(calls[0].options.windowsHide, true);
+  assert.equal(calls[0].options.stdio, 'inherit');
+});
+
+test('buildJourneyEnv strips inherited npm configuration', () =>
+  withScratch('journey-env-isolation', (scratch) => {
+    const wrapperBin = path.join(scratch, 'installed', 'coven');
+    const layout = createJourneyLayout(path.join(scratch, 'journey-root'));
+    mkdirSync(layout.scratchRoot, { recursive: true });
+    const env = buildJourneyEnv({
+      baseEnv: {
+        NPM_CONFIG_CACHE: path.join(scratch, 'outside-cache'),
+        PATH: process.env.PATH
+      },
+      layout,
+      platform: process.platform,
+      wrapperBin
+    });
+
+    assert.equal(env.NPM_CONFIG_CACHE, undefined);
+  }));
+
+test('runPackagedUserJourney rejects a pre-existing scratch root', () =>
+  withScratch('journey-owned-root', (scratch) => {
+    const wrapperBin = path.join(scratch, 'installed', 'coven');
+    const journeyRoot = path.join(scratch, 'journey-root');
+    const unrelatedFile = path.join(journeyRoot, 'keep.txt');
+    mkdirSync(path.dirname(wrapperBin), { recursive: true });
+    mkdirSync(journeyRoot, { recursive: true });
+    writeFileSync(wrapperBin, '#!/bin/sh\n');
+    writeFileSync(unrelatedFile, 'keep');
+
+    assert.throws(
+      () => runPackagedUserJourney({ scratchRoot: journeyRoot, wrapperBin }),
+      /scratch root already exists/
+    );
+    assert.equal(readFileSync(unrelatedFile, 'utf8'), 'keep');
+  }));
+
+test(
+  'initGitRepo ignores malicious caller HOME hooks and templates',
+  { skip: process.platform === 'win32' },
+  () =>
+    withScratch('git-home-isolation', (scratch) => {
+      const maliciousHome = path.join(scratch, 'malicious-home');
+      const maliciousHooksDir = path.join(scratch, 'malicious-hooks');
+      const maliciousTemplateDir = path.join(scratch, 'malicious-template');
+      const leakMarker = path.join(scratch, 'hook-ran');
+      const wrapperBin = path.join(scratch, 'installed', 'coven');
+      const layout = createJourneyLayout(path.join(scratch, 'journey-root'));
+      const baseEnv = {
+        ...process.env,
+        HOME: maliciousHome,
+        USERPROFILE: maliciousHome
+      };
+
+      for (const directory of [
+        maliciousHome,
+        maliciousHooksDir,
+        path.join(maliciousTemplateDir, 'hooks'),
+        path.dirname(wrapperBin),
+        layout.covenHome,
+        layout.gitHooksDir,
+        layout.gitTemplateDir,
+        layout.nodeShimDir,
+        layout.projectRoot,
+        layout.userHome,
+        layout.xdgConfigHome
+      ]) {
+        mkdirSync(directory, { recursive: true });
+      }
+      writeFileSync(wrapperBin, '#!/bin/sh\n');
+      writeFileSync(
+        path.join(maliciousHome, '.gitconfig'),
+        `[core]\n\thooksPath = ${maliciousHooksDir}\n[init]\n\ttemplateDir = ${maliciousTemplateDir}\n`,
+        'utf8'
+      );
+      for (const hookPath of [
+        path.join(maliciousHooksDir, 'pre-commit'),
+        path.join(maliciousTemplateDir, 'hooks', 'pre-commit')
+      ]) {
+        writeFileSync(hookPath, `#!/bin/sh\necho leaked > ${JSON.stringify(leakMarker)}\nexit 1\n`);
+        chmodSync(hookPath, 0o755);
+      }
+
+      createNodeShim(layout.nodeShimDir, { platform: process.platform });
+      createGitShim(layout.nodeShimDir, { baseEnv, platform: process.platform });
+      const env = buildJourneyEnv({
+        baseEnv,
+        layout,
+        platform: process.platform,
+        wrapperBin
+      });
+      const runner = createCommandRunner({ logger: { log() {} }, platform: process.platform });
+
+      initGitRepo(runner, layout.projectRoot, { env, layout });
+
+      assert.equal(existsSync(leakMarker), false);
+      const head = runner.runCapture('git', ['rev-parse', 'HEAD'], {
+        cwd: layout.projectRoot,
+        env
+      });
+      assert.match(head.stdout, /^[0-9a-f]{40}\n$/);
+    })
+);
+
+test(
+  'createNodeShim preserves special Unix path characters in shell shims',
+  { skip: process.platform === 'win32' },
+  () =>
+    withScratch('node-shim-quoting', (scratch) => {
+      const weirdComponent = "special $paths `ticks` 'quotes' and spaces";
+      const weirdDir = path.join(scratch, weirdComponent);
+      const targetPath = path.join(weirdDir, 'shim target');
+      mkdirSync(weirdDir, { recursive: true });
+      writeFileSync(targetPath, "#!/bin/sh\nprintf 'shim-target:%s\\n' \"$1\"\n");
+      chmodSync(targetPath, 0o755);
+
+      const shim = createNodeShim(path.join(scratch, 'shim-bin'), {
+        nodePath: targetPath,
+        platform: process.platform
+      });
+      const runner = createCommandRunner({ logger: { log() {} }, platform: process.platform });
+      const result = runner.runCapture(shim, ['quoted marker'], { cwd: scratch });
+
+      assert.equal(result.stdout, 'shim-target:quoted marker\n');
+    })
+);
+
+test(
+  'createFakeCodexFixture preserves special Unix path characters in fixture shims',
+  { skip: process.platform === 'win32' },
+  () =>
+    withScratch('fixture-shim-quoting', (scratch) => {
+      const weirdComponent = "special $paths `ticks` 'quotes' and spaces";
+      const weirdDir = path.join(scratch, weirdComponent);
+      const fixtureScript = path.join(weirdDir, 'fake codex fixture.mjs');
+      mkdirSync(weirdDir, { recursive: true });
+      writeFileSync(
+        fixtureScript,
+        readFileSync(path.join(repoRoot, 'scripts', 'fixtures', 'fake-codex.mjs'), 'utf8'),
+        'utf8'
+      );
+
+      const fixture = createFakeCodexFixture(path.join(scratch, 'bin'), {
+        fixtureScript,
+        platform: process.platform
+      });
+      const runner = createCommandRunner({ logger: { log() {} }, platform: process.platform });
+      const result = runner.runCapture(fixture.codexCommand, ['exec', '--', 'quoted marker'], {
+        cwd: scratch
+      });
+
+      assert.match(result.stdout, /fake codex complete: quoted marker/);
+    })
+);
+
+test('runPackagedUserJourney sequences installed-wrapper commands and full lifecycle checks', () =>
+  withScratch('journey-sequence', (scratch) => {
+    const wrapperBin = path.join(scratch, 'installed', 'coven');
+    const journeyRoot = path.join(scratch, 'journey-root');
+    const layout = createJourneyLayout(journeyRoot);
+    const maliciousHome = path.join(scratch, 'malicious-home');
+    mkdirSync(path.dirname(wrapperBin), { recursive: true });
+    writeFileSync(wrapperBin, '#!/bin/sh\n');
+
+    const sessionEnvelope = {
+      sessions: [
+        {
+          id: 'sess-1',
+          harness: 'codex',
+          status: 'completed',
+          exit_code: 0,
+          archived_at: null
+        }
+      ]
+    };
+    const archivedEnvelope = {
+      sessions: [
+        {
+          id: 'sess-1',
+          harness: 'codex',
+          status: 'completed',
+          exit_code: 0,
+          archived_at: '2026-01-01T00:00:00Z'
+        }
+      ]
+    };
+    const script = createScriptedRunner([
+      {
+        method: 'runCapture',
+        command: 'git',
+        args: gitInitArgs(layout),
+        assertOptions(options) {
+          assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome);
+        },
+        result: makeResult()
+      },
+      {
+        method: 'runCapture',
+        command: 'git',
+        args: gitCommitArgs(layout),
+        assertOptions(options) {
+          assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome);
+        },
+        result: makeResult()
+      },
+      { method: 'runCapture', command: wrapperBin, args: ['--version'], result: makeResult({ stdout: 'coven v1.2.3\n' }) },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['--help'],
+        result: makeResult({
+          stdout: ['Usage: coven', '', ...['doctor', 'run', 'sessions', 'attach', 'daemon', 'status', 'help'].map((name) => `  ${name}  summary`), ''].join('\n')
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['help', '--all', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            schemaVersion: 1,
+            groups: [
+              {
+                id: 'start-and-launch',
+                commands: [
+                  ...['doctor', 'run', 'sessions', 'daemon', 'summon', 'archive', 'sacrifice'].map(
+                    (name) => ({ name })
+                  )
+                ]
+              }
+            ]
+          })
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor'],
+        result: makeResult({
+          status: 1,
+          stdout: [
+            'Coven doctor',
+            'Set up at least one harness in this same shell',
+            'Codex: coven setup codex',
+            'Claude Code: coven setup claude',
+            'GitHub Copilot CLI: coven setup copilot',
+            'Doctor found problems; review the failing checks above.'
+          ].join('\n')
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor'],
+        result: makeResult({
+          stdout: 'Coven doctor\n[OK] Codex\n[OK] /fake/coven-code\n'
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            ok: true,
+            blocking: false,
+            checks: [
+              { id: 'harness:codex', status: 'pass' },
+              { id: 'engine', status: 'pass' }
+            ]
+          })
+        })
+      },
+      {
+        method: 'runDaemonStart',
+        command: wrapperBin,
+        result: makeResult({ stdout: 'Coven daemon: running\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'status'],
+        result: makeResult({ stdout: 'Coven daemon: running\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'status', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({ status: 'running', ok: true, pid: 123, socket: 'sock', started_at: 'now' })
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['run', 'codex', 'E2E journey marker'],
+        result: makeResult({ stdout: 'fake codex complete: E2E journey marker\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', '--json'],
+        result: makeResult({ stdout: JSON.stringify(sessionEnvelope) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', 'show', 'sess-1', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            id: 'sess-1',
+            harness: 'codex',
+            status: 'completed',
+            exit_code: 0
+          })
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', 'events', 'sess-1', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            events: [
+              { seq: 1, payload_json: '{"text":"E2E journey marker"}' },
+              { seq: 2, payload_json: '{"text":"fake codex complete: E2E journey marker"}' },
+              { seq: 3, kind: 'exit', payload_json: '{"status":"completed","exitCode":0}' }
+            ]
+          })
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', 'log', 'sess-1', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify([{ message: 'fake codex complete: E2E journey marker' }])
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['archive', 'sess-1'],
+        result: makeResult({ stdout: 'archived session\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', '--json'],
+        result: makeResult({ stdout: JSON.stringify({ sessions: [] }) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', '--all', '--json'],
+        result: makeResult({ stdout: JSON.stringify(archivedEnvelope) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['summon', 'sess-1'],
+        result: makeResult({ stdout: 'sess-1\nfake codex complete: E2E journey marker\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', '--json'],
+        result: makeResult({ stdout: JSON.stringify(sessionEnvelope) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sacrifice', 'sess-1', '--yes'],
+        result: makeResult({ stdout: 'sacrificed session\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', '--all', '--json'],
+        result: makeResult({ stdout: JSON.stringify({ sessions: [] }) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['run', 'codex', 'outside root attempt', '--cwd', path.join(scratch, 'journey-root', 'o')],
+        result: makeResult({ status: 1, stderr: 'failed to resolve cwd: cwd is outside the Coven project root' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'stop'],
+        result: makeResult({ stdout: 'Coven daemon: stopped\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'status', '--json'],
+        result: makeResult({ stdout: JSON.stringify({ status: 'stopped', ok: false }) })
+      }
+    ]);
+
+    const result = runPackagedUserJourney({
+      baseEnv: {
+        ...process.env,
+        HOME: maliciousHome,
+        USERPROFILE: maliciousHome,
+        GIT_CONFIG_GLOBAL: path.join(maliciousHome, '.gitconfig')
+      },
+      keepScratchDir: false,
+      platform: 'darwin',
+      runner: script.runner,
+      scratchRoot: journeyRoot,
+      wrapperBin
+    });
+
+    assert.equal(result.sessionId, 'sess-1');
+    assert.equal(existsSync(journeyRoot), false);
+    script.assertExhausted();
+  }));
+
+test('assertSessionInspection rejects missing terminal events after the completion marker', () => {
+  assert.throws(
+    () =>
+      assertSessionInspection(
+        makeSessionInspectionArgs([
+          { seq: 1, payload_json: '{"text":"E2E journey marker"}' },
+          { seq: 2, payload_json: '{"text":"fake codex complete: E2E journey marker"}' }
+        ])
+      ),
+    /did not record a completed terminal payload/
+  );
+});
+
+test('assertSessionInspection rejects terminal events that arrive before completion output', () => {
+  assert.throws(
+    () =>
+      assertSessionInspection(
+        makeSessionInspectionArgs([
+          { seq: 1, kind: 'exit', payload_json: '{"status":"completed","exitCode":0}' },
+          { seq: 2, payload_json: '{"text":"fake codex complete: E2E journey marker"}' }
+        ])
+      ),
+    /output-before-terminal ordering/
+  );
+});
+
+test('runPackagedUserJourney attempts bounded daemon stop after start failure', () =>
+  withScratch('journey-daemon-start-failure', (scratch) => {
+    const wrapperBin = path.join(scratch, 'installed', 'coven');
+    const journeyRoot = path.join(scratch, 'journey-root');
+    const layout = createJourneyLayout(journeyRoot);
+    const maliciousHome = path.join(scratch, 'malicious-home');
+    const requiredPublicCommands = ['doctor', 'run', 'sessions', 'daemon', 'summon', 'archive', 'sacrifice'];
+
+    mkdirSync(path.dirname(wrapperBin), { recursive: true });
+    writeFileSync(wrapperBin, '#!/bin/sh\n');
+
+    const script = createScriptedRunner([
+      {
+        method: 'runCapture',
+        command: 'git',
+        args: gitInitArgs(layout),
+        assertOptions(options) {
+          assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome);
+        },
+        result: makeResult()
+      },
+      {
+        method: 'runCapture',
+        command: 'git',
+        args: gitCommitArgs(layout),
+        assertOptions(options) {
+          assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome);
+        },
+        result: makeResult()
+      },
+      { method: 'runCapture', command: wrapperBin, args: ['--version'], result: makeResult({ stdout: 'coven v1.2.3\n' }) },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['--help'],
+        result: makeResult({
+          stdout: ['Usage: coven', '', ...['doctor', 'run', 'sessions', 'attach', 'daemon', 'status', 'help'].map((name) => `  ${name}  summary`), ''].join('\n')
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['help', '--all', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            schemaVersion: 1,
+            groups: [{ commands: requiredPublicCommands.map((name) => ({ name })) }]
+          })
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor'],
+        result: makeResult({
+          status: 1,
+          stdout: [
+            'Coven doctor',
+            'Set up at least one harness in this same shell',
+            'Codex: coven setup codex',
+            'Claude Code: coven setup claude',
+            'GitHub Copilot CLI: coven setup copilot',
+            'Doctor found problems; review the failing checks above.'
+          ].join('\n')
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor'],
+        result: makeResult({ stdout: 'Coven doctor\n[OK] Codex\n[OK] /fake/coven-code\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            ok: true,
+            blocking: false,
+            checks: [
+              { id: 'harness:codex', status: 'pass' },
+              { id: 'engine', status: 'pass' }
+            ]
+          })
+        })
+      },
+      {
+        method: 'runDaemonStart',
+        command: wrapperBin,
+        error: new Error('daemon start timed out after 60000ms')
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'stop'],
+        assertOptions(options) {
+          assert.equal(options.cwd, layout.projectRoot);
+          assert.equal(options.env.COVEN_HOME, layout.covenHome);
+          assert.deepEqual(options.allowedExitCodes, [0, 1]);
+          assert.equal(options.timeoutMs, 10_000);
+        },
+        error: new Error('cleanup stop timed out')
+      }
+    ]);
+
+    assert.throws(
+      () =>
+        runPackagedUserJourney({
+          baseEnv: {
+            ...process.env,
+            HOME: maliciousHome,
+            USERPROFILE: maliciousHome,
+            GIT_CONFIG_GLOBAL: path.join(maliciousHome, '.gitconfig')
+          },
+          platform: 'darwin',
+          runner: script.runner,
+          scratchRoot: journeyRoot,
+          wrapperBin
+        }),
+      /daemon start timed out after 60000ms; daemon cleanup failed: cleanup stop timed out; scratch preserved at/
+    );
+    assert.equal(
+      script.calls.filter((call) => call.command === wrapperBin && call.args[0] === 'daemon' && call.args[1] === 'stop')
+        .length,
+      1
+    );
+    assert.equal(existsSync(journeyRoot), true);
+    script.assertExhausted();
+  }));
+
+test('runPackagedUserJourney stops the daemon and removes scratch after mid-journey failure', () =>
+  withScratch('journey-cleanup', (scratch) => {
+    const wrapperBin = path.join(scratch, 'installed', 'coven');
+    const journeyRoot = path.join(scratch, 'journey-root');
+    const layout = createJourneyLayout(journeyRoot);
+    const maliciousHome = path.join(scratch, 'malicious-home');
+    mkdirSync(path.dirname(wrapperBin), { recursive: true });
+    writeFileSync(wrapperBin, '#!/bin/sh\n');
+    const requiredPublicCommands = ['doctor', 'run', 'sessions', 'daemon', 'summon', 'archive', 'sacrifice'];
+
+    const script = createScriptedRunner([
+      {
+        method: 'runCapture',
+        command: 'git',
+        args: gitInitArgs(layout),
+        assertOptions(options) {
+          assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome);
+        },
+        result: makeResult()
+      },
+      {
+        method: 'runCapture',
+        command: 'git',
+        args: gitCommitArgs(layout),
+        assertOptions(options) {
+          assertHermeticGitOptions(options, layout, wrapperBin, maliciousHome);
+        },
+        result: makeResult()
+      },
+      { method: 'runCapture', command: wrapperBin, args: ['--version'], result: makeResult({ stdout: 'coven v1.2.3\n' }) },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['--help'],
+        result: makeResult({
+          stdout: ['Usage: coven', '', ...['doctor', 'run', 'sessions', 'attach', 'daemon', 'status', 'help'].map((name) => `  ${name}  summary`), ''].join('\n')
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['help', '--all', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            schemaVersion: 1,
+            groups: [{ commands: requiredPublicCommands.map((name) => ({ name })) }]
+          })
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor'],
+        result: makeResult({
+          status: 1,
+          stdout: [
+            'Coven doctor',
+            'Set up at least one harness in this same shell',
+            'Codex: coven setup codex',
+            'Claude Code: coven setup claude',
+            'GitHub Copilot CLI: coven setup copilot',
+            'Doctor found problems; review the failing checks above.'
+          ].join('\n')
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor'],
+        result: makeResult({ stdout: 'Coven doctor\n[OK] Codex\n[OK] /fake/coven-code\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['doctor', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({
+            ok: true,
+            blocking: false,
+            checks: [
+              { id: 'harness:codex', status: 'pass' },
+              { id: 'engine', status: 'pass' }
+            ]
+          })
+        })
+      },
+      {
+        method: 'runDaemonStart',
+        command: wrapperBin,
+        result: makeResult({ stdout: 'Coven daemon: running\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'status'],
+        result: makeResult({ stdout: 'Coven daemon: running\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'status', '--json'],
+        result: makeResult({
+          stdout: JSON.stringify({ status: 'running', ok: true, pid: 123, socket: 'sock', started_at: 'now' })
+        })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['run', 'codex', 'E2E journey marker'],
+        result: makeResult({ stdout: 'fake codex complete: E2E journey marker\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', '--json'],
+        result: makeResult({ stdout: JSON.stringify({ sessions: [{ id: 'sess-1', harness: 'codex', status: 'completed', exit_code: 0, archived_at: null }] }) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', 'show', 'sess-1', '--json'],
+        result: makeResult({ stdout: JSON.stringify({ id: 'sess-1', harness: 'codex', status: 'completed', exit_code: 0 }) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', 'events', 'sess-1', '--json'],
+        result: makeResult({ stdout: JSON.stringify({ events: [] }) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['sessions', 'log', 'sess-1', '--json'],
+        result: makeResult({ stdout: JSON.stringify([]) })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'stop'],
+        result: makeResult({ stdout: 'Coven daemon: stopped\n' })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['daemon', 'status', '--json'],
+        assertOptions(options) {
+          assert.equal(options.timeoutMs, 10_000);
+        },
+        result: makeResult({
+          stdout: JSON.stringify({ status: 'stopped', ok: false })
+        })
+      }
+    ]);
+
+    assert.throws(
+      () =>
+        runPackagedUserJourney({
+          baseEnv: {
+            ...process.env,
+            HOME: maliciousHome,
+            USERPROFILE: maliciousHome,
+            GIT_CONFIG_GLOBAL: path.join(maliciousHome, '.gitconfig')
+          },
+          platform: 'darwin',
+          runner: script.runner,
+          scratchRoot: journeyRoot,
+          wrapperBin
+        }),
+      /returned no events/
+    );
+    assert.equal(existsSync(journeyRoot), false);
+    assert.equal(
+      script.calls.filter((call) => call.command === wrapperBin && call.args[0] === 'daemon' && call.args[1] === 'stop')
+        .length,
+      1
+    );
+    script.assertExhausted();
+  }));
+
+test('assertInvalidCwdFailure rejects unbounded or non-actionable errors', () => {
+  assert.doesNotThrow(() =>
+    assertInvalidCwdFailure(
+      makeResult({
+        status: 1,
+        stderr: 'failed to resolve cwd: cwd is outside the Coven project root'
+      })
+    )
+  );
+  assert.throws(
+    () => assertInvalidCwdFailure(makeResult({ status: 1, stderr: 'bad cwd' })),
+    /failed to resolve cwd/
+  );
+});

--- a/scripts/user-journey-e2e.mjs
+++ b/scripts/user-journey-e2e.mjs
@@ -1,0 +1,1100 @@
+#!/usr/bin/env node
+// Hermetic packaged-binary user journey smoke for the npm-distributed Coven CLI.
+//
+// This script assumes the wrapper + native package are already installed. It:
+//   1. isolates HOME/USERPROFILE/COVEN_HOME/PATH plus a temporary git repo,
+//   2. verifies concise help and `help --all --json`,
+//   3. verifies first-run doctor guidance with no harness on PATH,
+//   4. injects a deterministic fake Codex + coven-code engine fixture,
+//   5. exercises daemon lifecycle, a real packaged `coven run codex ...` turn,
+//   6. inspects sessions/show/events/log, archive/summon/sacrifice, and
+//   7. verifies bounded outside-root `--cwd` rejection plus daemon cleanup.
+
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+export const repoRoot = path.resolve(__dirname, '..');
+export const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
+
+const CURATED_COMMANDS = ['doctor', 'run', 'sessions', 'attach', 'daemon', 'status', 'help'];
+const REQUIRED_PUBLIC_COMMANDS = ['doctor', 'run', 'sessions', 'daemon', 'summon', 'archive', 'sacrifice'];
+const HIDDEN_HELP_COMMANDS = ['chat', 'config', 'process-supervisor', 'daemon serve'];
+const STRIP_ENV_PREFIXES = [
+  'ANTHROPIC_',
+  'AWS_',
+  'AZURE_',
+  'CLAUDE_CODE_',
+  'COPILOT_',
+  'COVEN_HARNESS_ADAPTER_',
+  'GIT_',
+  'GOOGLE_',
+  'GROQ_',
+  'NPM_CONFIG_',
+  'OPENAI_',
+  'OPENROUTER_',
+  'XAI_'
+];
+const STRIP_ENV_EXACT = [
+  'COVEN_ENGINE_BIN',
+  'COVEN_HOME',
+  'COVEN_SETTINGS_PATH',
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
+  'HOME',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'NODE_AUTH_TOKEN',
+  'NPM_TOKEN',
+  'PATH',
+  'Path',
+  'USERPROFILE',
+  'XDG_CONFIG_HOME'
+];
+
+export function isMainModule(importMetaUrl) {
+  return Boolean(process.argv[1]) && path.resolve(fileURLToPath(importMetaUrl)) === path.resolve(process.argv[1]);
+}
+
+export function fail(message) {
+  throw new Error(message);
+}
+
+export function createScratchDir(baseDir, label, options = {}) {
+  const pid = options.pid ?? process.pid;
+  const now = options.now ?? Date.now;
+  mkdirSync(baseDir, { recursive: true });
+  const seed = now();
+  for (let counter = 0; counter < 100; counter += 1) {
+    const candidate = path.join(baseDir, `${label}-${pid}-${seed}-${counter}`);
+    try {
+      mkdirSync(candidate);
+      return candidate;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') {
+        throw error;
+      }
+    }
+  }
+  fail(`could not allocate scratch directory under ${baseDir}`);
+}
+
+export function spawnOptionsForCommand(options = {}, platform = process.platform) {
+  return {
+    shell: false,
+    windowsHide: platform === 'win32',
+    ...options.spawnOptions
+  };
+}
+
+export function windowsCommandLine(command, commandArgs) {
+  return [command, ...commandArgs]
+    .map((value) => {
+      const argument = String(value);
+      if (/[\0\r\n"]/.test(argument)) {
+        fail(`unsupported character in Windows command argument: ${JSON.stringify(argument)}`);
+      }
+      return `"${argument.replaceAll('%', '%%')}"`;
+    })
+    .join(' ');
+}
+
+export function createCommandRunner({
+  repoRoot: commandRepoRoot = repoRoot,
+  platform = process.platform,
+  logger = console,
+  spawnSyncImpl = spawnSync
+} = {}) {
+  function spawnInvocation(command, commandArgs, env) {
+    if (platform !== 'win32') {
+      return { command, commandArgs };
+    }
+    return {
+      command: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
+      commandArgs: ['/d', '/s', '/c', windowsCommandLine(command, commandArgs)]
+    };
+  }
+
+  function run(command, commandArgs, options = {}) {
+    const printable = [command, ...commandArgs].join(' ');
+    logger.log?.(`$ ${printable}`);
+    const env = options.env ?? process.env;
+    const invocation = spawnInvocation(command, commandArgs, env);
+    const result = spawnSyncImpl(invocation.command, invocation.commandArgs, {
+      ...spawnOptionsForCommand(options, platform),
+      cwd: options.cwd ?? commandRepoRoot,
+      env,
+      stdio: 'inherit',
+      timeout: options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
+    });
+    handleSpawnResult(printable, result, options, { capture: false });
+    return result;
+  }
+
+  function runCapture(command, commandArgs, options = {}) {
+    const printable = [command, ...commandArgs].join(' ');
+    logger.log?.(`$ ${printable}`);
+    const env = options.env ?? process.env;
+    const invocation = spawnInvocation(command, commandArgs, env);
+    const result = spawnSyncImpl(invocation.command, invocation.commandArgs, {
+      ...spawnOptionsForCommand(options, platform),
+      cwd: options.cwd ?? commandRepoRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      timeout: options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
+    });
+    handleSpawnResult(printable, result, options, { capture: true });
+    return result;
+  }
+
+  function runDaemonStart(wrapperBin, env, options = {}) {
+    if (platform === 'win32') {
+      run(wrapperBin, ['daemon', 'start'], { ...options, env });
+      return undefined;
+    }
+    return runCapture(wrapperBin, ['daemon', 'start'], { ...options, env });
+  }
+
+  return { platform, logger, run, runCapture, runDaemonStart };
+}
+
+function handleSpawnResult(printable, result, options, { capture }) {
+  const stdout = textFromResult(result, 'stdout');
+  const stderr = textFromResult(result, 'stderr');
+  const timeoutMs = options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+  if (result.error?.code === 'ETIMEDOUT') {
+    fail(
+      `${printable} timed out after ${timeoutMs}ms` +
+        (capture ? `\nstdout:\n${stdout}\nstderr:\n${stderr}` : '')
+    );
+  }
+  if (result.error) {
+    fail(`${printable} failed: ${result.error.message}`);
+  }
+  if (result.status !== 0 && !(options.allowedExitCodes ?? []).includes(result.status)) {
+    fail(
+      `${printable} exited with ${result.status}` +
+        (capture ? `\nstdout:\n${stdout}\nstderr:\n${stderr}` : '')
+    );
+  }
+}
+
+function textFromResult(result, field) {
+  const value = result?.[field];
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString('utf8');
+  }
+  return value ? String(value) : '';
+}
+
+export function createJourneyLayout(scratchRoot) {
+  return {
+    scratchRoot,
+    covenHome: path.join(scratchRoot, 'h'),
+    fixtureBinDir: path.join(scratchRoot, 'f'),
+    fixtureLogPath: path.join(scratchRoot, 'l.jsonl'),
+    gitGlobalConfigPath: path.join(scratchRoot, 'g'),
+    gitHooksDir: path.join(scratchRoot, 'k'),
+    gitTemplateDir: path.join(scratchRoot, 't'),
+    nodeShimDir: path.join(scratchRoot, 'n'),
+    outsideRoot: path.join(scratchRoot, 'o'),
+    projectRoot: path.join(scratchRoot, 'p'),
+    userHome: path.join(scratchRoot, 'u'),
+    xdgConfigHome: path.join(scratchRoot, 'x')
+  };
+}
+
+function createCompactJourneyScratchRoot(baseDir = repoRoot) {
+  for (let counter = 0; counter < 100; counter += 1) {
+    const candidate = path.join(baseDir, `.j${counter.toString(36)}`);
+    try {
+      mkdirSync(candidate);
+      return candidate;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') {
+        throw error;
+      }
+    }
+  }
+  fail(`could not allocate compact journey scratch directory under ${baseDir}`);
+}
+
+function ensureJourneyLayout(layout) {
+  for (const directory of [
+    layout.covenHome,
+    layout.fixtureBinDir,
+    layout.gitHooksDir,
+    layout.gitTemplateDir,
+    layout.nodeShimDir,
+    layout.outsideRoot,
+    layout.projectRoot,
+    layout.userHome,
+    layout.xdgConfigHome
+  ]) {
+    mkdirSync(directory, { recursive: true });
+  }
+}
+
+export function createNodeShim(nodeShimDir, { nodePath = process.execPath, platform = process.platform } = {}) {
+  mkdirSync(nodeShimDir, { recursive: true });
+  if (platform === 'win32') {
+    const shim = path.join(nodeShimDir, 'node.cmd');
+    writeFileSync(shim, windowsCommandShim(nodePath));
+    return shim;
+  }
+  const shim = path.join(nodeShimDir, 'node');
+  writeFileSync(shim, unixCommandShim(nodePath));
+  chmodSync(shim, 0o755);
+  return shim;
+}
+
+export function createGitShim(shimDir, { baseEnv = process.env, platform = process.platform } = {}) {
+  const gitPath = resolveExecutableOnPath('git', { baseEnv, platform });
+  if (platform === 'win32') {
+    const shim = path.join(shimDir, 'git.cmd');
+    writeFileSync(shim, windowsCommandShim(gitPath));
+    return shim;
+  }
+  const shim = path.join(shimDir, 'git');
+  writeFileSync(shim, unixCommandShim(gitPath));
+  chmodSync(shim, 0o755);
+  return shim;
+}
+
+function posixSingleQuote(text) {
+  return `'${String(text).replace(/'/g, `'\\''`)}'`;
+}
+
+function unixCommandShim(targetPath) {
+  return `#!/bin/sh\nexec ${posixSingleQuote(targetPath)} "$@"\n`;
+}
+
+function windowsCommandShim(targetPath) {
+  return `@"${targetPath}" %*\r\n`;
+}
+
+export function createFakeCodexFixture(
+  binDir,
+  {
+    fixtureScript = path.join(__dirname, 'fixtures', 'fake-codex.mjs'),
+    nodePath = process.execPath,
+    platform = process.platform
+  } = {}
+) {
+  mkdirSync(binDir, { recursive: true });
+  if (platform === 'win32') {
+    const codexCommand = path.join(binDir, 'codex.cmd');
+    const engineCommand = path.join(binDir, 'coven-code.cmd');
+    writeFileSync(codexCommand, windowsShim(nodePath, fixtureScript, 'codex'));
+    writeFileSync(engineCommand, windowsShim(nodePath, fixtureScript, 'coven-code'));
+    return {
+      binDir,
+      codexCommand,
+      engineCommand,
+      files: [codexCommand, engineCommand]
+    };
+  }
+
+  const codexCommand = path.join(binDir, 'codex');
+  const engineCommand = path.join(binDir, 'coven-code');
+  writeFileSync(codexCommand, unixShim(nodePath, fixtureScript, 'codex'));
+  writeFileSync(engineCommand, unixShim(nodePath, fixtureScript, 'coven-code'));
+  chmodSync(codexCommand, 0o755);
+  chmodSync(engineCommand, 0o755);
+  return {
+    binDir,
+    codexCommand,
+    engineCommand,
+    files: [codexCommand, engineCommand]
+  };
+}
+
+function unixShim(nodePath, fixtureScript, kind) {
+  return `#!/bin/sh\nexec ${posixSingleQuote(nodePath)} ${posixSingleQuote(fixtureScript)} --fixture-kind ${posixSingleQuote(kind)} "$@"\n`;
+}
+
+function windowsShim(nodePath, fixtureScript, kind) {
+  return `@echo off\r\n"${nodePath}" "${fixtureScript}" --fixture-kind ${kind} %*\r\n`;
+}
+
+function resolveExecutableOnPath(command, { baseEnv = process.env, platform = process.platform } = {}) {
+  const pathValue = baseEnv.PATH ?? baseEnv.Path ?? '';
+  const directories = pathValue.split(path.delimiter).filter(Boolean);
+  const extensions =
+    platform === 'win32'
+      ? (baseEnv.PATHEXT ?? baseEnv.PathExt ?? '.COM;.EXE;.BAT;.CMD')
+          .split(';')
+          .filter(Boolean)
+      : [''];
+  for (const directory of directories) {
+    if (platform === 'win32') {
+      for (const extension of extensions) {
+        const normalized = extension.startsWith('.') ? extension : `.${extension}`;
+        const candidate = path.join(directory, `${command}${normalized}`);
+        if (existsSync(candidate)) {
+          return candidate;
+        }
+      }
+      continue;
+    }
+    const candidate = path.join(directory, command);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  fail(`required system command \`${command}\` was not found on PATH`);
+}
+
+function sanitizeBaseEnv(baseEnv = process.env, platform = process.platform) {
+  const env = { ...baseEnv };
+  for (const key of Object.keys(env)) {
+    const upper = key.toUpperCase();
+    const matchesPrefix = STRIP_ENV_PREFIXES.some((prefix) => upper.startsWith(prefix));
+    const looksSensitive =
+      upper.includes('TOKEN') || upper.includes('SECRET') || upper.includes('PASSWORD');
+    if (STRIP_ENV_EXACT.includes(key) || STRIP_ENV_EXACT.includes(upper) || matchesPrefix || looksSensitive) {
+      delete env[key];
+    }
+  }
+  if (platform === 'win32' && env.Path !== undefined && env.PATH === undefined) {
+    env.PATH = env.Path;
+  }
+  return env;
+}
+
+export function buildJourneyEnv({
+  baseEnv = process.env,
+  fixtureBinDir,
+  layout,
+  platform = process.platform,
+  wrapperBin
+}) {
+  const env = sanitizeBaseEnv(baseEnv, platform);
+  const pathValue = [path.dirname(wrapperBin), layout.nodeShimDir, fixtureBinDir]
+    .filter(Boolean)
+    .join(path.delimiter);
+  env.COVEN_FAKE_FIXTURE_LOG = layout.fixtureLogPath;
+  env.COVEN_HOME = layout.covenHome;
+  env.HOME = layout.userHome;
+  env.PATH = pathValue;
+  env.USERPROFILE = layout.userHome;
+  env.XDG_CONFIG_HOME = layout.xdgConfigHome;
+  writeFileSync(layout.gitGlobalConfigPath, '', 'utf8');
+  env.GIT_CONFIG_GLOBAL = layout.gitGlobalConfigPath;
+  env.GIT_CONFIG_NOSYSTEM = '1';
+  env.GIT_TEMPLATE_DIR = layout.gitTemplateDir;
+  if (platform === 'win32') {
+    env.Path = pathValue;
+    const homeRoot = path.parse(layout.userHome).root;
+    env.HOMEDRIVE = homeRoot.replace(/[\\/]$/, '');
+    env.HOMEPATH = layout.userHome.slice(homeRoot.length - 1);
+  }
+  return env;
+}
+
+function gitInitArgs(layout) {
+  return [
+    '-c',
+    `core.hooksPath=${layout.gitHooksDir}`,
+    '-c',
+    `init.templateDir=${layout.gitTemplateDir}`,
+    'init',
+    '--initial-branch=main'
+  ];
+}
+
+function gitCommitArgs(layout) {
+  return [
+    '-c',
+    `core.hooksPath=${layout.gitHooksDir}`,
+    '-c',
+    'user.name=Coven User Journey',
+    '-c',
+    'user.email=user-journey@example.invalid',
+    '-c',
+    'commit.gpgsign=false',
+    'commit',
+    '--allow-empty',
+    '-m',
+    'init'
+  ];
+}
+
+export function initGitRepo(runner, projectRoot, { env, layout } = {}) {
+  if (!env) {
+    fail('initGitRepo requires an isolated env');
+  }
+  if (!layout) {
+    fail('initGitRepo requires a journey layout');
+  }
+  runner.runCapture('git', gitInitArgs(layout), { cwd: projectRoot, env });
+  runner.runCapture(
+    'git',
+    gitCommitArgs(layout),
+    { cwd: projectRoot, env }
+  );
+}
+
+function listedCommands(helpText) {
+  return helpText
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.startsWith('  '))
+    .map((line) => line.trimStart().split(/\s+/)[0])
+    .filter((name) => /^[a-z0-9-]+$/.test(name));
+}
+
+function assertVersionOutput(output) {
+  if (!output.trim()) {
+    fail('`coven --version` produced no output');
+  }
+  if (!output.toLowerCase().includes('coven')) {
+    fail(`\`coven --version\` did not look like Coven output.\nstdout:\n${output}`);
+  }
+}
+
+export function assertConciseDefaultHelp(output) {
+  if (!output.toLowerCase().includes('usage')) {
+    fail(`\`coven --help\` missing usage section.\nstdout:\n${output}`);
+  }
+  const commands = listedCommands(output);
+  for (const command of CURATED_COMMANDS) {
+    if (!commands.includes(command)) {
+      fail(`\`coven --help\` is missing curated command ${command}.\nstdout:\n${output}`);
+    }
+  }
+  for (const hidden of HIDDEN_HELP_COMMANDS) {
+    if (output.includes(`\n  ${hidden}  `) || output.includes(hidden)) {
+      fail(`\`coven --help\` should stay concise and must not surface ${hidden}.\nstdout:\n${output}`);
+    }
+  }
+}
+
+export function parseJsonOutput(label, output) {
+  const stdout = typeof output === 'string' ? output : textFromResult(output, 'stdout');
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    fail(`${label} did not print valid JSON: ${error.message}\nstdout:\n${stdout}`);
+  }
+}
+
+export function assertHelpCatalogJson(output) {
+  const body = parseJsonOutput('`coven help --all --json`', output);
+  if (body.schemaVersion !== 1) {
+    fail(`unexpected help schemaVersion: ${body.schemaVersion}`);
+  }
+  const commands = (body.groups ?? [])
+    .flatMap((group) => group.commands ?? [])
+    .map((command) => command.name);
+  for (const command of REQUIRED_PUBLIC_COMMANDS) {
+    if (!commands.includes(command)) {
+      fail(`\`coven help --all --json\` missing public command ${command}`);
+    }
+  }
+  for (const hidden of ['process-supervisor', 'serve']) {
+    if (commands.includes(hidden)) {
+      fail(`\`coven help --all --json\` must not expose internal command ${hidden}`);
+    }
+  }
+}
+
+export function assertDoctorFailureGuidance(output, status) {
+  if (status !== 1) {
+    fail(`\`coven doctor\` on a bare runner should exit 1, got ${status}`);
+  }
+  for (const expected of [
+    'Coven doctor',
+    'Set up at least one harness in this same shell',
+    'Codex: coven setup codex',
+    'Claude Code: coven setup claude',
+    'GitHub Copilot CLI: coven setup copilot',
+    'Doctor found problems; review the failing checks above.'
+  ]) {
+    if (!output.includes(expected)) {
+      fail(`\`coven doctor\` missing first-run guidance "${expected}".\nstdout:\n${output}`);
+    }
+  }
+}
+
+function assertDashboardHelp(output) {
+  if (!output.includes('private local memory dashboard')) {
+    fail(
+      `\`coven memory open --help\` did not describe the private local dashboard.\nstdout:\n${output}`
+    );
+  }
+}
+
+export function assertDoctorPass(output) {
+  if (!output.includes('Coven doctor')) {
+    fail(`\`coven doctor\` did not print the expected banner.\nstdout:\n${output}`);
+  }
+  if (!output.includes('[OK] Codex') || !output.includes('[OK]') || !output.includes('coven-code')) {
+    fail(`\`coven doctor\` did not report the fake Codex + coven-code environment.\nstdout:\n${output}`);
+  }
+  if (output.includes('[!!]')) {
+    fail(`\`coven doctor\` should not report blocking failures after fixture install.\nstdout:\n${output}`);
+  }
+}
+
+export function assertDoctorJsonPass(output) {
+  const body = parseJsonOutput('`coven doctor --json`', output);
+  if (body.ok !== true || body.blocking !== false) {
+    fail(`\`coven doctor --json\` did not report a healthy environment.\nstdout:\n${textFromResult(output, 'stdout')}`);
+  }
+  const checks = body.checks ?? [];
+  const harness = checks.find((check) => check.id === 'harness:codex');
+  if (!harness || harness.status !== 'pass') {
+    fail(`\`coven doctor --json\` must report harness:codex as pass.\nstdout:\n${textFromResult(output, 'stdout')}`);
+  }
+  const engine = checks.find((check) => check.id === 'engine');
+  if (!engine || engine.status !== 'pass') {
+    fail(`\`coven doctor --json\` must report engine as pass.\nstdout:\n${textFromResult(output, 'stdout')}`);
+  }
+  if (checks.some((check) => check.status === 'fail')) {
+    fail(`\`coven doctor --json\` should have no failing checks once the fixture is installed.\nstdout:\n${textFromResult(output, 'stdout')}`);
+  }
+}
+
+function assertDaemonRunningText(label, output) {
+  if (!output.includes('Coven daemon: running')) {
+    fail(`${label} did not report a running daemon.\nstdout:\n${output}`);
+  }
+}
+
+export function assertDaemonStatusJson(output, expectedStatus, expectedOk) {
+  const body = parseJsonOutput('daemon status --json', output);
+  if (body.status !== expectedStatus || body.ok !== expectedOk) {
+    fail(
+      `unexpected daemon JSON health: expected ${expectedStatus}/${expectedOk}, got ${body.status}/${body.ok}\nstdout:\n${textFromResult(output, 'stdout')}`
+    );
+  }
+  return body;
+}
+
+function sessionsFromJson(label, output) {
+  const body = parseJsonOutput(label, output);
+  if (!Array.isArray(body.sessions)) {
+    fail(`${label} did not return a { sessions: [...] } envelope.`);
+  }
+  return body.sessions;
+}
+
+function eventPayloadStrings(events) {
+  return events.map((event) => {
+    if (typeof event.payload_json === 'string') {
+      return event.payload_json;
+    }
+    return JSON.stringify(event);
+  });
+}
+
+function parsedEventPayload(event) {
+  if (event?.payload_json && typeof event.payload_json === 'object') {
+    return event.payload_json;
+  }
+  if (typeof event?.payload_json !== 'string') {
+    return null;
+  }
+  try {
+    return JSON.parse(event.payload_json);
+  } catch {
+    return null;
+  }
+}
+
+export function assertSessionInspection({
+  eventsOutput,
+  fixtureLogPath,
+  logOutput,
+  marker,
+  sessionListOutput,
+  showOutput
+}) {
+  const sessions = sessionsFromJson('`coven sessions --json`', sessionListOutput);
+  if (sessions.length !== 1) {
+    fail(`expected exactly one active session after the packaged journey, got ${sessions.length}`);
+  }
+  const listed = sessions[0];
+  if (listed.harness !== 'codex' || listed.status !== 'completed') {
+    fail(`unexpected session summary: ${JSON.stringify(listed)}`);
+  }
+
+  const session = parseJsonOutput('`coven sessions show --json`', showOutput);
+  if (session.id !== listed.id) {
+    fail(`session detail id ${session.id} did not match sessions list id ${listed.id}`);
+  }
+  if (session.harness !== 'codex' || session.status !== 'completed' || session.exit_code !== 0) {
+    fail(`unexpected session detail: ${JSON.stringify(session)}`);
+  }
+
+  const eventsBody = parseJsonOutput('`coven sessions events --json`', eventsOutput);
+  const events = eventsBody.events ?? [];
+  if (events.length === 0) {
+    fail('`coven sessions events --json` returned no events');
+  }
+  for (let index = 1; index < events.length; index += 1) {
+    if ((events[index]?.seq ?? 0) <= (events[index - 1]?.seq ?? -1)) {
+      fail('session events were not ordered by increasing sequence number');
+    }
+  }
+  const payloads = eventPayloadStrings(events);
+  const completionIndex = payloads.findIndex((payload) => payload.includes(`fake codex complete: ${marker}`));
+  if (completionIndex === -1) {
+    fail(`session events did not preserve the packaged Codex output for ${marker}.\npayloads:\n${payloads.join('\n')}`);
+  }
+  const terminalIndex = events.findIndex((event) => {
+    const payload = parsedEventPayload(event);
+    return payload?.status === 'completed' && payload?.exitCode === 0;
+  });
+  if (terminalIndex === -1) {
+    fail(`session events did not record a completed terminal payload for ${marker}.\npayloads:\n${payloads.join('\n')}`);
+  }
+  if (terminalIndex <= completionIndex) {
+    fail(`session events did not preserve output-before-terminal ordering for ${marker}.\npayloads:\n${payloads.join('\n')}`);
+  }
+  if (fixtureLogPath && existsSync(fixtureLogPath)) {
+    const fixtureEvents = readFileSync(fixtureLogPath, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    if (!fixtureEvents.some((entry) => entry.kind === 'codex' && entry.argv.includes(marker))) {
+      fail(`fixture log did not record the Codex marker invocation for ${marker}.`);
+    }
+  }
+
+  const logLines = parseJsonOutput('`coven sessions log --json`', logOutput);
+  if (!Array.isArray(logLines) || logLines.length === 0) {
+    fail('`coven sessions log --json` returned no log lines');
+  }
+  const messages = logLines.map((line) => String(line.message ?? ''));
+  if (!messages.some((message) => message.includes(`fake codex complete: ${marker}`))) {
+    fail(`session log did not preserve the fake Codex completion marker.\nmessages:\n${messages.join('\n')}`);
+  }
+
+  return session.id;
+}
+
+function assertArchiveAndSummonVisibility(activeOutput, allOutput, sessionId) {
+  const activeSessions = sessionsFromJson('`coven sessions --json` after archive', activeOutput);
+  if (activeSessions.some((session) => session.id === sessionId)) {
+    fail(`archived session ${sessionId} should not appear in active sessions`);
+  }
+  const allSessions = sessionsFromJson('`coven sessions --all --json` after archive', allOutput);
+  const archived = allSessions.find((session) => session.id === sessionId);
+  if (!archived || !archived.archived_at) {
+    fail(`archived session ${sessionId} should still appear in --all output`);
+  }
+}
+
+function assertSummonOutput(output, sessionId, marker) {
+  const stdout = textFromResult(output, 'stdout');
+  if (!stdout.includes(marker)) {
+    fail(`\`coven summon\` did not replay the archived session.\nstdout:\n${stdout}`);
+  }
+}
+
+export function assertInvalidCwdFailure(output) {
+  const stdout = textFromResult(output, 'stdout');
+  const stderr = textFromResult(output, 'stderr');
+  const combined = `${stdout}\n${stderr}`;
+  if ((output.status ?? 0) === 0) {
+    fail('outside-root `coven run --cwd` unexpectedly succeeded');
+  }
+  for (const expected of ['failed to resolve cwd', 'outside the Coven project root']) {
+    if (!combined.includes(expected)) {
+      fail(`outside-root rejection must mention "${expected}".\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    }
+  }
+  if (combined.length > 2_000 || combined.includes('thread \'main\' panicked')) {
+    fail(`outside-root rejection was not bounded/actionable.\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+  }
+}
+
+function assertDaemonMetadataCleanup(layout, platform) {
+  if (existsSync(path.join(layout.covenHome, 'daemon.json'))) {
+    fail('daemon stop should remove daemon.json');
+  }
+  if (platform !== 'win32' && existsSync(path.join(layout.covenHome, 'coven.sock'))) {
+    fail('daemon stop should remove the Unix socket file');
+  }
+}
+
+export function runPackagedUserJourney({
+  baseEnv = process.env,
+  dashboardExpected = false,
+  keepScratchDir = false,
+  platform = process.platform,
+  runner = createCommandRunner({ platform }),
+  scratchRoot,
+  sessionPrompt = 'E2E journey marker',
+  wrapperBin
+} = {}) {
+  if (!wrapperBin) {
+    fail('runPackagedUserJourney requires wrapperBin');
+  }
+  const resolvedWrapperBin = path.resolve(wrapperBin);
+  if (!existsSync(resolvedWrapperBin)) {
+    fail(`installed wrapper not found at ${resolvedWrapperBin}`);
+  }
+
+  const suppliedScratchRoot = scratchRoot !== undefined;
+  const ownedScratchRoot = suppliedScratchRoot
+    ? path.resolve(scratchRoot)
+    : createCompactJourneyScratchRoot(repoRoot);
+  if (suppliedScratchRoot) {
+    mkdirSync(path.dirname(ownedScratchRoot), { recursive: true });
+    try {
+      mkdirSync(ownedScratchRoot);
+    } catch (error) {
+      if (error?.code === 'EEXIST') {
+        fail(`scratch root already exists; refusing to delete caller-owned path: ${ownedScratchRoot}`);
+      }
+      throw error;
+    }
+  }
+  const layout = createJourneyLayout(ownedScratchRoot);
+  let activeEnv = undefined;
+  let cleanupDaemon = false;
+  let result;
+  let primaryError;
+  const daemonCleanupTimeoutMs = Math.min(DEFAULT_COMMAND_TIMEOUT_MS, 10_000);
+
+  try {
+    ensureJourneyLayout(layout);
+    createNodeShim(layout.nodeShimDir, { platform });
+    createGitShim(layout.nodeShimDir, { baseEnv, platform });
+
+    activeEnv = buildJourneyEnv({
+      baseEnv,
+      layout,
+      platform,
+      wrapperBin: resolvedWrapperBin
+    });
+    cleanupDaemon = true;
+    initGitRepo(runner, layout.projectRoot, { env: activeEnv, layout });
+
+    const version = runner.runCapture(resolvedWrapperBin, ['--version'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertVersionOutput(textFromResult(version, 'stdout'));
+
+    const help = runner.runCapture(resolvedWrapperBin, ['--help'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertConciseDefaultHelp(textFromResult(help, 'stdout'));
+
+    const helpJson = runner.runCapture(resolvedWrapperBin, ['help', '--all', '--json'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertHelpCatalogJson(helpJson);
+
+    const firstDoctor = runner.runCapture(resolvedWrapperBin, ['doctor'], {
+      allowedExitCodes: [1],
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertDoctorFailureGuidance(textFromResult(firstDoctor, 'stdout'), firstDoctor.status);
+
+    if (dashboardExpected) {
+      const memoryHelp = runner.runCapture(resolvedWrapperBin, ['memory', 'open', '--help'], {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      });
+      assertDashboardHelp(textFromResult(memoryHelp, 'stdout'));
+    }
+
+    createFakeCodexFixture(layout.fixtureBinDir, { platform });
+    activeEnv = buildJourneyEnv({
+      baseEnv,
+      fixtureBinDir: layout.fixtureBinDir,
+      layout,
+      platform,
+      wrapperBin: resolvedWrapperBin
+    });
+
+    const doctor = runner.runCapture(resolvedWrapperBin, ['doctor'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertDoctorPass(textFromResult(doctor, 'stdout'));
+
+    const doctorJson = runner.runCapture(resolvedWrapperBin, ['doctor', '--json'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertDoctorJsonPass(doctorJson);
+
+    const daemonStart = runner.runDaemonStart(resolvedWrapperBin, activeEnv, {
+      cwd: layout.projectRoot
+    });
+    if (daemonStart !== undefined) {
+      assertDaemonRunningText('`coven daemon start`', textFromResult(daemonStart, 'stdout'));
+    }
+
+    const daemonStatus = runner.runCapture(resolvedWrapperBin, ['daemon', 'status'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertDaemonRunningText('`coven daemon status`', textFromResult(daemonStatus, 'stdout'));
+
+    const daemonStatusJson = runner.runCapture(
+      resolvedWrapperBin,
+      ['daemon', 'status', '--json'],
+      {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    assertDaemonStatusJson(daemonStatusJson, 'running', true);
+
+    const runOutput = runner.runCapture(resolvedWrapperBin, ['run', 'codex', sessionPrompt], {
+      cwd: layout.projectRoot,
+      env: activeEnv,
+      timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS
+    });
+    if (!textFromResult(runOutput, 'stdout').includes(sessionPrompt)) {
+      fail(`\`coven run codex\` did not emit the marker prompt.\nstdout:\n${textFromResult(runOutput, 'stdout')}`);
+    }
+
+    const sessions = runner.runCapture(resolvedWrapperBin, ['sessions', '--json'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    const listedSessions = sessionsFromJson('`coven sessions --json`', sessions);
+    if (listedSessions.length !== 1) {
+      fail(`expected one active session after run, got ${listedSessions.length}`);
+    }
+    const sessionId = listedSessions[0].id;
+    const show = runner.runCapture(
+      resolvedWrapperBin,
+      ['sessions', 'show', sessionId, '--json'],
+      {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    const events = runner.runCapture(
+      resolvedWrapperBin,
+      ['sessions', 'events', sessionId, '--json'],
+      {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    const log = runner.runCapture(resolvedWrapperBin, ['sessions', 'log', sessionId, '--json'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertSessionInspection({
+      eventsOutput: events,
+      fixtureLogPath: layout.fixtureLogPath,
+      logOutput: log,
+      marker: sessionPrompt,
+      sessionListOutput: sessions,
+      showOutput: show
+    });
+
+    const archive = runner.runCapture(resolvedWrapperBin, ['archive', sessionId], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    if (!textFromResult(archive, 'stdout').includes('archived session')) {
+      fail(`\`coven archive\` did not confirm the archive action.\nstdout:\n${textFromResult(archive, 'stdout')}`);
+    }
+
+    const activeAfterArchive = runner.runCapture(resolvedWrapperBin, ['sessions', '--json'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    const allAfterArchive = runner.runCapture(
+      resolvedWrapperBin,
+      ['sessions', '--all', '--json'],
+      {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    assertArchiveAndSummonVisibility(activeAfterArchive, allAfterArchive, sessionId);
+
+    const summon = runner.runCapture(resolvedWrapperBin, ['summon', sessionId], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertSummonOutput(summon, sessionId, sessionPrompt);
+
+    const activeAfterSummon = runner.runCapture(resolvedWrapperBin, ['sessions', '--json'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    const restored = sessionsFromJson('`coven sessions --json` after summon', activeAfterSummon)
+      .find((session) => session.id === sessionId);
+    if (!restored || restored.archived_at !== null) {
+      fail(`summoned session ${sessionId} should be active again`);
+    }
+
+    const sacrifice = runner.runCapture(
+      resolvedWrapperBin,
+      ['sacrifice', sessionId, '--yes'],
+      {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    if (!textFromResult(sacrifice, 'stdout').includes('sacrificed session')) {
+      fail(`\`coven sacrifice --yes\` did not confirm the delete.\nstdout:\n${textFromResult(sacrifice, 'stdout')}`);
+    }
+
+    const allAfterSacrifice = runner.runCapture(
+      resolvedWrapperBin,
+      ['sessions', '--all', '--json'],
+      {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    if (
+      sessionsFromJson('`coven sessions --all --json` after sacrifice', allAfterSacrifice).some(
+        (session) => session.id === sessionId
+      )
+    ) {
+      fail(`sacrificed session ${sessionId} should not remain in --all output`);
+    }
+
+    const invalidCwd = runner.runCapture(
+      resolvedWrapperBin,
+      ['run', 'codex', 'outside root attempt', '--cwd', layout.outsideRoot],
+      {
+        allowedExitCodes: [1],
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    assertInvalidCwdFailure(invalidCwd);
+
+    const stop = runner.runCapture(resolvedWrapperBin, ['daemon', 'stop'], {
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    if (!textFromResult(stop, 'stdout').includes('Coven daemon: stopped')) {
+      fail(`\`coven daemon stop\` did not confirm shutdown.\nstdout:\n${textFromResult(stop, 'stdout')}`);
+    }
+
+    const stopped = runner.runCapture(
+      resolvedWrapperBin,
+      ['daemon', 'status', '--json'],
+      {
+        cwd: layout.projectRoot,
+        env: activeEnv
+      }
+    );
+    assertDaemonStatusJson(stopped, 'stopped', false);
+    assertDaemonMetadataCleanup(layout, platform);
+    cleanupDaemon = false;
+
+    result = { scratchRoot: ownedScratchRoot, sessionId };
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    let cleanupError;
+    if (cleanupDaemon && activeEnv) {
+      try {
+        runner.runCapture(resolvedWrapperBin, ['daemon', 'stop'], {
+          allowedExitCodes: [0, 1],
+          cwd: layout.projectRoot,
+          env: activeEnv,
+          timeoutMs: daemonCleanupTimeoutMs
+        });
+        const stopped = runner.runCapture(
+          resolvedWrapperBin,
+          ['daemon', 'status', '--json'],
+          {
+            cwd: layout.projectRoot,
+            env: activeEnv,
+            timeoutMs: daemonCleanupTimeoutMs
+          }
+        );
+        assertDaemonStatusJson(stopped, 'stopped', false);
+        assertDaemonMetadataCleanup(layout, platform);
+      } catch (error) {
+        cleanupError = error;
+      }
+    }
+    if (!keepScratchDir && !cleanupError) {
+      rmSync(ownedScratchRoot, { recursive: true, force: true });
+    }
+    if (cleanupError) {
+      const cleanupMessage =
+        `daemon cleanup failed: ${cleanupError.message}; scratch preserved at ${ownedScratchRoot}`;
+      primaryError = primaryError
+        ? new AggregateError(
+            [primaryError, cleanupError],
+            `${primaryError.message}; ${cleanupMessage}`
+          )
+        : new Error(cleanupMessage, { cause: cleanupError });
+    }
+  }
+
+  if (primaryError) {
+    throw primaryError;
+  }
+  return result;
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (const arg of argv) {
+    if (arg === '--keep-scratchdir') {
+      options.keepScratchDir = true;
+      continue;
+    }
+    if (arg === '--dashboard-installed') {
+      options.dashboardExpected = true;
+      continue;
+    }
+    if (arg.startsWith('--scratch-root=')) {
+      options.scratchRoot = arg.slice('--scratch-root='.length);
+      continue;
+    }
+    if (arg.startsWith('--wrapper-bin=')) {
+      options.wrapperBin = arg.slice('--wrapper-bin='.length);
+      continue;
+    }
+    fail(`unknown argument: ${arg}`);
+  }
+  if (!options.wrapperBin) {
+    fail('usage: node scripts/user-journey-e2e.mjs --wrapper-bin=<installed-wrapper> [--scratch-root=<dir>] [--keep-scratchdir] [--dashboard-installed]');
+  }
+  return options;
+}
+
+if (isMainModule(import.meta.url)) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const result = runPackagedUserJourney(options);
+    console.log(`Packaged user journey passed (session ${result.sessionId}).`);
+    if (options.keepScratchDir) {
+      console.log(`Scratch preserved at ${result.scratchRoot}.`);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/user-journey-e2e.mjs
+++ b/scripts/user-journey-e2e.mjs
@@ -94,6 +94,7 @@ export function spawnOptionsForCommand(options = {}, platform = process.platform
   return {
     shell: false,
     windowsHide: platform === 'win32',
+    windowsVerbatimArguments: platform === 'win32',
     ...options.spawnOptions
   };
 }
@@ -117,7 +118,7 @@ export function windowsCommandInvocation(command, commandArgs, baseEnv = {}) {
   });
   return {
     command: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
-    commandArgs: ['/d', '/v:off', '/s', '/c', references.join(' ')],
+    commandArgs: ['/d', '/v:off', '/s', '/c', `"${references.join(' ')}"`],
     env
   };
 }

--- a/scripts/user-journey-e2e.mjs
+++ b/scripts/user-journey-e2e.mjs
@@ -13,6 +13,7 @@
 import { spawnSync } from 'node:child_process';
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -97,16 +98,28 @@ export function spawnOptionsForCommand(options = {}, platform = process.platform
   };
 }
 
-export function windowsCommandLine(command, commandArgs) {
-  return [command, ...commandArgs]
-    .map((value) => {
-      const argument = String(value);
-      if (/[\0\r\n"]/.test(argument)) {
-        fail(`unsupported character in Windows command argument: ${JSON.stringify(argument)}`);
-      }
-      return `"${argument.replaceAll('%', '%%')}"`;
-    })
-    .join(' ');
+export function windowsCommandInvocation(command, commandArgs, baseEnv = {}) {
+  const prefix = 'COVEN_JOURNEY_COMMAND_';
+  const env = Object.fromEntries(
+    Object.entries(baseEnv).filter(([name]) => !name.toUpperCase().startsWith(prefix))
+  );
+  const values = [command, ...commandArgs].map((value) => {
+    const argument = String(value);
+    if (/[\0\r\n"]/.test(argument)) {
+      fail(`unsupported character in Windows command argument: ${JSON.stringify(argument)}`);
+    }
+    return argument;
+  });
+  const references = values.map((value, index) => {
+    const name = `${prefix}${index}`;
+    env[name] = value;
+    return `"%${name}%"`;
+  });
+  return {
+    command: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
+    commandArgs: ['/d', '/v:off', '/s', '/c', references.join(' ')],
+    env
+  };
 }
 
 export function createCommandRunner({
@@ -117,12 +130,9 @@ export function createCommandRunner({
 } = {}) {
   function spawnInvocation(command, commandArgs, env) {
     if (platform !== 'win32') {
-      return { command, commandArgs };
+      return { command, commandArgs, env };
     }
-    return {
-      command: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
-      commandArgs: ['/d', '/s', '/c', windowsCommandLine(command, commandArgs)]
-    };
+    return windowsCommandInvocation(command, commandArgs, env);
   }
 
   function run(command, commandArgs, options = {}) {
@@ -133,7 +143,7 @@ export function createCommandRunner({
     const result = spawnSyncImpl(invocation.command, invocation.commandArgs, {
       ...spawnOptionsForCommand(options, platform),
       cwd: options.cwd ?? commandRepoRoot,
-      env,
+      env: invocation.env,
       stdio: 'inherit',
       timeout: options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
     });
@@ -149,8 +159,12 @@ export function createCommandRunner({
     const result = spawnSyncImpl(invocation.command, invocation.commandArgs, {
       ...spawnOptionsForCommand(options, platform),
       cwd: options.cwd ?? commandRepoRoot,
-      env,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      env: invocation.env,
+      stdio: [
+        options.spawnOptions?.input === undefined ? 'ignore' : 'pipe',
+        'pipe',
+        'pipe'
+      ],
       encoding: 'utf8',
       timeout: options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
     });
@@ -284,7 +298,7 @@ function unixCommandShim(targetPath) {
 }
 
 function windowsCommandShim(targetPath) {
-  return `@"${targetPath}" %*\r\n`;
+  return `@"${targetPath.replaceAll('%', '%%')}" %*\r\n`;
 }
 
 export function createFakeCodexFixture(
@@ -292,15 +306,77 @@ export function createFakeCodexFixture(
   {
     fixtureScript = path.join(__dirname, 'fixtures', 'fake-codex.mjs'),
     nodePath = process.execPath,
-    platform = process.platform
+    platform = process.platform,
+    baseEnv = process.env,
+    architecture = process.arch,
+    windowsNativeFixture
   } = {}
 ) {
   mkdirSync(binDir, { recursive: true });
   if (platform === 'win32') {
+    const target =
+      architecture === 'arm64'
+        ? {
+            cpu: 'arm64',
+            packageName: '@openai/codex-win32-arm64',
+            triple: 'aarch64-pc-windows-msvc'
+          }
+        : {
+            cpu: 'x64',
+            packageName: '@openai/codex-win32-x64',
+            triple: 'x86_64-pc-windows-msvc'
+          };
+    const packageRoot = path.join(binDir, 'node_modules', '@openai', 'codex');
+    const packageBin = path.join(packageRoot, 'bin');
+    const targetRoot = path.join(
+      packageRoot,
+      'node_modules',
+      '@openai',
+      target.packageName.slice('@openai/'.length)
+    );
+    const nativeBin = path.join(targetRoot, 'vendor', target.triple, 'bin');
+    mkdirSync(packageBin, { recursive: true });
+    mkdirSync(nativeBin, { recursive: true });
+    const nativeCodex = path.join(nativeBin, 'codex.exe');
+    if (windowsNativeFixture) {
+      copyFileSync(windowsNativeFixture, nativeCodex);
+    } else {
+      const rustc = resolveExecutableOnPath('rustc', { baseEnv, platform });
+      const source = path.join(__dirname, 'fixtures', 'fake-harness-windows.rs');
+      const printable = `${rustc} --edition=2021 ${source} -o ${nativeCodex}`;
+      const compile = spawnSync(rustc, ['--edition=2021', source, '-o', nativeCodex], {
+        cwd: repoRoot,
+        env: baseEnv,
+        shell: false,
+        stdio: 'inherit',
+        timeout: DEFAULT_COMMAND_TIMEOUT_MS
+      });
+      handleSpawnResult(printable, compile, {}, { capture: false });
+    }
+    writeFileSync(path.join(packageBin, 'codex.js'), '// validated fixture entry\n');
+    writeFileSync(
+      path.join(packageRoot, 'package.json'),
+      `${JSON.stringify({
+        name: '@openai/codex',
+        bin: { codex: 'bin/codex.js' },
+        optionalDependencies: { [target.packageName]: '0.0.0' }
+      })}\n`
+    );
+    writeFileSync(
+      path.join(targetRoot, 'package.json'),
+      `${JSON.stringify({
+        name: '@openai/codex',
+        os: ['win32'],
+        cpu: [target.cpu]
+      })}\n`
+    );
     const codexCommand = path.join(binDir, 'codex.cmd');
-    const engineCommand = path.join(binDir, 'coven-code.cmd');
-    writeFileSync(codexCommand, windowsShim(nodePath, fixtureScript, 'codex'));
-    writeFileSync(engineCommand, windowsShim(nodePath, fixtureScript, 'coven-code'));
+    const engineCommand = path.join(binDir, 'coven-code.exe');
+    writeFileSync(
+      codexCommand,
+      '@"%~dp0\\node_modules\\@openai\\codex\\bin\\codex.js" %*\r\n'
+    );
+    copyFileSync(nativeCodex, engineCommand);
     return {
       binDir,
       codexCommand,
@@ -328,7 +404,7 @@ function unixShim(nodePath, fixtureScript, kind) {
 }
 
 function windowsShim(nodePath, fixtureScript, kind) {
-  return `@echo off\r\n"${nodePath}" "${fixtureScript}" --fixture-kind ${kind} %*\r\n`;
+  return `@echo off\r\n"${nodePath.replaceAll('%', '%%')}" "${fixtureScript.replaceAll('%', '%%')}" --fixture-kind ${kind} %*\r\n`;
 }
 
 function resolveExecutableOnPath(command, { baseEnv = process.env, platform = process.platform } = {}) {
@@ -667,12 +743,21 @@ export function assertSessionInspection({
   if (terminalIndex <= completionIndex) {
     fail(`session events did not preserve output-before-terminal ordering for ${marker}.\npayloads:\n${payloads.join('\n')}`);
   }
-  if (fixtureLogPath && existsSync(fixtureLogPath)) {
+  if (fixtureLogPath) {
+    if (!existsSync(fixtureLogPath)) {
+      fail(`fixture log was not created at ${fixtureLogPath}.`);
+    }
     const fixtureEvents = readFileSync(fixtureLogPath, 'utf8')
       .split('\n')
       .filter(Boolean)
       .map((line) => JSON.parse(line));
-    if (!fixtureEvents.some((entry) => entry.kind === 'codex' && entry.argv.includes(marker))) {
+    if (
+      !fixtureEvents.some(
+        (entry) =>
+          entry.kind === 'codex' &&
+          (entry.prompt === marker || entry.argv.includes(marker))
+      )
+    ) {
       fail(`fixture log did not record the Codex marker invocation for ${marker}.`);
     }
   }
@@ -821,7 +906,7 @@ export function runPackagedUserJourney({
       assertDashboardHelp(textFromResult(memoryHelp, 'stdout'));
     }
 
-    createFakeCodexFixture(layout.fixtureBinDir, { platform });
+    createFakeCodexFixture(layout.fixtureBinDir, { baseEnv, platform });
     activeEnv = buildJourneyEnv({
       baseEnv,
       fixtureBinDir: layout.fixtureBinDir,

--- a/scripts/user-journey-e2e.mjs
+++ b/scripts/user-journey-e2e.mjs
@@ -280,9 +280,7 @@ export function createNodeShim(nodeShimDir, { nodePath = process.execPath, platf
 export function createGitShim(shimDir, { baseEnv = process.env, platform = process.platform } = {}) {
   const gitPath = resolveExecutableOnPath('git', { baseEnv, platform });
   if (platform === 'win32') {
-    const shim = path.join(shimDir, 'git.cmd');
-    writeFileSync(shim, windowsCommandShim(gitPath));
-    return shim;
+    return gitPath;
   }
   const shim = path.join(shimDir, 'git');
   writeFileSync(shim, unixCommandShim(gitPath));
@@ -456,12 +454,13 @@ function sanitizeBaseEnv(baseEnv = process.env, platform = process.platform) {
 export function buildJourneyEnv({
   baseEnv = process.env,
   fixtureBinDir,
+  gitBinDir,
   layout,
   platform = process.platform,
   wrapperBin
 }) {
   const env = sanitizeBaseEnv(baseEnv, platform);
-  const pathValue = [path.dirname(wrapperBin), layout.nodeShimDir, fixtureBinDir]
+  const pathValue = [path.dirname(wrapperBin), layout.nodeShimDir, fixtureBinDir, gitBinDir]
     .filter(Boolean)
     .join(path.delimiter);
   env.COVEN_FAKE_FIXTURE_LOG = layout.fixtureLogPath;
@@ -863,10 +862,12 @@ export function runPackagedUserJourney({
   try {
     ensureJourneyLayout(layout);
     createNodeShim(layout.nodeShimDir, { platform });
-    createGitShim(layout.nodeShimDir, { baseEnv, platform });
+    const gitCommand = createGitShim(layout.nodeShimDir, { baseEnv, platform });
+    const gitBinDir = platform === 'win32' ? path.dirname(gitCommand) : undefined;
 
     activeEnv = buildJourneyEnv({
       baseEnv,
+      gitBinDir,
       layout,
       platform,
       wrapperBin: resolvedWrapperBin
@@ -911,6 +912,7 @@ export function runPackagedUserJourney({
     activeEnv = buildJourneyEnv({
       baseEnv,
       fixtureBinDir: layout.fixtureBinDir,
+      gitBinDir,
       layout,
       platform,
       wrapperBin: resolvedWrapperBin


### PR DESCRIPTION
## Context

- Summary: Add a hermetic packaged-binary first-session journey that exercises discovery, setup guidance, daemon lifecycle, fake-harness execution, session inspection, archive/summon/sacrifice, cwd rejection, and verified shutdown.
- Files changed: packaged journey runner and fixtures, prepublish integration, CI classification/workflow coverage, and script contract tests.
- Closes #777

## Implementation

- Approach: Install the packed npm artifact, invoke only its wrapper, isolate HOME/COVEN_HOME/PATH/git/npm state, and use deterministic fake Codex/Coven Code shims.
- User-visible behavior: Prepublish verification now validates a complete first session and current `coven setup` guidance.
- Compatibility notes: Uses explicit quoted `cmd.exe` invocation for Windows `.cmd` wrappers; subprocesses are bounded on every platform.

## Verification

- [x] `cargo +1.98.0 fmt --check`
- [x] `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +1.98.0 test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node --test scripts/user-journey-e2e-test.mjs scripts/test-cli-prepublish-test.mjs`
- [x] `node scripts/onboarding-docs-test.mjs && node scripts/cli-docs-test.mjs`
- [x] `python scripts/classify-ci-changes-test.py && python scripts/check-ci-workflow-test.py`

## Risk and Rollback

- Risk level: Medium; cross-platform packaging and process lifecycle test path only.
- Rollback plan: Revert this commit to restore the prior prepublish smoke flow.

## Agent Handoff

- Current state: Complete and locally verified.
- Follow-ups: None required for issue #777.
- Known gaps: Windows process-tree termination remains owned by the underlying CLI/OS process model; cleanup verifies daemon stopped and metadata removed before deleting scratch.