### PR TITLE
feat: allow in-session maintenance participation

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -10888,7 +10888,7 @@ mod tests {
             .status()?;
         assert!(init.success());
         let gate = crate::maintenance_gate::MaintenanceGate::discover(&project_root)?;
-        let owner = gate.acquire_owner("cave-delete")?;
+        let owner = gate.acquire_owner("cave-delete", None)?;
         let runtime = RecordingRuntime::default();
         let body = json!({
             "projectRoot": project_root,
@@ -10938,7 +10938,7 @@ mod tests {
             .status()?;
         assert!(init.success());
         let gate = crate::maintenance_gate::MaintenanceGate::discover(&project_root)?;
-        let owner = gate.acquire_owner("cave-delete")?;
+        let owner = gate.acquire_owner("cave-delete", None)?;
 
         let (response, runtime) =
             run_bound_launch(&temp_dir, &project_root, "sage", root_binding("sage"))?;
@@ -11701,7 +11701,7 @@ mod tests {
 
         runtime.release_writer()?;
         assert!(maintenance.status()?.writers.is_empty());
-        let owner = maintenance.acquire_owner("after-retained-writer")?;
+        let owner = maintenance.acquire_owner("after-retained-writer", None)?;
         owner.assert_held()?;
         owner.release()?;
         Ok(())
@@ -11762,7 +11762,7 @@ mod tests {
         assert_eq!(store::list_sessions(&conn)?.len(), 1);
         assert_eq!(adoption_row_count(temp.path())?, 1);
         assert!(maintenance.status()?.writers.is_empty());
-        let owner = maintenance.acquire_owner("after-transaction-replay")?;
+        let owner = maintenance.acquire_owner("after-transaction-replay", None)?;
         owner.assert_held()?;
         owner.release()?;
         Ok(())
@@ -11827,7 +11827,7 @@ mod tests {
         assert_eq!(store::list_sessions(&conn)?.len(), 1);
         assert_eq!(adoption_row_count(temp.path())?, 1);
         assert!(maintenance.status()?.writers.is_empty());
-        let owner = maintenance.acquire_owner("after-transaction-conflict")?;
+        let owner = maintenance.acquire_owner("after-transaction-conflict", None)?;
         owner.assert_held()?;
         owner.release()?;
         Ok(())
@@ -11956,7 +11956,7 @@ mod tests {
         assert_eq!(first.status, 201, "{}", first.body);
 
         let maintenance = crate::maintenance_gate::MaintenanceGate::discover(&project_root)?;
-        let owner = maintenance.acquire_owner("test-maintenance")?;
+        let owner = maintenance.acquire_owner("test-maintenance", None)?;
         let replay = post_adopted_launch(temp.path(), &body, &runtime)?;
         assert_eq!(replay.status, 200, "{}", replay.body);
         owner.release()?;
@@ -12799,7 +12799,7 @@ mod tests {
             .status()?;
         assert!(git.success());
         let maintenance = crate::maintenance_gate::MaintenanceGate::discover(&project_root)?;
-        let owner = maintenance.acquire_owner("precedence-owner")?;
+        let owner = maintenance.acquire_owner("precedence-owner", None)?;
         let child = child_binding("sage", "missing-parent", "graph-1", "node-1", "attempt-1");
         let mut invalid_child =
             adopted_launch_body(&project_root, "sage", child, "invalid child key");
@@ -14550,7 +14550,7 @@ mod tests {
             .status()?;
         assert!(init.success());
         let gate = crate::maintenance_gate::MaintenanceGate::discover(&project_root)?;
-        let owner = gate.acquire_owner("cave-delete")?;
+        let owner = gate.acquire_owner("cave-delete", None)?;
 
         // An invalid binding (missing familiarId at the top level) must be
         // reported before the maintenance gate is ever consulted.

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -942,6 +942,19 @@ impl SessionRuntime for LiveSessionRuntime {
 }
 
 impl LiveSessionRuntime {
+    fn apply_writer_participant(
+        command: &mut pty_runner::HarnessCommand,
+        writer: Option<&crate::maintenance_gate::WriterLease>,
+    ) -> Result<()> {
+        if let Some(writer) = writer {
+            command.set_environment_override(
+                crate::maintenance_gate::MAINTENANCE_PARTICIPANT_ENV,
+                Some(writer.participant_capability()?),
+            );
+        }
+        Ok(())
+    }
+
     fn launch_session_inner(
         &self,
         launch: &SessionLaunch,
@@ -966,7 +979,7 @@ impl LiveSessionRuntime {
             launch_policy: launch.launch_policy.as_ref(),
             ..Default::default()
         };
-        let command = if launch.harness == "codex"
+        let mut command = if launch.harness == "codex"
             && launch.launch_mode == crate::harness::HarnessLaunchMode::NonInteractive
         {
             pty_runner::build_piped_harness_command_with_conversation(
@@ -989,6 +1002,7 @@ impl LiveSessionRuntime {
                 launch_options,
             )?
         };
+        Self::apply_writer_participant(&mut command, writer.as_ref())?;
         self.launch_prepared_session(launch, writer, command, ownership_established)
     }
 
@@ -7222,6 +7236,46 @@ mod tests {
     fn adopted_piped_registration_publishes_running_before_blocked_prompt_and_is_killable(
     ) -> Result<()> {
         assert_adopted_publication_precedes_blocked_delivery(false)
+    }
+
+    #[test]
+    fn daemon_harness_receives_maintenance_participant_without_debug_disclosure() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let gate =
+            crate::maintenance_gate::MaintenanceGate::at_for_test(temp_dir.path().to_path_buf());
+        let writer = gate.acquire_writer("daemon-session", "session")?;
+        let expected_capability = writer.participant_capability()?;
+        let mut command =
+            pty_runner::HarnessCommand::fixture("echo", Vec::new(), temp_dir.path().to_path_buf());
+
+        LiveSessionRuntime::apply_writer_participant(&mut command, Some(&writer))?;
+
+        assert_eq!(
+            command.environment_override_for_test(
+                crate::maintenance_gate::MAINTENANCE_PARTICIPANT_ENV
+            ),
+            Some(expected_capability.as_str())
+        );
+        assert!(!format!("{command:?}").contains(expected_capability.as_str()));
+        assert!(!format!("{:?}", command.cwd()).contains(expected_capability.as_str()));
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_harness_skips_maintenance_participant_without_writer() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let mut command =
+            pty_runner::HarnessCommand::fixture("echo", Vec::new(), temp_dir.path().to_path_buf());
+
+        LiveSessionRuntime::apply_writer_participant(&mut command, None)?;
+
+        assert_eq!(
+            command.environment_override_for_test(
+                crate::maintenance_gate::MAINTENANCE_PARTICIPANT_ENV
+            ),
+            None
+        );
+        Ok(())
     }
 
     #[cfg(any(unix, windows))]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -5360,7 +5360,7 @@ mod tests {
             .expect("writer should add maintenance participant override");
         assert_eq!(
             maintenance_gate::WriterParticipant::decode(capability)?,
-            writer.participant()
+            *writer.participant()
         );
 
         let mut command_without_writer =

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1579,7 +1579,7 @@ fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {
             wait_ms,
             json,
         } => {
-            let mut lease = gate.acquire_owner(owner)?;
+            let mut lease = gate.acquire_owner(owner, None)?;
             let deadline = std::time::Instant::now() + Duration::from_millis(wait_ms);
             let mut status = lease.refresh_phase()?;
             while !status.writers.is_empty() && std::time::Instant::now() < deadline {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::env::VarError;
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::io::Read;
@@ -1574,6 +1575,18 @@ fn maintenance_participant_from_value(
         .transpose()
 }
 
+fn maintenance_participant_from_env_value(
+    value: std::result::Result<String, VarError>,
+) -> Result<Option<maintenance_gate::WriterParticipant>> {
+    match value {
+        Ok(value) => maintenance_participant_from_value(Some(&value)),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(VarError::NotUnicode(_)) => {
+            anyhow::bail!("COVEN_MAINTENANCE_PARTICIPANT must be valid UTF-8")
+        }
+    }
+}
+
 fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let gate = maintenance_gate::MaintenanceGate::discover(&cwd)?;
@@ -1587,11 +1600,9 @@ fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {
             wait_ms,
             json,
         } => {
-            let participant = maintenance_participant_from_value(
-                std::env::var(maintenance_gate::MAINTENANCE_PARTICIPANT_ENV)
-                    .ok()
-                    .as_deref(),
-            )?;
+            let participant = maintenance_participant_from_env_value(std::env::var(
+                maintenance_gate::MAINTENANCE_PARTICIPANT_ENV,
+            ))?;
             let mut lease = gate.acquire_owner(owner, participant)?;
             let deadline = std::time::Instant::now() + Duration::from_millis(wait_ms);
             let mut status = lease.refresh_phase()?;
@@ -5214,6 +5225,8 @@ mod tests {
         MagicalTuiMove, MagicalTuiRequest, MAGICAL_TUI_MAX_INNER_WIDTH,
     };
     use crossterm::event::KeyEventKind;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
 
     #[test]
     fn tui_launcher_and_session_browser_are_owned_by_tui_modules() {
@@ -5343,6 +5356,26 @@ mod tests {
                 .expect("participant should parse");
         assert_eq!(participant.id, "writer-1");
         assert_eq!(participant.generation, "gen-1");
+    }
+
+    #[test]
+    fn maintenance_participant_env_helper_is_fail_closed() {
+        assert_eq!(
+            maintenance_participant_from_env_value(Err(VarError::NotPresent)).unwrap(),
+            None
+        );
+        assert!(maintenance_participant_from_env_value(Ok("not-json".into())).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn maintenance_participant_env_helper_rejects_non_utf8() {
+        let invalid = OsString::from_vec(vec![0x66, 0x6f, 0x80, 0x6f]);
+        let error = maintenance_participant_from_env_value(Err(VarError::NotUnicode(invalid)))
+            .expect_err("non-UTF-8 participant env must be rejected");
+        assert!(error
+            .to_string()
+            .contains("COVEN_MAINTENANCE_PARTICIPANT must be valid UTF-8"));
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1672,6 +1672,19 @@ fn acquire_session_writer(
     }
 }
 
+fn apply_maintenance_participant(
+    command: &mut pty_runner::HarnessCommand,
+    writer: Option<&maintenance_gate::WriterLease>,
+) -> Result<()> {
+    if let Some(writer) = writer {
+        command.set_environment_override(
+            maintenance_gate::MAINTENANCE_PARTICIPANT_ENV,
+            Some(writer.participant_capability()?),
+        );
+    }
+    Ok(())
+}
+
 fn run_bare_prompt(prompt: &[String]) -> Result<()> {
     // The bare-prompt catch-all swallows anything clap doesn't recognize, so
     // it has to do its own front-door validation: reject stray flags, catch
@@ -3287,7 +3300,7 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         request.harness_id.as_str(),
         session_launch::HarnessCheck::Available,
     )?;
-    let _maintenance_writer = acquire_session_writer(&request.repo.root, "patch-session")?;
+    let maintenance_writer = acquire_session_writer(&request.repo.root, "patch-session")?;
     let coven_home = coven_home_dir()?;
     let store_path = coven_home.join(STORE_FILE_NAME);
     let conn = store::open_store(&store_path)?;
@@ -3335,12 +3348,13 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
     // row was sacrificed or is otherwise non-`created`, the helper bails
     // before `run_harness_attached` ever runs.
     let launch_mode = harness_launch_mode_for_stdio(&selected_harness.id);
-    let command = pty_runner::build_harness_command(
+    let mut command = pty_runner::build_harness_command(
         &selected_harness.id,
         &brief,
         &request.repo.root,
         launch_mode,
     )?;
+    apply_maintenance_participant(&mut command, maintenance_writer.as_ref())?;
     let result = activate_direct_launch_with_runner(&conn, &record.id, || {
         run_harness_attached(&command, launch_mode, false)
     })?;
@@ -4133,7 +4147,7 @@ fn run_session(
             )),
             session_launch::LaunchPathError::Cwd(error) => error.context("failed to resolve cwd"),
         })?;
-    let _maintenance_writer = acquire_session_writer(&project_root, "session")?;
+    let maintenance_writer = acquire_session_writer(&project_root, "session")?;
     let coven_home = coven_home_dir()?;
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
@@ -4420,7 +4434,8 @@ fn run_session(
             familiar_for_args,
             launch_options,
         );
-        let exit_code = command.and_then(|command| {
+        let exit_code = command.and_then(|mut command| {
+            apply_maintenance_participant(&mut command, maintenance_writer.as_ref())?;
             pty_runner::stream_harness(
                 &command,
                 stream_json_input,
@@ -4541,7 +4556,7 @@ fn run_session(
             launch_options,
         )
     };
-    let command = match command {
+    let mut command = match command {
         Ok(command) => command,
         Err(error) => {
             store::update_session_status(
@@ -4565,6 +4580,7 @@ fn run_session(
             return Err(error);
         }
     };
+    apply_maintenance_participant(&mut command, maintenance_writer.as_ref())?;
     if stream_json && selected_harness.id == "codex" {
         let output_session_id = record.id.clone();
         let outcome = pty_runner::stream_codex_json(&command, move |text| {
@@ -5327,6 +5343,35 @@ mod tests {
                 .expect("participant should parse");
         assert_eq!(participant.id, "writer-1");
         assert_eq!(participant.generation, "gen-1");
+    }
+
+    #[test]
+    fn maintenance_participant_is_added_only_when_a_writer_exists() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = maintenance_gate::MaintenanceGate::at_for_test(temp.path().to_path_buf());
+        let writer = gate.acquire_writer("session-self", "session")?;
+        let mut command =
+            pty_runner::HarnessCommand::fixture("echo", Vec::new(), temp.path().to_path_buf());
+
+        apply_maintenance_participant(&mut command, Some(&writer))?;
+
+        let capability = command
+            .environment_override_for_test(maintenance_gate::MAINTENANCE_PARTICIPANT_ENV)
+            .expect("writer should add maintenance participant override");
+        assert_eq!(
+            maintenance_gate::WriterParticipant::decode(capability)?,
+            writer.participant()
+        );
+
+        let mut command_without_writer =
+            pty_runner::HarnessCommand::fixture("echo", Vec::new(), temp.path().to_path_buf());
+        apply_maintenance_participant(&mut command_without_writer, None)?;
+        assert_eq!(
+            command_without_writer
+                .environment_override_for_test(maintenance_gate::MAINTENANCE_PARTICIPANT_ENV),
+            None
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1566,6 +1566,14 @@ fn setup_candidate_commit() -> String {
     env!("COVEN_BUILD_COMMIT").to_owned()
 }
 
+fn maintenance_participant_from_value(
+    value: Option<&str>,
+) -> Result<Option<maintenance_gate::WriterParticipant>> {
+    value
+        .map(maintenance_gate::WriterParticipant::decode)
+        .transpose()
+}
+
 fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let gate = maintenance_gate::MaintenanceGate::discover(&cwd)?;
@@ -1579,7 +1587,12 @@ fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {
             wait_ms,
             json,
         } => {
-            let mut lease = gate.acquire_owner(owner, None)?;
+            let participant = maintenance_participant_from_value(
+                std::env::var(maintenance_gate::MAINTENANCE_PARTICIPANT_ENV)
+                    .ok()
+                    .as_deref(),
+            )?;
+            let mut lease = gate.acquire_owner(owner, participant)?;
             let deadline = std::time::Instant::now() + Duration::from_millis(wait_ms);
             let mut status = lease.refresh_phase()?;
             while !status.writers.is_empty() && std::time::Instant::now() < deadline {
@@ -5298,6 +5311,22 @@ mod tests {
                 command: ConfigCommand::Paths { json: true }
             })
         ));
+    }
+
+    #[test]
+    fn maintenance_participant_env_is_optional_and_strict() {
+        assert_eq!(maintenance_participant_from_value(None).unwrap(), None);
+        assert!(maintenance_participant_from_value(Some("not-json")).is_err());
+
+        let blank = maintenance_participant_from_value(Some(r#"{"id":"","generation":"g"}"#));
+        assert!(blank.is_err());
+
+        let participant =
+            maintenance_participant_from_value(Some(r#"{"id":"writer-1","generation":"gen-1"}"#))
+                .unwrap()
+                .expect("participant should parse");
+        assert_eq!(participant.id, "writer-1");
+        assert_eq!(participant.generation, "gen-1");
     }
 
     #[test]

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -9,7 +9,7 @@
 
 use std::{
     fs,
-    io::Write,
+    io::{Read, Write},
     path::{Path, PathBuf},
     sync::{Arc, Condvar, Mutex},
     thread,
@@ -336,10 +336,10 @@ impl MaintenanceGate {
         self.with_lock(|| {
             let now = unix_now();
             let owner = self.read_owner()?;
-            let writers = self.read_writers(now)?;
-            let writers = owner.as_ref().map_or(writers.clone(), |owner| {
-                blocking_writers(owner, writers.clone())
-            });
+            let mut writers = self.read_writers(now)?;
+            if let Some(owner) = owner.as_ref() {
+                writers = blocking_writers(owner, writers);
+            }
             Ok(GateStatus { owner, writers })
         })
     }
@@ -427,7 +427,14 @@ impl MaintenanceGate {
 
     fn validate_participant(&self, participant: &WriterParticipant, now: u64) -> Result<()> {
         let path = self.writers_dir().join(writer_file_name(&participant.id));
-        let data = fs::read(&path).map_err(|_| GateError::ParticipantInvalid)?;
+        let metadata = fs::symlink_metadata(&path).map_err(|_| GateError::ParticipantInvalid)?;
+        if !metadata.file_type().is_file() {
+            return Err(GateError::ParticipantInvalid.into());
+        }
+        let mut file = fs::File::open(&path).map_err(|_| GateError::ParticipantInvalid)?;
+        let mut data = Vec::with_capacity(metadata.len().try_into().unwrap_or(0));
+        file.read_to_end(&mut data)
+            .map_err(|_| GateError::ParticipantInvalid)?;
         let writer: WriterIntent =
             serde_json::from_slice(&data).map_err(|_| GateError::ParticipantInvalid)?;
         if writer.id != participant.id
@@ -441,9 +448,19 @@ impl MaintenanceGate {
 
     fn release_writer(&self, path: &Path, generation: &str) {
         let _ = self.with_lock(|| {
-            let Ok(data) = fs::read(path) else {
+            let Ok(metadata) = fs::symlink_metadata(path) else {
                 return Ok(());
             };
+            if !metadata.file_type().is_file() {
+                return Ok(());
+            }
+            let Ok(mut file) = fs::File::open(path) else {
+                return Ok(());
+            };
+            let mut data = Vec::with_capacity(metadata.len().try_into().unwrap_or(0));
+            if file.read_to_end(&mut data).is_err() {
+                return Ok(());
+            }
             let Ok(intent) = serde_json::from_slice::<WriterIntent>(&data) else {
                 return Ok(());
             };
@@ -962,6 +979,60 @@ mod tests {
             .is_some_and(|e| matches!(e, GateError::ParticipantInvalid)));
         assert!(gate.read_owner()?.is_none());
         drop(replacement_writer);
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn owner_rejects_symlinked_participant_writer_without_touching_target() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
+        let writer = gate.acquire_writer("session-self", "session")?;
+        let participant = writer.participant().clone();
+        let writer_path = gate.writers_dir().join(writer_file_name(&participant.id));
+        let external_path = temp.path().join("external-writer.json");
+        let external_writer = WriterIntent {
+            id: participant.id.clone(),
+            kind: "session".into(),
+            generation: participant.generation.clone(),
+            expires_at: unix_now() + WRITER_TTL.as_secs(),
+        };
+        fs::write(&external_path, serde_json::to_vec(&external_writer)?)?;
+        std::mem::forget(writer);
+        fs::remove_file(&writer_path)?;
+        symlink(&external_path, &writer_path)?;
+
+        let before = fs::read(&external_path)?;
+        let error = gate
+            .acquire_owner("cave", Some(participant))
+            .expect_err("symlinked participant writer must be rejected");
+        assert!(error
+            .downcast_ref::<GateError>()
+            .is_some_and(|e| matches!(e, GateError::ParticipantInvalid)));
+        assert_eq!(fs::read(&external_path)?, before);
+        assert!(gate.read_owner()?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn owner_rejects_non_regular_participant_writer() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
+        gate.ensure_layout()?;
+        let participant = WriterParticipant {
+            id: "session-self".into(),
+            generation: "gen-1".into(),
+        };
+        let writer_path = gate.writers_dir().join(writer_file_name(&participant.id));
+        fs::create_dir(&writer_path)?;
+
+        let error = gate
+            .acquire_owner("cave", Some(participant))
+            .expect_err("directory participant writer must be rejected");
+        assert!(error
+            .downcast_ref::<GateError>()
+            .is_some_and(|e| matches!(e, GateError::ParticipantInvalid)));
+        assert!(gate.read_owner()?.is_none());
         Ok(())
     }
 

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -232,7 +232,7 @@ impl MaintenanceGate {
     }
 
     #[cfg(test)]
-    fn at(common_dir: PathBuf) -> Self {
+    pub(crate) fn at_for_test(common_dir: PathBuf) -> Self {
         Self { common_dir }
     }
 
@@ -803,7 +803,7 @@ mod tests {
     #[test]
     fn live_gate_lock_blocks_a_second_acquirer() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         gate.ensure_layout()?;
         let _first = GateLock::acquire(gate.lock_path())?;
 
@@ -816,7 +816,7 @@ mod tests {
     #[test]
     fn dropping_gate_lock_allows_the_next_acquirer() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         gate.ensure_layout()?;
         let first = GateLock::acquire(gate.lock_path())?;
         drop(first);
@@ -829,7 +829,7 @@ mod tests {
     #[test]
     fn stale_mtime_does_not_allow_live_gate_lock_takeover() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         gate.ensure_layout()?;
         let _first = GateLock::acquire(gate.lock_path())?;
         let lock_file = fs::OpenOptions::new().write(true).open(gate.lock_path())?;
@@ -847,7 +847,7 @@ mod tests {
     #[test]
     fn symlinked_gate_lock_is_refused_without_touching_the_target() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         gate.ensure_layout()?;
         let outside = tempfile::NamedTempFile::new()?;
         fs::write(outside.path(), b"outside-lock-target")?;
@@ -864,7 +864,7 @@ mod tests {
     #[test]
     fn multiply_linked_gate_lock_is_refused() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         gate.ensure_layout()?;
         fs::write(gate.lock_path(), b"lock")?;
         let alias = temp.path().join("lock-alias");
@@ -880,7 +880,7 @@ mod tests {
     #[test]
     fn owner_rejects_a_writer_until_release() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let owner = gate.acquire_owner("cave", None)?;
         assert_eq!(owner.owner().phase, OwnerPhase::Held);
         let error = gate.acquire_writer("session-1", "session").unwrap_err();
@@ -895,7 +895,7 @@ mod tests {
     #[test]
     fn owner_drains_existing_writer_then_becomes_held() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let writer = gate.acquire_writer("session-1", "session")?;
         let mut owner = gate.acquire_owner("cave", None)?;
         assert_eq!(owner.owner().phase, OwnerPhase::Draining);
@@ -909,7 +909,7 @@ mod tests {
     #[test]
     fn owner_excludes_only_its_exact_participant_writer() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let writer_self = gate.acquire_writer("session-self", "session")?;
         let writer_other = gate.acquire_writer("session-other", "session")?;
         let participant = writer_self.participant();
@@ -930,7 +930,7 @@ mod tests {
     #[test]
     fn owner_rejects_a_stale_or_forged_participant_generation() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let writer = gate.acquire_writer("session-self", "session")?;
         let mut participant = writer.participant();
         participant.generation.push_str("-forged");
@@ -948,7 +948,7 @@ mod tests {
     #[test]
     fn owner_does_not_exclude_a_replacement_writer_with_the_same_id() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let first_writer = gate.acquire_writer("session-self", "session")?;
         let participant = first_writer.participant();
         drop(first_writer);
@@ -990,7 +990,7 @@ mod tests {
     #[test]
     fn writer_lease_participant_capability_uses_public_env_name() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let writer = gate.acquire_writer("session-self", "session")?;
         let capability = writer.participant_capability()?;
         let decoded = WriterParticipant::decode(&capability)?;
@@ -1002,7 +1002,7 @@ mod tests {
     #[test]
     fn malformed_owner_fails_closed() -> Result<()> {
         let temp = tempfile::tempdir()?;
-        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         gate.ensure_layout()?;
         fs::write(gate.owner_path(), b"not-json")?;
         let error = gate.acquire_writer("session-1", "session").unwrap_err();

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -29,6 +29,7 @@ const LOCK_WAIT: Duration = Duration::from_secs(5);
 const WRITER_TTL: Duration = Duration::from_secs(90);
 const OWNER_TTL: Duration = Duration::from_secs(120);
 const RENEW_EVERY: Duration = Duration::from_secs(20);
+pub const MAINTENANCE_PARTICIPANT_ENV: &str = "COVEN_MAINTENANCE_PARTICIPANT";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Owner {
@@ -36,6 +37,8 @@ pub struct Owner {
     pub generation: String,
     pub expires_at: u64,
     pub phase: OwnerPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub participant: Option<WriterParticipant>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -54,6 +57,27 @@ pub struct WriterIntent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WriterParticipant {
+    pub id: String,
+    pub generation: String,
+}
+
+impl WriterParticipant {
+    pub fn encode(&self) -> Result<String> {
+        serde_json::to_string(self).context("failed to serialize maintenance participant")
+    }
+
+    pub fn decode(value: &str) -> Result<Self> {
+        let participant: Self =
+            serde_json::from_str(value).context("failed to parse maintenance participant")?;
+        if participant.id.trim().is_empty() || participant.generation.trim().is_empty() {
+            anyhow::bail!("maintenance participant must include non-blank id and generation");
+        }
+        Ok(participant)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GateStatus {
     pub owner: Option<Owner>,
     pub writers: Vec<WriterIntent>,
@@ -67,6 +91,7 @@ pub enum GateError {
     OwnerChanged,
     LeaseExpired,
     Contended,
+    ParticipantInvalid,
 }
 
 impl std::fmt::Display for GateError {
@@ -95,6 +120,10 @@ impl std::fmt::Display for GateError {
             Self::OwnerChanged => write!(f, "maintenance ownership changed; acquire a new fence"),
             Self::LeaseExpired => write!(f, "maintenance lease expired; acquire a new fence"),
             Self::Contended => write!(f, "maintenance state is contended; retry"),
+            Self::ParticipantInvalid => write!(
+                f,
+                "maintenance participant is stale, missing, or mismatched"
+            ),
         }
     }
 }
@@ -266,13 +295,18 @@ impl MaintenanceGate {
     /// Acquire an owner fence. New writers are refused from the instant this
     /// record is published. Existing writers remain visible while Cave drains
     /// them; the phase becomes `held` only after they have all left.
-    pub fn acquire_owner(&self, owner_id: impl Into<String>) -> Result<OwnerLease> {
+    pub fn acquire_owner(
+        &self,
+        owner_id: impl Into<String>,
+        participant: Option<WriterParticipant>,
+    ) -> Result<OwnerLease> {
         self.ensure_layout()?;
         let owner = Owner {
             owner_id: owner_id.into(),
             generation: Uuid::new_v4().to_string(),
             expires_at: unix_now() + OWNER_TTL.as_secs(),
             phase: OwnerPhase::Draining,
+            participant,
         };
         self.with_lock(|| {
             if let Some(existing) = self.read_owner()? {
@@ -281,6 +315,9 @@ impl MaintenanceGate {
                 }
                 fs::remove_file(self.owner_path())
                     .with_context(|| "failed to remove expired maintenance owner")?;
+            }
+            if let Some(participant) = &owner.participant {
+                self.validate_participant(participant, unix_now())?;
             }
             self.write_new(&self.owner_path(), &owner)
                 .with_context(|| "failed to publish maintenance owner")?;
@@ -300,19 +337,24 @@ impl MaintenanceGate {
             let now = unix_now();
             let owner = self.read_owner()?;
             let writers = self.read_writers(now)?;
+            let writers = owner.as_ref().map_or(writers.clone(), |owner| {
+                blocking_writers(owner, writers.clone())
+            });
             Ok(GateStatus { owner, writers })
         })
     }
 
     pub fn heartbeat_owner(&self, owner_id: &str, generation: &str) -> Result<GateStatus> {
+        let owner = self.with_lock(|| {
+            let owner = self.read_owner()?.ok_or(GateError::OwnerChanged)?;
+            if owner.owner_id != owner_id || owner.generation != generation {
+                return Err(GateError::OwnerChanged.into());
+            }
+            Ok(owner)
+        })?;
         let mut lease = OwnerLease {
             gate: self.clone(),
-            owner: Owner {
-                owner_id: owner_id.to_string(),
-                generation: generation.to_string(),
-                expires_at: 0,
-                phase: OwnerPhase::Draining,
-            },
+            owner,
         };
         lease.refresh_phase()
     }
@@ -325,6 +367,7 @@ impl MaintenanceGate {
                 generation: generation.to_string(),
                 expires_at: 0,
                 phase: OwnerPhase::Draining,
+                participant: None,
             },
         }
         .release()
@@ -380,6 +423,20 @@ impl MaintenanceGate {
             intent.expires_at = unix_now() + WRITER_TTL.as_secs();
             self.replace(path, &intent)
         })
+    }
+
+    fn validate_participant(&self, participant: &WriterParticipant, now: u64) -> Result<()> {
+        let path = self.writers_dir().join(writer_file_name(&participant.id));
+        let data = fs::read(&path).map_err(|_| GateError::ParticipantInvalid)?;
+        let writer: WriterIntent =
+            serde_json::from_slice(&data).map_err(|_| GateError::ParticipantInvalid)?;
+        if writer.id != participant.id
+            || writer.generation != participant.generation
+            || writer.expires_at <= now
+        {
+            return Err(GateError::ParticipantInvalid.into());
+        }
+        Ok(())
     }
 
     fn release_writer(&self, path: &Path, generation: &str) {
@@ -471,7 +528,7 @@ fn replace_file(staged: &Path, path: &Path) -> std::io::Result<()> {
 pub struct WriterLease {
     gate: MaintenanceGate,
     path: PathBuf,
-    generation: String,
+    participant: WriterParticipant,
     stopper: Arc<(Mutex<bool>, Condvar)>,
     renewer: Option<thread::JoinHandle<()>>,
 }
@@ -482,7 +539,11 @@ impl WriterLease {
         let thread_stopper = Arc::clone(&stopper);
         let thread_gate = gate.clone();
         let thread_path = path.clone();
-        let generation = intent.generation.clone();
+        let participant = WriterParticipant {
+            id: intent.id.clone(),
+            generation: intent.generation.clone(),
+        };
+        let thread_participant = participant.clone();
         let renewer = thread::spawn(move || {
             loop {
                 let (stopped, wake) = &*thread_stopper;
@@ -494,7 +555,10 @@ impl WriterLease {
                     return;
                 }
                 drop(guard);
-                if thread_gate.renew_writer(&thread_path, &generation).is_err() {
+                if thread_gate
+                    .renew_writer(&thread_path, &thread_participant.generation)
+                    .is_err()
+                {
                     // Keep trying: a transient rename failure must not make a
                     // still-running session invisible to a maintenance owner.
                 }
@@ -503,10 +567,18 @@ impl WriterLease {
         Self {
             gate,
             path,
-            generation: intent.generation,
+            participant,
             stopper,
             renewer: Some(renewer),
         }
+    }
+
+    pub fn participant(&self) -> WriterParticipant {
+        self.participant.clone()
+    }
+
+    pub fn participant_capability(&self) -> Result<String> {
+        self.participant.encode()
     }
 }
 
@@ -520,10 +592,12 @@ impl Drop for WriterLease {
         if let Some(renewer) = self.renewer.take() {
             let _ = renewer.join();
         }
-        self.gate.release_writer(&self.path, &self.generation);
+        self.gate
+            .release_writer(&self.path, &self.participant.generation);
     }
 }
 
+#[derive(Debug)]
 pub struct OwnerLease {
     gate: MaintenanceGate,
     owner: Owner,
@@ -547,9 +621,10 @@ impl OwnerLease {
                 return Err(GateError::LeaseExpired.into());
             }
             let writers = self.gate.read_writers(unix_now())?;
+            let blocking_writers = blocking_writers(&current, writers);
             let mut next = current;
             next.expires_at = unix_now() + OWNER_TTL.as_secs();
-            next.phase = if writers.is_empty() {
+            next.phase = if blocking_writers.is_empty() {
                 OwnerPhase::Held
             } else {
                 OwnerPhase::Draining
@@ -558,7 +633,7 @@ impl OwnerLease {
             self.owner = next.clone();
             Ok(GateStatus {
                 owner: Some(next),
-                writers,
+                writers: blocking_writers,
             })
         })
     }
@@ -652,6 +727,17 @@ fn unix_now() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn blocking_writers(owner: &Owner, writers: Vec<WriterIntent>) -> Vec<WriterIntent> {
+    writers
+        .into_iter()
+        .filter(|writer| {
+            owner.participant.as_ref().is_none_or(|participant| {
+                writer.id != participant.id || writer.generation != participant.generation
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -795,7 +881,7 @@ mod tests {
     fn owner_rejects_a_writer_until_release() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let gate = MaintenanceGate::at(temp.path().to_path_buf());
-        let owner = gate.acquire_owner("cave")?;
+        let owner = gate.acquire_owner("cave", None)?;
         assert_eq!(owner.owner().phase, OwnerPhase::Held);
         let error = gate.acquire_writer("session-1", "session").unwrap_err();
         assert!(error
@@ -811,12 +897,105 @@ mod tests {
         let temp = tempfile::tempdir()?;
         let gate = MaintenanceGate::at(temp.path().to_path_buf());
         let writer = gate.acquire_writer("session-1", "session")?;
-        let mut owner = gate.acquire_owner("cave")?;
+        let mut owner = gate.acquire_owner("cave", None)?;
         assert_eq!(owner.owner().phase, OwnerPhase::Draining);
         drop(writer);
         assert!(owner.refresh_phase()?.writers.is_empty());
         owner.assert_held()?;
         owner.release()?;
+        Ok(())
+    }
+
+    #[test]
+    fn owner_excludes_only_its_exact_participant_writer() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let writer_self = gate.acquire_writer("session-self", "session")?;
+        let writer_other = gate.acquire_writer("session-other", "session")?;
+        let participant = writer_self.participant();
+        let mut owner = gate.acquire_owner("cave", Some(participant))?;
+
+        let status = owner.refresh_phase()?;
+        assert_eq!(status.writers.len(), 1);
+        assert_eq!(status.writers[0].id, "session-other");
+        assert_eq!(owner.owner().phase, OwnerPhase::Draining);
+
+        drop(writer_other);
+        assert!(owner.refresh_phase()?.writers.is_empty());
+        owner.assert_held()?;
+        owner.release()?;
+        Ok(())
+    }
+
+    #[test]
+    fn owner_rejects_a_stale_or_forged_participant_generation() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let writer = gate.acquire_writer("session-self", "session")?;
+        let mut participant = writer.participant();
+        participant.generation.push_str("-forged");
+
+        let error = gate
+            .acquire_owner("cave", Some(participant))
+            .expect_err("forged participant must be rejected");
+        assert!(error
+            .downcast_ref::<GateError>()
+            .is_some_and(|e| matches!(e, GateError::ParticipantInvalid)));
+        assert!(gate.read_owner()?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn owner_does_not_exclude_a_replacement_writer_with_the_same_id() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let first_writer = gate.acquire_writer("session-self", "session")?;
+        let participant = first_writer.participant();
+        drop(first_writer);
+
+        let replacement_writer = gate.acquire_writer("session-self", "session")?;
+        let error = gate
+            .acquire_owner("cave", Some(participant))
+            .expect_err("stale participant must be rejected");
+        assert!(error
+            .downcast_ref::<GateError>()
+            .is_some_and(|e| matches!(e, GateError::ParticipantInvalid)));
+        assert!(gate.read_owner()?.is_none());
+        drop(replacement_writer);
+        Ok(())
+    }
+
+    #[test]
+    fn owner_without_participant_remains_backward_compatible() -> Result<()> {
+        let owner: Owner = serde_json::from_str(
+            r#"{"owner_id":"cave","generation":"g1","expires_at":123,"phase":"held"}"#,
+        )?;
+        assert_eq!(owner.participant, None);
+        Ok(())
+    }
+
+    #[test]
+    fn writer_participant_encode_decode_round_trips_and_rejects_blank_fields() -> Result<()> {
+        let participant = WriterParticipant {
+            id: "session-self".into(),
+            generation: "gen-1".into(),
+        };
+        let encoded = participant.encode()?;
+        assert_eq!(WriterParticipant::decode(&encoded)?, participant);
+        assert!(WriterParticipant::decode(r#"{"id":" ","generation":"gen"}"#).is_err());
+        assert!(WriterParticipant::decode(r#"{"id":"session","generation":" "}"#).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn writer_lease_participant_capability_uses_public_env_name() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let writer = gate.acquire_writer("session-self", "session")?;
+        let capability = writer.participant_capability()?;
+        let decoded = WriterParticipant::decode(&capability)?;
+        assert_eq!(decoded, writer.participant());
+        assert_eq!(MAINTENANCE_PARTICIPANT_ENV, "COVEN_MAINTENANCE_PARTICIPANT");
         Ok(())
     }
 

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -427,11 +427,8 @@ impl MaintenanceGate {
 
     fn validate_participant(&self, participant: &WriterParticipant, now: u64) -> Result<()> {
         let path = self.writers_dir().join(writer_file_name(&participant.id));
-        let metadata = fs::symlink_metadata(&path).map_err(|_| GateError::ParticipantInvalid)?;
-        if !metadata.file_type().is_file() {
-            return Err(GateError::ParticipantInvalid.into());
-        }
-        let mut file = fs::File::open(&path).map_err(|_| GateError::ParticipantInvalid)?;
+        let (mut file, metadata) =
+            open_participant_file(&path).map_err(|_| GateError::ParticipantInvalid)?;
         let mut data = Vec::with_capacity(metadata.len().try_into().unwrap_or(0));
         file.read_to_end(&mut data)
             .map_err(|_| GateError::ParticipantInvalid)?;
@@ -448,19 +445,9 @@ impl MaintenanceGate {
 
     fn release_writer(&self, path: &Path, generation: &str) {
         let _ = self.with_lock(|| {
-            let Ok(metadata) = fs::symlink_metadata(path) else {
+            let Ok(data) = fs::read(path) else {
                 return Ok(());
             };
-            if !metadata.file_type().is_file() {
-                return Ok(());
-            }
-            let Ok(mut file) = fs::File::open(path) else {
-                return Ok(());
-            };
-            let mut data = Vec::with_capacity(metadata.len().try_into().unwrap_or(0));
-            if file.read_to_end(&mut data).is_err() {
-                return Ok(());
-            }
             let Ok(intent) = serde_json::from_slice::<WriterIntent>(&data) else {
                 return Ok(());
             };
@@ -499,6 +486,45 @@ impl MaintenanceGate {
             .with_context(|| format!("failed to replace {}", path.display()))?;
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn open_participant_file(path: &Path) -> std::io::Result<(fs::File, fs::Metadata)> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "participant entry is not a regular file",
+        ));
+    }
+    Ok((file, metadata))
+}
+
+#[cfg(windows)]
+fn open_participant_file(path: &Path) -> std::io::Result<(fs::File, fs::Metadata)> {
+    use std::os::windows::fs::{FileTypeExt, OpenOptionsExt};
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    let file_type = metadata.file_type();
+    if !metadata.is_file() || file_type.is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "participant entry is not a regular file",
+        ));
+    }
+    Ok((file, metadata))
 }
 
 #[cfg(not(windows))]
@@ -987,9 +1013,17 @@ mod tests {
     fn owner_rejects_symlinked_participant_writer_without_touching_target() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
-        let writer = gate.acquire_writer("session-self", "session")?;
-        let participant = writer.participant().clone();
+        let mut writer = Some(gate.acquire_writer("session-self", "session")?);
+        let participant = writer
+            .as_ref()
+            .expect("writer present")
+            .participant()
+            .clone();
         let writer_path = gate.writers_dir().join(writer_file_name(&participant.id));
+        let backup_path = gate
+            .writers_dir()
+            .join(format!("{}.backup", writer_file_name(&participant.id)));
+        fs::rename(&writer_path, &backup_path)?;
         let external_path = temp.path().join("external-writer.json");
         let external_writer = WriterIntent {
             id: participant.id.clone(),
@@ -998,8 +1032,6 @@ mod tests {
             expires_at: unix_now() + WRITER_TTL.as_secs(),
         };
         fs::write(&external_path, serde_json::to_vec(&external_writer)?)?;
-        std::mem::forget(writer);
-        fs::remove_file(&writer_path)?;
         symlink(&external_path, &writer_path)?;
 
         let before = fs::read(&external_path)?;
@@ -1011,6 +1043,9 @@ mod tests {
             .is_some_and(|e| matches!(e, GateError::ParticipantInvalid)));
         assert_eq!(fs::read(&external_path)?, before);
         assert!(gate.read_owner()?.is_none());
+        fs::remove_file(&writer_path)?;
+        fs::rename(&backup_path, &writer_path)?;
+        drop(writer.take());
         Ok(())
     }
 

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -573,12 +573,12 @@ impl WriterLease {
         }
     }
 
-    pub fn participant(&self) -> WriterParticipant {
-        self.participant.clone()
+    pub fn participant(&self) -> &WriterParticipant {
+        &self.participant
     }
 
     pub fn participant_capability(&self) -> Result<String> {
-        self.participant.encode()
+        self.participant().encode()
     }
 }
 
@@ -912,7 +912,7 @@ mod tests {
         let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let writer_self = gate.acquire_writer("session-self", "session")?;
         let writer_other = gate.acquire_writer("session-other", "session")?;
-        let participant = writer_self.participant();
+        let participant = writer_self.participant().clone();
         let mut owner = gate.acquire_owner("cave", Some(participant))?;
 
         let status = owner.refresh_phase()?;
@@ -932,7 +932,7 @@ mod tests {
         let temp = tempfile::tempdir()?;
         let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let writer = gate.acquire_writer("session-self", "session")?;
-        let mut participant = writer.participant();
+        let mut participant = writer.participant().clone();
         participant.generation.push_str("-forged");
 
         let error = gate
@@ -950,7 +950,7 @@ mod tests {
         let temp = tempfile::tempdir()?;
         let gate = MaintenanceGate::at_for_test(temp.path().to_path_buf());
         let first_writer = gate.acquire_writer("session-self", "session")?;
-        let participant = first_writer.participant();
+        let participant = first_writer.participant().clone();
         drop(first_writer);
 
         let replacement_writer = gate.acquire_writer("session-self", "session")?;
@@ -981,7 +981,7 @@ mod tests {
             generation: "gen-1".into(),
         };
         let encoded = participant.encode()?;
-        assert_eq!(WriterParticipant::decode(&encoded)?, participant);
+        assert_eq!(&WriterParticipant::decode(&encoded)?, &participant);
         assert!(WriterParticipant::decode(r#"{"id":" ","generation":"gen"}"#).is_err());
         assert!(WriterParticipant::decode(r#"{"id":"session","generation":" "}"#).is_err());
         Ok(())
@@ -994,7 +994,7 @@ mod tests {
         let writer = gate.acquire_writer("session-self", "session")?;
         let capability = writer.participant_capability()?;
         let decoded = WriterParticipant::decode(&capability)?;
-        assert_eq!(decoded, writer.participant());
+        assert_eq!(decoded, *writer.participant());
         assert_eq!(MAINTENANCE_PARTICIPANT_ENV, "COVEN_MAINTENANCE_PARTICIPANT");
         Ok(())
     }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -266,6 +266,23 @@ impl HarnessCommand {
         self.stdin_prompt = Some(prompt);
     }
 
+    pub(crate) fn set_environment_override(
+        &mut self,
+        name: impl Into<String>,
+        value: Option<impl Into<String>>,
+    ) {
+        self.env_overrides
+            .push((name.into(), value.map(Into::into)));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn environment_override_for_test(&self, name: &str) -> Option<&str> {
+        self.env_overrides
+            .iter()
+            .rev()
+            .find_map(|(candidate, value)| (candidate == name).then(|| value.as_deref()).flatten())
+    }
+
     fn to_command_builder(&self) -> CommandBuilder {
         let mut builder = CommandBuilder::new(&self.program);
         builder.args(&self.args);
@@ -5845,6 +5862,22 @@ mod tests {
             "natural root exit left inherited-output descendant {descendant_pid} running"
         );
         Ok(())
+    }
+
+    #[test]
+    fn harness_command_can_set_a_private_runtime_environment_value() {
+        let mut command = HarnessCommand::fixture("echo", Vec::new(), PathBuf::from("/tmp"));
+
+        command.set_environment_override("COVEN_TEST_CAPABILITY", Some("opaque-value"));
+
+        assert!(command.env_overrides.contains(&(
+            "COVEN_TEST_CAPABILITY".to_owned(),
+            Some("opaque-value".to_owned())
+        )));
+        assert_eq!(
+            command.environment_override_for_test("COVEN_TEST_CAPABILITY"),
+            Some("opaque-value")
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -280,7 +280,9 @@ impl HarnessCommand {
         self.env_overrides
             .iter()
             .rev()
-            .find_map(|(candidate, value)| (candidate == name).then(|| value.as_deref()).flatten())
+            .find_map(|(candidate, value)| {
+                (candidate == name).then_some(value.as_deref()).flatten()
+            })
     }
 
     fn to_command_builder(&self) -> CommandBuilder {

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -1278,6 +1278,184 @@ fn color_flag_parses_and_rejects_unknown_values() -> anyhow::Result<()> {
 }
 
 #[test]
+fn session_harness_can_acquire_maintenance_against_its_own_writer() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let project = temp_dir.path().join("project");
+    let fake_bin = temp_dir.path().join("bin");
+    let coven = coven_bin();
+    fs::create_dir_all(&coven_home)?;
+    fs::create_dir_all(&project)?;
+    fs::create_dir_all(&fake_bin)?;
+    init_git_repo(&project)?;
+    write_maintenance_participant_fake_codex(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
+
+    let self_only_acquisition = temp_dir.path().join("self-only-acquisition.json");
+    let self_only_held = temp_dir.path().join("self-only-held.json");
+    let self_only_ready = temp_dir.path().join("self-only-ready");
+    let self_only_generation = temp_dir.path().join("self-only-generation");
+    fs::write(&self_only_generation, b"self-only\n")?;
+    let self_only = run_coven_in(
+        &coven,
+        &coven_home,
+        &path,
+        &project,
+        &[
+            ("COVEN_TEST_COVEN_BIN", coven.to_string_lossy().as_ref()),
+            (
+                "COVEN_TEST_ACQUISITION_FILE",
+                self_only_acquisition.to_string_lossy().as_ref(),
+            ),
+            (
+                "COVEN_TEST_HELD_FILE",
+                self_only_held.to_string_lossy().as_ref(),
+            ),
+            (
+                "COVEN_TEST_PARTICIPANT_READY",
+                self_only_ready.to_string_lossy().as_ref(),
+            ),
+            (
+                "COVEN_TEST_PARTICIPANT_GENERATION",
+                self_only_generation.to_string_lossy().as_ref(),
+            ),
+        ],
+        &["run", "codex", "participant"],
+    )?;
+    assert_success("self-only participant run", &self_only);
+    let self_only_json =
+        parse_prefixed_json_line("self-only participant run", &self_only, "participant-held:")?;
+    assert_eq!(
+        self_only_json["owner"]["phase"].as_str(),
+        Some("held"),
+        "self-only acquire should reach held: {self_only_json}"
+    );
+    assert!(
+        self_only_json["writers"]
+            .as_array()
+            .is_some_and(|writers| writers.is_empty()),
+        "self-only acquire should exclude its own writer: {self_only_json}"
+    );
+
+    let blocker_ready = temp_dir.path().join("blocker-ready");
+    let release_blocker = temp_dir.path().join("release-blocker");
+    let participant_ready = temp_dir.path().join("participant-ready");
+    let participant_generation = temp_dir.path().join("participant-generation");
+    let acquisition_json = temp_dir.path().join("participant-acquisition.json");
+    let held_json = temp_dir.path().join("participant-held.json");
+
+    let mut blocker = ChildGuard::spawn(
+        Command::new(&coven)
+            .args(["run", "codex", "blocker"])
+            .env("COVEN_HOME", &coven_home)
+            .env("PATH", &path)
+            .env("COVEN_TEST_COVEN_BIN", &coven)
+            .env("COVEN_TEST_BLOCKER_READY", &blocker_ready)
+            .env("COVEN_TEST_RELEASE_BLOCKER", &release_blocker)
+            .current_dir(&project)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null()),
+    )?;
+    wait_until("blocker ready", || Ok(blocker_ready.exists()))?;
+
+    let participant_coven = coven.clone();
+    let participant_home = coven_home.clone();
+    let participant_path = path.clone();
+    let participant_project = project.clone();
+    let participant_acquisition = acquisition_json.clone();
+    let participant_held = held_json.clone();
+    let participant_ready_file = participant_ready.clone();
+    let participant_generation_file = participant_generation.clone();
+    let participant_thread = thread::spawn(move || {
+        run_coven_in(
+            &participant_coven,
+            &participant_home,
+            &participant_path,
+            &participant_project,
+            &[
+                (
+                    "COVEN_TEST_COVEN_BIN",
+                    participant_coven.to_string_lossy().as_ref(),
+                ),
+                (
+                    "COVEN_TEST_ACQUISITION_FILE",
+                    participant_acquisition.to_string_lossy().as_ref(),
+                ),
+                (
+                    "COVEN_TEST_HELD_FILE",
+                    participant_held.to_string_lossy().as_ref(),
+                ),
+                (
+                    "COVEN_TEST_PARTICIPANT_READY",
+                    participant_ready_file.to_string_lossy().as_ref(),
+                ),
+                (
+                    "COVEN_TEST_PARTICIPANT_GENERATION",
+                    participant_generation_file.to_string_lossy().as_ref(),
+                ),
+            ],
+            &["run", "codex", "participant"],
+        )
+    });
+
+    wait_until("participant acquisition json", || {
+        Ok(acquisition_json.exists())
+    })?;
+    wait_until("participant ready", || Ok(participant_ready.exists()))?;
+    let acquired: Value = serde_json::from_str(&fs::read_to_string(&acquisition_json)?)?;
+    assert_eq!(
+        acquired["owner"]["phase"].as_str(),
+        Some("draining"),
+        "blocked acquire should stay draining until blocker exits: {acquired}"
+    );
+    let writers = acquired["writers"]
+        .as_array()
+        .context("participant acquisition writers array")?;
+    assert_eq!(
+        writers.len(),
+        1,
+        "expected exactly one unrelated blocker writer: {acquired}"
+    );
+    let writer = &writers[0];
+    let writer_id = writer["id"].as_str().context("writer id")?;
+    assert_ne!(
+        writer_id, "in-session-owner",
+        "writer should be blocker, not owner: {acquired}"
+    );
+    assert!(
+        writer_id.starts_with("session-"),
+        "writer should be a session writer id: {acquired}"
+    );
+    assert_ne!(
+        writer_id, "participant",
+        "writer should not be participant script label: {acquired}"
+    );
+
+    fs::write(&release_blocker, b"release\n")?;
+    wait_for_child_exit_any_platform(&mut blocker, "blocker run")?;
+
+    let generation = acquired["owner"]["generation"]
+        .as_str()
+        .context("participant owner generation")?;
+    fs::write(&participant_generation, format!("{generation}\n"))?;
+
+    let participant_output = participant_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("participant thread panicked"))??;
+    assert_success("participant run with blocker", &participant_output);
+    let held: Value = serde_json::from_str(&fs::read_to_string(&held_json)?)?;
+    assert_eq!(held["owner"]["phase"].as_str(), Some("held"));
+    assert!(
+        held["writers"]
+            .as_array()
+            .is_some_and(|writers| writers.is_empty()),
+        "held maintenance status should have no writers: {held}"
+    );
+    Ok(())
+}
+
+#[test]
 fn piped_run_output_has_no_eof_control_artifact() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -2039,6 +2217,107 @@ fn prepend_path(fake_bin: &Path) -> OsString {
         paths.extend(std::env::split_paths(&existing));
     }
     std::env::join_paths(paths).expect("test PATH should be joinable")
+}
+
+fn parse_prefixed_json_line(label: &str, output: &Output, prefix: &str) -> anyhow::Result<Value> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{label} stdout did not contain {prefix:?}\nstdout:\n{stdout}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })?;
+    serde_json::from_str(line.trim()).map_err(|error| {
+        anyhow::anyhow!(
+            "{label} had invalid JSON after {prefix:?}: {error}\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn wait_for_child_exit_any_platform(child: &mut ChildGuard, label: &str) -> anyhow::Result<()> {
+    wait_until(&format!("{label} exit"), || Ok(!child.is_running()?))
+}
+
+fn write_maintenance_participant_fake_codex(fake_bin: &Path) -> anyhow::Result<()> {
+    let codex = fake_bin.join("codex");
+    fs::write(
+        &codex,
+        r#"#!/bin/sh
+set -eu
+mode=""
+for arg in "$@"; do
+  case "$arg" in
+    blocker|participant)
+      mode="$arg"
+      break
+      ;;
+  esac
+done
+case "$mode" in
+  blocker)
+    : "${COVEN_TEST_BLOCKER_READY:?}"
+    : "${COVEN_TEST_RELEASE_BLOCKER:?}"
+    : > "$COVEN_TEST_BLOCKER_READY"
+    i=0
+    while [ ! -f "$COVEN_TEST_RELEASE_BLOCKER" ] && [ "$i" -lt 200 ]; do
+      i=$((i + 1))
+      sleep 0.05
+    done
+    [ -f "$COVEN_TEST_RELEASE_BLOCKER" ]
+    ;;
+  participant)
+    : "${COVEN_MAINTENANCE_PARTICIPANT:?}"
+    : "${COVEN_TEST_COVEN_BIN:?}"
+    : "${COVEN_TEST_ACQUISITION_FILE:?}"
+    : "${COVEN_TEST_HELD_FILE:?}"
+    : "${COVEN_TEST_PARTICIPANT_READY:?}"
+    : "${COVEN_TEST_PARTICIPANT_GENERATION:?}"
+    acquisition="$($COVEN_TEST_COVEN_BIN maintenance acquire in-session-owner --wait-ms 100 --json)"
+    printf '%s\n' "$acquisition" > "$COVEN_TEST_ACQUISITION_FILE"
+    owner_generation=$(printf '%s\n' "$acquisition" | python3 -c 'import json,sys; print(json.load(sys.stdin)["owner"]["generation"])')
+    : > "$COVEN_TEST_PARTICIPANT_READY"
+    i=0
+    while [ ! -f "$COVEN_TEST_PARTICIPANT_GENERATION" ] && [ "$i" -lt 200 ]; do
+      i=$((i + 1))
+      sleep 0.05
+    done
+    [ -f "$COVEN_TEST_PARTICIPANT_GENERATION" ]
+    target_generation=$(tr -d '\r\n' < "$COVEN_TEST_PARTICIPANT_GENERATION")
+    if [ "$target_generation" = "self-only" ]; then
+      target_generation="$owner_generation"
+    fi
+    [ "$target_generation" = "$owner_generation" ]
+    i=0
+    while [ "$i" -lt 200 ]; do
+      held="$($COVEN_TEST_COVEN_BIN maintenance heartbeat in-session-owner "$target_generation" --json)"
+      printf '%s\n' "$held" > "$COVEN_TEST_HELD_FILE"
+      phase=$(printf '%s\n' "$held" | python3 -c 'import json,sys; print(json.load(sys.stdin)["owner"]["phase"])')
+      if [ "$phase" = "held" ]; then
+        $COVEN_TEST_COVEN_BIN maintenance release in-session-owner "$target_generation" >/dev/null
+        printf 'participant-held:%s\n' "$held"
+        exit 0
+      fi
+      i=$((i + 1))
+      sleep 0.05
+    done
+    echo "participant timed out waiting for held" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected fake codex mode: $mode" >&2
+    exit 64
+    ;;
+esac
+"#,
+    )?;
+    let mut permissions = fs::metadata(&codex)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&codex, permissions)?;
+    Ok(())
 }
 
 fn write_fake_codex(fake_bin: &Path) -> anyhow::Result<()> {

--- a/docs/reference/cli-maintenance.md
+++ b/docs/reference/cli-maintenance.md
@@ -29,6 +29,14 @@ mutations without admitting another one. Owners are fenced by a random
 generation and an expiry deadline. Heartbeat and release reject a different or
 expired generation; malformed owner or writer records also fail closed.
 
+When a maintenance client runs inside a Coven-managed harness, Coven
+automatically supplies a generation-bound participant capability for that
+session. The owner excludes only the exact supervisor-owned writer generation;
+all other existing writers must drain before the fence can be released. This
+capability is internal to the maintenance protocol, not a user-facing
+credential, and it must never be copied into logs or persisted in session
+metadata.
+
 Direct `coven run`, `coven patch`, daemon `POST /sessions`, and claim
 `acquire`, `release`, `heartbeat`, and `canary` register renewable writer
 intents before their mutation/launch path. A daemon session retains the intent

--- a/docs/superpowers/plans/2026-08-23-maintenance-participant.md
+++ b/docs/superpowers/plans/2026-08-23-maintenance-participant.md
@@ -1,0 +1,802 @@
+# Maintenance Participant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a maintenance command launched inside a Coven-managed session exclude only its own generation-bound writer intent while every other writer remains a blocker.
+
+**Architecture:** Extend the Rust maintenance protocol with an optional `WriterParticipant` stored on the owner record. `WriterLease` serializes an exact id/generation capability into the harness environment, owner acquisition validates it under the gate lock, and status calculation removes only that exact generation from the blocking `writers` set. Direct, patch, daemon, and adopted launch paths inject the capability immediately before spawning the harness.
+
+**Tech Stack:** Rust, `serde`/`serde_json`, `clap`, `portable-pty`, Cargo unit and integration tests.
+
+---
+
+## File map
+
+- Modify `crates/coven-cli/src/maintenance_gate.rs`
+  - Own the participant type, capability encoding/decoding, acquisition
+    validation, owner persistence, and effective writer-set calculation.
+- Modify `crates/coven-cli/src/main.rs`
+  - Read the inherited capability for maintenance acquisition and propagate a
+    writer capability into direct and patch harness commands.
+- Modify `crates/coven-cli/src/pty_runner.rs`
+  - Add one narrow `HarnessCommand` environment override method.
+- Modify `crates/coven-cli/src/daemon.rs`
+  - Add the capability to daemon/API-launched harness commands before spawn.
+- Modify `crates/coven-cli/tests/smoke.rs`
+  - Exercise the complete CLI contract with a fake harness process.
+- Modify `docs/reference/cli-maintenance.md`
+  - Document the corrected in-session maintenance behavior.
+
+### Task 1: Define and enforce the participant protocol
+
+**Files:**
+- Modify: `crates/coven-cli/src/maintenance_gate.rs`
+
+- [ ] **Step 1: Add failing tests for exact-generation participation**
+
+Add these tests beside `owner_drains_existing_writer_then_becomes_held`:
+
+```rust
+#[test]
+fn owner_excludes_only_its_exact_participant_writer() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    let participant = gate.acquire_writer("session-self", "session")?;
+    let blocker = gate.acquire_writer("session-other", "session")?;
+
+    let mut owner =
+        gate.acquire_owner("cave", Some(participant.participant().clone()))?;
+    assert_eq!(owner.owner().phase, OwnerPhase::Draining);
+    let status = owner.refresh_phase()?;
+    assert_eq!(
+        status.writers.iter().map(|writer| writer.id.as_str()).collect::<Vec<_>>(),
+        vec!["session-other"],
+    );
+
+    drop(blocker);
+    let status = owner.refresh_phase()?;
+    assert!(status.writers.is_empty());
+    owner.assert_held()?;
+    owner.release()?;
+    drop(participant);
+    Ok(())
+}
+
+#[test]
+fn owner_rejects_a_stale_or_forged_participant_generation() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    let writer = gate.acquire_writer("session-self", "session")?;
+    let mut participant = writer.participant().clone();
+    participant.generation = "wrong-generation".to_string();
+
+    let error = gate.acquire_owner("cave", Some(participant)).unwrap_err();
+    assert!(error
+        .downcast_ref::<GateError>()
+        .is_some_and(|error| matches!(error, GateError::ParticipantInvalid)));
+    assert!(gate.status()?.owner.is_none());
+    drop(writer);
+    Ok(())
+}
+
+#[test]
+fn owner_does_not_exclude_a_replacement_writer_with_the_same_id() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    let first = gate.acquire_writer("session-self", "session")?;
+    let participant = first.participant().clone();
+    drop(first);
+    let replacement = gate.acquire_writer("session-self", "session")?;
+
+    let error = gate.acquire_owner("cave", Some(participant)).unwrap_err();
+    assert!(error
+        .downcast_ref::<GateError>()
+        .is_some_and(|error| matches!(error, GateError::ParticipantInvalid)));
+    drop(replacement);
+    Ok(())
+}
+
+#[test]
+fn owner_without_participant_remains_backward_compatible() -> Result<()> {
+    let owner: Owner = serde_json::from_value(serde_json::json!({
+        "owner_id": "legacy",
+        "generation": "generation",
+        "expires_at": 9999999999_u64,
+        "phase": "held"
+    }))?;
+    assert_eq!(owner.participant, None);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p coven-cli maintenance_gate::tests::owner_ --locked
+```
+
+Expected: compilation fails because `WriterParticipant`,
+`WriterLease::participant`, `Owner::participant`, and the new
+`acquire_owner` argument do not exist.
+
+- [ ] **Step 3: Add the participant type and owner compatibility field**
+
+Add near `WriterIntent`:
+
+```rust
+pub const MAINTENANCE_PARTICIPANT_ENV: &str = "COVEN_MAINTENANCE_PARTICIPANT";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WriterParticipant {
+    pub id: String,
+    pub generation: String,
+}
+
+impl WriterParticipant {
+    pub fn encode(&self) -> Result<String> {
+        serde_json::to_string(self).context("failed to encode maintenance participant")
+    }
+
+    pub fn decode(value: &str) -> Result<Self> {
+        let participant: Self =
+            serde_json::from_str(value).context("invalid maintenance participant capability")?;
+        if participant.id.trim().is_empty() || participant.generation.trim().is_empty() {
+            anyhow::bail!("invalid maintenance participant capability");
+        }
+        Ok(participant)
+    }
+}
+```
+
+Extend `Owner`:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub participant: Option<WriterParticipant>,
+```
+
+Add `GateError::ParticipantInvalid` and render it as:
+
+```rust
+Self::ParticipantInvalid => {
+    write!(f, "maintenance participant is stale, missing, or mismatched")
+}
+```
+
+- [ ] **Step 4: Expose the exact writer capability**
+
+Store the full participant on `WriterLease`:
+
+```rust
+pub struct WriterLease {
+    gate: MaintenanceGate,
+    path: PathBuf,
+    participant: WriterParticipant,
+    stopper: Arc<(Mutex<bool>, Condvar)>,
+    renewer: Option<thread::JoinHandle<()>>,
+}
+```
+
+Construct it from the acquired intent and add:
+
+```rust
+pub fn participant(&self) -> &WriterParticipant {
+    &self.participant
+}
+
+pub fn participant_capability(&self) -> Result<String> {
+    self.participant.encode()
+}
+```
+
+Update `Drop` and the renewer thread to use
+`self.participant.generation` instead of the removed standalone field.
+
+- [ ] **Step 5: Validate participation atomically during owner acquisition**
+
+Change the signature:
+
+```rust
+pub fn acquire_owner(
+    &self,
+    owner_id: impl Into<String>,
+    participant: Option<WriterParticipant>,
+) -> Result<OwnerLease>
+```
+
+Inside the existing metadata lock, before writing the owner record, validate:
+
+```rust
+if let Some(participant) = participant.as_ref() {
+    let path = self.writers_dir().join(writer_file_name(&participant.id));
+    let data = fs::read(&path).map_err(|_| GateError::ParticipantInvalid)?;
+    let writer: WriterIntent =
+        serde_json::from_slice(&data).map_err(|_| GateError::ParticipantInvalid)?;
+    if writer.expires_at <= unix_now()
+        || writer.id != participant.id
+        || writer.generation != participant.generation
+    {
+        return Err(GateError::ParticipantInvalid.into());
+    }
+}
+```
+
+Persist `participant` on the new `Owner`. Update every non-participant caller
+to pass `None`.
+
+- [ ] **Step 6: Return only blocking writers while preserving participant state**
+
+Add:
+
+```rust
+fn blocking_writers(owner: Option<&Owner>, writers: Vec<WriterIntent>) -> Vec<WriterIntent> {
+    let Some(participant) = owner.and_then(|owner| owner.participant.as_ref()) else {
+        return writers;
+    };
+    writers
+        .into_iter()
+        .filter(|writer| {
+            writer.id != participant.id || writer.generation != participant.generation
+        })
+        .collect()
+}
+```
+
+Use it in `status` and `OwnerLease::refresh_phase`. Change `heartbeat_owner` to read the persisted owner first and reject a
+different owner id or generation before constructing `OwnerLease`. This
+preserves the stored participant:
+
+```rust
+pub fn heartbeat_owner(&self, owner_id: &str, generation: &str) -> Result<GateStatus> {
+    let owner = self.read_owner()?.ok_or(GateError::OwnerChanged)?;
+    if owner.owner_id != owner_id || owner.generation != generation {
+        return Err(GateError::OwnerChanged.into());
+    }
+    OwnerLease {
+        gate: self.clone(),
+        owner,
+    }
+    .refresh_phase()
+}
+```
+
+- [ ] **Step 7: Run the maintenance-gate tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli maintenance_gate::tests --locked
+```
+
+Expected: all maintenance-gate tests pass.
+
+- [ ] **Step 8: Commit the protocol core**
+
+```bash
+git add crates/coven-cli/src/maintenance_gate.rs
+git commit -s -m "feat: add maintenance participant capability"
+```
+
+### Task 2: Consume the capability in maintenance CLI commands
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+- Test: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Add a pure capability parser test**
+
+Add a helper:
+
+```rust
+fn maintenance_participant_from_value(
+    value: Option<&str>,
+) -> Result<Option<maintenance_gate::WriterParticipant>> {
+    value
+        .map(maintenance_gate::WriterParticipant::decode)
+        .transpose()
+}
+```
+
+Add tests:
+
+```rust
+#[test]
+fn maintenance_participant_env_is_optional_and_strict() {
+    assert_eq!(maintenance_participant_from_value(None).unwrap(), None);
+    assert!(maintenance_participant_from_value(Some("not-json")).is_err());
+    assert!(maintenance_participant_from_value(Some(r#"{"id":"","generation":"g"}"#)).is_err());
+    assert_eq!(
+        maintenance_participant_from_value(Some(r#"{"id":"session-1","generation":"g"}"#))
+            .unwrap()
+            .unwrap(),
+        maintenance_gate::WriterParticipant {
+            id: "session-1".to_string(),
+            generation: "g".to_string(),
+        },
+    );
+}
+```
+
+- [ ] **Step 2: Run the parser test and verify it passes only after the helper exists**
+
+Run:
+
+```bash
+cargo test -p coven-cli maintenance_participant_env_is_optional_and_strict --locked
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Wire acquisition to the inherited environment**
+
+In `run_maintenance_command`, change the acquire branch to:
+
+```rust
+let participant = maintenance_participant_from_value(
+    std::env::var(maintenance_gate::MAINTENANCE_PARTICIPANT_ENV)
+        .ok()
+        .as_deref(),
+)?;
+let mut lease = gate.acquire_owner(owner, participant)?;
+```
+
+Update every other `acquire_owner` call in tests and production to pass `None`.
+
+- [ ] **Step 4: Run CLI and protocol tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli maintenance_ --locked
+```
+
+Expected: all matching tests pass.
+
+- [ ] **Step 5: Commit CLI acquisition**
+
+```bash
+git add crates/coven-cli/src/main.rs
+git commit -s -m "feat: accept inherited maintenance participation"
+```
+
+### Task 3: Add a narrow harness environment API
+
+**Files:**
+- Modify: `crates/coven-cli/src/pty_runner.rs`
+
+- [ ] **Step 1: Add a failing environment override test**
+
+Inside `pty_runner.rs` tests:
+
+```rust
+#[test]
+fn harness_command_can_set_a_private_runtime_environment_value() {
+    let mut command = HarnessCommand::fixture("echo", Vec::new(), PathBuf::from("/tmp"));
+    command.set_environment_override("COVEN_TEST_CAPABILITY", Some("opaque-value"));
+    assert_eq!(
+        command.env_overrides,
+        vec![(
+            "COVEN_TEST_CAPABILITY".to_string(),
+            Some("opaque-value".to_string())
+        )]
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p coven-cli harness_command_can_set_a_private_runtime_environment_value --locked
+```
+
+Expected: compilation fails because the method is missing.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `impl HarnessCommand`:
+
+```rust
+pub(crate) fn set_environment_override(
+    &mut self,
+    name: impl Into<String>,
+    value: Option<impl Into<String>>,
+) {
+    self.env_overrides
+        .push((name.into(), value.map(Into::into)));
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+```bash
+cargo test -p coven-cli harness_command_can_set_a_private_runtime_environment_value --locked
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the command API**
+
+```bash
+git add crates/coven-cli/src/pty_runner.rs
+git commit -s -m "refactor: support private harness environment overrides"
+```
+
+### Task 4: Propagate participation through direct and patch sessions
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+- Test: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Return the lease capability from the session writer helper**
+
+Keep `acquire_session_writer` returning `Option<WriterLease>`, but add:
+
+```rust
+fn apply_maintenance_participant(
+    command: &mut pty_runner::HarnessCommand,
+    writer: Option<&maintenance_gate::WriterLease>,
+) -> Result<()> {
+    if let Some(writer) = writer {
+        command.set_environment_override(
+            maintenance_gate::MAINTENANCE_PARTICIPANT_ENV,
+            Some(writer.participant_capability()?),
+        );
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add a unit test for propagation**
+
+```rust
+#[test]
+fn maintenance_participant_is_added_only_when_a_writer_exists() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = maintenance_gate::MaintenanceGate::at_for_test(temp.path().to_path_buf());
+    let writer = gate.acquire_writer("session-1", "session")?;
+    let mut command =
+        pty_runner::HarnessCommand::fixture("echo", Vec::new(), temp.path().to_path_buf());
+
+    apply_maintenance_participant(&mut command, Some(&writer))?;
+    assert!(command.environment_override_for_test(
+        maintenance_gate::MAINTENANCE_PARTICIPANT_ENV
+    ).is_some());
+    Ok(())
+}
+```
+
+Expose `MaintenanceGate::at_for_test` and
+`HarnessCommand::environment_override_for_test` under `#[cfg(test)]`.
+
+- [ ] **Step 3: Apply the capability to direct `coven run` commands**
+
+Rename:
+
+```rust
+let _maintenance_writer = acquire_session_writer(&project_root, "session")?;
+```
+
+to:
+
+```rust
+let maintenance_writer = acquire_session_writer(&project_root, "session")?;
+```
+
+After the harness command is successfully built and before any spawn path:
+
+```rust
+let mut command = command?;
+apply_maintenance_participant(&mut command, maintenance_writer.as_ref())?;
+```
+
+Keep `maintenance_writer` alive through the complete harness run.
+
+- [ ] **Step 4: Apply the capability to patch sessions**
+
+Rename the patch writer binding to `maintenance_writer`. After building the
+patch harness command and before spawning it:
+
+```rust
+apply_maintenance_participant(&mut command, maintenance_writer.as_ref())?;
+```
+
+Keep the lease in scope until the patch harness exits.
+
+- [ ] **Step 5: Run direct and patch focused tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli maintenance_participant --locked
+cargo test -p coven-cli patch --locked
+```
+
+Expected: all matching tests pass.
+
+- [ ] **Step 6: Commit direct launch propagation**
+
+```bash
+git add crates/coven-cli/src/main.rs crates/coven-cli/src/maintenance_gate.rs crates/coven-cli/src/pty_runner.rs
+git commit -s -m "feat: propagate maintenance participation to harnesses"
+```
+
+### Task 5: Propagate participation through daemon and adopted sessions
+
+**Files:**
+- Modify: `crates/coven-cli/src/daemon.rs`
+- Test: `crates/coven-cli/src/daemon.rs`
+
+- [ ] **Step 1: Add a command-preparation helper**
+
+In `LiveSessionRuntime`:
+
+```rust
+fn apply_writer_participant(
+    command: &mut pty_runner::HarnessCommand,
+    writer: Option<&crate::maintenance_gate::WriterLease>,
+) -> Result<()> {
+    if let Some(writer) = writer {
+        command.set_environment_override(
+            crate::maintenance_gate::MAINTENANCE_PARTICIPANT_ENV,
+            Some(writer.participant_capability()?),
+        );
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add a daemon unit test**
+
+Construct a temporary gate, writer, and fixture `HarnessCommand`, call the
+helper, and assert the exact environment name and encoded value are present:
+
+```rust
+#[test]
+fn daemon_harness_receives_maintenance_participant_without_debug_disclosure() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = crate::maintenance_gate::MaintenanceGate::at_for_test(
+        temp.path().to_path_buf(),
+    );
+    let writer = gate.acquire_writer("daemon-session-1", "session")?;
+    let capability = writer.participant_capability()?;
+    let mut command =
+        pty_runner::HarnessCommand::fixture("echo", Vec::new(), temp.path().to_path_buf());
+
+    LiveSessionRuntime::apply_writer_participant(&mut command, Some(&writer))?;
+    assert_eq!(
+        command.environment_override_for_test(
+            crate::maintenance_gate::MAINTENANCE_PARTICIPANT_ENV
+        ),
+        Some(capability.as_str()),
+    );
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Apply the capability before daemon spawn**
+
+Make the command mutable in `launch_session_inner`:
+
+```rust
+let mut command = if ... { ... } else { ... };
+Self::apply_writer_participant(&mut command, writer.as_ref())?;
+self.launch_prepared_session(launch, writer, command, ownership_established)
+```
+
+Because both ordinary and adopted sessions flow through
+`launch_session_inner`, this covers both paths without duplicating logic.
+
+- [ ] **Step 4: Run daemon and API focused tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli daemon::tests --locked
+cargo test -p coven-cli api::tests --locked
+```
+
+Expected: all daemon/API tests pass.
+
+- [ ] **Step 5: Commit daemon propagation**
+
+```bash
+git add crates/coven-cli/src/daemon.rs crates/coven-cli/src/pty_runner.rs
+git commit -s -m "feat: propagate maintenance participation in daemon sessions"
+```
+
+### Task 6: Prove the end-to-end CLI behavior
+
+**Files:**
+- Modify: `crates/coven-cli/tests/smoke.rs`
+
+- [ ] **Step 1: Add a fake harness integration test**
+
+Add a Unix smoke test that creates a fake `codex` executable. The fake harness
+invokes the same built Coven binary through an explicit test-only environment
+path:
+
+```rust
+#[test]
+fn session_harness_can_acquire_maintenance_against_its_own_writer() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let coven_home = temp.path().join("coven-home");
+    let repo = temp.path().join("repo");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir_all(&repo)?;
+    fs::create_dir_all(&fake_bin)?;
+    init_git_repo(&repo)?;
+
+    let fake_codex = fake_bin.join("codex");
+    fs::write(
+        &fake_codex,
+        r#"#!/bin/sh
+set -eu
+test -n "${COVEN_MAINTENANCE_PARTICIPANT:-}"
+"${COVEN_TEST_COVEN_BIN}" maintenance acquire in-session-owner --wait-ms 1000 --json
+"#,
+    )?;
+    let mut permissions = fs::metadata(&fake_codex)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions)?;
+
+    let path = std::env::join_paths(
+        std::iter::once(fake_bin.clone())
+            .chain(std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())),
+    )?;
+    let coven = coven_bin();
+    let output = run_coven_in(
+        &coven,
+        &coven_home,
+        &path,
+        &repo,
+        &[("COVEN_TEST_COVEN_BIN", coven.to_str().context("non-UTF-8 coven path")?)],
+        &["run", "codex", "verify maintenance participation"],
+    )?;
+    assert_success("in-session maintenance acquire", &output);
+    let status_line = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find(|line| line.contains(r#""owner_id":"in-session-owner""#))
+        .context("missing maintenance status JSON")?;
+    let status: serde_json::Value = serde_json::from_str(status_line)?;
+    assert_eq!(status["owner"]["phase"], "held");
+    assert_eq!(status["writers"], serde_json::json!([]));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add the non-participant blocker assertion**
+
+Extend the fixture so a separately acquired writer remains live. Verify the
+in-session acquire reports `draining` and returns that writer in `writers`,
+then release the blocker and verify heartbeat reaches `held`.
+
+- [ ] **Step 3: Run the integration test**
+
+Run:
+
+```bash
+cargo test -p coven-cli --test smoke session_harness_can_acquire_maintenance_against_its_own_writer --locked -- --nocapture
+```
+
+Expected: PASS with the owner in `held` for the self-only case and `draining`
+while an unrelated writer remains.
+
+- [ ] **Step 4: Commit the integration proof**
+
+```bash
+git add crates/coven-cli/tests/smoke.rs
+git commit -s -m "test: prove in-session maintenance participation"
+```
+
+### Task 7: Document and validate the release-ready change
+
+**Files:**
+- Modify: `docs/reference/cli-maintenance.md`
+- Verify: repository-wide
+
+- [ ] **Step 1: Document participant behavior**
+
+Add after the acquisition example:
+
+```markdown
+When a maintenance client runs inside a Coven-managed harness, Coven supplies a
+generation-bound participant capability automatically. The owner excludes only
+that exact supervisor-owned writer from its blocker set; every other existing
+writer must still drain. The capability is internal, is not a user-facing
+credential, and must not be copied into logs or persisted session metadata.
+```
+
+- [ ] **Step 2: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --check
+```
+
+Expected: exit 0. If it reports diffs, run `cargo fmt`, inspect the changes, and
+rerun the check.
+
+- [ ] **Step 3: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: exit 0 with no warnings.
+
+- [ ] **Step 4: Run the complete Rust suite**
+
+Run:
+
+```bash
+cargo test --workspace --locked
+```
+
+Expected: all workspace tests pass.
+
+- [ ] **Step 5: Run repository safety checks**
+
+Run:
+
+```bash
+python scripts/check-secrets.py
+git add crates/coven-cli/src/maintenance_gate.rs \
+  crates/coven-cli/src/main.rs \
+  crates/coven-cli/src/pty_runner.rs \
+  crates/coven-cli/src/daemon.rs \
+  crates/coven-cli/tests/smoke.rs \
+  docs/reference/cli-maintenance.md \
+  docs/superpowers/specs/2026-08-23-maintenance-participant-design.md \
+  docs/superpowers/plans/2026-08-23-maintenance-participant.md
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: both checks pass with no secret or privacy findings.
+
+- [ ] **Step 6: Commit documentation and validation state**
+
+```bash
+git commit -s -m "docs: document in-session maintenance participation"
+```
+
+- [ ] **Step 7: Push and open the PR**
+
+```bash
+git push -u origin fix/795-maintenance-participant
+gh pr create \
+  --title "feat: allow in-session maintenance participation" \
+  --body-file .github/PULL_REQUEST_TEMPLATE.md
+```
+
+Fill the PR readiness packet with:
+
+- issue #795;
+- downstream `cave-cgk9v`;
+- exact local validation commands and results;
+- compatibility statement for old owner JSON and existing Cave clients;
+- explicit statement that unrelated live writers still block.
+
+- [ ] **Step 8: Resolve review and merge exact head**
+
+Require every required check to pass on the current `headRefOid`, resolve every
+actionable review thread, and squash-merge without administrative bypass.
+
+- [ ] **Step 9: Reconcile both trackers**
+
+After a released Coven version contains the merge:
+
+1. update Cave's `COVEN_MAINTENANCE_MINIMUM_VERSION`;
+2. add a Cave integration contract proving managed worktree creation succeeds
+   from a Coven-launched harness;
+3. remove the last-resort guidance that describes the catch-22;
+4. close `cave-cgk9v` with the Coven issue, PR, release, Cave adoption PR, and
+   exact-head CI evidence.

--- a/docs/superpowers/specs/2026-08-23-maintenance-participant-design.md
+++ b/docs/superpowers/specs/2026-08-23-maintenance-participant-design.md
@@ -1,0 +1,142 @@
+# Maintenance Participant Design
+
+Issue: [OpenCoven/coven#795](https://github.com/OpenCoven/coven/issues/795)  
+Downstream tracker: `cave-cgk9v`
+
+## Problem
+
+A Coven-launched harness holds a repository writer intent for its full lifetime.
+The supervisor renews that intent every 20 seconds. When a command inside the
+harness invokes `coven maintenance acquire`, the new owner enters `draining`
+and waits for every existing writer, including the invoking session's own
+supervisor-owned writer. That writer keeps renewing, so the wait cannot
+converge.
+
+Increasing the drain timeout does not fix the cycle. Stopping all renewals while
+an owner drains would be unsafe because unrelated live sessions would disappear
+from the blocker set while they can still write.
+
+## Decision
+
+Add generation-bound maintenance participation. A writer lease may mint a
+participant capability containing its writer id and generation. Coven injects
+that capability only into the harness process owned by the lease. A maintenance
+command launched by that harness may present the capability automatically.
+
+The owner records the exact participant identity. Owner phase calculation
+excludes only the matching writer id and generation. Every other live writer
+continues to block acquisition, and new writers remain fenced as soon as the
+owner record is published.
+
+## Protocol
+
+### Participant capability
+
+`WriterLease` exposes an opaque serialized capability containing:
+
+- writer id
+- writer generation
+
+The generation is the authority-bearing value. A writer id without the matching
+generation cannot participate. The capability is placed in the harness
+environment as `COVEN_MAINTENANCE_PARTICIPANT`.
+
+The value must not be printed, persisted in the session database, included in
+events, or copied into user-visible diagnostics.
+
+### Owner state
+
+`Owner` gains an optional participant field. Serialization omits the field when
+absent, and deserialization defaults it to `None`, preserving compatibility
+with existing owner records.
+
+`MaintenanceGate::acquire_owner` accepts an optional participant capability.
+While holding the metadata lock it verifies that:
+
+1. the referenced writer file exists;
+2. the writer id and generation exactly match the capability;
+3. the writer lease is not expired.
+
+Malformed, missing, expired, or mismatched capabilities fail closed before an
+owner record is published.
+
+### Effective writer set
+
+Status and owner refresh continue to read and clean all writer files. When the
+current owner has a participant, the exact matching writer is separated from
+the blocking `writers` array. The owner becomes `held` only when no
+non-participant writers remain.
+
+The participant remains observable through the owner record, while existing
+clients that decide readiness from `owner.phase` and `writers.length` continue
+to work without changes.
+
+If the participant writer later disappears, the owner remains valid. Its
+authority was proven at acquisition, and disappearance only reduces concurrent
+activity. A new writer using the same id but a different generation is never
+excluded.
+
+### CLI behavior
+
+`coven maintenance acquire` reads `COVEN_MAINTENANCE_PARTICIPANT` when present,
+parses it strictly, and passes it to the gate. No new user-facing flag is
+needed. An invalid inherited value is an error rather than silently falling
+back to ordinary acquisition.
+
+`heartbeat`, `status`, and `release` use the participant recorded in the owner
+state. They do not depend on the environment after acquisition.
+
+### Harness propagation
+
+Every supervisor-owned session writer must propagate its capability to the
+harness command:
+
+- attached and detached `coven run` launch paths;
+- patch sessions;
+- daemon/API-launched sessions, including adopted sessions.
+
+`HarnessCommand` receives a narrow environment-override helper. Runtime code
+adds the capability immediately before spawn. The capability is never added to
+stored launch metadata.
+
+## Error handling
+
+- Invalid capability encoding: reject maintenance acquisition.
+- Missing writer file: reject as a stale participant.
+- Generation mismatch: reject as a stale or forged participant.
+- Expired writer: remove it through normal cleanup and reject participation.
+- Other active writers: remain in `writers`; acquisition stays `draining`.
+- Owner or writer state corruption: retain existing fail-closed behavior.
+
+## Compatibility
+
+- Existing sessions without the environment capability retain current behavior.
+- Existing clients can deserialize the extended owner object because fields are
+  additive.
+- Existing owner records deserialize with no participant.
+- The JSON `writers` array remains the blocking writer set, matching the
+  semantics already consumed by Cave.
+
+## Tests
+
+Rust unit tests will prove:
+
+1. a live writer can participate and let its owner reach `held`;
+2. a second live writer still blocks that owner;
+3. wrong, expired, and missing generations fail closed;
+4. a replacement writer with the same id is not excluded;
+5. owner heartbeat preserves participant exclusion;
+6. old owner JSON without a participant still deserializes;
+7. harness command construction propagates the capability without logging or
+   persistence.
+
+CLI integration tests will run a fake harness inside `coven run`, invoke
+maintenance acquisition from that process, and verify the owner reaches `held`
+while the supervisor writer remains live.
+
+## Delivery
+
+The implementation lands in `OpenCoven/coven` through issue #795 and a protected
+pull request. Cave adoption must require the first released Coven version that
+contains this protocol before removing its last-resort guidance for
+`cave-cgk9v`.


### PR DESCRIPTION
## Context

- Summary: Let a maintenance command launched inside a Coven-managed harness exclude only its own generation-bound supervisor writer while every unrelated writer remains a blocker.
- Files changed: Rust maintenance protocol, CLI acquisition, direct/patch/daemon/adopted harness propagation, Unix integration coverage, and maintenance reference docs.
- Closes #795
- Downstream: `cave-cgk9v`

## Implementation

- Approach: Persist an optional exact writer participant on the maintenance owner, validate it atomically under the gate lock, and filter only that exact id/generation from blocker status.
- User-visible behavior: In-session maintenance can reach `held` without waiting on its own supervisor writer; unrelated live sessions still produce `draining` until they exit.
- Compatibility notes: Existing clients that inspect only `owner` and `writers` remain compatible. Legacy owner JSON without `participant` still deserializes. The capability is private runtime environment state and is not logged or stored in session metadata.

## Verification

- [x] `cargo +1.98.0 fmt --check`
- [x] `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +1.98.0 test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] staged privacy guards passed on every implementation commit
- [x] focused maintenance gate, CLI, direct/patch, daemon/API, and smoke tests
- [x] final whole-branch code review approved

## Risk and Rollback

- Risk level: Medium; changes maintenance authority coordination and harness runtime environment propagation.
- Rollback plan: Revert the squash commit to restore the previous all-writers-must-drain behavior.

## Agent Handoff

- Current state: Complete, locally verified, and review-approved.
- Follow-ups: After a released Coven version contains this change, update Cave's minimum version and integration contract, then close `cave-cgk9v` with release evidence.
- Known gaps: No Cave repository changes are included in this Coven PR.
