### PR TITLE
test(npm): cover headless setup in the packaged smoke journey

### DIFF
--- a/scripts/user-journey-e2e-test.mjs
+++ b/scripts/user-journey-e2e-test.mjs
@@ -545,6 +545,12 @@ test('runPackagedUserJourney sequences installed-wrapper commands and full lifec
         })
       },
       {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['setup', 'codex'],
+        result: makeResult({ status: 1, stdout: 'Codex: non_tty\n' })
+      },
+      {
         method: 'runDaemonStart',
         command: wrapperBin,
         result: makeResult({ stdout: 'Coven daemon: running\n' })
@@ -826,6 +832,12 @@ test('runPackagedUserJourney attempts bounded daemon stop after start failure', 
         })
       },
       {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['setup', 'codex'],
+        result: makeResult({ status: 1, stdout: 'Codex: non_tty\n' })
+      },
+      {
         method: 'runDaemonStart',
         command: wrapperBin,
         error: new Error('daemon start timed out after 60000ms')
@@ -949,6 +961,12 @@ test('runPackagedUserJourney stops the daemon and removes scratch after mid-jour
             ]
           })
         })
+      },
+      {
+        method: 'runCapture',
+        command: wrapperBin,
+        args: ['setup', 'codex'],
+        result: makeResult({ status: 1, stdout: 'Codex: non_tty\n' })
       },
       {
         method: 'runDaemonStart',

--- a/scripts/user-journey-e2e-test.mjs
+++ b/scripts/user-journey-e2e-test.mjs
@@ -104,6 +104,19 @@ function gitCommitArgs(layout) {
   ];
 }
 
+// `coven setup` is the one journey step expected to exit nonzero, so the
+// scripted runner has to pin its options too: without `allowedExitCodes: [1]`
+// the real journey aborts on the fail-closed path it is meant to assert.
+function assertSetupStepOptions(options, layout) {
+  assert.deepEqual(options.allowedExitCodes, [1]);
+  assert.equal(options.cwd, layout.projectRoot);
+  assert.equal(options.env.COVEN_HOME, layout.covenHome);
+  assert.ok(
+    options.env.PATH.split(path.delimiter).includes(layout.fixtureBinDir),
+    'setup must run with the fake harness on PATH'
+  );
+}
+
 function createScriptedRunner(script) {
   const queue = [...script];
   const calls = [];
@@ -548,6 +561,9 @@ test('runPackagedUserJourney sequences installed-wrapper commands and full lifec
         method: 'runCapture',
         command: wrapperBin,
         args: ['setup', 'codex'],
+        assertOptions(options) {
+          assertSetupStepOptions(options, layout);
+        },
         result: makeResult({ status: 1, stdout: 'Codex: non_tty\n' })
       },
       {
@@ -835,6 +851,9 @@ test('runPackagedUserJourney attempts bounded daemon stop after start failure', 
         method: 'runCapture',
         command: wrapperBin,
         args: ['setup', 'codex'],
+        assertOptions(options) {
+          assertSetupStepOptions(options, layout);
+        },
         result: makeResult({ status: 1, stdout: 'Codex: non_tty\n' })
       },
       {
@@ -966,6 +985,9 @@ test('runPackagedUserJourney stops the daemon and removes scratch after mid-jour
         method: 'runCapture',
         command: wrapperBin,
         args: ['setup', 'codex'],
+        assertOptions(options) {
+          assertSetupStepOptions(options, layout);
+        },
         result: makeResult({ status: 1, stdout: 'Codex: non_tty\n' })
       },
       {

--- a/scripts/user-journey-e2e.mjs
+++ b/scripts/user-journey-e2e.mjs
@@ -627,6 +627,18 @@ export function assertDoctorPass(output) {
   }
 }
 
+export function assertSetupNonTty(output, status) {
+  // The packed smoke runs headless, so `coven setup` must fail closed rather
+  // than attempt a provider login it cannot supervise. This is the only place
+  // the packaged artifact proves its setup command is wired at all.
+  if (status !== 1) {
+    fail(`\`coven setup codex\` on a headless runner should exit 1, got ${status}`);
+  }
+  if (!output.includes('Codex: non_tty')) {
+    fail(`\`coven setup codex\` did not report the non-TTY outcome.\nstdout:\n${output}`);
+  }
+}
+
 export function assertDoctorJsonPass(output) {
   const body = parseJsonOutput('`coven doctor --json`', output);
   if (body.ok !== true || body.blocking !== false) {
@@ -929,6 +941,13 @@ export function runPackagedUserJourney({
       env: activeEnv
     });
     assertDoctorJsonPass(doctorJson);
+
+    const setup = runner.runCapture(resolvedWrapperBin, ['setup', 'codex'], {
+      allowedExitCodes: [1],
+      cwd: layout.projectRoot,
+      env: activeEnv
+    });
+    assertSetupNonTty(textFromResult(setup, 'stdout'), setup.status);
 
     const daemonStart = runner.runDaemonStart(resolvedWrapperBin, activeEnv, {
       cwd: layout.projectRoot


### PR DESCRIPTION
## Context

`coven-v041-package-smoke` requires the packed artifacts to prove "install, executable selection, diagnostics, guidance, and **fake installed-harness setup**" on all four npm targets.

Auditing the gate at `9527145` showed the first four are covered and the last is not: `runPackagedUserJourney` never invokes `coven setup`. It only asserts that `doctor`'s missing-harness guidance *mentions* the `coven setup <provider>` commands. A packaging regression that broke this release's flagship setup command — wrapper argv handling, the pre-state-init dispatch at `main.rs:1180`, exit-code mapping — would ship without any of the four targets noticing.

## Implementation

- `scripts/user-journey-e2e.mjs`: after the fake Codex fixture is on PATH and `doctor` passes, run `coven setup codex` through the installed wrapper. New `assertSetupNonTty` requires exit 1 and `Codex: non_tty` on stdout.
- `scripts/user-journey-e2e-test.mjs`: add the step to all three scripted-runner sequences.

Headless is the correct assertion here, not a limitation. `run_setup` short-circuits every provider to `Outcome::NonTty` before mode dispatch when the terminal is not interactive, so a CI runner must see the fail-closed path. The `Codex: non_tty` string is already pinned at the Rust level by `crates/coven-cli/tests/setup_cli.rs:174`; this proves the packed artifact reaches that same code path.

## Verification

Run at `9527145` (clean worktree):

- `node --test scripts/user-journey-e2e-test.mjs` — 18/18 pass
- `cargo build --release --package coven-cli --target aarch64-apple-darwin` — rc 0
- `cargo build --release -p coven-afs --features mount --bins --target aarch64-apple-darwin` — rc 0
- `COVEN_NPM_DRY_RUN_VERSION=999.0.0 node scripts/test-cli-prepublish.mjs --target=macos --skip-build --skip-secrets-scan` — **rc 0**, `packaged user journey ok`, `All 4 pre-publish checks passed for target=macos`
- `python3 scripts/check-secrets.py` — rc 0; `python3 scripts/check-coven-privacy.py --staged` — rc 0
- `cargo test --workspace --locked` on macOS arm64 at this SHA — rc 0, first attempt

The other three targets (`macos-x64`, `linux-x64`, `windows`) are exercised by the `npm onboarding smoke` matrix on merge to main.

## Risk

Low, and confined to test scaffolding — no shipped code changes. The new assertion is strict about exit code and outcome string; if `setup`'s non-TTY rendering ever changes, this fails alongside the existing Rust test that pins the same string.

## Agent Handoff

Filed while taking `coven-v041-package-smoke`. Note that neither this bead nor `coven-v041-reliability` can close until `coven-v041-freeze` lands, since both require evidence at the frozen candidate SHA; this PR is deliberately landed **before** freeze so the gate is complete when that evidence is collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG