### PR TITLE
fix(deps): update chacha20 past the yanked 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3665,7 +3665,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]


### PR DESCRIPTION
## Context

**`main` is currently red on the `Dependency audit` gate.** This is not caused by any change in flight — crates.io yanked `chacha20 0.10.1` and published `0.10.2` on 2026-08-27 17:51 UTC, after main's last green CI run (`32865757038`, 2026-08-25).

Surfaced while auditing `coven-v041-reliability`: PR #837 carries a JS-only diff and still failed `cargo deny check advisories`.

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
   ┌─ /github/workspace/Cargo.lock:46:1
46 │ chacha20 0.10.1 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
   ├ chacha20 v0.10.1
     └── rand v0.10.2
         └── coven-cli v0.0.0

advisories FAILED, bans ok, licenses ok, sources ok
```

Both `0.10.0` and `0.10.1` are yanked; `0.10.2` is the only non-yanked release on that line. The separate `chacha20 0.9.1` in the tree is not yanked and is untouched.

## Implementation

`cargo update -p chacha20@0.10.1 --precise 0.10.2`. Lockfile-only, 3 lines, no manifest change and no other dependency moved.

## Verification

- Reproduced on `main` at `9527145` with a refreshed index: `cargo deny check advisories` -> `advisories FAILED`
- On this branch: `cargo deny check advisories licenses bans sources` -> `advisories ok, bans ok, licenses ok, sources ok`
- Full `cargo test --workspace --locked` on Linux and Windows is delegated to CI on this PR rather than run locally, so the reliability stress loops running on this machine stayed free of CPU contention.

## Risk

Low. Patch bump of a transitive crypto crate to the version the upstream yank directs users to; `--precise` keeps the rest of the graph pinned.

## Agent Handoff

Blocks `coven-v041-reliability` and `coven-v041-freeze` — the release cannot freeze a SHA whose dependency audit is failing. Merge this before #837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
