### PR TITLE
docs(release): close the runbook postflight and tag-immutability gaps

### DIFF
--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -82,7 +82,49 @@ You can leave the `npm-publish` environment itself in place or remove it — the
    ```
 4. Confirm the changelog and any README / brand updates have already landed on `main`.
 
+### Certification packet
+
+Produce the redacted certification report for every supported built-in harness
+against the exact commit you intend to tag. Each report is a one-provider
+artifact and the destination must not already exist:
+
+```sh
+coven setup codex   --verify-only --report-json cert/codex.json
+coven setup claude  --verify-only --report-json cert/claude.json
+coven setup copilot --verify-only --report-json cert/copilot.json
+```
+
+Verification requires an interactive terminal and explicit network/cost
+consent, so this cannot run in CI — it is an operator step on a machine with
+all three providers authenticated. A non-interactive shell reports `non_tty`
+and publishes nothing.
+
+Each report must show `"completed": true` and a `candidate_commit` equal to the
+commit being tagged:
+
+```sh
+jq -r '"\(.harness) \(.completed) \(.candidate_commit)"' cert/*.json
+```
+
+`candidate_commit` is baked into the binary at build time, so a report whose
+value does not match the release commit was produced by a different build and
+does not certify this release. Reports are success-only and published
+atomically; if verification fails, no file appears and the CLI exits nonzero.
+
+Keep the packet with the release record. It contains only `harness`,
+`cli_version`, `platform`, `candidate_commit`, `duration`, `exit_class`, and
+`completed` — no output, account data, tokens, or private paths — so it is safe
+to retain and share.
+
 ### Tag and push
+
+Release tags are **immutable**. A pushed release tag is never moved, deleted,
+recreated, or reused for different content, and a version that has been
+published to npm is never republished. Every recovery path in this document
+bumps forward to a new version instead. This is not a style preference: the
+tag is the object that the npm provenance attestation, the GitHub Release, and
+the certification packet all attest to, so moving it silently invalidates all
+three.
 
 The tag must be **annotated and cryptographically signed**. Lightweight tags (`git tag vX.Y.Z`) are refused by the workflow.
 
@@ -127,6 +169,60 @@ The workflow creates or repairs one GitHub Release titled `Coven vX.Y.Z` using t
 - `SHA256SUMS`
 
 `SHA256SUMS` contains exactly four lexically ordered entries naming only those four archive filenames. The GitHub Release is the public binary/checksum surface; npm provenance remains the package-integrity surface.
+
+Download the published assets and verify the checksums actually match, rather
+than trusting that the file exists:
+
+```sh
+gh release download vX.Y.Z --repo OpenCoven/coven --dir release-check
+cd release-check && shasum -a 256 -c SHA256SUMS
+```
+
+### Verify a fresh consumer install
+
+The dry-run and packed smoke prove the artifacts *build*; only a real install
+from the registry proves what a user actually gets. Do this in an environment
+that has never had Coven installed — a container, a fresh VM, or a throwaway
+user account — because a stale global install on `PATH` will shadow the new one
+and make a broken release look fine:
+
+```sh
+npm install -g @opencoven/cli@X.Y.Z
+which -a coven          # must resolve to exactly one path
+coven --version         # must print X.Y.Z
+coven doctor            # exits 1 with setup guidance on a bare machine
+```
+
+`which -a coven` returning more than one path means you are not testing the
+version you just installed. Resolve that before trusting any other result here.
+
+Verify the install is provenance-backed and pulled only the canonical five
+packages:
+
+```sh
+npm audit signatures
+npm ls -g --depth 1 @opencoven/cli
+```
+
+Repeat on each platform you can reach. The `npm-onboarding` CI matrix covers
+packed tarballs on all four targets, but it never installs from the public
+registry, so this step is the only check of the real dist-tag resolution and
+optional-dependency selection a user experiences.
+
+### Confirm the certification packet
+
+Re-check the preflight certification reports against what actually shipped:
+
+```sh
+jq -r '"\(.harness) \(.cli_version) \(.completed) \(.candidate_commit)"' cert/*.json
+git rev-list -n 1 vX.Y.Z
+```
+
+Every report's `candidate_commit` must equal the commit the tag resolves to,
+and every `completed` must be `true`. A mismatch means the packet certifies a
+different build than the one published, and the packet must be regenerated
+against the released commit before the release is considered closed out. File
+the reports with the release record alongside the checksum verification above.
 
 ### Recover GitHub Release assets without touching npm
 

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -89,15 +89,20 @@ against the exact commit you intend to tag. Each report is a one-provider
 artifact and the destination must not already exist:
 
 ```sh
+mkdir -p cert
 coven setup codex   --verify-only --report-json cert/codex.json
 coven setup claude  --verify-only --report-json cert/claude.json
 coven setup copilot --verify-only --report-json cert/copilot.json
 ```
 
+Create the destination directory first: publication is fail-if-exists on the
+report file itself, but Coven does not create parent directories, so a missing
+`cert/` fails the command.
+
 Verification requires an interactive terminal and explicit network/cost
 consent, so this cannot run in CI — it is an operator step on a machine with
-all three providers authenticated. A non-interactive shell reports `non_tty`
-and publishes nothing.
+all three providers authenticated. Run non-interactively, the command exits
+nonzero and writes no report.
 
 Each report must show `"completed": true` and a `candidate_commit` equal to the
 commit being tagged:
@@ -178,6 +183,22 @@ gh release download vX.Y.Z --repo OpenCoven/coven --dir release-check
 cd release-check && shasum -a 256 -c SHA256SUMS
 ```
 
+`shasum -c` is macOS / Linux. On Windows PowerShell, compare hashes against the
+same file explicitly:
+
+```powershell
+gh release download vX.Y.Z --repo OpenCoven/coven --dir release-check
+cd release-check
+Get-Content SHA256SUMS | ForEach-Object {
+  $expected, $name = $_ -split '\s+', 2
+  $actual = (Get-FileHash -Algorithm SHA256 $name.Trim()).Hash.ToLower()
+  "$name $(if ($actual -eq $expected) { 'OK' } else { "FAILED ($actual)" })"
+}
+```
+
+All four archives must report `OK`. This is the one checksum surface, so a
+single mismatch fails the release regardless of what npm reports.
+
 ### Verify a fresh consumer install
 
 The dry-run and packed smoke prove the artifacts *build*; only a real install
@@ -188,21 +209,35 @@ and make a broken release look fine:
 
 ```sh
 npm install -g @opencoven/cli@X.Y.Z
-which -a coven          # must resolve to exactly one path
 coven --version         # must print X.Y.Z
 coven doctor            # exits 1 with setup guidance on a bare machine
 ```
 
-`which -a coven` returning more than one path means you are not testing the
-version you just installed. Resolve that before trusting any other result here.
+Confirm the `coven` you just ran is the only one on `PATH`. More than one
+result means you are not testing the version you installed, and you must
+resolve that before trusting any other result in this section:
 
-Verify the install is provenance-backed and pulled only the canonical five
-packages:
+```sh
+which -a coven                     # macOS / Linux
+```
+
+```powershell
+Get-Command coven -All             # Windows PowerShell
+```
+
+Verify the install is provenance-backed and resolved to the expected packages:
 
 ```sh
 npm audit signatures
 npm ls -g --depth 1 @opencoven/cli
 ```
+
+Expect exactly two entries: the `@opencoven/cli` wrapper and the one native
+package matching the current platform (for example `@opencoven/cli-macos` on
+Apple silicon), both at `X.Y.Z`. A native package for a *different* platform, a
+version mismatch between wrapper and native, or a missing native package are
+each a failed release — not a cosmetic difference. All five packages are never
+installed together on one machine; they are selected per platform.
 
 Repeat on each platform you can reach. The `npm-onboarding` CI matrix covers
 packed tarballs on all four targets, but it never installs from the public


### PR DESCRIPTION
## Context

`coven-v041-runbook` requires the operator runbook to document: automated GitHub Release creation, bump-forward recovery from partial npm publication, tags never reused, and a postflight covering "packages, provenance, assets, checksums, installs, and the certification packet."

Audited `docs/reference/releasing.md` at `8ae39cd`. The first two were already documented thoroughly. Three requirements were not met:

1. **Installs were never verified.** Postflight checked `npm view` versions, provenance badges, and that the GitHub Release assets exist — but never installed the published packages. Nothing anywhere in the pipeline installs from the public registry: the `npm-onboarding` CI matrix only exercises locally packed tarballs. Dist-tag resolution and optional native-package selection — the two things most likely to break for a real user — were unverified at release time.
2. **The certification packet was absent from the runbook entirely**, despite being the artifact that ties a release to verified provider behaviour, and despite `coven-v041-cert` and `coven-v041-postflight` both depending on it existing.
3. **Tag immutability was stated only incidentally**, inside recovery procedures ("never moves or reuses the tag", "Never move or reuse a release tag"), never as a normative rule in the release-cutting flow where an operator would look first.

## Implementation

Docs-only, `docs/reference/releasing.md`, +96 lines.

- **Preflight -> Certification packet**: per-harness `coven setup <p> --verify-only --report-json`, with the `candidate_commit` equality check against the commit being tagged. Notes this is operator-only — verification needs a TTY and explicit network/cost consent, and a non-interactive shell reports `non_tty` and publishes nothing. Documents the exact redacted field set so operators know the packet is safe to retain.
- **Tag and push**: a normative immutability rule that explains *why* — the tag is the object npm provenance, the GitHub Release, and the certification packet all attest to, so moving it invalidates all three at once.
- **Postflight**: checksum verification of downloaded assets (`shasum -a 256 -c SHA256SUMS`), a new "Verify a fresh consumer install" section, and a "Confirm the certification packet" cross-check against `git rev-list -n 1 vX.Y.Z`.

The install section calls out the shadowed-global-install trap explicitly (`which -a coven` must return exactly one path), because a stale global install on `PATH` makes a broken release look fine.

## Verification

- `python3 scripts/check-api-contract-docs.py` -> rc 0
- `node --test scripts/onboarding-docs-test.mjs scripts/cli-docs-test.mjs` -> 23/23 pass
- `python3 scripts/check-secrets.py` -> rc 0
- `python3 scripts/check-coven-privacy.py --staged` -> rc 0

Every documented command and field was checked against the implementation rather than written from memory: the report schema against `SetupReport`/`publish_report` in `crates/coven-cli/src/setup/mod.rs`, the `--report-json` constraints against `docs/reference/cli-setup.md`, the `doctor` exit-1-with-guidance claim against `assertDoctorFailureGuidance`, and the install command against `README.md`.

## Risk

None to shipped code. The risk is documentation drift, which the existing docs tests cover.

## Agent Handoff

Unblocks `coven-v041-freeze` on the runbook axis. `freeze` still needs `coven-v041-cleanup`, and `coven-v041-npm` still needs authenticated Trusted Publishers evidence that cannot be produced from an agent session.

Note the dependency shape: this bead nominally depends on `coven-v041-npm`, but the npm preflight facts it would document are already recorded in that bead's notes. The only outstanding npm item is the Trusted Publishers settings evidence, which does not change any runbook text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
