### PR TITLE
ci: warm the test build before the bounded release stress loop

### DIFF
--- a/.github/workflows/release-stress.yml
+++ b/.github/workflows/release-stress.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Install native link dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      # Build the test binaries outside the timed loop. The stress harness
+      # applies --command-timeout-ms per cargo invocation, so on a cold cache
+      # the first surface spends its whole budget compiling and times out
+      # without ever running the test it is meant to bound.
+      - name: Warm the test build
+        run: cargo test --workspace --locked --no-run
       - name: Run bounded release stress
         timeout-minutes: 42
         run: node scripts/release-stress.mjs --suite unix --iterations 10 --command-timeout-ms 180000 --log "release-stress-${RUNNER_OS}.log"
@@ -72,6 +78,11 @@ jobs:
           key: ${{ runner.os }}-release-stress-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-release-stress-
+      # See the unix job: the per-command timeout must bound the test, not a
+      # cold compile. Windows is where this actually bit -- the first surface
+      # hit 180s while still downloading and compiling dependencies.
+      - name: Warm the test build
+        run: cargo test --workspace --locked --no-run
       - name: Run bounded release stress
         timeout-minutes: 42
         run: node scripts/release-stress.mjs --suite windows --iterations 10 --command-timeout-ms 180000 --log "release-stress-${env:RUNNER_OS}.log"


### PR DESCRIPTION
## Context

The `Release stress` workflow had **never been dispatched at any SHA** — `gh run list --workflow "Release stress"` returned empty. Surfaced while taking `coven-v041-reliability`, whose acceptance criteria require the targeted loops to pass on Linux, macOS, and Windows.

First dispatch (run [33146989910](https://github.com/OpenCoven/coven/actions/runs/33146989910), at `8ae39cd`):

| job | result |
| --- | --- |
| Release stress (ubuntu-latest) | success |
| Release stress (macos-26) | success |
| Release stress (Windows) | **failure** |

## Root cause

Not a flaky surface — the harness was measuring the wrong thing.

`release-stress.mjs` applies `--command-timeout-ms` to *each cargo invocation*. On a cold cache the first surface spends that entire budget resolving git dependencies and compiling, and is killed before the test under stress ever starts.

The Windows log is unambiguous:

```
06:10:08.6604538Z iteration=1 surface=Windows PTY timeout and process cleanup
06:13:08.6948066Z     Updating crates.io index
06:13:08.6950556Z     Updating git repository `https://github.com/OpenCoven/coven-runtimes`
...                    Downloaded / Compiling ...
06:13:08.8220489Z ##[error]Process completed with exit code 1.
```

Exactly **180.000s** between iteration start and death — the configured timeout — with the output still listing `Downloaded`/`Compiling` and no test result at all.

All three jobs reported `Cache not found for input keys: <os>-release-stress-...`. Linux and macOS happened to fit a cold build inside 180s; Windows did not. That is the only reason Windows was the one that went red, and it means the other two are one dependency bump away from the same failure.

## Implementation

Add a `Warm the test build` step (`cargo test --workspace --locked --no-run`) before the timed loop in both jobs.

Raising the timeout was the wrong fix and I did not take it: the bound exists to catch a surface that *hangs*, and folding compile time into it makes the threshold meaningless and machine-dependent. Building outside the loop restores the intended meaning — the timeout measures execution only.

## Verification

- `bash scripts/check-workflows.sh` (actionlint) — pass
- `python3 scripts/check-workflows-test.py` — 8 tests, OK
- `python3 scripts/check-secrets.py` / `check-coven-privacy.py --staged` — pass

CI cannot exercise this PR's effect directly, since `release-stress.yml` is `workflow_dispatch` only. I will dispatch it again once this lands and report the result on `coven-v041-reliability`.

## Risk

Low. Workflow-only, adds a build step; no change to the stress commands, iteration count, or timeout. Worst case is a longer job, which the existing `timeout-minutes: 45` already bounds.

## Agent Handoff

For `coven-v041-reliability`. Note the gate is still not satisfied even with this fix — evidence has to be collected at the frozen candidate SHA, and CI still has no macOS `cargo test --workspace` job, so that leg of the gate currently depends on a local operator run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
