### PR TITLE
test(windows): stop the launcher hang guard from flaking under load

### DIFF
--- a/crates/coven-cli/tests/windows_daemon_lifecycle.rs
+++ b/crates/coven-cli/tests/windows_daemon_lifecycle.rs
@@ -131,7 +131,15 @@ fn captured_output_with_timeout(
     command: &mut Command,
     coven_home: &Path,
 ) -> Result<Output> {
-    const LAUNCHER_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+    // A hang guard, not a promptness contract. Nothing here asserts how fast
+    // the launcher starts -- the two-second budget this suite enforces is on
+    // `daemon stop`, not on start. This bound exists only so a wedged
+    // node.exe -> npm wrapper -> coven.exe chain fails with a diagnosable
+    // message instead of hanging until the CI job is killed, so it must sit
+    // far above anything ordinary runner load can produce. Fifteen seconds
+    // did not: it flaked on windows-latest against Rust code identical to a
+    // passing run.
+    const LAUNCHER_EXIT_TIMEOUT: Duration = Duration::from_secs(120);
     const CAPTURE_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
     const LAUNCHER_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -181,7 +189,10 @@ fn captured_output_with_timeout(
                 terminate_recorded_daemon(coven_home);
                 launcher.terminate();
                 let _ = result_rx.recv_timeout(CAPTURE_CLOSE_TIMEOUT);
-                anyhow::bail!("{label} launcher did not exit within fifteen seconds")
+                anyhow::bail!(
+                    "{label} launcher did not exit within {}s; this is a hang guard, so treat it as a wedged launcher rather than a slow runner",
+                    LAUNCHER_EXIT_TIMEOUT.as_secs()
+                )
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
@@ -682,7 +693,10 @@ fn abrupt_daemon_stop_kills_live_piped_descendants() -> Result<()> {
         .env("PATH", &path)
         .output()?;
     assert_success("abrupt Windows daemon stop with descendant", &stop);
-    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "Windows daemon stop exceeded its documented two-second contract"
+    );
     wait_until("Windows daemon descendant termination", || {
         Ok(!process_is_alive(descendant_pid))
     })?;


### PR DESCRIPTION
## Context

`coven-uac`. `abrupt_daemon_stop_kills_live_piped_descendants` failed on `windows-latest` during PR #840:

```
test abrupt_daemon_stop_kills_live_piped_descendants ... FAILED
Error: captured hidden npm-wrapper Windows daemon start launcher
       did not exit within fifteen seconds
```

**Established as a flake, not a regression, before changing anything.** The same PR passed `Rust tests (Windows)` at `c1c978c` and failed at `3846191`. The only difference between those commits is a rebase across `e5cfe19`, which is docs-only, and the branch's entire diff versus `main` was 11 added lines in `.github/workflows/release-stress.yml`. No Rust code differed between the passing and failing runs, and `windows_daemon_lifecycle.rs` had not been touched since #760.

## Why raising this bound is not the same as hiding the problem

`LAUNCHER_EXIT_TIMEOUT` is **not a promptness contract**. Nothing in this suite asserts how fast the daemon *starts*. The documented two-second budget is on `daemon stop` (`crates/coven-cli/src/daemon.rs:4475`), asserted here and in `smoke.rs:453,530` — and those assertions are deliberately left strict.

This bound exists only so a wedged `node.exe -> npm wrapper -> coven.exe` chain fails with a readable message instead of hanging until CI kills the job. A hang guard has to sit far above anything ordinary runner load can produce. Fifteen seconds did not.

Contrast with #840, where I refused to raise a timeout: there the bound was *meant* to measure test execution and was instead measuring a cold compile, so raising it would have destroyed the bound's meaning. Here the bound's meaning is "did this wedge", and 15s was simply the wrong number for that question on a loaded Windows runner.

## Implementation

- `LAUNCHER_EXIT_TIMEOUT` 15s -> 120s, with a comment stating what it is and is not.
- Report the configured value instead of a hardcoded "fifteen seconds" that silently drifts from the constant.
- Give the descendant test's two-second stop assertion the failure message its sibling at the pre-attachment barrier already carries. A bare `assert!` firing in CI printed nothing useful.

`CAPTURE_CLOSE_TIMEOUT` **stays at two seconds.** That is the actual regression detector — it only begins counting after the launcher has already exited, so it is not sensitive to spawn or startup load, and loosening it would blunt the inherited-capture-handle check this fixture exists for.

## Verification

`crates/coven-cli/tests/windows_daemon_lifecycle.rs` is `#![cfg(windows)]`, so it compiles to nothing on macOS and I could not run it locally. Verification is this PR's `Rust tests (Windows)` job.

Locally: `cargo fmt --check` rc 0, `python3 scripts/check-secrets.py` rc 0, `python3 scripts/check-coven-privacy.py --staged` rc 0.

## Risk

Low, and confined to a Windows test fixture. The failure mode of the change is a wedged launcher taking 120s instead of 15s to report — slower, but it still reports. No product code and no contract assertion is touched.

## Agent Handoff

Unblocks `coven-v041-reliability`, which forbids success-by-rerun and could therefore have this flake invalidate Windows evidence at the frozen candidate SHA at random.

Worth noting for whoever closes that gate: this is the third load-sensitive wall-clock deadline found in this suite (after #801 and `11a525d`), which suggests the pattern is worth a sweep rather than another one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
