### PR TITLE
ci: run the macOS workspace suite on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,32 @@ jobs:
             ${{ runner.os }}-rust-test-
       - run: cargo test --workspace --locked
 
+  # macOS runners bill at roughly ten times the Linux rate, so this follows the
+  # npm-onboarding split: a cheap matrix on pull requests, the full one on main.
+  # Gated on `rust` as well as the event so a docs-only merge does not spend a
+  # macOS runner. Before this existed the macOS workspace suite had no CI job at
+  # all -- only AFS mount coverage -- so that leg of the release reliability gate
+  # depended on an operator remembering to run it locally.
+  rust-test-macos:
+    name: Rust tests (macOS)
+    needs: changes
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.rust == 'true' }}
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-test-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-test-
+      - run: cargo test --workspace --locked
+
   afs-mount-linux:
     name: AFS mount backend (Linux)
     needs: changes
@@ -463,6 +489,7 @@ jobs:
       - rust-lint-linux
       - rust-test-linux
       - rust-test-windows
+      - rust-test-macos
       - afs-mount-linux
       - afs-mount-macos
       - performance-baseline

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -32,6 +32,7 @@ class CheckCiWorkflowTests(unittest.TestCase):
             'rust-lint-linux',
             'rust-test-linux',
             'rust-test-windows',
+            'rust-test-macos',
             'afs-mount-linux',
             'afs-mount-macos',
         ]:


### PR DESCRIPTION
## Context

While collecting evidence for `coven-v041-reliability` I found that **CI has no macOS `cargo test --workspace` job at all**. Linux and Windows have had one since forever; macOS only has `AFS mount backend (macOS)`, which exercises a single crate's mount backend.

That gate's acceptance criteria require "Linux, macOS, and Windows targeted loops and workspace suites pass". The macOS workspace leg was therefore satisfiable only by an operator running the suite by hand and pasting the result — which is exactly the kind of evidence a release gate should not depend on.

## Implementation

Add `Rust tests (macOS)` on `macos-26`, gated to **push events on main** rather than every pull request.

macOS runners bill at roughly ten times the Linux rate. This follows the split the `npm-onboarding` jobs already use in this same workflow — a cheap matrix on pull requests (`npm-onboarding-pr`, 2 targets), the full one on main (`npm-onboarding-main`, 4 targets). The condition also requires `needs.changes.outputs.rust`, which the `changes` job computes on push as well as `pull_request`, so a docs-only merge does not spend a macOS runner.

**The tradeoff is explicit:** a macOS-only regression now lands on `main` before it is caught, rather than being blocked at review. That is the same tradeoff already accepted for the `macos` and `macos-x64` npm onboarding smokes, so this does not introduce a new class of risk — but it is a real one and I would rather state it than bury it.

Also:
- Added to `pr-gate`'s `needs` so its result is accounted for. It reports `skipped` on pull requests, which the gate already tolerates for `npm-onboarding-main`.
- Added to the required-job list in `check-ci-workflow-test.py` so a future edit cannot silently drop it.

## Verification

- `bash scripts/check-workflows.sh` (actionlint) — pass
- `python3 scripts/check-ci-workflow-test.py` — 9 tests, OK (including the expanded required-job list)
- `python3 scripts/check-workflows-test.py` — 8 tests, OK
- `python3 scripts/classify-ci-changes-test.py` — 19 tests, OK
- `python3 scripts/check-secrets.py` / `check-coven-privacy.py --staged` — pass

The new job cannot run on this PR by construction, since it is push-gated. Its first real execution is the merge commit on `main`.

## Risk

Low. Additive; no existing job's gating, timeout, or cache policy changes. The cost is one macOS runner per Rust-touching merge to main.

## Agent Handoff

For `coven-v041-reliability`. With this merged, all three platforms have workspace-suite CI coverage and the targeted stress loops pass on all three (run 33149940918). The gate's remaining blocker is `coven-v041-freeze` — evidence still has to be re-collected at the frozen candidate SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
