### PR TITLE
fix(test): widen the start-readiness bound past scheduler jitter

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -5570,8 +5570,16 @@ mod tests {
         .expect_err("the single outer start budget must expire");
 
         assert_eq!(calls.get(), 1, "no fixed post-deadline probe is allowed");
+        // `calls == 1` is what actually proves the behaviour this test names:
+        // the budget expired and no further probe was issued. The elapsed bound
+        // only has to separate "returned once the in-flight probe finished"
+        // from "waited on some long fixed delay afterwards", and the probe
+        // itself sleeps 25ms, so a correct run lands near 25-30ms. 100ms left
+        // barely any room for scheduler jitter and flaked on a loaded macOS
+        // runner; two seconds still catches a regression that reintroduces a
+        // fixed post-deadline wait.
         assert!(
-            started.elapsed() < Duration::from_millis(100),
+            started.elapsed() < Duration::from_secs(2),
             "start readiness materially overshot its 20ms budget"
         );
         assert!(

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -5578,9 +5578,11 @@ mod tests {
         // barely any room for scheduler jitter and flaked on a loaded macOS
         // runner; two seconds still catches a regression that reintroduces a
         // fixed post-deadline wait.
+        let elapsed = started.elapsed();
         assert!(
-            started.elapsed() < Duration::from_secs(2),
-            "start readiness materially overshot its 20ms budget"
+            elapsed < Duration::from_secs(2),
+            "start readiness materially overshot its 20ms budget: took {elapsed:?}, \
+             ceiling is 2s and a correct run lands near the probe's own 25ms sleep"
         );
         assert!(
             error


### PR DESCRIPTION
## Context

**`main` is red.** The `Rust tests (macOS)` job added in #842 failed on its very first run, at `28fa0af`:

```
daemon::tests::windows_start_wait_does_not_probe_again_after_its_total_budget
panicked at crates/coven-cli/src/daemon.rs:5573:
start readiness materially overshot its 20ms budget
```

The same commit passed `Rust tests (Linux)`, `Rust tests (Windows)`, and a local macOS run of the full workspace suite. This is scheduler jitter on a loaded runner, not a regression — and the new job finding a latent flake on day one is the argument for the job, not against it.

## Implementation

`calls == 1` is what actually proves the behaviour this test is named for: the budget expired and no further probe was issued. That assertion is deterministic and **untouched**.

The elapsed bound only has to separate "returned once the in-flight probe finished" from "waited on some long fixed delay afterwards". The probe closure itself sleeps 25ms, so a correct run lands near 25–30ms. A 100ms ceiling left almost no headroom on a shared runner.

Widened to two seconds.

## Verification

- Target test passes locally on macOS.
- **The bound is still live, not vacuous:** patching the probe closure to sleep 2500ms makes the assertion fail (`test result: FAILED ... finished in 2.51s`). A regression that reintroduces a fixed post-deadline wait is still caught.
- `cargo fmt --check` rc 0
- `cargo clippy -p coven-cli --all-targets --locked -- -D warnings` rc 0
- `python3 scripts/check-secrets.py` / `check-coven-privacy.py --staged` rc 0

## Risk

Low. One test assertion in `#[cfg(test)]` code; no product behaviour changes.

## Agent Handoff

**This is the fourth one-off fix of the same pattern**, after #801, `11a525d`, and #841. I filed `coven-gma` (P1, blocking `coven-v041-reliability`) to sweep the remaining twenty `Instant::elapsed()` promptness assertions, with a full inventory ranked tightest-first.

That is deliberately a separate bead rather than extra scope here, because the sites are **not** interchangeable and a blanket bump would silently destroy real coverage:

- Some encode the **documented two-second daemon-stop budget** (`daemon.rs:4475`, asserted in `windows_daemon_lifecycle.rs:624,685` and `smoke.rs:453,530`) and must stay strict.
- Some are **hang guards** where the number only needs to clear jitter.
- Some are **discriminating thresholds** that should sit midway between a fast path and an injected slow path — `daemon.rs:5527` bounds at 250ms against a 500ms injected diagnostic delay.
- Some are **pure promptness claims already covered deterministically** in the same test and should be deleted outright, which is what #801 and `11a525d` did.

Also relevant to that sweep: #842 increases exposure, since these assertions now run on a third platform on every Rust merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
