### PR TITLE
test: widen wall-clock bounds that sat too close to nominal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,22 @@ justifying comment.
   policy and adapter contracts are stable. Don't add speculative harness adapters.
 - **Never weaken the secret scan.** If `check-secrets.py` flags something, fix
   the content — don't allowlist your way past it.
+- **Wall-clock assertions in tests must clear scheduler jitter.** A bound like
+  `assert!(started.elapsed() < …)` runs on shared CI runners, so a threshold
+  close to the nominal duration will flake. Before adding or "fixing" one, work
+  out which kind it is — they are not interchangeable, and a blanket bump
+  deletes real coverage:
+  - **A documented contract** (e.g. the two-second `daemon stop` budget in
+    `daemon.rs`): keep it strict. This is the assertion's whole point.
+  - **A discriminating threshold** separating a fast path from an injected slow
+    path: put the bound near the *midpoint*, not just above the fast path.
+  - **A hang guard** that only turns a wedge into a readable failure: set it far
+    above anything load can produce, and say so in a comment.
+  - **A promptness claim already proven deterministically** in the same test
+    (a call count, an ordering, an error string): delete it rather than tune it.
+
+  Report the observed duration in the failure message, or the next flake tells
+  you nothing.
 - Prefer the fast loop (`cargo check`, debug builds) over `--release` unless you
   specifically need optimized output.
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -5523,8 +5523,12 @@ mod tests {
         )?;
 
         assert!(restarted.0);
+        // The injected diagnostic delay is 500ms and the restart deadline is
+        // 100ms, so any bound strictly between them proves the scan did not
+        // block. 250ms sat close to the fast path; 400ms keeps the same signal
+        // with more room for jitter.
         assert!(
-            started_at.elapsed() < Duration::from_millis(250),
+            started_at.elapsed() < Duration::from_millis(400),
             "optional diagnostic scan delayed restart completion"
         );
         Ok(())

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -6640,7 +6640,10 @@ mod tests {
         drop(watcher);
 
         dropped_rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        assert!(started.elapsed() < Duration::from_secs(1));
+        // The poll interval this drop must interrupt is 60s, so five seconds
+        // still fails loudly if the interrupt regresses while tolerating a
+        // slow thread wake-up.
+        assert!(started.elapsed() < Duration::from_secs(5));
     }
 
     #[test]

--- a/crates/coven-client/src/transport/windows.rs
+++ b/crates/coven-client/src/transport/windows.rs
@@ -1296,7 +1296,10 @@ mod tests {
                 .contains("connection closed before response completed"),
             "unexpected error: {error}"
         );
-        assert!(started.elapsed() < Duration::from_millis(100));
+        // Discriminates "returned on the disconnect" from "waited out the 1s
+        // deadline above". Half the deadline keeps that separation unambiguous
+        // while leaving room for scheduler jitter on a loaded runner.
+        assert!(started.elapsed() < Duration::from_millis(500));
     }
 
     struct AlwaysNoDataReader {
@@ -1716,7 +1719,10 @@ mod tests {
             error,
             crate::ClientError::Io { source, .. } if source.raw_os_error() == Some(109)
         ));
-        assert!(started.elapsed() < Duration::from_millis(100));
+        // Discriminates "returned on the disconnect" from "waited out the 1s
+        // deadline above". Half the deadline keeps that separation unambiguous
+        // while leaving room for scheduler jitter on a loaded runner.
+        assert!(started.elapsed() < Duration::from_millis(500));
     }
 
     struct DisconnectedWriter;
@@ -1746,6 +1752,9 @@ mod tests {
             error,
             crate::ClientError::Io { source, .. } if source.raw_os_error() == Some(232)
         ));
-        assert!(started.elapsed() < Duration::from_millis(100));
+        // Discriminates "returned on the disconnect" from "waited out the 1s
+        // deadline above". Half the deadline keeps that separation unambiguous
+        // while leaving room for scheduler jitter on a loaded runner.
+        assert!(started.elapsed() < Duration::from_millis(500));
     }
 }

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -1503,8 +1503,11 @@ fn lifecycle_probe_rejects_trickling_and_unbounded_responses_quickly() {
         let started = std::time::Instant::now();
         let result = probe_unix_daemon_health(&home.path, Duration::from_millis(30));
         assert!(result.is_err(), "malformed unbounded response was accepted");
+        // The failure mode is an unbounded read, so any finite bound proves
+        // the 30ms deadline held. Widened off 250ms because the bound only has
+        // to be finite, not tight, and a tight one is pure jitter exposure.
         assert!(
-            started.elapsed() < Duration::from_millis(250),
+            started.elapsed() < Duration::from_secs(1),
             "response deadline was reset by trickling bytes"
         );
         server.join().expect("server thread");


### PR DESCRIPTION
## Context

`coven-gma`. **Four** separate one-off fixes for this flake class had already landed — #801, `11a525d`, #841, #843 — before anyone swept the pattern. The most recent one flaked on the very first run of the new `Rust tests (macOS)` job and turned `main` red.

Classified all 23 `Instant::elapsed()` bounds in the workspace. **Six needed changing.** The headline result is that the sweep is much narrower than the bead assumed, because most bounds are already fine.

## Widened

| site | was | now | why |
| --- | --- | --- | --- |
| `transport/windows.rs` ×3 | 100ms | 500ms | discriminates against a 1s deadline, so half of it keeps the signal unambiguous |
| `daemon.rs:5527` | 250ms | 400ms | injected diagnostic delay is 500ms and the deadline is 100ms; the bound belongs at the midpoint, not next to the fast path |
| `health.rs:1507` | 250ms | 1s | the failure mode is an *unbounded* read, so the bound only has to be finite — a tight one is pure jitter exposure |
| `pty_runner.rs:6643` | 1s | 5s | the poll this drop interrupts is 60s, so 5s still fails loudly |

Each carries a comment explaining the reasoning at the site.

## Left strict on purpose

The two-second `daemon stop` budget asserted in `windows_daemon_lifecycle.rs:624,685` and `smoke.rs:453,530`. That is a **documented product contract** (`daemon.rs:4475`), not a test threshold. Loosening it as "load-sensitive" would have quietly deleted the guarantee — the exact failure mode a blanket sweep invites, and the reason this was filed as a bead instead of being done inline with #843.

## Left unchanged

The remaining thirteen already carry 20–100x headroom over nominal. Widening them would be churn with no flake resistance gained.

## The rule

Recorded in `AGENTS.md` under repo invariants, since the bead's actual ask was that the fifth instance not get fixed one-off too. It names the four categories — contract bounds stay strict, discriminating thresholds sit at the midpoint, hang guards go far above load, promptness claims already proven deterministically get deleted rather than tuned — and requires reporting the observed duration, because a bound that trips without printing what it saw tells the next person nothing.

## Verification

- `cargo test --workspace --locked` — **rc 0**, 31 suites, no failures
- `cargo fmt --check` — rc 0
- `python3 scripts/check-secrets.py`, `check-coven-privacy.py --staged` — rc 0
- `python3 scripts/check-api-contract-docs.py` — rc 0
- `node --test scripts/onboarding-docs-test.mjs scripts/cli-docs-test.mjs` — 23/23

**Local clippy could not validate this change.** This machine runs rustc 1.95.0 while CI runs 1.98.0, and 1.95 reports a `nonminimal_bool` lint in `coven-relay/src/ws.rs:132` that 1.98 does not. That lint reproduces on unmodified `main` with a clean tree and is untouched by this change, so it is local toolchain skew rather than a repo problem. CI clippy is the authority.

## Risk

Low. Test-only assertions plus a docs addition; no product code changes. Every widened bound was checked to still discriminate against its slow path rather than becoming vacuous.

## Agent Handoff

Closes `coven-gma`, which blocks `coven-v041-reliability`. After this the gate's only remaining blocker is `coven-v041-freeze`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
