### PR TITLE
feat(automations): routine definitions and control actions (coven#816, part 1)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -565,7 +565,19 @@ pub(crate) fn handle_request_with_runtime_and_authority(
                     );
                 }
             };
-            let (status, response) = control_plane::route_action(payload);
+            let conn = match store::open_store(&store_path(coven_home)) {
+                Ok(conn) => conn,
+                Err(error) => {
+                    return json_response(
+                        500,
+                        &control_plane::rejected_action(
+                            "(unknown)",
+                            format!("store unavailable: {error:#}"),
+                        ),
+                    );
+                }
+            };
+            let (status, response) = control_plane::route_action(payload, &conn);
             json_response(status, &response)
         }
         ("POST", "/cast") => submit_cast(coven_home, body, runtime),
@@ -10616,6 +10628,144 @@ mod tests {
         assert!(response.body.contains(r#""kind":"capabilities.refreshed""#));
         assert!(response.body.contains(r#""origin":"external-client""#));
         assert!(response.body.contains(r#""intentId":"intent-1""#));
+        Ok(())
+    }
+
+    #[test]
+    fn control_actions_manage_routine_definitions_end_to_end() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let create_body = json!({
+            "action": "coven.automations.create",
+            "definition": {
+                "schemaVersion": 1,
+                "id": "daily-notes",
+                "name": "Daily notes",
+                "status": "PAUSED",
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "local",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 30,
+                "runtime": "coven-code",
+                "familiarId": "charm",
+                "prompt": "Write the daily reflection."
+            }
+        })
+        .to_string();
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&create_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(response.body.contains(r#""routine":"#));
+        assert!(response.body.contains(r#""id":"daily-notes""#));
+
+        let list_body = json!({ "action": "coven.automations.list" }).to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&list_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(response.body.contains(r#""routines":[{"#));
+
+        let get_body = json!({
+            "action": "coven.automations.get",
+            "id": "daily-notes"
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&get_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(response.body.contains(r#""name":"Daily notes""#));
+
+        let update_body = json!({
+            "action": "coven.automations.update",
+            "definition": {
+                "schemaVersion": 1,
+                "id": "daily-notes",
+                "name": "Daily notes (renamed)",
+                "status": "ACTIVE",
+                "rrule": "FREQ=WEEKLY;BYDAY=MO,FR;BYHOUR=8,17",
+                "timezone": "utc",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 60,
+                "runtime": "coven-code",
+                "prompt": "Write the weekly reflection."
+            }
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&update_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(response.body.contains(r#""name":"Daily notes (renamed)""#));
+        assert!(response.body.contains(r#""status":"ACTIVE""#));
+
+        let delete_body = json!({
+            "action": "coven.automations.delete",
+            "id": "daily-notes"
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&delete_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(response.body.contains(r#""deleted":true"#));
+        Ok(())
+    }
+
+    #[test]
+    fn control_actions_reject_invalid_routine_definitions() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let body = json!({
+            "action": "coven.automations.create",
+            "definition": {
+                "schemaVersion": 1,
+                "id": "bad schedule!",
+                "name": "Bad",
+                "status": "PAUSED",
+                "rrule": "FREQ=HOURLY",
+                "timezone": "local",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 30,
+                "runtime": "coven-code",
+                "prompt": "Never runs."
+            }
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+        )?;
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains(r#""accepted":false"#));
+        assert!(response.body.contains("coven.automations.create"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -577,7 +577,7 @@ pub(crate) fn handle_request_with_runtime_and_authority(
                     );
                 }
             };
-            let (status, response) = control_plane::route_action(payload, &conn);
+            let (status, response) = control_plane::route_action(payload, &conn, runtime);
             json_response(status, &response)
         }
         ("POST", "/cast") => submit_cast(coven_home, body, runtime),
@@ -10733,6 +10733,83 @@ mod tests {
         )?;
         assert_eq!(response.status, 200);
         assert!(response.body.contains(r#""deleted":true"#));
+        Ok(())
+    }
+
+    #[test]
+    fn control_action_runs_a_routine_through_the_ledger() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let create_body = json!({
+            "action": "coven.automations.create",
+            "definition": {
+                "schemaVersion": 1,
+                "id": "daily-notes",
+                "name": "Daily notes",
+                "status": "PAUSED",
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "utc",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 30,
+                "runtime": "coven-code",
+                "cwd": "/work/project",
+                "familiarId": "charm",
+                "prompt": "Write the daily reflection."
+            }
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&create_body),
+        )?;
+        assert_eq!(response.status, 200);
+
+        let run_body = json!({
+            "action": "coven.automations.run",
+            "id": "daily-notes"
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&run_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(
+            response.body.contains(r#""status":"succeeded""#),
+            "{}",
+            response.body
+        );
+        assert!(
+            response.body.contains(r#""sessionId":"session-"#),
+            "{}",
+            response.body
+        );
+
+        let runs_body = json!({
+            "action": "coven.automations.runs",
+            "id": "daily-notes"
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&runs_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(response.body.contains(r#""runs":[{""#), "{}", response.body);
+        assert!(
+            response.body.contains(r#""status":"succeeded""#),
+            "{}",
+            response.body
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/automations/definition.rs
+++ b/crates/coven-cli/src/automations/definition.rs
@@ -1,0 +1,217 @@
+//! Coven-native routine definitions.
+//!
+//! A routine is a durable, Coven-owned automation definition: a recurring
+//! schedule plus a familiar-bound prompt that a runtime executes. Definitions
+//! are the source of truth for identity and lifecycle; execution state lives
+//! in the occurrence ledger, not here (coven#816).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::rrule::{parse_rrule, ParsedRrule};
+
+pub const AUTOMATION_SCHEMA_VERSION: u32 = 1;
+
+/// An automation identifier. Keep it stable across edits: the ledger and the
+/// scheduler key occurrences by this id.
+pub const AUTOMATION_ID_MAX_CHARS: usize = 96;
+
+/// Accepted `status` values. New definitions default to PAUSED so nothing
+/// runs until a human opts in (coven#816 acceptance: "default PAUSED").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum RoutineStatus {
+    Active,
+    Paused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RoutineTimezone {
+    Local,
+    Utc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RoutineMisfire {
+    /// On recovery, only the latest missed occurrence runs.
+    Latest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RoutineOverlap {
+    /// A run is skipped when the previous occurrence has not settled.
+    Forbid,
+}
+
+/// A validated routine definition. Serialized to `definition_json` in the
+/// store with camelCase keys, mirroring the control-plane wire style.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutineDefinition {
+    pub schema_version: u32,
+    pub id: String,
+    pub name: String,
+    pub status: RoutineStatus,
+    /// RRULE text, e.g. `FREQ=DAILY;BYHOUR=9,17`.
+    pub rrule: String,
+    pub timezone: RoutineTimezone,
+    pub misfire: RoutineMisfire,
+    pub overlap: RoutineOverlap,
+    /// Per-run wall-clock timeout in minutes. Bounded and required.
+    pub timeout_minutes: u32,
+    /// Runtime identifier (harness), default `coven-code`.
+    pub runtime: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub familiar_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Optional atomic output target path (delivery lands there only on a
+    /// completed, verified run).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_target: Option<String>,
+    pub prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<String>,
+}
+
+impl RoutineDefinition {
+    /// Validates a parsed definition and returns a structured error message
+    /// for the control plane. Parsing and validation are one reviewable
+    /// surface so every path (create, update, import) applies the same rules.
+    pub fn from_json(value: &Value) -> Result<Self, String> {
+        let parsed: Self = serde_json::from_value(value.clone())
+            .map_err(|error| format!("routine definition failed validation: {error}"))?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != AUTOMATION_SCHEMA_VERSION {
+            return Err(format!(
+                "schemaVersion must be {AUTOMATION_SCHEMA_VERSION}, got {}",
+                self.schema_version
+            ));
+        }
+        if self.id.is_empty() || self.id.len() > AUTOMATION_ID_MAX_CHARS {
+            return Err(format!(
+                "id must be 1..={AUTOMATION_ID_MAX_CHARS} characters, got {}",
+                self.id.len()
+            ));
+        }
+        if !self
+            .id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        {
+            return Err("id may contain only ASCII letters, digits, '-', '_', and '.'".to_string());
+        }
+        let trimmed_name = self.name.trim();
+        if trimmed_name.is_empty() || trimmed_name.len() > 160 {
+            return Err("name must be 1..=160 characters".to_string());
+        }
+        if self.rrule.trim().is_empty() {
+            return Err("rrule is required".to_string());
+        }
+        let _: ParsedRrule = parse_rrule(&self.rrule)
+            .map_err(|error| format!("rrule failed validation: {error}"))?;
+        if self.timeout_minutes == 0 || self.timeout_minutes > 60 * 24 * 31 {
+            return Err("timeoutMinutes must be 1..=44640".to_string());
+        }
+        if self.runtime.trim().is_empty() || self.runtime.len() > 64 {
+            return Err("runtime must be 1..=64 characters".to_string());
+        }
+        if self.prompt.trim().is_empty() {
+            return Err("prompt is required".to_string());
+        }
+        if let Some(familiar_id) = &self.familiar_id {
+            let trimmed = familiar_id.trim();
+            if trimmed.is_empty() || trimmed.len() > 64 {
+                return Err("familiarId must be 1..=64 characters".to_string());
+            }
+        }
+        Ok(())
+    }
+
+    /// Normalized wire form (camelCase, schema stamped) used by list/get.
+    pub fn to_json(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn valid_definition() -> Value {
+        json!({
+            "schemaVersion": 1,
+            "id": "daily-notes",
+            "name": "Daily notes",
+            "status": "PAUSED",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "local",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "familiarId": "charm",
+            "prompt": "Write the daily reflection."
+        })
+    }
+
+    #[test]
+    fn parses_and_validates_a_complete_definition() {
+        let definition = RoutineDefinition::from_json(&valid_definition()).unwrap();
+        assert_eq!(definition.id, "daily-notes");
+        assert_eq!(definition.status, RoutineStatus::Paused);
+        assert_eq!(definition.timezone, RoutineTimezone::Local);
+        assert_eq!(definition.timeout_minutes, 30);
+    }
+
+    #[test]
+    fn rejects_a_missing_prompt() {
+        let mut value = valid_definition();
+        value.as_object_mut().unwrap().remove("prompt");
+        let error = RoutineDefinition::from_json(&value).unwrap_err();
+        assert!(error.contains("failed validation"), "{error}");
+    }
+
+    #[test]
+    fn rejects_a_bad_identifier() {
+        let mut value = valid_definition();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("id".to_string(), json!("daily notes!"));
+        let error = RoutineDefinition::from_json(&value).unwrap_err();
+        assert!(error.contains("id may contain only"), "{error}");
+    }
+
+    #[test]
+    fn rejects_an_unsupported_rrule() {
+        let mut value = valid_definition();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("rrule".to_string(), json!("FREQ=HOURLY"));
+        let error = RoutineDefinition::from_json(&value).unwrap_err();
+        assert!(error.contains("rrule"), "{error}");
+    }
+
+    #[test]
+    fn rejects_zero_timeout() {
+        let mut value = valid_definition();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("timeoutMinutes".to_string(), json!(0));
+        let error = RoutineDefinition::from_json(&value).unwrap_err();
+        assert!(error.contains("timeoutMinutes"), "{error}");
+    }
+}

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -7,7 +7,9 @@
 //! seams.
 
 pub mod definition;
+pub mod occurrences;
 pub mod rrule;
+pub mod schedule;
 pub mod store;
 
 pub use definition::RoutineDefinition;

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -9,6 +9,7 @@
 pub mod definition;
 pub mod occurrences;
 pub mod rrule;
+pub mod runner;
 pub mod runs;
 pub mod schedule;
 pub mod store;

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -1,0 +1,13 @@
+//! Coven-native routine automations (coven#816).
+//!
+//! Routines replace harness-owned schedules with durable Coven definitions.
+//! This module owns definition parsing/validation, the RRULE vocabulary the
+//! scheduler understands, and definition persistence. Occurrence planning,
+//! claim/lease, and run delivery land in follow-up modules on the same
+//! seams.
+
+pub mod definition;
+pub mod rrule;
+pub mod store;
+
+pub use definition::RoutineDefinition;

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -9,6 +9,7 @@
 pub mod definition;
 pub mod occurrences;
 pub mod rrule;
+pub mod runs;
 pub mod schedule;
 pub mod store;
 

--- a/crates/coven-cli/src/automations/occurrences.rs
+++ b/crates/coven-cli/src/automations/occurrences.rs
@@ -25,6 +25,7 @@ pub const AUTOMATION_OCCURRENCES_SCHEMA_SQL: &str = "
         lease_owner TEXT,
         lease_expires_at TEXT,
         attempt INTEGER NOT NULL DEFAULT 0,
+        failure_reason TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         UNIQUE(automation_id, scheduled_for)
@@ -38,6 +39,7 @@ pub const AUTOMATION_OCCURRENCES_SCHEMA_SQL: &str = "
 ";
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // planning-only report; the production tick reports the superset TickReport
 pub struct PlanTickReport {
     pub planned: Vec<String>,
     pub already_fenced: usize,
@@ -51,6 +53,167 @@ pub struct PlannedOccurrence {
     pub automation_id: String,
     pub scheduled_for: String,
     pub state: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TickReport {
+    pub planned: Vec<String>,
+    pub already_fenced: usize,
+    pub paused_skipped: usize,
+    pub recovered: usize,
+    pub claimed: Vec<String>,
+    pub failed: Vec<String>,
+}
+
+const OCCURRENCE_TERMINAL_STATES: [&str; 2] = ["succeeded", "failed"];
+
+/// Claims the earliest due PLANNED occurrence for a routine with a bounded
+/// lease. Returns the claimed occurrence id, or `None` when nothing is due.
+/// The compare-and-set WHERE clause makes claims race-safe across callers.
+///
+/// The runner (coven#816 part 4) is the production caller; until then tests
+/// and the daemon tick exercise the path directly.
+#[allow(dead_code)]
+pub fn claim_due_occurrence(
+    conn: &Connection,
+    automation_id: &str,
+    owner: &str,
+    lease_minutes: i64,
+    now: DateTime<Utc>,
+) -> Result<Option<String>, String> {
+    if lease_minutes <= 0 || lease_minutes > 24 * 60 {
+        return Err("lease minutes must be 1..=1440".to_string());
+    }
+    let expires = now + chrono::Duration::minutes(lease_minutes);
+    let now_iso = iso(now);
+    let expires_iso = iso(expires);
+    let changed = conn
+        .execute(
+            "UPDATE automation_occurrences
+             SET state = 'claimed',
+                 lease_owner = ?3,
+                 lease_expires_at = ?4,
+                 attempt = attempt + 1,
+                 updated_at = ?2
+             WHERE automation_id = ?1
+               AND state = 'planned'
+               AND scheduled_for <= ?2
+               AND id = (
+                   SELECT id FROM automation_occurrences
+                   WHERE automation_id = ?1
+                     AND state = 'planned'
+                     AND scheduled_for <= ?2
+                   ORDER BY scheduled_for ASC
+                   LIMIT 1
+               )",
+            params![automation_id, now_iso, owner, expires_iso],
+        )
+        .map_err(|error| format!("failed to claim occurrence: {error}"))?;
+    if changed == 0 {
+        return Ok(None);
+    }
+    let id: String = conn
+        .query_row(
+            "SELECT id FROM automation_occurrences WHERE automation_id = ?1 AND state = 'claimed' AND lease_owner = ?2 ORDER BY scheduled_for ASC LIMIT 1",
+            params![automation_id, owner],
+            |row| row.get(0),
+        )
+        .map_err(|error| format!("failed to read claim: {error}"))?;
+    Ok(Some(id))
+}
+
+/// Marks occurrences whose lease has expired as failed with a stale reason.
+/// A stale lease must never render as live work (coven#816).
+pub fn recover_expired_leases(conn: &Connection, now: DateTime<Utc>) -> Result<usize, String> {
+    let now_iso = iso(now);
+    let changed = conn
+        .execute(
+            "UPDATE automation_occurrences
+             SET state = 'failed',
+                 failure_reason = 'lease expired',
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 updated_at = ?1
+             WHERE state IN ('claimed', 'running')
+               AND lease_expires_at IS NOT NULL
+               AND lease_expires_at < ?1",
+            params![now_iso],
+        )
+        .map_err(|error| format!("failed to recover expired leases: {error}"))?;
+    Ok(changed)
+}
+
+/// Finalizes an occurrence into a terminal state. Releasing a PLANNED
+/// occurrence is refused — only claimed work can settle.
+#[allow(dead_code)]
+pub fn settle_occurrence(
+    conn: &Connection,
+    occurrence_id: &str,
+    terminal_state: &str,
+    failure_reason: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<bool, String> {
+    if !OCCURRENCE_TERMINAL_STATES.contains(&terminal_state) {
+        return Err(format!(
+            "terminal state must be one of {OCCURRENCE_TERMINAL_STATES:?}"
+        ));
+    }
+    let now_iso = iso(now);
+    let changed = conn
+        .execute(
+            "UPDATE automation_occurrences
+             SET state = ?2,
+                 failure_reason = ?3,
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 updated_at = ?4
+             WHERE id = ?1 AND state IN ('claimed', 'running')",
+            params![occurrence_id, terminal_state, failure_reason, now_iso],
+        )
+        .map_err(|error| format!("failed to settle occurrence: {error}"))?;
+    Ok(changed > 0)
+}
+
+/// One full tick: plan due slots, recover expired leases, then claim the
+/// earliest due occurrence of every ACTIVE routine that has one.
+pub fn tick(conn: &Connection, now: DateTime<Utc>) -> Result<TickReport> {
+    let mut report = TickReport::default();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    let definitions = active_definitions(conn)?;
+    for definition in &definitions {
+        if !seen.insert(definition.id.clone()) {
+            continue;
+        }
+        let created_at = definition_created_at(conn, &definition.id).unwrap_or(now);
+        match plan_latest_due_occurrence(conn, definition, created_at, now) {
+            Ok(PlanOutcome::Planned(occurrence)) => report.planned.push(occurrence.id),
+            Ok(PlanOutcome::AlreadyFenced) => report.already_fenced += 1,
+            Ok(PlanOutcome::NotDue) => {}
+            Err(error) => report.failed.push(format!("{}: {error}", definition.id)),
+        }
+    }
+
+    report.recovered = recover_expired_leases(conn, now).unwrap_or(0);
+
+    for definition in &definitions {
+        match claim_due_occurrence(conn, &definition.id, "daemon", 60, now) {
+            Ok(Some(id)) => report.claimed.push(id),
+            Ok(None) => {}
+            Err(error) => report.failed.push(format!("{}: {error}", definition.id)),
+        }
+    }
+
+    let paused: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM automation_definitions WHERE status = 'PAUSED'",
+            [],
+            |row| row.get(0),
+        )
+        .context("failed to count paused routines")?;
+    report.paused_skipped = paused as usize;
+
+    Ok(report)
 }
 
 fn iso(instant: DateTime<Utc>) -> String {
@@ -177,7 +340,10 @@ pub fn plan_latest_due_occurrence(
 }
 
 /// One planning tick across every stored routine. Idempotent: a repeated
-/// tick fences nothing twice.
+/// tick fences nothing twice. Production ticks go through `tick`, which
+/// adds lease recovery and claiming; this stays public for planning-only
+/// callers and tests.
+#[allow(dead_code)]
 pub fn tick_planning(conn: &Connection, now: DateTime<Utc>) -> Result<PlanTickReport> {
     let mut report = PlanTickReport::default();
     let mut seen: BTreeSet<String> = BTreeSet::new();
@@ -331,6 +497,86 @@ mod tests {
             "future slots must not be fenced: {report:?}"
         );
         assert_eq!(report.already_fenced, 0);
+    }
+
+    #[test]
+    fn claims_the_earliest_due_occurrence_with_a_lease() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
+        let old_created = (real_now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+        tick_planning(&conn, real_now()).unwrap();
+
+        let claimed = claim_due_occurrence(&conn, "daily", "daemon-a", 60, real_now()).unwrap();
+        assert!(claimed.is_some());
+
+        // A second claimant finds nothing left to claim.
+        let second = claim_due_occurrence(&conn, "daily", "daemon-b", 60, real_now()).unwrap();
+        assert!(second.is_none());
+    }
+
+    #[test]
+    fn recovers_expired_leases_to_failed() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
+        let old_created = (real_now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+        tick_planning(&conn, real_now()).unwrap();
+        claim_due_occurrence(&conn, "daily", "daemon-a", 60, real_now()).unwrap();
+
+        // Expire the lease by hand, then tick: recovery marks it failed.
+        conn.execute(
+            "UPDATE automation_occurrences SET lease_expires_at = '2020-01-01T00:00:00.000Z'",
+            [],
+        )
+        .unwrap();
+        let report = tick(&conn, real_now()).unwrap();
+        assert_eq!(report.recovered, 1);
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "failed");
+    }
+
+    #[test]
+    fn settles_claimed_work_but_never_planned() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
+        let old_created = (real_now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+        tick_planning(&conn, real_now()).unwrap();
+
+        let planned: String = conn
+            .query_row(
+                "SELECT id FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!settle_occurrence(&conn, &planned, "succeeded", None, real_now()).unwrap());
+
+        claim_due_occurrence(&conn, "daily", "daemon-a", 60, real_now()).unwrap();
+        assert!(settle_occurrence(&conn, &planned, "succeeded", None, real_now()).unwrap());
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/occurrences.rs
+++ b/crates/coven-cli/src/automations/occurrences.rs
@@ -1,0 +1,349 @@
+//! Occurrence planning with misfire-latest semantics (coven#816).
+//!
+//! The planner walks each ACTIVE routine's schedule forward from a bounded
+//! lookback and plans exactly the latest due slot: if the daemon was down
+//! for three days of a daily routine, only the most recent missed slot is
+//! fenced — earlier slots are collapsed, never backfilled. The
+//! `UNIQUE(automation_id, scheduled_for)` fence makes planning idempotent
+//! across ticks, replicas, and restarts.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use super::definition::{RoutineDefinition, RoutineStatus};
+use crate::automations::schedule::next_due;
+
+pub const AUTOMATION_OCCURRENCES_SCHEMA_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS automation_occurrences (
+        id TEXT PRIMARY KEY NOT NULL,
+        automation_id TEXT NOT NULL,
+        scheduled_for TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'planned',
+        lease_owner TEXT,
+        lease_expires_at TEXT,
+        attempt INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(automation_id, scheduled_for)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_automation_occurrences_scheduled
+        ON automation_occurrences(automation_id, scheduled_for);
+
+    CREATE INDEX IF NOT EXISTS idx_automation_occurrences_state
+        ON automation_occurrences(state, lease_expires_at);
+";
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PlanTickReport {
+    pub planned: Vec<String>,
+    pub already_fenced: usize,
+    pub paused_skipped: usize,
+    pub failed: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedOccurrence {
+    pub id: String,
+    pub automation_id: String,
+    pub scheduled_for: String,
+    pub state: String,
+}
+
+fn iso(instant: DateTime<Utc>) -> String {
+    instant.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Reads the ACTIVE definitions from the store as validated records.
+fn active_definitions(conn: &Connection) -> Result<Vec<RoutineDefinition>> {
+    let records = super::store::list_definitions(conn)?;
+    let mut definitions = Vec::new();
+    for record in records {
+        if record.status != "ACTIVE" {
+            continue;
+        }
+        let definition: RoutineDefinition = serde_json::from_str(&record.definition_json)
+            .with_context(|| format!("stored routine `{}` is unreadable", record.id))?;
+        if definition.status != RoutineStatus::Active {
+            continue;
+        }
+        definitions.push(definition);
+    }
+    Ok(definitions)
+}
+
+fn definition_created_at(conn: &Connection, id: &str) -> Result<DateTime<Utc>> {
+    let created: String = conn
+        .query_row(
+            "SELECT created_at FROM automation_definitions WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .with_context(|| format!("routine `{id}` has no definition row"))?;
+    chrono::DateTime::parse_from_rfc3339(&created)
+        .map(|parsed| parsed.with_timezone(&Utc))
+        .context("routine created_at is not a valid RFC3339 timestamp")
+}
+
+/// Latest due slot for `definition` at or before `now`, walking forward from
+/// `cursor` (never further back than the routine's creation time). Returns
+/// `None` when the next slot is still in the future.
+fn latest_due_slot_after(
+    definition: &RoutineDefinition,
+    cursor: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, String> {
+    let mut walk = cursor;
+    let mut latest: Option<DateTime<Utc>> = None;
+
+    for _ in 0..96 {
+        let Some(next) = next_due(&definition.rrule, definition.timezone, walk)? else {
+            break;
+        };
+        if next > now {
+            break;
+        }
+        latest = Some(next);
+        walk = next;
+    }
+
+    Ok(latest)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanOutcome {
+    Planned(PlannedOccurrence),
+    NotDue,
+    AlreadyFenced,
+}
+
+/// Fences the latest due slot for one routine.
+///
+/// The walk starts at the later of the definition's creation time and its
+/// latest fenced occurrence: slots before the routine existed are never
+/// backfilled, and slots already fenced are never re-planned.
+pub fn plan_latest_due_occurrence(
+    conn: &Connection,
+    definition: &RoutineDefinition,
+    created_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<PlanOutcome, String> {
+    if definition.status != RoutineStatus::Active {
+        return Ok(PlanOutcome::NotDue);
+    }
+    let latest_fenced: Option<String> = conn
+        .query_row(
+            "SELECT MAX(scheduled_for) FROM automation_occurrences WHERE automation_id = ?1",
+            params![definition.id],
+            |row| row.get(0),
+        )
+        .map_err(|error| format!("failed to read occurrence fence: {error}"))?;
+    let cursor = match latest_fenced {
+        Some(iso_text) => match chrono::DateTime::parse_from_rfc3339(&iso_text) {
+            Ok(parsed) => parsed.with_timezone(&Utc).max(created_at),
+            Err(_) => created_at,
+        },
+        None => created_at,
+    };
+    let Some(slot) = latest_due_slot_after(definition, cursor, now)? else {
+        return Ok(PlanOutcome::NotDue);
+    };
+
+    let slot_iso = iso(slot);
+    let now_iso = iso(now);
+    let id = format!("{}-{}", definition.id, slot.timestamp_millis());
+    let changed = conn
+        .execute(
+            "INSERT OR IGNORE INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'planned', 0, ?4, ?4)",
+            params![id, definition.id, slot_iso, now_iso],
+        )
+        .map_err(|error| format!("failed to fence occurrence: {error}"))?;
+
+    if changed == 0 {
+        return Ok(PlanOutcome::AlreadyFenced);
+    }
+
+    Ok(PlanOutcome::Planned(PlannedOccurrence {
+        id,
+        automation_id: definition.id.clone(),
+        scheduled_for: slot_iso,
+        state: "planned".to_string(),
+    }))
+}
+
+/// One planning tick across every stored routine. Idempotent: a repeated
+/// tick fences nothing twice.
+pub fn tick_planning(conn: &Connection, now: DateTime<Utc>) -> Result<PlanTickReport> {
+    let mut report = PlanTickReport::default();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    let definitions = active_definitions(conn)?;
+    for definition in definitions {
+        if !seen.insert(definition.id.clone()) {
+            continue;
+        }
+        let created_at = definition_created_at(conn, &definition.id).unwrap_or(now);
+        match plan_latest_due_occurrence(conn, &definition, created_at, now) {
+            Ok(PlanOutcome::Planned(occurrence)) => report.planned.push(occurrence.id),
+            Ok(PlanOutcome::AlreadyFenced) => report.already_fenced += 1,
+            Ok(PlanOutcome::NotDue) => {}
+            Err(error) => report.failed.push(format!("{}: {error}", definition.id)),
+        }
+    }
+
+    // Count paused routines for observability.
+    let paused: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM automation_definitions WHERE status = 'PAUSED'",
+            [],
+            |row| row.get(0),
+        )
+        .context("failed to count paused routines")?;
+    report.paused_skipped = paused as usize;
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automations::definition::RoutineDefinition;
+    use crate::automations::store::insert_definition;
+    use crate::store::initialize_store;
+    use chrono::Timelike;
+    use serde_json::json;
+
+    fn temp_store() -> (tempfile::TempDir, Connection) {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_store(&path).unwrap();
+        (temp, conn)
+    }
+
+    fn definition(id: &str, status: &str, rrule: &str) -> RoutineDefinition {
+        RoutineDefinition::from_json(&json!({
+            "schemaVersion": 1,
+            "id": id,
+            "name": id,
+            "status": status,
+            "rrule": rrule,
+            "timezone": "utc",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "prompt": "Do the thing."
+        }))
+        .unwrap()
+    }
+
+    /// The definition row is stamped with the real current time by
+    /// insert_definition, so every test ticks at the real now (or later) to
+    /// stay past the routine's creation.
+    fn real_now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    #[test]
+    fn plans_the_latest_missed_daily_slot() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
+        // Backdate creation one day so at least one 09:00 slot is missed at
+        // any tick hour (today's 09:00 when now is past it, yesterday's
+        // otherwise).
+        let old_created = (real_now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+
+        let report = tick_planning(&conn, real_now()).unwrap();
+        assert_eq!(report.planned.len(), 1);
+        assert_eq!(report.already_fenced, 0);
+
+        // A second tick has the same slot fenced and the next slot still in
+        // the future: nothing new is planned and nothing is double-counted.
+        let second = tick_planning(&conn, real_now()).unwrap();
+        assert!(second.planned.is_empty());
+        assert_eq!(second.already_fenced, 0);
+    }
+
+    #[test]
+    fn collapses_three_missed_days_to_the_latest() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
+        // Simulate a routine created four days ago.
+        let old_created = (real_now() - chrono::Duration::days(4))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+
+        let report = tick_planning(&conn, real_now()).unwrap();
+        assert_eq!(
+            report.planned.len(),
+            1,
+            "misfire latest plans exactly one slot"
+        );
+
+        let scheduled: String = conn
+            .query_row(
+                "SELECT scheduled_for FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(scheduled.ends_with("T09:00:00.000Z"), "{scheduled}");
+        // The fenced slot is within the last day-and-a-half, not a four-day
+        // backfill of every missed morning.
+        let scheduled_at = chrono::DateTime::parse_from_rfc3339(&scheduled)
+            .unwrap()
+            .with_timezone(&Utc);
+        assert!(
+            scheduled_at > real_now() - chrono::Duration::hours(36),
+            "{scheduled}"
+        );
+    }
+
+    #[test]
+    fn future_slots_are_not_fenced() {
+        let (_temp, conn) = temp_store();
+        let now = real_now();
+        // A slot strictly later today (wrapping into tomorrow when late in
+        // the evening) is in the future for this routine.
+        let future_hour = (now.hour() + 2) % 24;
+        let rrule = format!("FREQ=DAILY;BYHOUR={future_hour}");
+        insert_definition(&conn, &definition("future", "ACTIVE", &rrule)).unwrap();
+
+        let report = tick_planning(&conn, now).unwrap();
+        assert!(
+            report.planned.is_empty(),
+            "future slots must not be fenced: {report:?}"
+        );
+        assert_eq!(report.already_fenced, 0);
+    }
+
+    #[test]
+    fn paused_routines_never_plan() {
+        let (_temp, conn) = temp_store();
+        insert_definition(
+            &conn,
+            &definition("paused", "PAUSED", "FREQ=DAILY;BYHOUR=9"),
+        )
+        .unwrap();
+
+        let report = tick_planning(&conn, real_now()).unwrap();
+        assert!(report.planned.is_empty());
+        assert_eq!(report.paused_skipped, 1);
+    }
+}

--- a/crates/coven-cli/src/automations/rrule.rs
+++ b/crates/coven-cli/src/automations/rrule.rs
@@ -1,0 +1,180 @@
+//! Scoped RRULE parsing for routine schedules (coven#816).
+//!
+//! Only the recurrence vocabulary the acceptance criteria need is supported:
+//! `FREQ=DAILY` and `FREQ=WEEKLY`, an optional `BYHOUR` list, and an optional
+//! `BYDAY` list for weekly schedules. Anything else is refused, so a
+//! definition can never silently schedule work the scheduler does not
+//! understand.
+
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RruleFrequency {
+    Daily,
+    Weekly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedRrule {
+    pub frequency: RruleFrequency,
+    pub by_hour: Vec<u8>,
+    pub by_day: Vec<String>,
+}
+
+fn parse_u8_list(raw: &str, label: &str, bound: u8) -> Result<Vec<u8>, String> {
+    let mut values = Vec::new();
+    for part in raw.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(format!("{label} contains an empty entry"));
+        }
+        let parsed: u8 = part
+            .parse()
+            .map_err(|_| format!("{label} entry `{part}` is not an integer"))?;
+        if parsed > bound {
+            return Err(format!("{label} entry {parsed} exceeds {bound}"));
+        }
+        if values.contains(&parsed) {
+            return Err(format!("{label} repeats entry {parsed}"));
+        }
+        values.push(parsed);
+    }
+    values.sort_unstable();
+    Ok(values)
+}
+
+fn parse_by_day(raw: &str) -> Result<Vec<String>, String> {
+    const ALLOWED: [&str; 14] = [
+        "MO", "TU", "WE", "TH", "FR", "SA", "SU", "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN",
+    ];
+    let mut days = BTreeSet::new();
+    for part in raw.split(',') {
+        let part = part.trim().to_ascii_uppercase();
+        if !ALLOWED.contains(&part.as_str()) {
+            return Err(format!("BYDAY entry `{part}` is not a weekday"));
+        }
+        // Canonicalize the two-letter form.
+        days.insert(part[..2].to_string());
+    }
+    Ok(days.into_iter().collect())
+}
+
+pub fn parse_rrule(text: &str) -> Result<ParsedRrule, String> {
+    let mut frequency: Option<RruleFrequency> = None;
+    let mut by_hour: Option<Vec<u8>> = None;
+    let mut by_day: Option<Vec<String>> = None;
+
+    for part in text.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = part.split_once('=') else {
+            return Err(format!("rrule part `{part}` is not KEY=VALUE"));
+        };
+        let key = key.trim().to_ascii_uppercase();
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(format!("rrule {key} has an empty value"));
+        }
+        match key.as_str() {
+            "FREQ" => {
+                frequency = Some(match value.to_ascii_uppercase().as_str() {
+                    "DAILY" => RruleFrequency::Daily,
+                    "WEEKLY" => RruleFrequency::Weekly,
+                    other => {
+                        return Err(format!("FREQ `{other}` is not supported (DAILY or WEEKLY)"));
+                    }
+                });
+            }
+            "BYHOUR" => {
+                by_hour = Some(parse_u8_list(value, "BYHOUR", 23)?);
+            }
+            "BYDAY" => {
+                by_day = Some(parse_by_day(value)?);
+            }
+            other => {
+                return Err(format!("rrule key `{other}` is not supported"));
+            }
+        }
+    }
+
+    let frequency = frequency.ok_or_else(|| "rrule requires FREQ".to_string())?;
+    let by_hour = by_hour.unwrap_or_else(|| vec![9]);
+    if by_hour.is_empty() {
+        return Err("BYHOUR must contain at least one hour".to_string());
+    }
+    let by_day = match frequency {
+        RruleFrequency::Daily => Vec::new(),
+        RruleFrequency::Weekly => {
+            let days = by_day.unwrap_or_else(|| vec!["MO".to_string()]);
+            if days.is_empty() {
+                return Err("BYDAY must contain at least one weekday".to_string());
+            }
+            days
+        }
+    };
+
+    Ok(ParsedRrule {
+        frequency,
+        by_hour,
+        by_day,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_daily_with_hours() {
+        let parsed = parse_rrule("FREQ=DAILY;BYHOUR=9,17").unwrap();
+        assert_eq!(parsed.frequency, RruleFrequency::Daily);
+        assert_eq!(parsed.by_hour, vec![9, 17]);
+        assert!(parsed.by_day.is_empty());
+    }
+
+    #[test]
+    fn defaults_byhour_to_nine() {
+        let parsed = parse_rrule("FREQ=DAILY").unwrap();
+        assert_eq!(parsed.by_hour, vec![9]);
+    }
+
+    #[test]
+    fn parses_weekly_with_days() {
+        let parsed = parse_rrule("FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=8").unwrap();
+        assert_eq!(parsed.frequency, RruleFrequency::Weekly);
+        assert_eq!(parsed.by_day, vec!["FR", "MO", "WE"]);
+        assert_eq!(parsed.by_hour, vec![8]);
+    }
+
+    #[test]
+    fn rejects_unsupported_frequency() {
+        let error = parse_rrule("FREQ=HOURLY").unwrap_err();
+        assert!(error.contains("not supported"), "{error}");
+    }
+
+    #[test]
+    fn rejects_unsupported_key() {
+        let error = parse_rrule("FREQ=DAILY;COUNT=3").unwrap_err();
+        assert!(error.contains("COUNT"), "{error}");
+    }
+
+    #[test]
+    fn rejects_out_of_range_hour() {
+        let error = parse_rrule("FREQ=DAILY;BYHOUR=24").unwrap_err();
+        assert!(error.contains("exceeds 23"), "{error}");
+    }
+
+    #[test]
+    fn rejects_unknown_weekday() {
+        let error = parse_rrule("FREQ=WEEKLY;BYDAY=XX").unwrap_err();
+        assert!(error.contains("not a weekday"), "{error}");
+    }
+
+    #[test]
+    fn rejects_missing_frequency() {
+        let error = parse_rrule("BYHOUR=9").unwrap_err();
+        assert!(error.contains("requires FREQ"), "{error}");
+    }
+}

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -1,0 +1,292 @@
+//! Routine run dispatch (coven#816).
+//!
+//! A run is a claimed occurrence dispatched through the exact session-launch
+//! path every other launch uses: the definition is re-read, the familiar and
+//! runtime are re-validated per run, a SessionLaunch is built, and the
+//! occurrence plus the run ledger settle together. Coven (not a harness home)
+//! owns the record.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+
+use super::definition::RoutineDefinition;
+use super::occurrences::{settle_occurrence, PlanOutcome};
+use super::runs::{record_run_finish, record_run_start, RunFinish};
+use crate::api::{SessionLaunch, SessionRuntime};
+use crate::harness::HarnessLaunchMode;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunOutcome {
+    pub run_id: String,
+    pub status: String,
+    pub session_id: Option<String>,
+    pub error: Option<String>,
+}
+
+fn fresh_id(prefix: &str) -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+    format!("{prefix}-{millis}")
+}
+
+/// Runs a routine once, now: fences and claims an immediate occurrence,
+/// records a ledger row, dispatches through the shared session-launch path,
+/// and settles occurrence + ledger together. A missing cwd fails the run
+/// with a recorded reason instead of guessing a project.
+pub fn run_routine_now(
+    conn: &Connection,
+    runtime: &dyn SessionRuntime,
+    definition: &RoutineDefinition,
+    now: DateTime<Utc>,
+) -> Result<RunOutcome, String> {
+    let Some(cwd) = definition
+        .cwd
+        .as_deref()
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return Ok(RunOutcome {
+            run_id: String::new(),
+            status: "failed".to_string(),
+            session_id: None,
+            error: Some("routine has no cwd; add a cwd before running".to_string()),
+        });
+    };
+
+    let occurrence_id = fresh_id("occ");
+    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let inserted = conn
+        .execute(
+            "INSERT OR IGNORE INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'planned', 0, ?3, ?3)",
+            rusqlite::params![occurrence_id, definition.id, now_iso],
+        )
+        .map_err(|error| format!("failed to fence immediate occurrence: {error}"))?;
+    if inserted == 0 {
+        return Err("immediate occurrence fence collided; retry".to_string());
+    }
+    let _ = PlanOutcome::Planned; // keep the import meaningful if API changes
+
+    let claimed =
+        super::occurrences::claim_due_occurrence(conn, &definition.id, "manual", 60, now)?;
+    let occurrence_id = claimed.unwrap_or(occurrence_id);
+
+    let run_id = fresh_id("run");
+    record_run_start(
+        conn,
+        &run_id,
+        &definition.id,
+        Some(&occurrence_id),
+        definition.familiar_id.as_deref(),
+        &definition.runtime,
+        now,
+    )
+    .map_err(|error| format!("failed to record run start: {error:#}"))?;
+
+    let launch = SessionLaunch {
+        id: fresh_id("session"),
+        project_root: cwd.to_string(),
+        cwd: cwd.to_string(),
+        harness: definition.runtime.clone(),
+        model: definition.model.clone(),
+        launch_mode: HarnessLaunchMode::NonInteractive,
+        launch_policy: None,
+        prompt: definition.prompt.clone(),
+        title: definition.name.clone(),
+        conversation: None,
+        conversation_id: None,
+        familiar_id: definition.familiar_id.clone(),
+        caller_familiar_id: None,
+    };
+
+    match runtime.launch_session(&launch) {
+        Ok(()) => {
+            let _ = settle_occurrence(conn, &occurrence_id, "succeeded", None, now);
+            let _ = record_run_finish(
+                conn,
+                &run_id,
+                RunFinish {
+                    status: "succeeded",
+                    exit_code: Some(0),
+                    session_id: Some(launch.id.clone()),
+                    log_json: None,
+                    output_commit: None,
+                },
+                now,
+            );
+            Ok(RunOutcome {
+                run_id,
+                status: "succeeded".to_string(),
+                session_id: Some(launch.id),
+                error: None,
+            })
+        }
+        Err(error) => {
+            let reason = format!("{error:#}");
+            let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
+            let _ = record_run_finish(
+                conn,
+                &run_id,
+                RunFinish {
+                    status: "failed",
+                    exit_code: None,
+                    session_id: None,
+                    log_json: None,
+                    output_commit: None,
+                },
+                now,
+            );
+            Ok(RunOutcome {
+                run_id,
+                status: "failed".to_string(),
+                session_id: None,
+                error: Some(reason),
+            })
+        }
+    }
+}
+
+/// Reads and validates a stored definition for dispatch.
+pub fn load_definition_for_run(
+    conn: &Connection,
+    id: &str,
+) -> Result<Option<RoutineDefinition>, String> {
+    let Some(record) =
+        super::store::get_definition(conn, id).map_err(|error| format!("{error:#}"))?
+    else {
+        return Ok(None);
+    };
+    let definition: RoutineDefinition = serde_json::from_str(&record.definition_json)
+        .map_err(|error| format!("stored routine `{id}` is unreadable: {error}"))?;
+    Ok(Some(definition))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automations::definition::RoutineDefinition;
+    use crate::automations::store::insert_definition;
+    use crate::store::initialize_store;
+    use serde_json::json;
+
+    struct RejectingRuntime;
+
+    impl SessionRuntime for RejectingRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            anyhow::bail!("synthetic launch failure")
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn definition(id: &str) -> RoutineDefinition {
+        RoutineDefinition::from_json(&json!({
+            "schemaVersion": 1,
+            "id": id,
+            "name": id,
+            "status": "PAUSED",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "cwd": "/work/project",
+            "familiarId": "charm",
+            "prompt": "Do the thing."
+        }))
+        .unwrap()
+    }
+
+    fn temp_store() -> (tempfile::TempDir, Connection) {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_store(&path).unwrap();
+        (temp, conn)
+    }
+
+    #[test]
+    fn successful_run_settles_occurrence_and_ledger() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "succeeded");
+        assert!(outcome.session_id.is_some());
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "succeeded");
+        assert_eq!(runs[0].familiar_id.as_deref(), Some("charm"));
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "succeeded");
+    }
+
+    #[test]
+    fn failed_launch_records_a_failed_run() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let outcome =
+            run_routine_now(&conn, &RejectingRuntime, &definition("daily"), Utc::now()).unwrap();
+        assert_eq!(outcome.status, "failed");
+        assert!(outcome.error.as_deref().unwrap().contains("synthetic"));
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs[0].status, "failed");
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "failed");
+    }
+
+    #[test]
+    fn missing_cwd_fails_without_launching() {
+        let (_temp, conn) = temp_store();
+        let mut definition = definition("nocwd");
+        definition.cwd = None;
+        insert_definition(&conn, &definition).unwrap();
+
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition,
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "failed");
+        assert!(outcome.error.as_deref().unwrap().contains("no cwd"));
+    }
+}

--- a/crates/coven-cli/src/automations/runs.rs
+++ b/crates/coven-cli/src/automations/runs.rs
@@ -1,0 +1,307 @@
+//! The run ledger for routine executions (coven#816).
+//!
+//! Every claimed occurrence that reaches a runtime records exactly one
+//! automation_runs row: session id, familiar, runtime, bounded log, exit
+//! code, terminal status, and output-commit state. The ledger is the single
+//! observability surface Cave's UI reads — never a per-harness history file.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, SecondsFormat, Utc};
+use rusqlite::{params, Connection};
+
+pub const AUTOMATION_RUNS_SCHEMA_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS automation_runs (
+        id TEXT PRIMARY KEY NOT NULL,
+        automation_id TEXT NOT NULL,
+        occurrence_id TEXT,
+        session_id TEXT,
+        familiar_id TEXT,
+        runtime TEXT,
+        status TEXT NOT NULL,
+        exit_code INTEGER,
+        log_json TEXT,
+        output_commit TEXT,
+        started_at TEXT NOT NULL,
+        finished_at TEXT,
+        FOREIGN KEY (occurrence_id) REFERENCES automation_occurrences(id) ON DELETE SET NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_automation_runs_automation_started
+        ON automation_runs(automation_id, started_at DESC);
+";
+
+#[allow(dead_code)]
+const LOG_ENTRY_MAX_CHARS: usize = 64 * 1024;
+
+#[allow(dead_code)]
+fn iso(instant: DateTime<Utc>) -> String {
+    instant.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunRecord {
+    pub id: String,
+    pub automation_id: String,
+    pub occurrence_id: Option<String>,
+    pub session_id: Option<String>,
+    pub familiar_id: Option<String>,
+    pub runtime: String,
+    pub status: String,
+    pub exit_code: Option<i64>,
+    pub log_json: Option<String>,
+    pub output_commit: Option<String>,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+}
+
+#[allow(dead_code)] // consumed by the part-4 dispatch path; tests cover it today
+pub fn record_run_start(
+    conn: &Connection,
+    run_id: &str,
+    automation_id: &str,
+    occurrence_id: Option<&str>,
+    familiar_id: Option<&str>,
+    runtime: &str,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO automation_runs
+            (id, automation_id, occurrence_id, familiar_id, runtime, status, started_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'running', ?6)",
+        params![
+            run_id,
+            automation_id,
+            occurrence_id,
+            familiar_id,
+            runtime,
+            iso(now)
+        ],
+    )
+    .context("failed to record run start")?;
+    Ok(())
+}
+
+#[allow(dead_code)] // consumed by the part-4 dispatch path; tests cover it today
+pub struct RunFinish {
+    pub status: &'static str,
+    pub exit_code: Option<i64>,
+    pub session_id: Option<String>,
+    pub log_json: Option<String>,
+    pub output_commit: Option<String>,
+}
+
+#[allow(dead_code)] // consumed by the part-4 dispatch path; tests cover it today
+pub fn record_run_finish(
+    conn: &Connection,
+    run_id: &str,
+    finish: RunFinish,
+    now: DateTime<Utc>,
+) -> Result<bool> {
+    let RunFinish {
+        status,
+        exit_code,
+        session_id,
+        log_json,
+        output_commit,
+    } = finish;
+    if status != "succeeded" && status != "failed" && status != "cancelled" {
+        return Err(anyhow::anyhow!(
+            "run status must be succeeded, failed, or cancelled"
+        ));
+    }
+    let bounded_log = log_json
+        .as_deref()
+        .map(|log| {
+            if log.chars().count() > LOG_ENTRY_MAX_CHARS {
+                let mut truncated: String = log.chars().take(LOG_ENTRY_MAX_CHARS).collect();
+                truncated.push_str("…(truncated)");
+                truncated
+            } else {
+                log.to_string()
+            }
+        })
+        .filter(|log| !log.is_empty());
+    let changed = conn
+        .execute(
+            "UPDATE automation_runs
+             SET status = ?2,
+                 exit_code = ?3,
+                 session_id = ?4,
+                 log_json = ?5,
+                 output_commit = ?6,
+                 finished_at = ?7
+             WHERE id = ?1 AND status = 'running'",
+            params![
+                run_id,
+                status,
+                exit_code,
+                session_id,
+                bounded_log,
+                output_commit,
+                iso(now)
+            ],
+        )
+        .context("failed to record run finish")?;
+    Ok(changed > 0)
+}
+
+pub fn list_runs(conn: &Connection, automation_id: &str, limit: i64) -> Result<Vec<RunRecord>> {
+    let bounded = limit.clamp(1, 100);
+    let mut statement = conn
+        .prepare(
+            "SELECT id, automation_id, occurrence_id, session_id, familiar_id, runtime,
+                    status, exit_code, log_json, output_commit, started_at, finished_at
+             FROM automation_runs
+             WHERE automation_id = ?1
+             ORDER BY started_at DESC
+             LIMIT ?2",
+        )
+        .context("failed to prepare run list query")?;
+    let rows = statement
+        .query_map(params![automation_id, bounded], |row| {
+            Ok(RunRecord {
+                id: row.get(0)?,
+                automation_id: row.get(1)?,
+                occurrence_id: row.get(2)?,
+                session_id: row.get(3)?,
+                familiar_id: row.get(4)?,
+                runtime: row.get(5)?,
+                status: row.get(6)?,
+                exit_code: row.get(7)?,
+                log_json: row.get(8)?,
+                output_commit: row.get(9)?,
+                started_at: row.get(10)?,
+                finished_at: row.get(11)?,
+            })
+        })
+        .context("failed to list runs")?;
+
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.context("failed to read run row")?);
+    }
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::initialize_store;
+    use chrono::TimeZone;
+
+    fn utc(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, h, min, 0).unwrap()
+    }
+
+    fn temp_store() -> (tempfile::TempDir, Connection) {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_store(&path).unwrap();
+        (temp, conn)
+    }
+
+    #[test]
+    fn run_lifecycle_round_trip() {
+        let (_temp, conn) = temp_store();
+        let start = utc(2026, 8, 28, 9, 0);
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+             VALUES ('occ-1', 'daily', '2026-08-28T09:00:00.000Z', 'claimed', 1,
+                     '2026-08-28T09:00:00.000Z', '2026-08-28T09:00:00.000Z')",
+            [],
+        )
+        .unwrap();
+        record_run_start(
+            &conn,
+            "run-1",
+            "daily",
+            Some("occ-1"),
+            Some("charm"),
+            "coven-code",
+            start,
+        )
+        .unwrap();
+
+        let finished = record_run_finish(
+            &conn,
+            "run-1",
+            RunFinish {
+                status: "succeeded",
+                exit_code: Some(0),
+                session_id: Some("session-1".to_string()),
+                log_json: Some("log line".to_string()),
+                output_commit: Some("committed".to_string()),
+            },
+            start + chrono::Duration::minutes(5),
+        )
+        .unwrap();
+        assert!(finished);
+
+        let runs = list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "succeeded");
+        assert_eq!(runs[0].session_id.as_deref(), Some("session-1"));
+        assert_eq!(runs[0].familiar_id.as_deref(), Some("charm"));
+    }
+
+    #[test]
+    fn finishing_a_non_running_run_is_a_no_op() {
+        let (_temp, conn) = temp_store();
+        let start = utc(2026, 8, 28, 9, 0);
+        record_run_start(&conn, "run-2", "daily", None, None, "coven-code", start).unwrap();
+        record_run_finish(
+            &conn,
+            "run-2",
+            RunFinish {
+                status: "succeeded",
+                exit_code: None,
+                session_id: None,
+                log_json: None,
+                output_commit: None,
+            },
+            start,
+        )
+        .unwrap();
+
+        let again = record_run_finish(
+            &conn,
+            "run-2",
+            RunFinish {
+                status: "failed",
+                exit_code: Some(1),
+                session_id: None,
+                log_json: None,
+                output_commit: None,
+            },
+            start + chrono::Duration::minutes(1),
+        )
+        .unwrap();
+        assert!(!again);
+
+        let runs = list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs[0].status, "succeeded");
+    }
+
+    #[test]
+    fn rejects_unknown_terminal_status() {
+        let (_temp, conn) = temp_store();
+        let start = utc(2026, 8, 28, 9, 0);
+        record_run_start(&conn, "run-3", "daily", None, None, "coven-code", start).unwrap();
+        let error = record_run_finish(
+            &conn,
+            "run-3",
+            RunFinish {
+                status: "meh",
+                exit_code: None,
+                session_id: None,
+                log_json: None,
+                output_commit: None,
+            },
+            start,
+        )
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("succeeded, failed, or cancelled"));
+    }
+}

--- a/crates/coven-cli/src/automations/schedule.rs
+++ b/crates/coven-cli/src/automations/schedule.rs
@@ -5,9 +5,7 @@
 //! The planner in `occurrences.rs` walks this function forward to find the
 //! latest due slot for misfire-latest semantics.
 
-use chrono::{
-    DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Utc, Weekday,
-};
+use chrono::{DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Utc, Weekday};
 
 use super::definition::RoutineTimezone;
 use super::rrule::{parse_rrule, ParsedRrule, RruleFrequency};

--- a/crates/coven-cli/src/automations/schedule.rs
+++ b/crates/coven-cli/src/automations/schedule.rs
@@ -1,0 +1,180 @@
+//! Schedule math for routine recurrence (coven#816).
+//!
+//! Given the scoped RRULE vocabulary from `rrule.rs` and a definition
+//! timezone, compute the next occurrence instant strictly after a cursor.
+//! The planner in `occurrences.rs` walks this function forward to find the
+//! latest due slot for misfire-latest semantics.
+
+use chrono::{
+    DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Utc, Weekday,
+};
+
+use super::definition::RoutineTimezone;
+use super::rrule::{parse_rrule, ParsedRrule, RruleFrequency};
+
+/// The earliest schedule instant strictly after `from`, or `None` when the
+/// recurrence vocabulary cannot produce one (unreachable for the supported
+/// DAILY/WEEKLY subset, kept for forward compatibility).
+pub fn next_due(
+    rrule_text: &str,
+    timezone: RoutineTimezone,
+    from: DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, String> {
+    let parsed = parse_rrule(rrule_text)?;
+    Ok(next_due_parsed(&parsed, timezone, from))
+}
+
+/// Interprets a naive local date+hour in the definition's timezone and
+/// returns the UTC instant, skipping wall-clock times that do not exist
+/// (DST spring-forward gaps).
+fn resolve_local(timezone: RoutineTimezone, date: NaiveDate, hour: u8) -> Option<DateTime<Utc>> {
+    let naive = date.and_hms_opt(hour as u32, 0, 0)?;
+    match timezone {
+        RoutineTimezone::Utc => Some(Utc.from_utc_datetime(&naive)),
+        RoutineTimezone::Local => match Local.from_local_datetime(&naive) {
+            LocalResult::Single(instant) => Some(instant.with_timezone(&Utc)),
+            // DST fall-back repeats the hour: take the earliest (first pass).
+            LocalResult::Ambiguous(earliest, _) => Some(earliest.with_timezone(&Utc)),
+            LocalResult::None => None,
+        },
+    }
+}
+
+fn weekday_index(weekday: Weekday) -> u32 {
+    weekday.num_days_from_monday()
+}
+
+fn next_due_parsed(
+    parsed: &ParsedRrule,
+    timezone: RoutineTimezone,
+    from: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    // Walk up to 9 days of candidate dates; the supported subset always
+    // yields a candidate inside this window (DAILY=1 day, WEEKLY<=7 days).
+    let window_start = match timezone {
+        RoutineTimezone::Utc => from.with_timezone(&Utc).date_naive(),
+        RoutineTimezone::Local => from.with_timezone(&Local).date_naive(),
+    };
+
+    let allowed_days: Vec<u32> = match parsed.frequency {
+        RruleFrequency::Daily => (0..7).collect(),
+        RruleFrequency::Weekly => {
+            let mut days: Vec<u32> = parsed
+                .by_day
+                .iter()
+                .filter_map(|day| match day.as_str() {
+                    "MO" => Some(0),
+                    "TU" => Some(1),
+                    "WE" => Some(2),
+                    "TH" => Some(3),
+                    "FR" => Some(4),
+                    "SA" => Some(5),
+                    "SU" => Some(6),
+                    _ => None,
+                })
+                .collect();
+            days.sort_unstable();
+            days
+        }
+    };
+
+    for offset in 0..10i64 {
+        let date = window_start + Duration::days(offset);
+        let is_allowed_day = match parsed.frequency {
+            RruleFrequency::Daily => true,
+            RruleFrequency::Weekly => allowed_days.contains(&weekday_index(date.weekday())),
+        };
+        if !is_allowed_day {
+            continue;
+        }
+
+        for hour in &parsed.by_hour {
+            if let Some(instant) = resolve_local(timezone, date, *hour) {
+                if instant > from {
+                    return Some(instant);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn utc(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, h, min, 0).unwrap()
+    }
+
+    #[test]
+    fn daily_nine_after_ten_is_next_morning() {
+        let next = next_due(
+            "FREQ=DAILY;BYHOUR=9",
+            RoutineTimezone::Utc,
+            utc(2026, 8, 28, 10, 0),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(next, utc(2026, 8, 29, 9, 0));
+    }
+
+    #[test]
+    fn daily_nine_before_nine_is_today() {
+        let next = next_due(
+            "FREQ=DAILY;BYHOUR=9",
+            RoutineTimezone::Utc,
+            utc(2026, 8, 28, 8, 0),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(next, utc(2026, 8, 28, 9, 0));
+    }
+
+    #[test]
+    fn twice_daily_picks_the_next_of_two_hours() {
+        let next = next_due(
+            "FREQ=DAILY;BYHOUR=9,17",
+            RoutineTimezone::Utc,
+            utc(2026, 8, 28, 12, 0),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(next, utc(2026, 8, 28, 17, 0));
+    }
+
+    #[test]
+    fn weekly_skips_to_the_next_allowed_day() {
+        // 2026-08-28 is a Friday. MO,WE,FR -> next is Monday 08-31.
+        let next = next_due(
+            "FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=8",
+            RoutineTimezone::Utc,
+            utc(2026, 8, 28, 9, 0),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(next, utc(2026, 8, 31, 8, 0));
+    }
+
+    #[test]
+    fn weekly_same_day_later_hour() {
+        let next = next_due(
+            "FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=8,17",
+            RoutineTimezone::Utc,
+            utc(2026, 8, 28, 9, 0),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(next, utc(2026, 8, 28, 17, 0));
+    }
+
+    #[test]
+    fn default_hour_is_nine() {
+        let next = next_due("FREQ=DAILY", RoutineTimezone::Utc, utc(2026, 8, 28, 10, 0))
+            .unwrap()
+            .unwrap();
+        assert_eq!(next, utc(2026, 8, 29, 9, 0));
+    }
+}

--- a/crates/coven-cli/src/automations/store.rs
+++ b/crates/coven-cli/src/automations/store.rs
@@ -1,0 +1,240 @@
+//! SQLite persistence for routine definitions (coven#816).
+//!
+//! Definitions live in the single Coven store as `definition_json` rows. The
+//! scheduler and run ledger join on `id`; the definition row is the identity
+//! anchor, so updates mutate in place while the id stays stable.
+
+use anyhow::{Context, Result};
+use chrono::{SecondsFormat, Utc};
+use rusqlite::{params, Connection};
+
+use super::definition::RoutineDefinition;
+
+pub const AUTOMATION_DEFINITIONS_SCHEMA_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS automation_definitions (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        status TEXT NOT NULL,
+        definition_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_automation_definitions_updated_at
+        ON automation_definitions(updated_at DESC);
+";
+
+#[allow(dead_code)]
+pub struct RoutineRecord {
+    pub id: String,
+    pub name: String,
+    pub status: String,
+    pub definition_json: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+fn now_iso() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+pub fn list_definitions(conn: &Connection) -> Result<Vec<RoutineRecord>> {
+    let mut statement = conn
+        .prepare(
+            "SELECT id, name, status, definition_json, created_at, updated_at
+             FROM automation_definitions
+             ORDER BY name ASC, id ASC",
+        )
+        .context("failed to prepare routine list query")?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(RoutineRecord {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                status: row.get(2)?,
+                definition_json: row.get(3)?,
+                created_at: row.get(4)?,
+                updated_at: row.get(5)?,
+            })
+        })
+        .context("failed to list routine definitions")?;
+
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.context("failed to read routine row")?);
+    }
+    Ok(records)
+}
+
+pub fn get_definition(conn: &Connection, id: &str) -> Result<Option<RoutineRecord>> {
+    let mut statement = conn
+        .prepare(
+            "SELECT id, name, status, definition_json, created_at, updated_at
+             FROM automation_definitions
+             WHERE id = ?1",
+        )
+        .context("failed to prepare routine get query")?;
+    let mut rows = statement
+        .query_map(params![id], |row| {
+            Ok(RoutineRecord {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                status: row.get(2)?,
+                definition_json: row.get(3)?,
+                created_at: row.get(4)?,
+                updated_at: row.get(5)?,
+            })
+        })
+        .context("failed to get routine definition")?;
+
+    match rows.next() {
+        Some(row) => Ok(Some(row.context("failed to read routine row")?)),
+        None => Ok(None),
+    }
+}
+
+pub fn insert_definition(
+    conn: &Connection,
+    definition: &RoutineDefinition,
+) -> Result<RoutineRecord> {
+    let now = now_iso();
+    let definition_json =
+        serde_json::to_string(definition).context("failed to serialize routine definition")?;
+    conn.execute(
+        "INSERT INTO automation_definitions
+            (id, name, status, definition_json, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
+        params![
+            definition.id,
+            definition.name,
+            status_text(definition.status),
+            definition_json,
+            now,
+        ],
+    )
+    .context("failed to insert routine definition")?;
+    Ok(RoutineRecord {
+        id: definition.id.clone(),
+        name: definition.name.clone(),
+        status: status_text(definition.status).to_string(),
+        definition_json,
+        created_at: now.clone(),
+        updated_at: now,
+    })
+}
+
+pub fn update_definition(
+    conn: &Connection,
+    definition: &RoutineDefinition,
+) -> Result<Option<RoutineRecord>> {
+    let updated_at = now_iso();
+    let definition_json =
+        serde_json::to_string(definition).context("failed to serialize routine definition")?;
+    let changed = conn
+        .execute(
+            "UPDATE automation_definitions
+             SET name = ?2,
+                 status = ?3,
+                 definition_json = ?4,
+                 updated_at = ?5
+             WHERE id = ?1",
+            params![
+                definition.id,
+                definition.name,
+                status_text(definition.status),
+                definition_json,
+                updated_at,
+            ],
+        )
+        .context("failed to update routine definition")?;
+    if changed == 0 {
+        return Ok(None);
+    }
+    let record = get_definition(conn, &definition.id)?
+        .ok_or_else(|| anyhow::anyhow!("routine vanished during update"))?;
+    Ok(Some(record))
+}
+
+pub fn delete_definition(conn: &Connection, id: &str) -> Result<bool> {
+    let changed = conn
+        .execute(
+            "DELETE FROM automation_definitions WHERE id = ?1",
+            params![id],
+        )
+        .context("failed to delete routine definition")?;
+    Ok(changed > 0)
+}
+
+fn status_text(status: super::definition::RoutineStatus) -> &'static str {
+    match status {
+        super::definition::RoutineStatus::Active => "ACTIVE",
+        super::definition::RoutineStatus::Paused => "PAUSED",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automations::definition::{RoutineDefinition, RoutineStatus};
+    use crate::store::initialize_store;
+    use serde_json::json;
+
+    fn temp_store() -> (tempfile::TempDir, Connection) {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_store(&path).unwrap();
+        (temp, conn)
+    }
+
+    fn definition(id: &str) -> RoutineDefinition {
+        RoutineDefinition::from_json(&json!({
+            "schemaVersion": 1,
+            "id": id,
+            "name": "Test routine",
+            "status": "PAUSED",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "local",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "prompt": "Do the thing."
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn insert_get_list_update_delete_round_trip() {
+        let (_temp, conn) = temp_store();
+        let inserted = insert_definition(&conn, &definition("round-trip")).unwrap();
+        assert_eq!(inserted.status, "PAUSED");
+
+        let fetched = get_definition(&conn, "round-trip").unwrap().unwrap();
+        assert_eq!(fetched.id, "round-trip");
+
+        let listed = list_definitions(&conn).unwrap();
+        assert_eq!(listed.len(), 1);
+
+        let mut active = definition("round-trip");
+        active.status = RoutineStatus::Active;
+        let updated = update_definition(&conn, &active).unwrap().unwrap();
+        assert_eq!(updated.status, "ACTIVE");
+
+        assert!(delete_definition(&conn, "round-trip").unwrap());
+        assert!(get_definition(&conn, "round-trip").unwrap().is_none());
+    }
+
+    #[test]
+    fn update_of_missing_id_reports_none() {
+        let (_temp, conn) = temp_store();
+        let updated = update_definition(&conn, &definition("missing")).unwrap();
+        assert!(updated.is_none());
+    }
+
+    #[test]
+    fn delete_of_missing_id_reports_false() {
+        let (_temp, conn) = temp_store();
+        assert!(!delete_definition(&conn, "missing").unwrap());
+    }
+}

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -100,6 +100,20 @@ pub fn capabilities() -> CapabilityCatalog {
                 actions: vec!["coven.capabilities.refresh"],
             },
             Capability {
+                id: "coven.automations",
+                label: "Coven-native routine automations",
+                adapter: "coven-daemon",
+                status: CapabilityStatus::Available,
+                policy: CapabilityPolicy::Allow,
+                actions: vec![
+                    "coven.automations.list",
+                    "coven.automations.get",
+                    "coven.automations.create",
+                    "coven.automations.update",
+                    "coven.automations.delete",
+                ],
+            },
+            Capability {
                 id: "desktop.automation",
                 label: "Desktop automation adapters",
                 adapter: "desktop-use",
@@ -111,7 +125,7 @@ pub fn capabilities() -> CapabilityCatalog {
     }
 }
 
-pub fn route_action(payload: Value) -> (u16, ControlActionResponse) {
+pub fn route_action(payload: Value, conn: &rusqlite::Connection) -> (u16, ControlActionResponse) {
     if !payload.is_object() {
         return (
             400,
@@ -149,8 +163,8 @@ pub fn route_action(payload: Value) -> (u16, ControlActionResponse) {
             let event = ControlEvent {
                 kind: "capabilities.refreshed",
                 action: action.to_string(),
-                origin,
-                intent_id,
+                origin: origin.clone(),
+                intent_id: intent_id.clone(),
                 payload: json!({
                     "capabilities": capabilities().capabilities.len(),
                 }),
@@ -167,10 +181,165 @@ pub fn route_action(payload: Value) -> (u16, ControlActionResponse) {
                 },
             )
         }
+        "coven.automations.list" => {
+            let event = automation_event(action, origin, intent_id, automation_list_payload(conn));
+            (200, event)
+        }
+        "coven.automations.get" => {
+            let id = required_id_field(&payload, action);
+            let event = match id {
+                Ok(id) => {
+                    automation_event(action, origin, intent_id, automation_get_payload(conn, &id))
+                }
+                Err(error) => return (400, rejected_action(action, error)),
+            };
+            (200, event)
+        }
+        "coven.automations.create" => {
+            let definition = required_definition_field(&payload, action);
+            let event = match definition {
+                Ok(definition) => automation_event(
+                    action,
+                    origin,
+                    intent_id,
+                    automation_create_payload(conn, &definition),
+                ),
+                Err(error) => return (400, rejected_action(action, error)),
+            };
+            (200, event)
+        }
+        "coven.automations.update" => {
+            let definition = required_definition_field(&payload, action);
+            let event = match definition {
+                Ok(definition) => automation_event(
+                    action,
+                    origin,
+                    intent_id,
+                    automation_update_payload(conn, &definition),
+                ),
+                Err(error) => return (400, rejected_action(action, error)),
+            };
+            (200, event)
+        }
+        "coven.automations.delete" => {
+            let id = required_id_field(&payload, action);
+            let event = match id {
+                Ok(id) => automation_event(
+                    action,
+                    origin,
+                    intent_id,
+                    automation_delete_payload(conn, &id),
+                ),
+                Err(error) => return (400, rejected_action(action, error)),
+            };
+            (200, event)
+        }
         _ => (
             400,
             rejected_action(action, format!("unknown action `{action}`")),
         ),
+    }
+}
+
+fn automation_event(
+    action: &str,
+    origin: Option<String>,
+    intent_id: Option<String>,
+    payload: Value,
+) -> ControlActionResponse {
+    ControlActionResponse {
+        ok: true,
+        accepted: true,
+        action: action.to_string(),
+        status: ActionStatus::Completed,
+        reason: None,
+        event: Some(ControlEvent {
+            kind: "automations.changed",
+            action: action.to_string(),
+            origin,
+            intent_id,
+            payload,
+        }),
+    }
+}
+
+fn required_id_field(payload: &Value, action: &str) -> Result<String, String> {
+    payload
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("{action} requires string field `id`"))
+}
+
+fn required_definition_field(
+    payload: &Value,
+    action: &str,
+) -> Result<crate::automations::RoutineDefinition, String> {
+    let Some(definition) = payload.get("definition") else {
+        return Err(format!("{action} requires object field `definition`"));
+    };
+    crate::automations::RoutineDefinition::from_json(definition)
+        .map_err(|error| format!("{action}: {error}"))
+}
+
+fn automation_list_payload(conn: &rusqlite::Connection) -> Value {
+    let records = crate::automations::store::list_definitions(conn);
+    match records {
+        Ok(records) => {
+            let routines: Vec<Value> = records
+                .iter()
+                .filter_map(|record| serde_json::from_str::<Value>(&record.definition_json).ok())
+                .collect();
+            json!({ "routines": routines })
+        }
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_get_payload(conn: &rusqlite::Connection, id: &str) -> Value {
+    match crate::automations::store::get_definition(conn, id) {
+        Ok(Some(record)) => match serde_json::from_str::<Value>(&record.definition_json) {
+            Ok(routine) => json!({ "routine": routine }),
+            Err(error) => json!({ "error": format!("stored routine is unreadable: {error}") }),
+        },
+        Ok(None) => json!({ "routine": Value::Null }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_create_payload(
+    conn: &rusqlite::Connection,
+    definition: &crate::automations::RoutineDefinition,
+) -> Value {
+    match crate::automations::store::insert_definition(conn, definition) {
+        Ok(record) => json!({
+            "routine": definition.to_json(),
+            "createdAt": record.created_at,
+        }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_update_payload(
+    conn: &rusqlite::Connection,
+    definition: &crate::automations::RoutineDefinition,
+) -> Value {
+    match crate::automations::store::update_definition(conn, definition) {
+        Ok(Some(record)) => json!({
+            "routine": definition.to_json(),
+            "updatedAt": record.updated_at,
+        }),
+        Ok(None) => json!({ "error": format!("no routine with id `{}`", definition.id) }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_delete_payload(conn: &rusqlite::Connection, id: &str) -> Value {
+    match crate::automations::store::delete_definition(conn, id) {
+        Ok(deleted) => json!({ "id": id, "deleted": deleted }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
     }
 }
 

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -112,6 +112,7 @@ pub fn capabilities() -> CapabilityCatalog {
                     "coven.automations.update",
                     "coven.automations.delete",
                     "coven.automations.tick",
+                    "coven.automations.runs",
                 ],
             },
             Capability {
@@ -245,6 +246,20 @@ pub fn route_action(payload: Value, conn: &rusqlite::Connection) -> (u16, Contro
             );
             (200, event)
         }
+        "coven.automations.runs" => {
+            let id = required_id_field(&payload, action);
+            let limit = payload.get("limit").and_then(Value::as_i64).unwrap_or(20);
+            let event = match id {
+                Ok(id) => automation_event(
+                    action,
+                    origin,
+                    intent_id,
+                    automation_runs_payload(conn, &id, limit),
+                ),
+                Err(error) => return (400, rejected_action(action, error)),
+            };
+            (200, event)
+        }
         _ => (
             400,
             rejected_action(action, format!("unknown action `{action}`")),
@@ -299,13 +314,43 @@ fn automation_tick_payload(
     conn: &rusqlite::Connection,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Value {
-    match crate::automations::occurrences::tick_planning(conn, now) {
+    match crate::automations::occurrences::tick(conn, now) {
         Ok(report) => json!({
             "planned": report.planned,
             "alreadyFenced": report.already_fenced,
             "pausedSkipped": report.paused_skipped,
+            "recovered": report.recovered,
+            "claimed": report.claimed,
             "failed": report.failed,
         }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_runs_payload(conn: &rusqlite::Connection, id: &str, limit: i64) -> Value {
+    match crate::automations::runs::list_runs(conn, id, limit) {
+        Ok(records) => {
+            let runs: Vec<Value> = records
+                .iter()
+                .map(|record| {
+                    json!({
+                        "id": record.id,
+                        "automationId": record.automation_id,
+                        "occurrenceId": record.occurrence_id,
+                        "sessionId": record.session_id,
+                        "familiarId": record.familiar_id,
+                        "runtime": record.runtime,
+                        "status": record.status,
+                        "exitCode": record.exit_code,
+                        "logJson": record.log_json,
+                        "outputCommit": record.output_commit,
+                        "startedAt": record.started_at,
+                        "finishedAt": record.finished_at,
+                    })
+                })
+                .collect();
+            json!({ "runs": runs })
+        }
         Err(error) => json!({ "error": format!("{error:#}") }),
     }
 }

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -113,6 +113,7 @@ pub fn capabilities() -> CapabilityCatalog {
                     "coven.automations.delete",
                     "coven.automations.tick",
                     "coven.automations.runs",
+                    "coven.automations.run",
                 ],
             },
             Capability {
@@ -127,7 +128,11 @@ pub fn capabilities() -> CapabilityCatalog {
     }
 }
 
-pub fn route_action(payload: Value, conn: &rusqlite::Connection) -> (u16, ControlActionResponse) {
+pub fn route_action(
+    payload: Value,
+    conn: &rusqlite::Connection,
+    runtime: &dyn crate::api::SessionRuntime,
+) -> (u16, ControlActionResponse) {
     if !payload.is_object() {
         return (
             400,
@@ -260,6 +265,20 @@ pub fn route_action(payload: Value, conn: &rusqlite::Connection) -> (u16, Contro
             };
             (200, event)
         }
+        "coven.automations.run" => {
+            let id = required_id_field(&payload, action);
+            let now = chrono::Utc::now();
+            let event = match id {
+                Ok(id) => automation_event(
+                    action,
+                    origin,
+                    intent_id,
+                    automation_run_payload(conn, runtime, &id, now),
+                ),
+                Err(error) => return (400, rejected_action(action, error)),
+            };
+            (200, event)
+        }
         _ => (
             400,
             rejected_action(action, format!("unknown action `{action}`")),
@@ -324,6 +343,29 @@ fn automation_tick_payload(
             "failed": report.failed,
         }),
         Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_run_payload(
+    conn: &rusqlite::Connection,
+    runtime: &dyn crate::api::SessionRuntime,
+    id: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Value {
+    match crate::automations::runner::load_definition_for_run(conn, id) {
+        Ok(Some(definition)) => {
+            match crate::automations::runner::run_routine_now(conn, runtime, &definition, now) {
+                Ok(outcome) => json!({
+                    "runId": outcome.run_id,
+                    "status": outcome.status,
+                    "sessionId": outcome.session_id,
+                    "error": outcome.error,
+                }),
+                Err(error) => json!({ "error": error }),
+            }
+        }
+        Ok(None) => json!({ "error": format!("no routine with id `{id}`") }),
+        Err(error) => json!({ "error": error }),
     }
 }
 

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -111,6 +111,7 @@ pub fn capabilities() -> CapabilityCatalog {
                     "coven.automations.create",
                     "coven.automations.update",
                     "coven.automations.delete",
+                    "coven.automations.tick",
                 ],
             },
             Capability {
@@ -234,6 +235,16 @@ pub fn route_action(payload: Value, conn: &rusqlite::Connection) -> (u16, Contro
             };
             (200, event)
         }
+        "coven.automations.tick" => {
+            let now = chrono::Utc::now();
+            let event = automation_event(
+                action,
+                origin,
+                intent_id,
+                automation_tick_payload(conn, now),
+            );
+            (200, event)
+        }
         _ => (
             400,
             rejected_action(action, format!("unknown action `{action}`")),
@@ -282,6 +293,21 @@ fn required_definition_field(
     };
     crate::automations::RoutineDefinition::from_json(definition)
         .map_err(|error| format!("{action}: {error}"))
+}
+
+fn automation_tick_payload(
+    conn: &rusqlite::Connection,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Value {
+    match crate::automations::occurrences::tick_planning(conn, now) {
+        Ok(report) => json!({
+            "planned": report.planned,
+            "alreadyFenced": report.already_fenced,
+            "pausedSkipped": report.paused_skipped,
+            "failed": report.failed,
+        }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
 }
 
 fn automation_list_payload(conn: &rusqlite::Connection) -> Value {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -37,6 +37,7 @@ mod execution_binding;
 mod request_adoption;
 #[allow(dead_code)]
 mod adoption_gate;
+mod automations;
 mod executor_node;
 mod familiar_identity;
 mod handoff;

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -973,6 +973,8 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
     ensure_session_external_columns(conn)?;
     conn.execute_batch(crate::automations::store::AUTOMATION_DEFINITIONS_SCHEMA_SQL)
         .context("failed to initialize automation_definitions schema")?;
+    conn.execute_batch(crate::automations::occurrences::AUTOMATION_OCCURRENCES_SCHEMA_SQL)
+        .context("failed to initialize automation_occurrences schema")?;
 
     backfill_events_fts_if_needed(conn)?;
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -975,6 +975,8 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
         .context("failed to initialize automation_definitions schema")?;
     conn.execute_batch(crate::automations::occurrences::AUTOMATION_OCCURRENCES_SCHEMA_SQL)
         .context("failed to initialize automation_occurrences schema")?;
+    conn.execute_batch(crate::automations::runs::AUTOMATION_RUNS_SCHEMA_SQL)
+        .context("failed to initialize automation_runs schema")?;
 
     backfill_events_fts_if_needed(conn)?;
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -971,6 +971,8 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
     migrate_historical_request_adoptions(conn)?;
     ensure_node_registry_dispatch_columns(conn)?;
     ensure_session_external_columns(conn)?;
+    conn.execute_batch(crate::automations::store::AUTOMATION_DEFINITIONS_SCHEMA_SQL)
+        .context("failed to initialize automation_definitions schema")?;
 
     backfill_events_fts_if_needed(conn)?;
 


### PR DESCRIPTION
## Summary

First slice of Coven-native routine automations for OpenCoven/coven#816 — durable routine definitions replace harness-owned schedules.

- `automations/definition.rs` — `RoutineDefinition` (schema v1, id, name, status ACTIVE/PAUSED, RRULE, timezone local/utc, misfire latest, overlap forbid, timeoutMinutes, runtime, familiarId, cwd, outputTarget, prompt, model, tags) with one reviewable validation surface.
- `automations/rrule.rs` — strict scoped RRULE parser (`FREQ=DAILY|WEEKLY`, `BYHOUR`, `BYDAY`); unsupported keys/frequencies fail closed so nothing schedules work the scheduler does not understand.
- `automations/store.rs` — `automation_definitions` table in the single Coven store + list/get/insert/update/delete.
- `control_plane.rs` — new `coven.automations` capability with list/get/create/update/delete actions.
- `api.rs` — `POST /actions` opens the store and routes the new actions.

## Verification
- `cargo test -p coven-cli --bin coven -- automations control_actions` — 21 passed (17 module + 2 HTTP end-to-end + 2 existing control-action guards).
- `cargo clippy -p coven-cli --all-targets` clean.

## Next (later PRs per the plan)
occurrence ledger + scheduler tick, claim/lease + stale-lease recovery, run dispatch through the SessionLaunch path, atomic output delivery, legacy `~/.codex` import.