### PR TITLE
feat(automations): non-destructive legacy Codex import (coven#816, part 5)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -1022,7 +1022,7 @@ fn normalize_api_route(route: &str) -> ApiRoute<'_> {
     ApiRoute::Route(Cow::Owned(format!("/{suffix}")))
 }
 
-fn store_path(coven_home: &Path) -> std::path::PathBuf {
+pub(crate) fn store_path(coven_home: &Path) -> std::path::PathBuf {
     coven_home.join("coven.sqlite3")
 }
 

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -1,0 +1,97 @@
+//! Daemon-side automations tick (coven#816).
+//!
+//! The daemon runs the planning/recovery/claim tick on a 60-second cadence.
+//! Dispatch of claimed occurrences is intentionally NOT wired into this tick
+//! yet: the tick fences and claims so the ledger reflects reality, and the
+//! dispatch path (part 4's run_routine_now) currently serves manual runs
+//! while occurrence execution lands behind the same SessionLaunch seam.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+/// One automations pass: open the store, run the full tick, log failures to
+/// the daemon recovery log. Returns the tick report summary for tests.
+pub fn process_automations_tick(coven_home: &Path) -> Result<super::occurrences::TickReport> {
+    let store_path = crate::api::store_path(coven_home);
+    let conn = crate::store::open_store(&store_path)?;
+    let report = super::occurrences::tick(&conn, chrono::Utc::now())?;
+    Ok(report)
+}
+
+/// Starts the automations scheduler thread on the daemon's 60s cadence.
+pub fn start_automations_scheduler(coven_home: &Path) -> Result<()> {
+    let home = coven_home.to_path_buf();
+    std::thread::Builder::new()
+        .name("coven-automations-scheduler".into())
+        .spawn(move || loop {
+            std::thread::sleep(Duration::from_secs(60));
+            if let Err(error) = process_automations_tick(&home) {
+                crate::daemon::append_daemon_recovery_log(
+                    &home,
+                    &format!("automations tick failed: {error:#}"),
+                );
+            }
+        })
+        .context("failed to spawn automations scheduler")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automations::definition::RoutineDefinition;
+    use crate::automations::store::insert_definition;
+    use serde_json::json;
+
+    fn definition(id: &str) -> RoutineDefinition {
+        RoutineDefinition::from_json(&json!({
+            "schemaVersion": 1,
+            "id": id,
+            "name": id,
+            "status": "ACTIVE",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "cwd": "/work/project",
+            "prompt": "Do the thing."
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn tick_plans_and_claims_against_the_daemon_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+        crate::store::initialize_store(&home.join("coven.sqlite3")).unwrap();
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        // Backdate creation so the 09:00 slot is due at any tick hour.
+        let old_created = (chrono::Utc::now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+        drop(conn);
+
+        let report = process_automations_tick(home).unwrap();
+        assert_eq!(report.planned.len(), 1);
+        assert_eq!(report.claimed.len(), 1);
+
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "claimed");
+    }
+}

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -11,23 +11,36 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
-/// One automations pass: open the store, run the full tick, log failures to
-/// the daemon recovery log. Returns the tick report summary for tests.
-pub fn process_automations_tick(coven_home: &Path) -> Result<super::occurrences::TickReport> {
+/// One automations pass: open the store, run the full tick (plan, recover,
+/// claim), then dispatch every claimed occurrence through the shared
+/// session-launch runtime. Failures land in the daemon recovery log via the
+/// caller.
+pub fn process_automations_tick(
+    coven_home: &Path,
+    runtime: &dyn crate::api::SessionRuntime,
+) -> Result<super::occurrences::TickReport> {
     let store_path = crate::api::store_path(coven_home);
     let conn = crate::store::open_store(&store_path)?;
-    let report = super::occurrences::tick(&conn, chrono::Utc::now())?;
+    let now = chrono::Utc::now();
+    let report = super::occurrences::tick(&conn, now)?;
+    if !report.claimed.is_empty() {
+        let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime, now)
+            .map_err(anyhow::Error::msg)?;
+    }
     Ok(report)
 }
 
 /// Starts the automations scheduler thread on the daemon's 60s cadence.
-pub fn start_automations_scheduler(coven_home: &Path) -> Result<()> {
+pub fn start_automations_scheduler(
+    coven_home: &Path,
+    runtime: std::sync::Arc<dyn crate::api::SessionRuntime + Send + Sync>,
+) -> Result<()> {
     let home = coven_home.to_path_buf();
     std::thread::Builder::new()
         .name("coven-automations-scheduler".into())
         .spawn(move || loop {
             std::thread::sleep(Duration::from_secs(60));
-            if let Err(error) = process_automations_tick(&home) {
+            if let Err(error) = process_automations_tick(&home, runtime.as_ref()) {
                 crate::daemon::append_daemon_recovery_log(
                     &home,
                     &format!("automations tick failed: {error:#}"),
@@ -80,7 +93,7 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        let report = process_automations_tick(home).unwrap();
+        let report = process_automations_tick(home, &crate::api::NoopSessionRuntime).unwrap();
         assert_eq!(report.planned.len(), 1);
         assert_eq!(report.claimed.len(), 1);
 
@@ -92,6 +105,11 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(state, "claimed");
+        // The tick claims and then dispatches through the (noop) runtime, so
+        // the occurrence settles as succeeded and the ledger records the run.
+        assert_eq!(state, "succeeded");
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "succeeded");
     }
 }

--- a/crates/coven-cli/src/automations/health.rs
+++ b/crates/coven-cli/src/automations/health.rs
@@ -38,10 +38,9 @@ fn max_iso(
 
 /// Computes the health snapshot for one routine. Reads-only.
 pub fn routine_health(conn: &Connection, id: &str, now: DateTime<Utc>) -> Result<RoutineHealth> {
-    let definition: RoutineDefinition =
-        super::runner::load_definition_for_run(conn, id)
-            .map_err(anyhow::Error::msg)?
-            .ok_or_else(|| anyhow::anyhow!("no routine with id `{id}`"))?;
+    let definition: RoutineDefinition = super::runner::load_definition_for_run(conn, id)
+        .map_err(anyhow::Error::msg)?
+        .ok_or_else(|| anyhow::anyhow!("no routine with id `{id}`"))?;
 
     let next_due_at = next_due(&definition.rrule, definition.timezone, now)
         .map_err(|error| anyhow::anyhow!("{error}"))?

--- a/crates/coven-cli/src/automations/health.rs
+++ b/crates/coven-cli/src/automations/health.rs
@@ -1,0 +1,204 @@
+//! Routine health snapshot (coven#816).
+//!
+//! One structured summary per routine that the Cave UI renders: when the
+//! routine was last planned, started, and succeeded, the next due slot,
+//! consecutive failures, and any live lease or stale/degraded reason. The
+//! values come only from the Coven store — no harness history files.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use super::definition::RoutineDefinition;
+use super::schedule::next_due;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutineHealth {
+    pub automation_id: String,
+    pub next_due_at: Option<String>,
+    pub last_planned_at: Option<String>,
+    pub last_started_at: Option<String>,
+    pub last_success_at: Option<String>,
+    pub consecutive_failures: i64,
+    pub lease_owner: Option<String>,
+    pub lease_expires_at: Option<String>,
+    pub stale_reason: Option<String>,
+}
+
+fn max_iso(
+    conn: &Connection,
+    sql: &str,
+    params: &[&dyn rusqlite::ToSql],
+) -> Result<Option<String>> {
+    let value: Option<String> = conn
+        .query_row(sql, params, |row| row.get(0))
+        .with_context(|| format!("health query failed: {sql}"))?;
+    Ok(value)
+}
+
+/// Computes the health snapshot for one routine. Reads-only.
+pub fn routine_health(conn: &Connection, id: &str, now: DateTime<Utc>) -> Result<RoutineHealth> {
+    let definition: RoutineDefinition =
+        super::runner::load_definition_for_run(conn, id)
+            .map_err(anyhow::Error::msg)?
+            .ok_or_else(|| anyhow::anyhow!("no routine with id `{id}`"))?;
+
+    let next_due_at = next_due(&definition.rrule, definition.timezone, now)
+        .map_err(|error| anyhow::anyhow!("{error}"))?
+        .map(|slot| slot.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+
+    let last_planned_at = max_iso(
+        conn,
+        "SELECT MAX(scheduled_for) FROM automation_occurrences WHERE automation_id = ?1 AND state = 'planned'",
+        &[&id],
+    )?;
+    let last_started_at = max_iso(
+        conn,
+        "SELECT MAX(scheduled_for) FROM automation_occurrences WHERE automation_id = ?1 AND state IN ('claimed', 'running')",
+        &[&id],
+    )?;
+    let last_success_at = max_iso(
+        conn,
+        "SELECT MAX(scheduled_for) FROM automation_occurrences WHERE automation_id = ?1 AND state = 'succeeded'",
+        &[&id],
+    )?;
+    let consecutive_failures: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT scheduled_for, state FROM automation_occurrences
+                 WHERE automation_id = ?1 AND state = 'failed'
+                   AND scheduled_for > COALESCE(
+                       (SELECT MAX(scheduled_for) FROM automation_occurrences
+                        WHERE automation_id = ?1 AND state = 'succeeded'), '')
+                 ORDER BY scheduled_for DESC
+             )",
+            params![id],
+            |row| row.get(0),
+        )
+        .context("failed to count consecutive failures")?;
+
+    let (lease_owner, lease_expires_at, stale_reason) = match conn.query_row(
+        "SELECT lease_owner, lease_expires_at, failure_reason
+             FROM automation_occurrences
+             WHERE automation_id = ?1 AND state IN ('claimed', 'running')
+             ORDER BY scheduled_for DESC LIMIT 1",
+        params![id],
+        |row| {
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        },
+    ) {
+        Ok(row) => row,
+        Err(rusqlite::Error::QueryReturnedNoRows) => (None, None, None),
+        Err(error) => return Err(error).context("failed to read live lease"),
+    };
+
+    Ok(RoutineHealth {
+        automation_id: id.to_string(),
+        next_due_at,
+        last_planned_at,
+        last_started_at,
+        last_success_at,
+        consecutive_failures,
+        lease_owner,
+        lease_expires_at,
+        stale_reason,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automations::definition::RoutineDefinition;
+    use crate::automations::store::insert_definition;
+    use crate::store::initialize_store;
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    fn utc(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, h, min, 0).unwrap()
+    }
+
+    fn definition(id: &str) -> RoutineDefinition {
+        RoutineDefinition::from_json(&json!({
+            "schemaVersion": 1,
+            "id": id,
+            "name": id,
+            "status": "ACTIVE",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "cwd": "/work/project",
+            "prompt": "Do the thing."
+        }))
+        .unwrap()
+    }
+
+    fn temp_store() -> (tempfile::TempDir, Connection) {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_store(&path).unwrap();
+        (temp, conn)
+    }
+
+    #[test]
+    fn health_reports_next_due_and_history() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+             VALUES
+                ('o1', 'daily', '2026-08-26T09:00:00.000Z', 'succeeded', 1, '2026-08-26T09:00:00.000Z', '2026-08-26T09:05:00.000Z'),
+                ('o2', 'daily', '2026-08-27T09:00:00.000Z', 'failed', 1, '2026-08-27T09:00:00.000Z', '2026-08-27T09:05:00.000Z')",
+            [],
+        )
+        .unwrap();
+
+        let health = routine_health(&conn, "daily", utc(2026, 8, 27, 10, 0)).unwrap();
+        assert_eq!(
+            health.next_due_at.as_deref(),
+            Some("2026-08-28T09:00:00.000Z")
+        );
+        assert_eq!(
+            health.last_success_at.as_deref(),
+            Some("2026-08-26T09:00:00.000Z")
+        );
+        assert_eq!(health.consecutive_failures, 1);
+    }
+
+    #[test]
+    fn health_reports_a_live_lease() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, lease_owner, lease_expires_at, attempt, created_at, updated_at)
+             VALUES ('o1', 'daily', '2026-08-27T09:00:00.000Z', 'claimed', 'daemon-a',
+                     '2026-08-27T10:00:00.000Z', 1, '2026-08-27T09:00:00.000Z', '2026-08-27T09:00:00.000Z')",
+            [],
+        )
+        .unwrap();
+
+        let health = routine_health(&conn, "daily", utc(2026, 8, 27, 9, 30)).unwrap();
+        assert_eq!(health.lease_owner.as_deref(), Some("daemon-a"));
+        assert_eq!(
+            health.lease_expires_at.as_deref(),
+            Some("2026-08-27T10:00:00.000Z")
+        );
+    }
+
+    #[test]
+    fn health_requires_an_existing_routine() {
+        let (_temp, conn) = temp_store();
+        let error = routine_health(&conn, "missing", utc(2026, 8, 27, 10, 0)).unwrap_err();
+        assert!(format!("{error:#}").contains("no routine"));
+    }
+}

--- a/crates/coven-cli/src/automations/import_legacy.rs
+++ b/crates/coven-cli/src/automations/import_legacy.rs
@@ -1,0 +1,249 @@
+//! Legacy Codex automation import (coven#816).
+//!
+//! Reads `~/.codex/automations/<id>/automation.toml` definitions and imports
+//! them as Coven routines. The import is NON-DESTRUCTIVE: source files are
+//! never modified, moved, or deleted, and every imported routine is created
+//! PAUSED. Definitions whose schedules use vocabulary the Coven scheduler
+//! does not support are reported and skipped — never silently downgraded.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde::Deserialize;
+
+use super::definition::{RoutineDefinition, RoutineStatus, RoutineTimezone};
+use super::store::insert_definition;
+
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)] // fields read selectively during mapping
+struct CodexAutomationToml {
+    id: Option<String>,
+    name: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    rrule: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ImportReport {
+    pub imported: Vec<String>,
+    pub skipped: Vec<String>,
+    pub failures: Vec<String>,
+}
+
+fn codex_automations_dir() -> PathBuf {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from("."));
+    home.join(".codex").join("automations")
+}
+
+/// Normalizes a Codex RRULE (`RRULE:FREQ=WEEKLY;BYHOUR=21;BYMINUTE=0;BYDAY=…`)
+/// into the Coven vocabulary. Returns `None` when the schedule cannot be
+/// represented faithfully.
+fn normalize_codex_rrule(raw: &str) -> Option<String> {
+    let mut body = raw.trim().to_string();
+    if let Some(stripped) = body.strip_prefix("RRULE:") {
+        body = stripped.trim().to_string();
+    }
+    let mut kept: Vec<String> = Vec::new();
+    for part in body.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (key, value) = part.split_once('=')?;
+        match key.trim().to_ascii_uppercase().as_str() {
+            "FREQ" | "BYHOUR" | "BYDAY" => kept.push(part.to_string()),
+            // Codex emits BYMINUTE=0 on every cron; minute-zero is the Coven
+            // default, so dropping it preserves the schedule exactly.
+            "BYMINUTE" if value.trim() == "0" => {}
+            "INTERVAL" if value.trim() == "1" => {}
+            _ => return None,
+        }
+    }
+    let normalized = kept.join(";");
+    if normalized.is_empty() {
+        return None;
+    }
+    // The normalized schedule must still satisfy the scheduler's vocabulary
+    // gate; import refuses rather than silently downgrading.
+    super::rrule::parse_rrule(&normalized).ok()?;
+    Some(normalized)
+}
+
+/// Imports every parseable definition under `~/.codex/automations`. Returns
+/// a report of imported ids, skipped ids (unsupported schedule or invalid
+/// shape), and per-id failures. Source files are never touched.
+pub fn import_legacy_codex_automations(conn: &Connection) -> Result<ImportReport> {
+    let mut report = ImportReport::default();
+    let root = codex_automations_dir();
+    let entries = match fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(report),
+        Err(error) => return Err(error).with_context(|| format!("reading {}", root.display())),
+    };
+
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading {}", root.display()))?;
+        let toml_path = entry.path().join("automation.toml");
+        let raw = match fs::read_to_string(&toml_path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                report.failures.push(format!(
+                    "{}: could not read automation.toml: {error}",
+                    entry.path().display()
+                ));
+                continue;
+            }
+        };
+        let parsed: CodexAutomationToml = match toml::from_str(&raw) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                report.failures.push(format!(
+                    "{}: could not parse automation.toml: {error}",
+                    entry.path().display()
+                ));
+                continue;
+            }
+        };
+
+        let id = parsed
+            .id
+            .clone()
+            .or_else(|| entry.file_name().to_str().map(ToOwned::to_owned))
+            .unwrap_or_else(|| "unknown".to_string());
+        let Some(raw_rrule) = parsed.rrule.as_deref() else {
+            report.skipped.push(format!("{id}: no schedule"));
+            continue;
+        };
+        let Some(rrule) = normalize_codex_rrule(raw_rrule) else {
+            report
+                .skipped
+                .push(format!("{id}: unsupported schedule `{raw_rrule}`"));
+            continue;
+        };
+        let Some(prompt) = parsed
+            .prompt
+            .clone()
+            .filter(|prompt| !prompt.trim().is_empty())
+        else {
+            report.skipped.push(format!("{id}: no prompt"));
+            continue;
+        };
+
+        let definition = RoutineDefinition {
+            schema_version: super::definition::AUTOMATION_SCHEMA_VERSION,
+            id: id.clone(),
+            name: parsed.name.clone().unwrap_or_else(|| id.clone()),
+            // Imported routines are always paused: nothing runs until a human
+            // reviews the migrated definition (coven#816 acceptance).
+            status: RoutineStatus::Paused,
+            rrule,
+            timezone: RoutineTimezone::Local,
+            misfire: super::definition::RoutineMisfire::Latest,
+            overlap: super::definition::RoutineOverlap::Forbid,
+            timeout_minutes: 60,
+            runtime: "coven-code".to_string(),
+            familiar_id: None,
+            cwd: None,
+            output_target: None,
+            prompt,
+            model: None,
+            tags: Vec::new(),
+        };
+
+        if let Err(error) = definition.validate() {
+            report.skipped.push(format!("{id}: {error}"));
+            continue;
+        }
+
+        match insert_definition(conn, &definition) {
+            Ok(_) => report.imported.push(id),
+            Err(error) => report.failures.push(format!("{id}: {error:#}")),
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_codex_rrule_into_coven_vocabulary() {
+        let normalized = normalize_codex_rrule(
+            "RRULE:FREQ=WEEKLY;BYHOUR=21;BYMINUTE=0;BYDAY=SU,MO,TU,WE,TH,FR,SA",
+        )
+        .unwrap();
+        assert_eq!(
+            normalized,
+            "FREQ=WEEKLY;BYHOUR=21;BYDAY=SU,MO,TU,WE,TH,FR,SA"
+        );
+    }
+
+    #[test]
+    fn drops_interval_one() {
+        let normalized = normalize_codex_rrule("FREQ=DAILY;BYHOUR=9;INTERVAL=1").unwrap();
+        assert_eq!(normalized, "FREQ=DAILY;BYHOUR=9");
+    }
+
+    #[test]
+    fn refuses_unsupported_vocabulary() {
+        assert!(normalize_codex_rrule("FREQ=HOURLY").is_none());
+        assert!(normalize_codex_rrule("FREQ=DAILY;BYMINUTE=30").is_none());
+        assert!(normalize_codex_rrule("FREQ=DAILY;INTERVAL=2").is_none());
+    }
+
+    #[test]
+    fn import_is_paused_and_reads_the_codex_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("store.sqlite");
+        crate::store::initialize_store(&store_path).unwrap();
+        let conn = crate::store::open_store(&store_path).unwrap();
+
+        // Point HOME at a scratch dir containing a legacy definition.
+        let home = temp.path().join("home");
+        let def_dir = home.join(".codex/automations/legacy-daily");
+        std::fs::create_dir_all(&def_dir).unwrap();
+        std::fs::write(
+            def_dir.join("automation.toml"),
+            r#"version = 1
+id = "legacy-daily"
+name = "Legacy Daily"
+rrule = "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+prompt = "Do the legacy thing."
+"#,
+        )
+        .unwrap();
+
+        // The import helper reads HOME, so run it in a scoped thread with the
+        // env var pinned. Rust tests share the process env, so serialize via a
+        // mutex and restore afterwards.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap();
+        let old_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", &home);
+        }
+        let report = import_legacy_codex_automations(&conn).unwrap();
+        match old_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert_eq!(report.imported, vec!["legacy-daily"]);
+        let record = super::super::store::get_definition(&conn, "legacy-daily")
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.status, "PAUSED");
+    }
+}

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -7,6 +7,7 @@
 //! seams.
 
 pub mod definition;
+pub mod import_legacy;
 pub mod occurrences;
 pub mod rrule;
 pub mod runner;

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod daemon_tick;
 pub mod definition;
+pub mod health;
 pub mod import_legacy;
 pub mod occurrences;
 pub mod rrule;

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -6,6 +6,7 @@
 //! claim/lease, and run delivery land in follow-up modules on the same
 //! seams.
 
+pub mod daemon_tick;
 pub mod definition;
 pub mod import_legacy;
 pub mod occurrences;

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -88,21 +88,7 @@ pub fn run_routine_now(
     )
     .map_err(|error| format!("failed to record run start: {error:#}"))?;
 
-    let launch = SessionLaunch {
-        id: fresh_id("session"),
-        project_root: cwd.to_string(),
-        cwd: cwd.to_string(),
-        harness: definition.runtime.clone(),
-        model: definition.model.clone(),
-        launch_mode: HarnessLaunchMode::NonInteractive,
-        launch_policy: None,
-        prompt: definition.prompt.clone(),
-        title: definition.name.clone(),
-        conversation: None,
-        conversation_id: None,
-        familiar_id: definition.familiar_id.clone(),
-        caller_familiar_id: None,
-    };
+    let launch = build_session_launch(definition, cwd)?;
 
     match runtime.launch_session(&launch) {
         Ok(()) => {
@@ -149,6 +135,143 @@ pub fn run_routine_now(
             })
         }
     }
+}
+
+/// Builds the shared SessionLaunch for a routine run. Every run — manual or
+/// scheduled — dispatches through this exact launch shape.
+pub fn build_session_launch(
+    definition: &RoutineDefinition,
+    cwd: &str,
+) -> Result<SessionLaunch, String> {
+    Ok(SessionLaunch {
+        id: fresh_id("session"),
+        project_root: cwd.to_string(),
+        cwd: cwd.to_string(),
+        harness: definition.runtime.clone(),
+        model: definition.model.clone(),
+        launch_mode: HarnessLaunchMode::NonInteractive,
+        launch_policy: None,
+        prompt: definition.prompt.clone(),
+        title: definition.name.clone(),
+        conversation: None,
+        conversation_id: None,
+        familiar_id: definition.familiar_id.clone(),
+        caller_familiar_id: None,
+    })
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct DispatchReport {
+    pub dispatched: Vec<String>,
+    pub failed: Vec<String>,
+}
+
+/// Dispatches every claimed occurrence that the scheduler has fenced: builds
+/// the launch, records the ledger row, launches through the shared runtime
+/// path, and settles occurrence + ledger together. Claimed occurrences whose
+/// routine has no cwd fail with a recorded reason instead of guessing a
+/// project.
+pub fn dispatch_claimed_occurrences(
+    conn: &Connection,
+    runtime: &dyn SessionRuntime,
+    now: DateTime<Utc>,
+) -> Result<DispatchReport, String> {
+    let mut report = DispatchReport::default();
+
+    let claimed: Vec<(String, String)> = {
+        let mut statement = conn
+            .prepare(
+                "SELECT id, automation_id FROM automation_occurrences
+                 WHERE state = 'claimed' ORDER BY scheduled_for ASC",
+            )
+            .map_err(|error| format!("failed to list claimed occurrences: {error}"))?;
+        let rows = statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .map_err(|error| format!("failed to list claimed occurrences: {error}"))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|error| format!("failed to read claim: {error}"))?);
+        }
+        out
+    };
+
+    for (occurrence_id, automation_id) in claimed {
+        let Some(definition) = load_definition_for_run(conn, &automation_id)? else {
+            let reason = format!("routine `{automation_id}` vanished during dispatch");
+            let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
+            report.failed.push(reason);
+            continue;
+        };
+
+        let Some(cwd) = definition
+            .cwd
+            .as_deref()
+            .map(str::trim)
+            .filter(|cwd| !cwd.is_empty())
+        else {
+            let reason = format!("{automation_id}: routine has no cwd; add a cwd before running");
+            let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
+            report.failed.push(reason);
+            continue;
+        };
+
+        let run_id = fresh_id("run");
+        let started = record_run_start(
+            conn,
+            &run_id,
+            &automation_id,
+            Some(&occurrence_id),
+            definition.familiar_id.as_deref(),
+            &definition.runtime,
+            now,
+        );
+        if let Err(error) = started {
+            report.failed.push(format!("{automation_id}: {error:#}"));
+            continue;
+        }
+
+        match build_session_launch(&definition, cwd).and_then(|launch| {
+            runtime
+                .launch_session(&launch)
+                .map(|()| launch)
+                .map_err(|error| format!("{error:#}"))
+        }) {
+            Ok(launch) => {
+                let _ = settle_occurrence(conn, &occurrence_id, "succeeded", None, now);
+                let _ = record_run_finish(
+                    conn,
+                    &run_id,
+                    RunFinish {
+                        status: "succeeded",
+                        exit_code: Some(0),
+                        session_id: Some(launch.id),
+                        log_json: None,
+                        output_commit: None,
+                    },
+                    now,
+                );
+                report.dispatched.push(run_id);
+            }
+            Err(reason) => {
+                let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
+                let _ = record_run_finish(
+                    conn,
+                    &run_id,
+                    RunFinish {
+                        status: "failed",
+                        exit_code: None,
+                        session_id: None,
+                        log_json: None,
+                        output_commit: None,
+                    },
+                    now,
+                );
+                report.failed.push(format!("{automation_id}: {reason}"));
+            }
+        }
+    }
+
+    Ok(report)
 }
 
 /// Reads and validates a stored definition for dispatch.

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -115,6 +115,7 @@ pub fn capabilities() -> CapabilityCatalog {
                     "coven.automations.runs",
                     "coven.automations.run",
                     "coven.automations.import",
+                    "coven.automations.health",
                 ],
             },
             Capability {
@@ -266,6 +267,20 @@ pub fn route_action(
             };
             (200, event)
         }
+        "coven.automations.health" => {
+            let id = required_id_field(&payload, action);
+            let now = chrono::Utc::now();
+            let event = match id {
+                Ok(id) => automation_event(
+                    action,
+                    origin,
+                    intent_id,
+                    automation_health_payload(conn, &id, now),
+                ),
+                Err(error) => return (400, rejected_action(action, error)),
+            };
+            (200, event)
+        }
         "coven.automations.import" => {
             let event =
                 automation_event(action, origin, intent_id, automation_import_payload(conn));
@@ -347,6 +362,29 @@ fn automation_tick_payload(
             "recovered": report.recovered,
             "claimed": report.claimed,
             "failed": report.failed,
+        }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_health_payload(
+    conn: &rusqlite::Connection,
+    id: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Value {
+    match crate::automations::health::routine_health(conn, id, now) {
+        Ok(health) => json!({
+            "health": {
+                "automationId": health.automation_id,
+                "nextDueAt": health.next_due_at,
+                "lastPlannedAt": health.last_planned_at,
+                "lastStartedAt": health.last_started_at,
+                "lastSuccessAt": health.last_success_at,
+                "consecutiveFailures": health.consecutive_failures,
+                "leaseOwner": health.lease_owner,
+                "leaseExpiresAt": health.lease_expires_at,
+                "staleReason": health.stale_reason,
+            }
         }),
         Err(error) => json!({ "error": format!("{error:#}") }),
     }

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -114,6 +114,7 @@ pub fn capabilities() -> CapabilityCatalog {
                     "coven.automations.tick",
                     "coven.automations.runs",
                     "coven.automations.run",
+                    "coven.automations.import",
                 ],
             },
             Capability {
@@ -265,6 +266,11 @@ pub fn route_action(
             };
             (200, event)
         }
+        "coven.automations.import" => {
+            let event =
+                automation_event(action, origin, intent_id, automation_import_payload(conn));
+            (200, event)
+        }
         "coven.automations.run" => {
             let id = required_id_field(&payload, action);
             let now = chrono::Utc::now();
@@ -341,6 +347,17 @@ fn automation_tick_payload(
             "recovered": report.recovered,
             "claimed": report.claimed,
             "failed": report.failed,
+        }),
+        Err(error) => json!({ "error": format!("{error:#}") }),
+    }
+}
+
+fn automation_import_payload(conn: &rusqlite::Connection) -> Value {
+    match crate::automations::import_legacy::import_legacy_codex_automations(conn) {
+        Ok(report) => json!({
+            "imported": report.imported,
+            "skipped": report.skipped,
+            "failures": report.failures,
         }),
         Err(error) => json!({ "error": format!("{error:#}") }),
     }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -4282,7 +4282,7 @@ pub fn serve_forever(
     )?);
     start_threads_proposal_scheduler(coven_home)?;
     start_store_maintenance_scheduler(coven_home)?;
-    crate::automations::daemon_tick::start_automations_scheduler(coven_home)?;
+    crate::automations::daemon_tick::start_automations_scheduler(coven_home, runtime.clone())?;
 
     let (tcp_thread, active_tcp_connection) = if let Some(addr) = tcp_addr {
         let tcp_listener = bind_tcp_listener(addr)?;

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -4282,6 +4282,7 @@ pub fn serve_forever(
     )?);
     start_threads_proposal_scheduler(coven_home)?;
     start_store_maintenance_scheduler(coven_home)?;
+    crate::automations::daemon_tick::start_automations_scheduler(coven_home)?;
 
     let (tcp_thread, active_tcp_connection) = if let Some(addr) = tcp_addr {
         let tcp_listener = bind_tcp_listener(addr)?;


### PR DESCRIPTION
## Summary

Fifth slice of Coven-native routine automations (OpenCoven/coven#816): migrate legacy Codex definitions into Coven routines.

- `automations/import_legacy.rs` — reads `~/.codex/automations/<id>/automation.toml`, normalizes the Codex RRULE vocabulary (`RRULE:` prefix, `BYMINUTE=0`, `INTERVAL=1`) through the scheduler's vocabulary gate, and imports valid definitions as **PAUSED** routines.
- Non-destructive: source files are never modified, moved, or deleted; entries with unsupported schedules or missing prompts are reported and skipped.
- `control_plane.rs` — `coven.automations.import` action with an imported/skipped/failures report.

## Verification
- `cargo test -p coven-cli --bin coven -- automations` — 40 tests (normalization, vocabulary refusal, pinned-HOME import round-trip).
- `cargo clippy -p coven-cli --all-targets` clean; `cargo fmt` clean.