### PR TITLE
fix(release): stop gh rejecting the GitHub Release creation

### DIFF
--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -26,6 +26,7 @@ const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release-github
 const ciWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'ci.yml');
 const workflowText = readFileSync(workflowPath, 'utf8');
 const ciWorkflowText = readFileSync(ciWorkflowPath, 'utf8');
+const releaseScriptText = readFileSync(path.join(repoRoot, 'scripts', 'package-github-release.mjs'), 'utf8');
 const fixtureRoot = path.join(repoRoot, 'scripts', 'fixtures', 'package-github-release', 'source-artifacts');
 const scratchRoot = path.join(repoRoot, 'npm', 'dist', '.package-github-release-tests');
 const SOURCE_DATE_EPOCH = 1_786_939_861;
@@ -2004,4 +2005,24 @@ test('syncGitHubRelease preflights later mismatches before uploading earlier mis
     assert.deepEqual(client.state.downloads, [windowsAssetName]);
     assert.equal(client.state.uploads.length, 0);
   });
+});
+
+test('release creation never combines --notes-from-tag with --repo', () => {
+  // v0.4.1 published to npm and then produced no GitHub Release at all,
+  // because recent `gh` rejects this exact pair:
+  //   using `--notes-from-tag` with `--repo` is not supported
+  // The unit tests above stub createRelease, so nothing exercised the real
+  // argv and the incompatibility shipped. This guards the argv itself.
+  assert.ok(
+    releaseScriptText.includes("'--repo'"),
+    'the release client must keep --repo; it cannot assume its cwd is the target repository'
+  );
+  assert.ok(
+    !releaseScriptText.includes("'--notes-from-tag'"),
+    'gh refuses --notes-from-tag alongside --repo; resolve the tag annotation and pass --notes-file instead'
+  );
+  assert.ok(
+    releaseScriptText.includes("'--notes-file'"),
+    'release notes must still come from the signed tag annotation, via --notes-file'
+  );
 });

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -2013,16 +2013,21 @@ test('release creation never combines --notes-from-tag with --repo', () => {
   //   using `--notes-from-tag` with `--repo` is not supported
   // The unit tests above stub createRelease, so nothing exercised the real
   // argv and the incompatibility shipped. This guards the argv itself.
+  // Match the argv construction rather than raw text: quote style is
+  // incidental, and a bare search for the flag name would also hit the
+  // explanatory comment above createRelease.
+  const pushes = (flag) =>
+    new RegExp(String.raw`args\.push\(\s*['"]` + flag + String.raw`['"]`).test(releaseScriptText);
   assert.ok(
-    releaseScriptText.includes("'--repo'"),
+    /['"]--repo['"]/.test(releaseScriptText),
     'the release client must keep --repo; it cannot assume its cwd is the target repository'
   );
   assert.ok(
-    !releaseScriptText.includes("'--notes-from-tag'"),
+    !pushes('--notes-from-tag'),
     'gh refuses --notes-from-tag alongside --repo; resolve the tag annotation and pass --notes-file instead'
   );
   assert.ok(
-    releaseScriptText.includes("'--notes-file'"),
+    pushes('--notes-file'),
     'release notes must still come from the signed tag annotation, via --notes-file'
   );
 });

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -2,7 +2,8 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { closeSync, mkdirSync, openSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { closeSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { gzipSync } from 'node:zlib';
@@ -1328,15 +1329,48 @@ function createGhReleaseClient({ repository = process.env.GITHUB_REPOSITORY } = 
       }
       return JSON.parse(result.stdout);
     },
+    /// Read the annotated tag's message through the API rather than asking
+    /// `gh release create --notes-from-tag` to do it. Recent `gh` refuses
+    /// `--notes-from-tag` together with `--repo` ("using `--notes-from-tag`
+    /// with `--repo` is not supported"), which silently became a release
+    /// blocker: v0.4.1 published to npm and then failed to produce any GitHub
+    /// Release. Dropping `--repo` is not an option -- this script does not
+    /// assume its cwd is the target repository -- so the notes are resolved
+    /// here and passed as a file instead.
+    async readTagAnnotation(releaseTag) {
+      const refEndpoint = `/repos/${repository}/git/ref/tags/${encodeURIComponent(releaseTag)}`;
+      const ref = JSON.parse(runCommand('gh', ['api', refEndpoint]));
+      if (ref?.object?.type !== 'tag') {
+        throw new Error(
+          `Refusing GitHub release: ${releaseTag} is not an annotated tag (object type ${ref?.object?.type ?? 'unknown'}).`
+        );
+      }
+      const tagEndpoint = `/repos/${repository}/git/tags/${encodeURIComponent(ref.object.sha)}`;
+      const message = JSON.parse(runCommand('gh', ['api', tagEndpoint]))?.message;
+      if (typeof message !== 'string' || message.trim().length === 0) {
+        throw new Error(`Refusing GitHub release: ${releaseTag} has an empty tag annotation.`);
+      }
+      return message;
+    },
     async createRelease({ releaseTag, title, notesFromTag, verifyTag }) {
       const args = ['release', 'create', releaseTag, '--repo', repository, '--title', title];
+      let notesPath;
       if (notesFromTag) {
-        args.push('--notes-from-tag');
+        const notes = await this.readTagAnnotation(releaseTag);
+        notesPath = path.join(mkdtempSync(path.join(tmpdir(), 'coven-release-notes-')), 'notes.md');
+        writeFileSync(notesPath, notes.endsWith('\n') ? notes : `${notes}\n`);
+        args.push('--notes-file', notesPath);
       }
       if (verifyTag) {
         args.push('--verify-tag');
       }
-      runCommand('gh', args);
+      try {
+        runCommand('gh', args);
+      } finally {
+        if (notesPath) {
+          rmSync(path.dirname(notesPath), { recursive: true, force: true });
+        }
+      }
       const release = await this.getReleaseByTag(releaseTag);
       if (!release) {
         throw new Error(`GitHub release ${releaseTag} was created but could not be reloaded.`);

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -1354,21 +1354,24 @@ function createGhReleaseClient({ repository = process.env.GITHUB_REPOSITORY } = 
     },
     async createRelease({ releaseTag, title, notesFromTag, verifyTag }) {
       const args = ['release', 'create', releaseTag, '--repo', repository, '--title', title];
-      let notesPath;
-      if (notesFromTag) {
-        const notes = await this.readTagAnnotation(releaseTag);
-        notesPath = path.join(mkdtempSync(path.join(tmpdir(), 'coven-release-notes-')), 'notes.md');
-        writeFileSync(notesPath, notes.endsWith('\n') ? notes : `${notes}\n`);
-        args.push('--notes-file', notesPath);
-      }
-      if (verifyTag) {
-        args.push('--verify-tag');
-      }
+      // The cleanup guard opens before the directory exists and closes after
+      // gh returns, so a throw from writeFileSync leaves nothing behind either.
+      let notesDir;
       try {
+        if (notesFromTag) {
+          const notes = await this.readTagAnnotation(releaseTag);
+          notesDir = mkdtempSync(path.join(tmpdir(), 'coven-release-notes-'));
+          const notesPath = path.join(notesDir, 'notes.md');
+          writeFileSync(notesPath, notes.endsWith('\n') ? notes : `${notes}\n`);
+          args.push('--notes-file', notesPath);
+        }
+        if (verifyTag) {
+          args.push('--verify-tag');
+        }
         runCommand('gh', args);
       } finally {
-        if (notesPath) {
-          rmSync(path.dirname(notesPath), { recursive: true, force: true });
+        if (notesDir) {
+          rmSync(notesDir, { recursive: true, force: true });
         }
       }
       const release = await this.getReleaseByTag(releaseTag);


### PR DESCRIPTION
## Context

**`v0.4.1` published all five npm packages successfully and then produced no GitHub Release at all.** `Publish GitHub Release` run [33178686131](https://github.com/OpenCoven/coven/actions/runs/33178686131) failed at *Synchronize canonical GitHub release assets*:

```
using `--notes-from-tag` with `--repo` is not supported
```

`createRelease()` passed both flags. Recent `gh` refuses the combination, so the public binary/checksum surface — the four platform archives plus `SHA256SUMS` — was never published. npm provenance was unaffected.

This is latent, not a v0.4.1 regression: the flag pair has been there since the workflow was automated in `6b7639d` and only started failing when the runner's `gh` picked up the restriction. v0.4.0 predates it.

## Implementation

Dropping `--repo` is not an option — this script does not assume its cwd is the target repository. So the annotation is resolved explicitly instead: `git/ref/tags/<tag>` for the tag object, `git/tags/<sha>` for its message, written to a temp file and passed via `--notes-file`.

Release notes still come from the signed tag annotation, which is the entire point of `--notes-from-tag`; only the mechanism changes.

`readTagAnnotation` also fails closed on a lightweight tag or an empty annotation, rather than silently publishing a Release with no notes.

## Why this shipped, and the test that stops it recurring

The existing suite stubs `createRelease` wholesale, so **nothing ever exercised the real argv**. That is precisely how an incompatible flag pair reached production.

Added a guard asserting the script keeps `--repo`, never passes `--notes-from-tag`, and does pass `--notes-file`. **Verified it bites:** reinstating `--notes-from-tag` fails it.

## Verification

- `node --test scripts/package-github-release-test.mjs` — 34/34
- `node --test scripts/publish-npm-test.mjs` — 82 pass, 0 fail
- `node --check` — syntax clean
- secret + privacy guards — rc 0

## Risk

Low. Release tooling only; no product code. The failure mode of the change is a refused release with a clear message rather than a silent one.

## Agent Handoff

Recovery for the already-published v0.4.1 once this lands is the path documented in `docs/reference/releasing.md`: re-dispatch **Publish GitHub Release** via `workflow_dispatch` with `release_tag=v0.4.1`, `source_run_id=33174565767`, `source_run_attempt=1`. That path is additive-only and never republishes npm.

Blocks `coven-v041-postflight`, which requires the four archives plus `SHA256SUMS` to verify. Filed as `coven-4f2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
