### PR TITLE
fix(setup): extract versions that end in a sentence period

### DIFF
--- a/crates/coven-cli/src/setup/process.rs
+++ b/crates/coven-cli/src/setup/process.rs
@@ -165,6 +165,13 @@ fn extract_version(output: &str, expected_program: Option<&str>) -> Option<Strin
             let normalized = raw.trim_matches(|character: char| {
                 !character.is_ascii_alphanumeric() && !matches!(character, '.' | '_' | '+' | '-')
             });
+            // '.' has to survive the trim above because versions are full of
+            // them, which leaves a sentence-ending period attached: GitHub
+            // Copilot CLI prints "GitHub Copilot CLI 1.0.81." and the trailing
+            // dot made valid_version see an empty final component, so no
+            // version was extracted at all. A version never legitimately ends
+            // in '.', so strip it here rather than loosening validation.
+            let normalized = normalized.trim_end_matches('.');
             (raw, normalized)
         })
         .collect::<Vec<_>>();
@@ -498,5 +505,40 @@ mod windows_job {
         let previous_suspend_count = unsafe { ResumeThread(thread) };
         unsafe { CloseHandle(thread) };
         previous_suspend_count == 1
+    }
+}
+
+#[cfg(test)]
+mod version_extraction_tests {
+    use super::*;
+
+    #[test]
+    fn copilot_version_output_with_a_trailing_period_is_extracted() {
+        // GitHub Copilot CLI ends its version line with a sentence period:
+        //   GitHub Copilot CLI 1.0.81.
+        // A trailing '.' is punctuation, never part of a version, but the token
+        // normalizer keeps '.' because versions contain them. That left
+        // "1.0.81." which valid_version rejects (an empty final component), so
+        // no version was extracted and `coven setup copilot --report-json`
+        // failed privacy validation with no report written.
+        assert_eq!(
+            extract_version(
+                "GitHub Copilot CLI 1.0.81.\nRun 'copilot update' to check for updates.",
+                Some("copilot")
+            ),
+            Some("1.0.81".to_string())
+        );
+    }
+
+    #[test]
+    fn versions_without_trailing_punctuation_still_extract() {
+        assert_eq!(
+            extract_version("OpenAI Codex v0.145.0", Some("codex")),
+            Some("v0.145.0".to_string())
+        );
+        assert_eq!(
+            extract_version("2.1.220 (Claude Code)", Some("claude")),
+            Some("2.1.220".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Context

**Copilot certification is impossible in the shipped v0.4.1 build.** Found by actually running the certification packet against real provider accounts — the provider turn *succeeds*, copilot replies `OK.`, and then:

```
Error: setup report failed privacy validation
```

No report is written. Codex and Claude both certify fine.

## Root cause

GitHub Copilot CLI prints:

```
GitHub Copilot CLI 1.0.81.
Run 'copilot update' to check for updates.
```

Note the **sentence-ending period**. The token normalizer in `extract_version` must keep `.` because versions are full of them, so `1.0.81.` survives intact. `valid_version` then splits on `.`, sees an empty final component, and rejects it. No candidate is found, the version is `None`, and `publish_report` — which requires a version — returns `Rejected` and writes nothing.

Deterministic, not flaky. It makes `coven-v041-cert` unsatisfiable for one of the three supported harnesses.

## Implementation

A version never legitimately ends in `.`, so strip a trailing period during normalization. The alternative — loosening `valid_version` to tolerate an empty trailing component — would start accepting malformed versions everywhere, which is the wrong trade for a field that lands in a signed certification artifact.

## Verification

Test-first: the failing test was written before the fix and reproduced the exact behaviour — `extract_version` returned `None` for Copilot's real output. It now returns `"1.0.81"`. Codex (`v0.145.0`) and Claude (`2.1.220`) extraction are unchanged and covered by the same test.

`cargo test -p coven-cli --test setup_cli -- --test-threads=1` — **42/42**.

## A correction worth recording

I initially reported that this change broke two `setup_cli` tests. **That was wrong**, and I want it in the record rather than quietly dropped.

`setup_cli` fails 3–4 of 42 under parallel load on macOS, and does so on **unmodified `main`** as much as with this change. Measured three runs each way:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| unmodified `main` | 4 failed | 3 failed | 3 failed |
| with this change | 2 failed | 4 failed | 2 failed |

Same distribution — the change is irrelevant, the parallelism is not. Serial: 42 passed, 0 failed. My first conclusion came from a single lucky baseline run.

Filed separately as **`coven-hph`**. The inner helper's error is the same `SetupError::Rejected`, reachable when the version probe's deadline is lost under load — putting it in the same family as `coven-9ts`.

## Risk

Low. One normalization step in version parsing, covered by a test that fails without it.

## Agent Handoff

Once this ships, `coven-v041-cert` becomes satisfiable for Copilot. Note the packet must be regenerated from a build containing this fix, so its `candidate_commit` will be the new SHA rather than v0.4.1's `d07302c` — the v0.4.1 packet cannot be completed retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
