### PR TITLE
chore(release): move the certification helper into scripts/ and generalize it

### DIFF
--- a/scripts/certify-release.sh
+++ b/scripts/certify-release.sh
@@ -1,35 +1,73 @@
 #!/usr/bin/env bash
-# Produce the v0.4.1 three-harness certification packet (coven-v041-cert).
+# Produce a three-harness release certification packet.
 #
-# Run from the repo root, in a real terminal:   ./certify-v0.4.1.sh
+#   scripts/certify-release.sh <tag>        e.g. scripts/certify-release.sh v0.4.1
+#
+# Runs `coven setup <provider> --verify-only --report-json` against real Codex,
+# Claude Code and GitHub Copilot CLI accounts and checks that every report
+# certifies the tagged commit.
 #
 # Needs a TTY: `coven setup` asks for explicit network/cost consent and runs one
-# bounded real turn per provider. It exits nonzero and writes nothing when piped.
-# This script is untracked scratch -- delete it when the packet is filed.
+# bounded real turn per provider, so it exits nonzero and writes nothing when
+# piped. Each turn costs real provider usage; the script is ordered to fail
+# before spending turns it does not need to.
+#
+# Environment:
+#   COVEN_BIN  pin a specific coven binary (required when several are on PATH)
+#   OUT_DIR    where reports are written (default ~/coven-cert-<tag>)
 
 set -euo pipefail
 
-EXPECTED_TAG="v0.4.1"
-OUT_DIR="${OUT_DIR:-$HOME/coven-cert-v0.4.1}"
+usage() {
+  printf 'usage: %s <tag>\n  e.g. %s v0.4.1\n' "$0" "$0" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+case "$1" in
+  -h|--help) usage ;;
+  v[0-9]*) ;;
+  *) printf 'error: tag must look like v1.2.3, got %s\n' "$1" >&2; usage ;;
+esac
+
+EXPECTED_TAG="$1"
+EXPECTED_VERSION="${EXPECTED_TAG#v}"
+OUT_DIR="${OUT_DIR:-$HOME/coven-cert-$EXPECTED_TAG}"
 
 say()  { printf '\n\033[1m== %s\033[0m\n' "$*"; }
 ok()   { printf '   \033[32mok\033[0m   %s\n' "$*"; }
 bad()  { printf '   \033[31mFAIL\033[0m %s\n' "$*" >&2; }
 die()  { bad "$*"; exit 1; }
 
-# Read one field from a report without requiring jq.
+# Read one field from a report without requiring jq. Never fails: an unreadable
+# or malformed report yields an empty value so the caller reports it as a packet
+# problem instead of aborting the run under `set -e` with a traceback.
 field() { # field <file> <key>
-  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],""))' "$1" "$2"
+  python3 -c 'import json, sys
+try:
+    value = json.load(open(sys.argv[1])).get(sys.argv[2], "")
+except Exception:
+    value = ""
+print(value)' "$1" "$2" 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
 say "1/5  repo root and expected commit"
 # ---------------------------------------------------------------------------
-[ -d .git ] || die "run this from the repo root (no .git here)"
-git rev-parse --verify "$EXPECTED_TAG" >/dev/null 2>&1 \
+# `.git` is a *file* in a linked worktree and absent in subdirectories, so ask
+# git instead of stat-ing a directory.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || die "run this from inside the coven checkout (no git work tree here)"
+# Resolve through refs/tags explicitly: a bare tag-shaped rev also matches a local
+# *branch* of that name, which would sail past the "fetch your tags" guard.
+EXPECTED_SHA="$(git rev-parse --verify --quiet "refs/tags/$EXPECTED_TAG^{commit}")" \
   || die "tag $EXPECTED_TAG not found locally -- run: git fetch origin --tags"
-EXPECTED_SHA="$(git rev-list -n 1 "$EXPECTED_TAG")"
 ok "$EXPECTED_TAG -> $EXPECTED_SHA"
+
+# Every report read below goes through python3. Fail here, before any consent
+# prompt, rather than after a paid provider turn has already been spent.
+command -v python3 >/dev/null 2>&1 \
+  || die "python3 is required to read the reports -- install it before running this"
 
 # ---------------------------------------------------------------------------
 say "2/5  the coven on PATH is the released build"
@@ -41,7 +79,12 @@ PATHS="$(type -aP coven 2>/dev/null | sort -u || true)"
 if [ -n "$PATHS" ]; then
   while IFS= read -r p; do
     [ -n "$p" ] || continue
-    printf '        %-56s %s\n' "$p" "$("$p" --version 2>/dev/null | head -1 || echo '(failed)')"
+    # No `| head -1` here: under `pipefail` a multi-line writer takes SIGPIPE,
+    # the pipeline reports 141, and the `|| echo` fallback would append
+    # "(failed)" *after* a version line that was actually read fine.
+    ver="$("$p" --version 2>/dev/null || true)"
+    ver="${ver%%$'\n'*}"
+    printf '        %-56s %s\n' "$p" "${ver:-(failed)}"
   done <<< "$PATHS"
 fi
 
@@ -51,20 +94,23 @@ if [ -n "${COVEN_BIN:-}" ]; then
   ok "using explicit COVEN_BIN=$COVEN"
 else
   COUNT="$(printf '%s\n' "$PATHS" | grep -c . || true)"
-  [ "$COUNT" -ge 1 ] || die "coven is not on PATH -- npm install -g @opencoven/cli@0.4.1"
+  [ "$COUNT" -ge 1 ] || die "coven is not on PATH -- npm install -g @opencoven/cli@$EXPECTED_VERSION"
   if [ "$COUNT" -ne 1 ]; then
     bad "$COUNT coven binaries on PATH -- certifying the wrong one is silent and undetectable later"
-    die "re-run pinned to the v0.4.1 one, e.g.:  COVEN_BIN=/path/to/coven ./certify-v0.4.1.sh"
+    die "re-run pinned to the $EXPECTED_TAG one, e.g.:  COVEN_BIN=/path/to/coven $0"
   fi
   COVEN="$(printf '%s\n' "$PATHS" | head -1)"
   ok "exactly one coven on PATH"
 fi
 
-VERSION_LINE="$("$COVEN" --version)"
+VERSION_LINE="$("$COVEN" --version)" \
+  || die "$COVEN --version failed -- the install is broken; fix it before certifying"
 printf '        %s\n' "$VERSION_LINE"
+# `coven --version` always prints "coven <desc> (engine ...)". Anchor on the
+# leading token: an unanchored *v0.4.1* also matches v0.4.10 and v0.4.1-rc1.
 case "$VERSION_LINE" in
-  *"v0.4.1"*) ok "version is v0.4.1" ;;
-  *) die "expected v0.4.1, got: $VERSION_LINE  (npm install -g @opencoven/cli@0.4.1)" ;;
+  "coven $EXPECTED_TAG "*) ok "version is $EXPECTED_TAG" ;;
+  *) die "expected $EXPECTED_TAG, got: $VERSION_LINE  (npm install -g @opencoven/cli@$EXPECTED_VERSION)" ;;
 esac
 
 # ---------------------------------------------------------------------------
@@ -92,7 +138,12 @@ for h in codex claude copilot; do
     FAILED="$FAILED $h"
   fi
 
-  if [ "$h" = "codex" ] && [ -f "$OUT_DIR/codex.json" ]; then
+  if [ "$h" = "codex" ]; then
+    # No codex report means the baked commit is unverifiable, which is exactly
+    # the state the codex-first ordering exists to stop at -- don't fall through
+    # and spend the other two provider turns on an unidentified build.
+    [ -f "$OUT_DIR/codex.json" ] \
+      || die "no codex report, so this binary's candidate_commit is unverifiable; stopping before spending the other two provider turns"
     GOT="$(field "$OUT_DIR/codex.json" candidate_commit)"
     if [ "$GOT" != "$EXPECTED_SHA" ]; then
       bad "candidate_commit is $GOT, expected $EXPECTED_SHA"


### PR DESCRIPTION
## Context

`bdec6c1` committed this helper at the **repo root**, while its own header still described it as "untracked scratch -- delete it when the packet is filed". It also hardcoded `v0.4.1`, so it would rot the moment v0.4.2 shipped.

Move it to `scripts/` where every other helper lives, rename to `certify-release.sh`, and take the tag as a required argument:

```
scripts/certify-release.sh v0.4.1
```

This also lands the code-review fixes that were sitting uncommitted in the working tree.

## The seven fixes, and why they mattered

| # | issue | why it bit |
| --- | --- | --- |
| 1 | `[ -d .git ]` | `.git` is a **file** in a linked worktree, and absent in subdirectories. This repo's workflow pushes worktrees heavily, so the guard rejected the *common* case with "no .git here" while standing in a valid checkout. Now uses `git rev-parse --is-inside-work-tree`. |
| 2 | tag guard matched a branch | `git rev-parse --verify v0.4.1` also resolves a local **branch** of that name, sailing past the "fetch your tags" guard and deriving `EXPECTED_SHA` from it — silently certifying the wrong commit. Now resolves `refs/tags/<tag>^{commit}`. |
| 3 | cost guard self-defeating | It was gated on the codex report existing, but reports are **success-only**. A failed codex turn made the guard no-op, and the script then spent the claude and copilot turns against an unverified build — the exact outcome it existed to prevent. Now a hard stop. |
| 4 | undeclared `python3` | Only exercised *after* a paid turn. On a clean macOS `python3` is an Xcode-CLT stub that exits nonzero, killing the run under `set -e` with an opaque prompt. Now preflighted before any consent prompt, and `field()` is exception-safe so a malformed report is a packet problem, not a traceback after three spent turns. |
| 5 | version gate ignored the tag, unanchored | `EXPECTED_TAG` was defined but `v0.4.1` was hardcoded in five places, and the glob was unanchored — `v0.4.10` and `v0.4.1-rc1` both passed as "v0.4.1". |
| 6 | unguarded `--version` | A binary that exists but cannot run (broken platform package, Node too old) aborted with no script-level diagnostic. |
| 7 | `pipefail` + `head -1` | Misfired in exactly the case `head -1` existed for: a multi-line writer takes SIGPIPE, the pipeline reports 141, and the fallback appends `(failed)` *after* a version line that read fine. |

Findings 1, 2 and 3 are the ones I'd flag as substantive — each silently produces a wrong or wasteful outcome rather than an error.

## Verification

- `shellcheck` — clean
- no argument, and a malformed tag like `0.4.1` — exit 2 with usage
- unknown tag `v9.9.9` — fails with the `git fetch origin --tags` hint
- **version anchoring proven both directions with a stub `coven`:** `v0.4.10` now fails against tag `v0.4.1` (previously passed); exact `v0.4.1` passes
- preflight run against a real installed v0.4.1 binary reaches step 3
- secret and privacy guards — pass

## Risk

None to shipped code — an operator helper, not part of any build or release path. It is strictly harder to misuse than before.

## Agent Handoff

The three remaining `v0.4.1` occurrences are documentation examples in the usage text and one explanatory comment, not logic.

Note the helper is now general but the v0.4.1 packet itself cannot be completed: `coven setup copilot --report-json` fails on the shipped build (fixed in #850), so that packet is permanently 2-of-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
