### PR TITLE
fix(test): stop the publish dry-run test hardcoding a real release version

### DIFF
--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -33,6 +33,11 @@ const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/'
 };
 
+/// A version npm can never accept a publish for, so a dry run in a test can
+/// never collide with a real release. Any real version number here passes only
+/// until that version ships.
+const UNPUBLISHABLE_VERSION = '999.0.0';
+
 test('release staging removes stale generated npm output before regeneration', () => {
   const fixture = mkdtempSync(path.join(tmpdir(), 'coven-stale-dist-'));
   try {
@@ -77,20 +82,26 @@ test('wrapper dry-run cannot reuse a stale generated package version', () => {
     );
     writeFileSync(path.join(fixture, 'npm', 'dist', 'stale-platform.txt'), 'stale\n');
 
+    // This reaches a real `npm publish --dry-run`, and npm refuses to publish
+    // over an existing version. A real release number is therefore a time bomb:
+    // it passes until that version ships, then fails forever. v0.4.1 was
+    // hardcoded here and broke every onboarding smoke on main the moment
+    // v0.4.1 was published. Use the same unpublishable sentinel that
+    // test-cli-prepublish.mjs uses for its dry runs.
     const result = spawnSync(
       process.execPath,
       [path.join(fixture, 'scripts', 'publish-npm.mjs'), '--wrapper-only', '--dry-run'],
       {
         encoding: 'utf8',
         cwd: fixture,
-        env: { ...process.env, COVEN_NPM_VERSION: '0.4.1' }
+        env: { ...process.env, COVEN_NPM_VERSION: UNPUBLISHABLE_VERSION }
       }
     );
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
       JSON.parse(readFileSync(stalePackage, 'utf8')).version,
-      '0.4.1',
+      UNPUBLISHABLE_VERSION,
       'generated package must be restamped from the release version'
     );
     assert.equal(
@@ -468,7 +479,7 @@ test('publish path fails closed on a wrapper dependency npm cannot install', () 
     const result = spawnSync(
       process.execPath,
       [path.join(fixture, 'scripts', 'publish-npm.mjs'), '--wrapper-only', '--dry-run'],
-      { encoding: 'utf8', cwd: fixture, env: { ...process.env, COVEN_NPM_VERSION: '0.4.1' } }
+      { encoding: 'utf8', cwd: fixture, env: { ...process.env, COVEN_NPM_VERSION: UNPUBLISHABLE_VERSION } }
     );
     assert.notEqual(result.status, 0, 'publish must fail closed on a git dependency');
     assert.match(

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -33,10 +33,13 @@ const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/'
 };
 
-/// A version npm can never accept a publish for, so a dry run in a test can
-/// never collide with a real release. Any real version number here passes only
-/// until that version ships.
-const UNPUBLISHABLE_VERSION = '999.0.0';
+/// Reserved sentinel for test and CI dry runs, matching the value
+/// test-cli-prepublish.mjs uses. It is not special to npm -- npm would accept a
+/// publish of 999.0.0 like any other version. What makes it safe is that it
+/// sits far above any version this project will realistically ship, so a dry
+/// run cannot collide with an already-published release. A real version number
+/// here passes only until that version ships, then fails permanently.
+const DRY_RUN_SENTINEL_VERSION = '999.0.0';
 
 test('release staging removes stale generated npm output before regeneration', () => {
   const fixture = mkdtempSync(path.join(tmpdir(), 'coven-stale-dist-'));
@@ -86,22 +89,21 @@ test('wrapper dry-run cannot reuse a stale generated package version', () => {
     // over an existing version. A real release number is therefore a time bomb:
     // it passes until that version ships, then fails forever. v0.4.1 was
     // hardcoded here and broke every onboarding smoke on main the moment
-    // v0.4.1 was published. Use the same unpublishable sentinel that
-    // test-cli-prepublish.mjs uses for its dry runs.
+    // v0.4.1 was published.
     const result = spawnSync(
       process.execPath,
       [path.join(fixture, 'scripts', 'publish-npm.mjs'), '--wrapper-only', '--dry-run'],
       {
         encoding: 'utf8',
         cwd: fixture,
-        env: { ...process.env, COVEN_NPM_VERSION: UNPUBLISHABLE_VERSION }
+        env: { ...process.env, COVEN_NPM_VERSION: DRY_RUN_SENTINEL_VERSION }
       }
     );
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
       JSON.parse(readFileSync(stalePackage, 'utf8')).version,
-      UNPUBLISHABLE_VERSION,
+      DRY_RUN_SENTINEL_VERSION,
       'generated package must be restamped from the release version'
     );
     assert.equal(
@@ -479,7 +481,7 @@ test('publish path fails closed on a wrapper dependency npm cannot install', () 
     const result = spawnSync(
       process.execPath,
       [path.join(fixture, 'scripts', 'publish-npm.mjs'), '--wrapper-only', '--dry-run'],
-      { encoding: 'utf8', cwd: fixture, env: { ...process.env, COVEN_NPM_VERSION: UNPUBLISHABLE_VERSION } }
+      { encoding: 'utf8', cwd: fixture, env: { ...process.env, COVEN_NPM_VERSION: DRY_RUN_SENTINEL_VERSION } }
     );
     assert.notEqual(result.status, 0, 'publish must fail closed on a git dependency');
     assert.match(


### PR DESCRIPTION
## Context

**`main` is red on all four `npm onboarding smoke` targets, and has been since v0.4.1 published.** It blocks every open PR (#849, #850, #851 all fail on it).

`scripts/publish-npm-test.mjs` hardcoded `COVEN_NPM_VERSION: '0.4.1'` for a test that reaches a real `npm publish --dry-run`. npm refuses to publish over an existing version:

```
npm error You cannot publish over the previously published versions: 0.4.1.
npm publish --dry-run exited with 1
1 !== 0
```

That value was **safe when written** — 0.4.1 was unpublished — and became a permanent failure the moment the release shipped. It is a time bomb that re-arms every release: any real version number in this position passes until that version ships, then fails forever.

## Implementation

Both sites now use an `UNPUBLISHABLE_VERSION` sentinel of `999.0.0` — the same convention `test-cli-prepublish.mjs` already uses for its dry runs — with a comment recording why a real version must never appear here.

The second site (the git-dependency test) aborts before npm is invoked, so it was not failing, but it carried the identical latent trap and is fixed too.

## Verification, stated precisely

`node --test scripts/publish-npm-test.mjs` — 82 pass, 0 fail.

**The local negative test did not reproduce.** Restoring `'0.4.1'` still passes on my machine, because the local npm is authenticated and has cached registry metadata, so it does not take the same path as CI. I am not claiming a proof I do not have: the fix is correct **by construction** — `999.0.0` can never collide with a real release — but **CI is the verifier here, not a local run.** The check to watch on this PR is `npm onboarding smoke`, which is currently failing on `main`.

## Risk

Low, and it unblocks four PRs. Test-only.

## Agent Handoff

Merge this **first** — #849, #850 and #851 cannot go green until it lands.

Worth a follow-up: a lint or test guarding against real release versions in dry-run positions would prevent the next instance. This class is invisible in review because the value is correct right up until release day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J86YXtYgkNVZkDriuA3qJG
