### PR TITLE
feat(codex): relay per-turn token usage through the stream-json result (cave-0osmn)

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -4455,6 +4455,7 @@ fn run_session(
                 session_id: record.id.clone(),
                 harness_session_id: None,
                 error: None,
+                usage: None,
             }))?;
         }
         return Ok(());
@@ -4524,6 +4525,7 @@ fn run_session(
                     session_id: record.id.clone(),
                     harness_session_id: None,
                     error: Some(format!("{error:#}")),
+                    usage: None,
                 }))?;
                 return Err(error);
             }
@@ -4549,6 +4551,7 @@ fn run_session(
             session_id: record.id.clone(),
             harness_session_id: None,
             error: None,
+            usage: None,
         }))?;
         if archive {
             let archived_at = current_timestamp();
@@ -4636,6 +4639,7 @@ fn run_session(
                     session_id: record.id.clone(),
                     harness_session_id: None,
                     error: Some(format!("{error:#}")),
+                    usage: None,
                 }))?;
             }
             return Err(error);
@@ -4676,6 +4680,7 @@ fn run_session(
                     session_id: record.id.clone(),
                     harness_session_id: None,
                     error: Some(format!("{error:#}")),
+                    usage: None,
                 }))?;
                 return Err(error);
             }
@@ -4715,6 +4720,7 @@ fn run_session(
             session_id: record.id.clone(),
             harness_session_id: outcome.harness_session_id.clone(),
             error: outcome.error.clone(),
+            usage: outcome.usage.clone(),
         }))?;
         if archive {
             let archived_at = current_timestamp();
@@ -4834,6 +4840,7 @@ fn run_session(
                     session_id: record.id.clone(),
                     harness_session_id: None,
                     error: None,
+                    usage: None,
                 }))?;
             }
             if archive {
@@ -4882,6 +4889,7 @@ fn run_session(
                     session_id: record.id.clone(),
                     harness_session_id: None,
                     error: Some(format!("{error:#}")),
+                    usage: None,
                 }))?;
             }
             Err(error)

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -47,6 +47,11 @@ pub struct CodexJsonRunResult {
     pub harness_session_id: Option<String>,
     pub error: Option<String>,
     pub emitted_assistant: bool,
+    /// Codex's terminal `turn.completed.usage`, normalized to the snake_case
+    /// contract Cave's `parseStreamJsonUsage` reads (`input_tokens`,
+    /// `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`).
+    /// `None` when Codex reported no usage — absent, not zero.
+    pub usage: Option<serde_json::Value>,
 }
 
 pub struct DetachedPtySession {
@@ -1311,6 +1316,7 @@ struct CodexJsonState {
     harness_session_id: Option<String>,
     protocol_error: Option<String>,
     emitted_assistant: bool,
+    usage: Option<serde_json::Value>,
 }
 
 /// Own a one-shot child process tree. A wrapper can outlive or outspawn the
@@ -2937,6 +2943,7 @@ where
         harness_session_id: state.harness_session_id,
         error: state.protocol_error,
         emitted_assistant: state.emitted_assistant,
+        usage: state.usage,
     })
 }
 
@@ -2965,6 +2972,14 @@ where
                 state.harness_session_id = Some(thread_id.to_string());
             }
         }
+        "turn.completed" => {
+            // Codex's terminal frame carries the turn's token usage. Normalize
+            // its field names to Cave's snake_case contract so the daemon does
+            // not leak a harness-specific shape downstream.
+            if let Some(usage) = event.get("usage").and_then(serde_json::Value::as_object) {
+                state.usage = Some(normalize_codex_usage(usage));
+            }
+        }
         "item.completed" => {
             let Some(item) = event.get("item") else {
                 return Ok(true);
@@ -2990,6 +3005,24 @@ where
         _ => {}
     }
     Ok(true)
+}
+
+/// Map Codex's usage field names onto Cave's snake_case contract. Only the
+/// fields Cave's `parseStreamJsonUsage` reads are forwarded; unknown counters
+/// (e.g. `reasoning_output_tokens`) are dropped rather than leaked.
+fn normalize_codex_usage(usage: &serde_json::Map<String, serde_json::Value>) -> serde_json::Value {
+    let mut normalized = serde_json::Map::new();
+    for (source, target) in [
+        ("input_tokens", "input_tokens"),
+        ("output_tokens", "output_tokens"),
+        ("cached_input_tokens", "cache_read_input_tokens"),
+        ("cache_write_input_tokens", "cache_creation_input_tokens"),
+    ] {
+        if let Some(value) = usage.get(source) {
+            normalized.insert(target.to_string(), value.clone());
+        }
+    }
+    serde_json::Value::Object(normalized)
 }
 
 fn append_bounded_tail(tail: &mut Vec<u8>, chunk: &[u8], max_bytes: usize) {
@@ -9426,6 +9459,50 @@ exit 0
             Some("request rejected by Codex")
         );
         assert!(assistant.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn codex_turn_completed_usage_is_normalized() -> anyhow::Result<()> {
+        let mut state = CodexJsonState::default();
+        let mut assistant = Vec::new();
+
+        let valid = handle_codex_json_line(
+            r#"{"type":"turn.completed","usage":{"input_tokens":11,"cached_input_tokens":3,"cache_write_input_tokens":2,"output_tokens":7,"reasoning_output_tokens":1}}"#,
+            &mut state,
+            &mut |text| {
+                assistant.push(text.to_string());
+                Ok(())
+            },
+        )?;
+
+        assert!(valid);
+        assert_eq!(
+            state.usage,
+            Some(serde_json::json!({
+                "input_tokens": 11,
+                "output_tokens": 7,
+                "cache_read_input_tokens": 3,
+                "cache_creation_input_tokens": 2,
+            }))
+        );
+        assert!(assistant.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn codex_turn_completed_without_usage_leaves_no_meter() -> anyhow::Result<()> {
+        let mut state = CodexJsonState::default();
+        let mut assistant = Vec::new();
+
+        let valid =
+            handle_codex_json_line(r#"{"type":"turn.completed"}"#, &mut state, &mut |text| {
+                assistant.push(text.to_string());
+                Ok(())
+            })?;
+
+        assert!(valid);
+        assert!(state.usage.is_none(), "absent usage stays absent, not zero");
         Ok(())
     }
 

--- a/crates/coven-cli/src/stream_json.rs
+++ b/crates/coven-cli/src/stream_json.rs
@@ -123,6 +123,11 @@ pub struct RunResult {
     /// back to the harness on a later resume.
     pub harness_session_id: Option<String>,
     pub error: Option<String>,
+    /// Per-turn token usage, relayed for consumers that persist it (Cave's
+    /// `parseStreamJsonUsage` reads the snake_case contract). Omitted from
+    /// the wire when the harness reported none — absent, not zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<serde_json::Value>,
 }
 
 /// Emit one event as a JSONL frame followed by a single `\n`. Flushes the
@@ -185,6 +190,7 @@ mod tests {
             session_id: "s1".into(),
             harness_session_id: None,
             error: None,
+            usage: None,
         });
         let mut buf = Vec::new();
         emit_event(&mut buf, &event).unwrap();
@@ -197,6 +203,35 @@ mod tests {
         assert_eq!(v["session_id"], "s1");
         assert!(v.get("harness_session_id").is_some());
         assert!(v.get("error").is_some(), "null error field is preserved");
+        assert!(
+            v.get("usage").is_none(),
+            "absent usage is omitted, never serialized as null"
+        );
+    }
+
+    #[test]
+    fn result_usage_relays_when_present() {
+        let event = Event::Result(RunResult {
+            subtype: "success".into(),
+            duration_ms: 12,
+            is_error: false,
+            num_turns: 1,
+            session_id: "s1".into(),
+            harness_session_id: None,
+            error: None,
+            usage: Some(serde_json::json!({
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "cache_read_input_tokens": 2,
+            })),
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let line = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v["usage"]["input_tokens"], 10);
+        assert_eq!(v["usage"]["output_tokens"], 4);
+        assert_eq!(v["usage"]["cache_read_input_tokens"], 2);
     }
 
     #[test]
@@ -394,6 +429,7 @@ mod tests {
                 session_id: "s1".into(),
                 harness_session_id: None,
                 error: None,
+                usage: None,
             }),
         )
         .unwrap();


### PR DESCRIPTION
## Summary

Supports **cave-0osmn** from the daemon side: `coven run --stream-json codex` bridges `codex exec --json` frames into Coven's stream-json protocol, but the bridge dropped the `turn.completed.usage` block, so Codex turns reached Cave with no usage meter.

## Changes

- `pty_runner.rs`: `CodexJsonState`/`CodexJsonRunResult` gain an optional normalized `usage`; the `turn.completed` arm normalizes Codex's field names to Cave's snake_case contract (`cached_input_tokens` → `cache_read_input_tokens`, `cache_write_input_tokens` → `cache_creation_input_tokens`), dropping unknown counters.
- `stream_json.rs`: `RunResult.usage` (optional, `skip_serializing_if` — omitted from the wire when absent, never a null).
- `main.rs`: the Codex one-shot result emission attaches the relayed usage; all other result emissions pass `None`.
- Tests: usage normalization + absent-usage no-meter tests in `pty_runner.rs`; wire-shape tests in `stream_json.rs` (absent → omitted, present → relayed).

## Verification

- `cargo fmt` clean, clippy 0 warnings, targeted unit tests pass.

Companion Cave-side PR: OpenCoven/coven-cave#5156.