### PR TITLE
docs: consolidate Coven security policy, threat boundary, and support claims

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,7 +97,8 @@ a draft spec or design goal is in
 
 The privacy guard is deliberately a **baseline for new changes**: it applies to
 newly staged and PR-changed files while the repository's legacy path examples
-are inventoried and converted to placeholders. It does not claim that
+are inventoried and converted to placeholders. It rejects sensitive examples,
+including invite/handoff URLs containing tokens. It does not claim that
 historical commits satisfy the newer privacy rules, and rewriting public
 history requires explicit maintainer approval.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,114 +1,224 @@
 # Security Policy
 
-Coven is an early local-first harness substrate for project-scoped coding-agent sessions.
-Please treat the repository as pre-1.0 software and avoid running untrusted harnesses or prompts in sensitive repositories.
+Coven is an early local-first harness substrate for project-scoped coding-agent
+sessions: a small Rust authority layer that launches supported harness CLIs
+inside explicit local project boundaries, plus TypeScript integration packages
+around it. This is pre-1.0 software. This document is the single normative
+security policy for the `OpenCoven/coven` repository. It separates what is
+**enforced today**, what is a **residual risk**, and what remains a **design
+goal**.
 
-OpenClaw integration is externalized through the `@opencoven/coven` plugin. OpenClaw core is not part of Coven's trust root; the plugin should be treated as a local socket client, and the Rust daemon must continue validating launch paths, harness ids, input, and kill requests before acting.
+> Scope note: this policy covers Coven the runtime/daemon/CLI and the code in
+> this repository. Organization-wide OpenCoven reporting (protocol, memory
+> substrate, other repositories) belongs in the
+> [organization-level security policy](https://github.com/OpenCoven/.github/blob/main/SECURITY.md).
+> The canonical public overviews live at
+> [docs.opencoven.ai](https://docs.opencoven.ai/docs/reference/safety); this
+> file stays beside the code as the source-adjacent contract.
 
-## Reporting vulnerabilities
+## 1. Supported surfaces and security status
 
-Please report suspected vulnerabilities privately through GitHub Security Advisories for this repository.
-If advisories are unavailable, contact the maintainer privately and avoid posting exploit details in public issues.
+**Supported release family.** Security fixes land on the current minor release
+line published in
+[repository releases](https://github.com/OpenCoven/coven/releases) (v0.4.x as
+of this update). Coven has no long-term-support commitment before 1.0; run the
+latest release to pick up security fixes.
 
-## Local data and credentials
+**Security-supported surfaces.**
 
-Coven should not require repository-stored secrets. Runtime state belongs outside source control:
+- The Rust daemon authority boundary and its versioned local API,
+  `coven.daemon.v1`, over same-user local IPC. See the
+  [local API contract](docs/API-CONTRACT.md) and
+  [authentication and local access](docs/AUTH.md).
+- The bundled CLI and daemon lifecycle surfaces that drive the same boundary
+  (see [README.md](README.md) and the
+  [safety model](docs/SAFETY-MODEL.md)).
+- Local session state: the SQLite event store, default event/log redaction, and
+  artifact persistence defaults. See the
+  [session artifacts spec](specs/coven-session-artifacts/TECH.md) and the
+  [trust layer contract](specs/coven-trust-layer/PRODUCT.md).
+- Repository content guards: the secret scan and the Coven privacy guard run in
+  CI (`Policy guard`) and in managed local hooks.
 
-- `.coven/`
-- `*.sqlite`, `*.sqlite3`, `*.db`
-- `*.sock`
-- `.env*` files
-- private keys and certificates
+**Experimental or disabled surfaces — not security-supported.**
 
-The CI secret guard scans both the current tree and git history for common token/key patterns without printing matched values.
+- **AgentFS NFS mount backend.** The `coven-afs` storage engine is shipped and
+  conformance-tested, but every mount backend sits behind the opt-in `mount`
+  cargo feature and remains a spike. Loopback access control and single-writer
+  SQLite remain open gates in
+  [`specs/coven-agent-fs/MOUNT-SPIKE.md`](specs/coven-agent-fs/MOUNT-SPIKE.md),
+  and the mount surface does not leave experimental status until the
+  dedicated end-to-end certification gate (#779) passes. Do not expose a
+  Coven AFS export beyond the local machine.
+- **OpenClaw bridge plugin.** Disabled by default; it must be explicitly
+  selected as the ACP backend. OpenClaw core is not a Coven trust root, and
+  the plugin's client-side socket validation is defense in depth, not the
+  enforcement boundary. See [authentication and local access](docs/AUTH.md).
+- **Remote and tunnel transports.** The daemon does not bind TCP by default
+  and has no remote authentication design yet. Only the documented remote
+  access paths are supported; do not proxy the raw local IPC endpoint into a
+  network or browser surface. A separate authenticated remote listener is
+  drafted but unshipped (#463).
 
-### Coven privacy guard
+**Same-user trust is not sandboxing.** Coven's boundary assumes the operating
+system separates users and that the person running `coven` controls the
+machine. It distinguishes two different threats:
 
-As of 2026-07-26, Coven uses two explicit scanning tiers:
+- *Same-user local trust* — what Coven relies on: OS-enforced local IPC
+  permissions (a private Unix socket or owner-only named pipe) plus same-user
+  process locality.
+- *Sandboxing against hostile local processes, prompts, or providers* — what
+  Coven does **not** provide. Harnesses run with your user's privileges. A
+  malicious prompt, harness output, or provider response can steer a harness
+  within those privileges; the daemon's checks validate requests against the
+  local API contract, they do not contain a running harness. Never run
+  untrusted harnesses or prompts in sensitive repositories.
 
-1. `scripts/check-secrets.py` scans the current tree and full git history for
-   classic credentials, private keys, and high-entropy secret material.
-2. `scripts/check-coven-privacy.py` fails closed on newly staged and
-   pull-request-changed files containing private session identifiers, messenger
-   IDs, absolute home paths, runtime-internal paths, phone numbers, or
-   invite/handoff URLs containing tokens. Managed hooks installed by
-   `coven hooks install` run this guard before commits, and CI is the
-   authoritative enforcement layer.
+Coven makes no absolute containment claim (such as "cannot escape") for any
+surface. Where a property is enforced, it is tied to the named contracts and
+verification families in the next section.
 
-The second tier intentionally applies to new changes while the repository's
-legacy path examples are inventoried and converted to placeholders. This is a
-documented baseline, not a claim that historical commits satisfy the newer
-privacy rules. Rewriting public history requires explicit maintainer approval.
+## 2. Enforced properties today
+
+Each property below is backed by a normative source-adjacent contract and a
+verification family. This table is the whole list; anything documented only as
+a draft spec or design goal is in
+[Design goals vs guarantees](#5-design-goals-vs-guarantees).
+
+| Property | Normative contract | Verification |
+|---|---|---|
+| Rust-owned validation is authoritative over untrusted clients; every sensitive request is revalidated at the daemon and fails closed on unknown versions, action ids, harnesses, and session ids | [Safety model — trust boundary](docs/SAFETY-MODEL.md), [Authentication — Rust authority checks](docs/AUTH.md) | Rust workspace test suites (`cargo test --workspace`) run in CI on every PR |
+| Capability advertisement never grants permission: `/api/v1/health` capabilities describe availability only, and clients must still pass every per-operation check | [API contract](docs/API-CONTRACT.md) (`Capabilities advertise availability and never grant permission`) | Health-negotiation contract tests (`crates/coven-client/tests/health.rs`) and daemon contract tests |
+| Project, path, and session checks happen before effects: canonicalized `projectRoot`/`cwd`, allowlisted harness ids, live-session validation, and argv-only launch (never `sh -c`) | [Safety model — core rules](docs/SAFETY-MODEL.md), [API contract — error envelopes and fail-closed routes](docs/API-CONTRACT.md) | Rust workspace test suites, including daemon lifecycle and harness parity tests |
+| Owner-protected local transport and peer negotiation: the daemon API travels only over same-user local IPC; the bundled Rust client discovers only the current user's private socket/pipe, binds health negotiation to a transport peer fingerprint, and never auto-replays a mutation | [Authentication and local access](docs/AUTH.md), [API contract — reusable Rust client](docs/API-CONTRACT.md) | Client transport and negotiation tests (`crates/coven-client/tests/health.rs`), Windows daemon lifecycle tests |
+| Event/log redaction and sensitive-artifact defaults: event payloads are redacted before they are stored or returned by the API; raw sensitive artifact persistence is opt-in, off by default, and encrypted at rest with a private per-home key file | [Trust layer contract — defaults that must hold](specs/coven-trust-layer/PRODUCT.md), [Session artifacts spec](specs/coven-session-artifacts/TECH.md) | Redaction unit tests (`crates/coven-cli/src/privacy.rs`) and artifact store tests in the Rust workspace |
+| Secret and privacy guards with a stated baseline: the secret scan covers the full tree and git history; the Coven privacy guard fails closed on new and PR-changed files; CI is the authoritative enforcement layer | [`scripts/check-secrets.py`](scripts/check-secrets.py), [`scripts/check-coven-privacy.py`](scripts/check-coven-privacy.py) | CI `Policy guard` job; managed hooks from `coven hooks install` |
+| Mutation replay is explicit, never implicit: adopted launch/input operations use a normative replay-before-mutable ordering with exact first-adoption and exact-replay responses, and retained ambiguity is surfaced instead of silently resolved | [API contract — request ordering and durable side effects](docs/API-CONTRACT.md) | Adopted-route contract tests in the Rust workspace |
+
+The privacy guard is deliberately a **baseline for new changes**: it applies to
+newly staged and PR-changed files while the repository's legacy path examples
+are inventoried and converted to placeholders. It does not claim that
+historical commits satisfy the newer privacy rules, and rewriting public
+history requires explicit maintainer approval.
 
 Memory-layer code, tests, documentation, and PR discussion must describe memory
-shape without including real memory content. Use synthetic placeholders such
-as `FAMILIAR_ROOT`, `<familiar-id>`, and `01JEXAMPLE...`; never copy real
+shape without including real memory content. Use synthetic placeholders such as
+`FAMILIAR_ROOT`, `<familiar-id>`, and `01JEXAMPLE...`; never copy real
 attestation prose, session identifiers, chat IDs, or local workspace paths into
 the repository.
 
-## Session logs and sensitive artifacts
+## 3. Residual risk and safe configuration
 
-Coven treats session logs, prompts, harness output, tool payloads, and event history as sensitive local data. Do not place secrets in prompts or session context.
+**What local-first does not protect against.** Local-first keeps data on your
+machine and keeps the API off the network by default; it is not a defense
+against software already running as your user, harness processes acting with
+your privileges, or a hostile prompt/provider steering a harness. It also does
+not yet harden daemon-side `COVEN_HOME` ownership and permission checks before
+creating or removing daemon state; that remains a documented hardening priority
+(see [authentication — current hardening gap](docs/AUTH.md)), so client-side
+socket validation should be treated as defense in depth, not a complete
+boundary.
 
-Default session event payloads are redacted before they are stored in SQLite or returned from `/events`, `/sessions/:id/events`, or `/sessions/:id/log`. Redaction covers common authorization headers, cookies, provider token shapes, private key blocks, secret-like `.env` assignments, private gateway URLs, and configured extra patterns.
+**Raw-artifact opt-in risk.** Setting `persist_raw_artifacts = true` in
+`privacy.toml` (or `COVEN_PERSIST_RAW_ARTIFACTS=1`) stores unredacted payload
+artifacts. They are encrypted at rest with a key generated under
+`<COVEN_HOME>/keys/session-artifacts.key` with private file permissions, and
+the key is not stored in the repository or the database. The local key-file
+provider is an MVP for local-first encryption: it protects raw artifact rows
+from casual database inspection, but it is not OS keychain-backed key
+management and is not intended for shared or higher-risk machines.
 
-Raw sensitive artifact persistence is disabled by default. If `privacy.toml` sets `persist_raw_artifacts = true` or `COVEN_PERSIST_RAW_ARTIFACTS=1`, Coven stores raw payload artifacts separately from normal logs using authenticated local encryption. The encryption key is generated under `<COVEN_HOME>/keys/session-artifacts.key` with private file permissions and is not stored in the repository or SQLite database.
+**Retention is data minimization, not secure deletion.** Raw encrypted
+artifacts are retained for 7 days and redacted event logs for 30 days by
+default, with manual pruning via `coven logs prune`. Retention bounds how long
+sensitive rows persist in Coven's store; it does not overwrite database pages
+or other copies your operating system or backup tooling may hold.
 
-The local key-file provider is an MVP for local-first encryption. It protects raw artifact rows from casual database inspection, but it is not a replacement for OS keychain-backed key management on shared or higher-risk machines.
+**Untrusted harnesses and prompts.** Supported harness CLIs (Codex, Claude
+Code, GitHub Copilot CLI; opt-in recipes beyond that set) execute with your
+user's privileges inside the project you point them at. Coven validates how
+they are launched and which sessions they reach; it does not police what a
+running harness does inside those privileges. Do not paste secrets into
+prompts, do not ask a harness to dump environment variables, and use throwaway
+projects for demos and smoke tests.
 
-Default retention is short for raw encrypted artifacts and bounded for operational logs:
+**AgentFS mount safe configuration.** Treat every AFS mount as experimental
+scratch state for a single user on a single machine: loopback only, no
+multi-user export, no exposure beyond localhost, and no use as durable
+storage. The backend is feature-gated and uncertified; its remaining gates and
+go/no-go status are tracked in
+[`specs/coven-agent-fs/MOUNT-SPIKE.md`](specs/coven-agent-fs/MOUNT-SPIKE.md)
+and the certification work under #779, which this section follows. If the
+mount surface ships for real, this policy is updated before that release.
 
-- Raw encrypted artifacts: 7 days.
-- Redacted event logs: 30 days.
-- Manual pruning: `coven logs prune`.
+**Targets and design goals are not enforced properties.** Performance targets,
+SLOs, and architectural goals — in this repository or the wider OpenCoven
+protocol work — are not security properties of Coven until a corresponding
+test suite and release prove them, and release-gating security claims are
+recorded in the shipped-truth/certification evidence produced by the release
+governance work (#779, #805).
 
----
-
-## OpenCoven Security Disclosure Addendum
-
-## Security Policy
-
-### Reporting a Vulnerability
-
-If you discover a security vulnerability in OpenCoven, please report it responsibly.
+## 4. Reporting a vulnerability
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Contact the maintainers directly:
-- Discord: https://discord.gg/OpenCoven (DM @BunsDev)
-- Or open a GitHub Security Advisory on the repository
+- **Primary path:** open a private
+  [GitHub Security Advisory](https://github.com/OpenCoven/coven/security/advisories/new)
+  on this repository. This is the monitored intake for Coven.
+- **Organization-wide findings** (protocol behavior, cross-repository issues,
+  other OpenCoven repositories) belong in the
+  [organization-level security policy](https://github.com/OpenCoven/.github/blob/main/SECURITY.md).
+- If you cannot use Security Advisories, mark a related tracking issue private
+  by contacting a maintainer through an organization-owned channel — please do
+  not depend on any individual's personal account as the reporting path, and
+  never post exploit details in public issues.
 
-We will acknowledge receipt within 48 hours and aim to address confirmed vulnerabilities within 14 days.
+Coven deliberately publishes **no acknowledgment or remediation deadline**.
+Maintainers triage advisories through normal repository maintenance. Adding
+response-time commitments requires an accountable process that can meet and
+measure them; until such a process exists, this policy does not promise one.
+Researchers who responsibly disclose may request credit in a release note, with
+their permission.
 
-### Scope
+**Third-party dependencies and providers.** Findings that live purely inside a
+third-party dependency or a model provider's API are best reported upstream to
+that maintainer. Report them here as well — via a Security Advisory — when they
+materially compromise Coven's supported behavior: bundled or pinned versions,
+Coven's integration defaults, credential-handling boundaries, or anything that
+turns a dependency flaw into a Coven compromise.
 
-Security reports are welcome for:
-- OpenCoven core harness and routing logic
-- OpenTrust memory and session substrate
-- Authentication and identity handling
-- Agent sandbox and execution boundaries
-- Any mechanism that could allow one agent or user to access another's context
+## 5. Design goals vs guarantees
 
-### Out of Scope
+The retired repository policy listed broad isolation properties beside enforced
+behavior. They are **design goals of the OpenCoven protocol**, not enforced
+Coven properties today, and they now live where they belong:
 
-- Issues in third-party dependencies (report to the dependency maintainer)
-- Issues in model provider APIs (report to the provider)
+- **Session isolation** across users and agents, **memory ownership**, and
+  **familiar identity integrity** are protocol-level goals described in the
+  [trust layer contract](specs/coven-trust-layer/PRODUCT.md) and related
+  OpenCoven protocol documents.
+- **Agent-to-agent boundary policy and delegation** are active work in
+  #803 (input-guardrail parity across handoffs) and #804 (invocation and
+  delegation contracts). Coven's current local Runner does not implement A2A
+  isolation; do not rely on it as if it did.
+- **Execution boundaries** are enforced only to the extent of the properties in
+  [Enforced properties today](#2-enforced-properties-today).
 
-### Our Commitment
+A property becomes a Coven guarantee when an executable acceptance or control
+family tests it on a shipped release — the table in section 2 is that list.
+Violating an enforced property is a security report. A path that would defeat a
+design goal (for example, cross-user or cross-agent access) is also worth
+reporting, but it should be described as a protocol-boundary finding, not as a
+broken Coven guarantee.
 
-We take security seriously because OpenCoven handles personal context and agent execution on behalf of users. We will credit researchers who responsibly disclose vulnerabilities (with their permission).
+## Policy maintenance
 
----
+- This file is the single normative security policy for this repository; the
+  organization-level default policy is not additive here.
+- Update it in the same change as any security or secret-handling rule, per
+  [documentation maintenance](docs/DOCS-MAINTENANCE.md).
+- Internal links are relative repository links so they resolve in both the
+  repository and deployed-doc contexts; docs link and freshness validation is
+  tracked under #778.
 
-## Architectural Security Properties
-
-The following properties are design goals of OpenCoven. If you find a way to violate them, that's a security report:
-
-1. **Session isolation** — one user's agent context must not be accessible to another user or agent without explicit permission
-2. **Memory ownership** — a user's stored memory and context must remain under their control
-3. **Agent identity integrity** — a familiar's identity must not be forgeable by another agent or external caller
-4. **Execution boundaries** — agent tool calls must not escape their intended scope
-
----
-
-*Last updated: 2026-07-26*
+*Last updated: 2026-08-30*


### PR DESCRIPTION
## Summary

- Replace the duplicated `SECURITY.md` (repository policy followed by a copied organization-wide `OpenCoven Security Disclosure Addendum`) with one Coven-specific operational security contract that keeps exactly one normative policy and visibly separates its five concerns: supported surfaces/status, enforced properties today, residual risk and safe configuration, private vulnerability reporting, and design goals vs guarantees.
- Retire the stale `OpenTrust`-scope addendum, the personal Discord DM (`@BunsDev`) as a normative reporting path, and the 48-hour acknowledgment / 14-day remediation promises that no accountable process currently backs. GitHub Security Advisories on this repository are the primary private intake; organization-wide reporting is pointed at the organization-level security policy.
- Tie every enforced property to its source-adjacent contract and verification family instead of restating implementation details: Rust authority revalidation and fail-closed handling ([`docs/SAFETY-MODEL.md`](docs/SAFETY-MODEL.md), [`docs/AUTH.md`](docs/AUTH.md)), capability advertisement never grants permission and explicit replay-before-mutable ordering ([`docs/API-CONTRACT.md`](docs/API-CONTRACT.md)), owner-protected local transport and peer negotiation (same-user IPC, peer-fingerprint-bound client negotiation), redaction and sensitive-artifact defaults ([`specs/coven-trust-layer/PRODUCT.md`](specs/coven-trust-layer/PRODUCT.md), [`specs/coven-session-artifacts/TECH.md`](specs/coven-session-artifacts/TECH.md)), and the secret/privacy guards (`scripts/check-secrets.py`, `scripts/check-coven-privacy.py`, CI `Policy guard`) with their documented new-changes baseline.
- Mark experimental surfaces explicitly: the AFS NFS mount backend is feature-gated and stays uncertified until the #779 certification gate closes the remaining loopback/SQLite gates in `specs/coven-agent-fs/MOUNT-SPIKE.md`; the OpenClaw plugin and remote/tunnel transports are opt-in/unsupported without a separate auth design (#463). State that same-user local trust is not sandboxing, and that no absolute containment ("cannot escape") claim is made for any surface.
- Move aspirational properties (session isolation, memory ownership, familiar identity integrity, execution boundaries) into a labeled design-goals section cross-referencing #803/#804, rather than implying the current local Runner implements A2A isolation; note that release-gating security claims belong in the shipped-truth/certification evidence (#779, #805) and docs link/freshness validation under #778.

## Issue

Refs OpenCoven/coven#808

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#808.

## Implementation

- Approach: docs-only rewrite of `SECURITY.md` (~114 → ~215 lines), preserving the still-accurate operational content of the current policy (privacy-guard baseline, retention defaults, redaction coverage, synthetic placeholder rules) reorganized under the required structure. Internal links are relative repo links so they resolve in repository and deployed-doc contexts; external pointers (docs.opencoven.ai safety overview, org-level policy, releases, Security Advisories) are full URLs.
- User-visible behavior: the repository security policy rendered on GitHub and by docs tooling changes; no runtime, API, or build behavior changes.
- Compatibility notes: none (documentation only). The retired addendum's commitments are intentionally removed; researchers are directed to GitHub Security Advisories and the org-level policy for organization-wide scope.

## Test plan

Local (docs-only change; Rust/npm suites unaffected and not executable in this environment — no cargo/python toolchain available, deferred to CI):

- [x] Link validation: every relative link resolves against the tree; section anchors (`#2-enforced-properties-today`, `#5-design-goals-vs-guarantees`) verified against heading slugs; all five external URLs point at live, verified targets (org-level policy verified via REST).
- [x] `git diff --check` (whitespace) — clean.
- [x] Claim freshness pass against current source: retention defaults (7/30 days, `coven logs prune`), redaction implementation and unit tests (`crates/coven-cli/src/privacy.rs`), client peer-fingerprint negotiation tests (`crates/coven-client/tests/health.rs`), AFS conformance tests (`crates/coven-afs/tests/spec_consistency.rs`), `mount` feature gating (`crates/coven-afs/Cargo.toml`), release family (v0.4.x) — all verified at base SHA.
- [x] Synthetic placeholders only; no real session ids, chat ids, phone numbers, absolute home paths, or credentials in examples.
- [ ] `python scripts/check-secrets.py` and `python scripts/check-coven-privacy.py` — deferred to CI `Policy guard` (no local Python).
- [ ] Maintainer/security-owner review of the operational commitments (advisory intake, no-SLA stance, scope split) — requested via review.

CI (docs-only classification expects `changes`, `Policy guard`, and `PR gate`):

- [ ] `Policy guard` (secret scan + privacy guard + workflow/script checks) green.
- [ ] `PR gate` green.

## Risk and Rollback

- Risk level: low — documentation only; worst case is imprecise wording, mitigated by linking each claim to its owning contract/spec and keeping non-guarantees in a separate labeled section.
- Rollback plan: revert the single commit.

## Agent Handoff

- Current state: single signed commit on `agent/issue-808-p1-consolidate-coven-security-policy-threat`; draft until CI is green.
- Follow-ups: link this policy from the canonical docs/support path in `OpenCoven/coven-docs` (that repository is outside this diff) and keep the AgentFS section synchronized with #779; fold in a maintainer/security-owner review of the reporting process.
- Known gaps: no accountable on-call rotation exists for advisory triage yet, so no acknowledgment/remediation SLA is published; fallback contact beyond GitHub Security Advisories is intentionally left unspecified rather than pointing at a personal channel.


## CI note (fork vehicle)

- **No CI exists on this fork vehicle.** 11+ minutes after opening, the head commit has 0 check runs, 0 workflow runs, and 0 commit statuses (`gh api repos/CompleteDotTech/coven/commits/<sha>/check-runs` → `total_count=0`; `actions/runs` → 0) even though Actions are enabled on the fork. The upstream `OpenCoven/coven` CI (Classify changes → Policy guard → PR gate) has not run and cannot be triggered from here. The local verification checkboxes above are the only executed evidence; treat the `Policy guard`/`PR gate` boxes as pending until the PR is re-targeted upstream or CI runs on this vehicle.

---

> Recreated upstream from [CompleteDotTech/coven#1](https://github.com/CompleteDotTech/coven/pull/1), preserving source head `405478fc13945e5e686c1a054d7bacd0ae6d8e5b` and branch `agent/issue-808-p1-consolidate-coven-security-policy-threat`.