### PR TITLE
docs: operationalize Coven Automations v1 tracker roadmap and drift check (coven#859)

### DIFF
--- a/docs/roadmaps/coven-automations-v1.mapping.json
+++ b/docs/roadmaps/coven-automations-v1.mapping.json
@@ -1,0 +1,206 @@
+{
+  "schema": "coven.automations-v1.tracker-mapping",
+  "schema_version": 1,
+  "description": "Machine-readable Bead <-> GitHub outcome mapping for the Coven Automations v1 program (OpenCoven/coven#859). GitHub owns public outcomes, acceptance gates, and durable evidence links. Beads (in the OpenCoven/coven-cave embedded Dolt database `cave`) owns the implementation dependency graph, execution ownership, and mirror inputs. This file is the reconciliation contract between the two; it is hand-reviewed, not hand-synced.",
+  "sync": {
+    "last_sync": "2026-08-30T15:05:00Z",
+    "source_branch": "agent/issue-859-p0-control-operationalize-coven-automations-v1",
+    "writer": "One canonical writer/process is designated for this setup; see docs/superpowers/plans/2026-08-30-issue-859-coven-automations-v1-tracker-operationalization.md (Decision D1). Persisted tracker changes land only through reviewed PRs.",
+    "canonical_bead_store": "OpenCoven/coven-cave embedded Dolt database `cave`; provisioning is routed through OpenCoven/coven-cave#5220. A competing Beads database must not be initialized in OpenCoven/coven (operational correction on OpenCoven/coven#859, 2026-08-30).",
+    "public_bead_export": "OpenCoven/coven-cave `.beads/issues.jsonl` is a public-scrubbed review export, never canonical state and never a hand-edited sync mechanism.",
+    "beads_tool_reference": "Beads 1.2.2, schema v53, as recorded in docs/superpowers/plans/2026-08-20-coven-v0.4.1-release-program.md; live schema/version verification is owned by OpenCoven/coven-cave#5220.",
+    "drift_check": "node docs/roadmaps/drift-check.mjs (add --beads-export <issues.jsonl> to cross-check an export; --selftest to verify detection rules)",
+    "priority_policy": {
+      "P0": "Current v1 correctness, security, data-loss/duplicate-execution risk, authority violation, broken migration, or certification blocker.",
+      "P1": "Committed SDK/product/docs/ecosystem work required to make the certified core usable and operable.",
+      "P2": "Post-v1 expansion or research that must not silently enter the release critical path."
+    }
+  },
+  "program": "https://github.com/OpenCoven/coven/issues/854",
+  "outcomes": [
+    {
+      "slug": "program",
+      "role": "program",
+      "github": {
+        "repo": "OpenCoven/coven",
+        "issue": 854,
+        "url": "https://github.com/OpenCoven/coven/issues/854",
+        "title": "Program: Coven Automations v1 — reliable, identity-bound familiar routines",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/program",
+        "surface": "shared",
+        "title": "Coven Automations v1 program (GitHub OpenCoven/coven#854)",
+        "id": null,
+        "provisioning": "pending:OpenCoven/coven-cave#5220",
+        "disposition": "active:release-gate-ownership",
+        "gate": "Owns release gates and cross-repository rollup; final #854 release rollup must be generable from reconciled tracker state and exact evidence. Must not be used as a catch-all implementation task.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": [],
+      "depends_on_external": [],
+      "notes": "Priority is P0 program/control: it gates the release but must not absorb implementation work."
+    },
+    {
+      "slug": "foundation",
+      "role": "p0-foundation",
+      "github": {
+        "repo": "OpenCoven/coven",
+        "issue": 816,
+        "url": "https://github.com/OpenCoven/coven/issues/816",
+        "title": "Native familiar automations: replace harness-owned schedules with durable Coven routines",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/foundation",
+        "surface": "shared",
+        "title": "Coven Automations v1 — native routine foundation (GitHub OpenCoven/coven#816)",
+        "id": null,
+        "provisioning": "pending:OpenCoven/coven-cave#5220 (no pre-existing bead found in the public-scrubbed export at sync time; reuse-if-present check owned by OpenCoven/coven-cave#5220)",
+        "disposition": "active:reconciling-landed-evidence",
+        "gate": "#816 evidence checklist: landed commit/PR series linked with an exact final foundation revision; clean-clone automation-test verification; pre-automations schema migration and rollback proof; daemon startup/tick/shutdown/restart proof on supported platforms; one scheduled and one manual run shown to traverse the same claim/ledger/runtime/delivery path; stale lease cannot block the next eligible occurrence indefinitely; failed output delivery cannot report success; every original acceptance criterion reconciled as implemented, deferred, or superseded; Cave ownership migration (OpenCoven/coven-cave#4990) linked with remaining compatibility facade documented.",
+        "evidence_status": "partial",
+        "evidence": [
+          "https://github.com/OpenCoven/coven/pull/846 (merged 2026-08-28; routine definitions and control actions, part 1)",
+          "https://github.com/OpenCoven/coven/pull/847 (merged 2026-08-28; legacy import series, parts 5-8)",
+          "https://github.com/OpenCoven/coven/issues/816 (program-status section of the issue body, updated 2026-08-30: landed inventory and open evidence checklist)"
+        ]
+      },
+      "depends_on": [],
+      "depends_on_external": [],
+      "notes": "Implementation materially landed on main 2026-08-28 (crates/coven-cli/src/automations/); the issue stays open for foundation reconciliation and exact evidence."
+    },
+    {
+      "slug": "protocol",
+      "role": "p0-workstream",
+      "github": {
+        "repo": "OpenCoven/coven",
+        "issue": 855,
+        "url": "https://github.com/OpenCoven/coven/issues/855",
+        "title": "P0: Specify coven.automations.v1 schemas, state machines, idempotency, and changefeed",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/protocol",
+        "surface": "shared",
+        "title": "Coven Automations v1 — protocol schemas, state, idempotency, changefeed (GitHub OpenCoven/coven#855)",
+        "id": null,
+        "provisioning": "pending:OpenCoven/coven-cave#5220",
+        "disposition": "blocked:pending-foundation-reconciliation-and-bead-provisioning",
+        "gate": "coven.automations.v1 schemas, state machines, idempotency rules, and changefeed contract are specified, reviewed, and covered by tests; schema/conformance artifact revisions recorded as evidence.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["foundation"],
+      "depends_on_external": [],
+      "notes": "Feeds SDK read/types/changefeed (P1), SDK mutations/approvals (P1), Cave oversight/recovery (P1), and Psyche adapter (P1) once those outcomes are created."
+    },
+    {
+      "slug": "scheduler",
+      "role": "p0-workstream",
+      "github": {
+        "repo": "OpenCoven/coven",
+        "issue": 856,
+        "url": "https://github.com/OpenCoven/coven/issues/856",
+        "title": "P0: Harden automation time, retries, cancellation, fencing, and crash recovery",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/scheduler",
+        "surface": "shared",
+        "title": "Coven Automations v1 — time, retry, cancel, fencing, recovery (GitHub OpenCoven/coven#856)",
+        "id": null,
+        "provisioning": "pending:OpenCoven/coven-cave#5220",
+        "disposition": "blocked:pending-foundation-reconciliation-and-bead-provisioning",
+        "gate": "Time, retry, cancellation, fencing, and crash-recovery behaviors verified by tests, including stale-lease recovery, misfire semantics, and cancellation without duplicate execution.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["foundation", "protocol"],
+      "depends_on_external": [],
+      "notes": "Depends on #816 and #855 where state/error semantics are required."
+    },
+    {
+      "slug": "authority",
+      "role": "p0-workstream",
+      "github": {
+        "repo": "OpenCoven/coven",
+        "issue": 857,
+        "url": "https://github.com/OpenCoven/coven/issues/857",
+        "title": "P0: Bind automation runs to principal authority, familiar revisions, capabilities, approvals, and receipts",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/authority",
+        "surface": "shared",
+        "title": "Coven Automations v1 — principal/familiar/authority/approval/receipt binding (GitHub OpenCoven/coven#857)",
+        "id": null,
+        "provisioning": "pending:OpenCoven/coven-cave#5220",
+        "disposition": "blocked:pending-foundation-reconciliation-and-bead-provisioning",
+        "gate": "Runs are bound to principal authority, familiar revisions, capabilities, approvals, and receipts; negative tests prove authority bypass fails closed; receipts are tamper-evident and out of tracker scope.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["foundation", "protocol"],
+      "depends_on_external": [],
+      "notes": "Additionally depends on upstream Familiar Contract and Threads profile outcomes once created; no such cross-repository outcomes existed at sync time, so depends_on_external is empty and must be made explicit when they appear."
+    },
+    {
+      "slug": "certification",
+      "role": "p0-workstream",
+      "github": {
+        "repo": "OpenCoven/coven",
+        "issue": 858,
+        "url": "https://github.com/OpenCoven/coven/issues/858",
+        "title": "P0: Build automations conformance, chaos, SLO, and operator diagnostics",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/certification",
+        "surface": "shared",
+        "title": "Coven Automations v1 — conformance, chaos, SLO, operator diagnostics (GitHub OpenCoven/coven#858)",
+        "id": null,
+        "provisioning": "pending:OpenCoven/coven-cave#5220",
+        "disposition": "blocked:pending-p0-workstreams-and-bead-provisioning",
+        "gate": "Conformance, chaos, SLO, and operator-diagnostics suites exist and run without ambient production credentials; the v1 release gate report is produced from them and linked here.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["protocol", "scheduler", "authority"],
+      "depends_on_external": [],
+      "notes": "Certification blocker for the v1 release gate owned by the program outcome."
+    }
+  ],
+  "cross_repository_children": [],
+  "cross_repository_children_policy": "One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome created under OpenCoven/coven#854, mapped one-to-one in this file as each is created. They generally depend on the protocol outcome and, where authority-bearing, the authority outcome; exact dependencies must be explicit rather than inferred from the program parent.",
+  "p2_exclusions": [
+    "Event triggers",
+    "Multi-host routing",
+    "Hosted execution",
+    "Broad external action adapters"
+  ],
+  "p2_exclusions_policy": "These remain post-v1 (P2) and must not be encoded as implicit P0 blockers anywhere in the graph.",
+  "invariants": [
+    "Each GitHub outcome maps to exactly one Bead; each Bead maps to exactly one GitHub outcome.",
+    "Dependencies and P0/P1/P2 priorities in Beads match this file and the roadmap table generated from it.",
+    "A P0 Bead has one accountable owner, one canonical GitHub outcome, explicit dependencies, a current acceptance gate, an active or explicitly blocked disposition, evidence requirements, and no contradictory closed public mirror.",
+    "A Bead closes only when the corresponding GitHub acceptance criteria are satisfied or the outcome is explicitly cancelled/superseded with rationale.",
+    "Generated mirror bodies (including the generated mapping table in docs/roadmaps/coven-automations-v1.md) change only through the generator contract (node docs/roadmaps/drift-check.mjs --render).",
+    "Tracker data is never queried as production automation state; the Coven runtime owns definitions, occurrences, runs, attempts, leases, approvals, artifacts, events, and receipts.",
+    "Tracker output must not contain secrets, private prompts, terminal dumps, credentials, unrestricted personal paths, or sensitive identity/authority payloads."
+  ]
+}

--- a/docs/roadmaps/coven-automations-v1.md
+++ b/docs/roadmaps/coven-automations-v1.md
@@ -1,0 +1,181 @@
+---
+title: "Coven Automations v1 delivery roadmap"
+summary: "Canonical Bead <-> GitHub outcome graph, priorities, dependencies, release gates, and drift controls for the Coven Automations v1 program (OpenCoven/coven#854, operationalized by OpenCoven/coven#859)."
+read_when:
+  - Working on any Coven Automations v1 P0/P1 outcome
+  - Reconciling Beads state against GitHub outcomes
+  - Running or interpreting the tracker drift check
+description: "Delivery roadmap for Coven Automations v1: tracker roles, ownership, the P0/P1/P2 table, the Bead-GitHub mapping, the dependency graph, release gates, and active blockers."
+---
+
+# Coven Automations v1 delivery roadmap
+
+_Last synchronized: 2026-08-30T15:05:00Z (see the sync metadata block below)_
+
+> [!WARNING]
+> **Generated content.** The mapping table in the marked block below is generated from
+> `docs/roadmaps/coven-automations-v1.mapping.json` by
+> `node docs/roadmaps/drift-check.mjs --render`. Edit the mapping, never the block.
+> Mutable run status is deliberately **not** duplicated here: authoritative state lives
+> in the trackers and is linked from this document.
+
+## Program
+
+**Coven Automations v1 — reliable, identity-bound familiar routines**
+([OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854)).
+Tracker operationalization control:
+[OpenCoven/coven#859](https://github.com/OpenCoven/coven/issues/859).
+Parent of the initial P0 graph (#816, #855, #856, #857, #858). The program owns release
+gates and cross-repository rollup and must not be used as a catch-all implementation task.
+
+## Canonical tracker roles
+
+| Tracker | Owns | Must never own |
+| --- | --- | --- |
+| **Beads** (canonical store: `OpenCoven/coven-cave` embedded Dolt database `cave`) | implementation dependency graph; task/quest assignment and active execution ownership; current priority and blocked state; branch/worktree linkage; interaction/delivery evidence references; generated GitHub mirror synchronization inputs | public acceptance criteria, cross-repository issue links, or any role as a runtime ledger |
+| **GitHub** | public outcome and rationale; canonical acceptance criteria and release gates; cross-repository issue links; durable PR/release/conformance evidence links; design/governance decisions | mutable execution state that belongs to the Coven runtime |
+| **Coven runtime** | automation definitions and revisions; occurrences, runs, attempts, leases, approvals, artifacts, events, receipts | — tracker data is never queried as production automation state |
+
+`.beads/issues.jsonl` in `OpenCoven/coven-cave` is a public-scrubbed review export —
+never canonical state and never a hand-edited sync mechanism. Tracker changes land only
+through reviewed PRs (see
+[the #859 status/decision record](../superpowers/plans/2026-08-30-issue-859-coven-automations-v1-tracker-operationalization.md)).
+
+## Sync metadata
+
+- **Last synchronization:** 2026-08-30T15:05:00Z (UTC)
+- **Source branch:** `agent/issue-859-p0-control-operationalize-coven-automations-v1` (based on upstream `main` at `1364cec`)
+- **Machine-readable mapping:** [`coven-automations-v1.mapping.json`](./coven-automations-v1.mapping.json) (schema `coven.automations-v1.tracker-mapping`, version 1)
+- **Drift check:** `node docs/roadmaps/drift-check.mjs` (add `--beads-export <issues.jsonl>` to cross-check an export; `--selftest` verifies detection rules) — runs locally and in CI without ambient production credentials
+- **Beads tool reference:** Beads 1.2.2, schema v53, as recorded in
+  [the v0.4.1 release program record](../superpowers/plans/2026-08-20-coven-v0.4.1-release-program.md);
+  live schema/version verification and bead provisioning are owned by
+  [OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220)
+- **Writer:** exactly one canonical writer/process for this setup (Decision D1 in the
+  #859 status/decision record); concurrent independent migrations and direct writes from
+  unrelated worktrees are refused
+
+## P0 / P1 / P2 policy
+
+- **P0:** current v1 correctness, security, data-loss/duplicate-execution risk, authority violation, broken migration, or certification blocker.
+- **P1:** committed SDK/product/docs/ecosystem work required to make the certified core usable and operable.
+- **P2:** post-v1 expansion or research that must not silently enter the release critical path (event triggers, multi-host routing, hosted execution, broad external action adapters).
+
+Every P0 bead must have: one accountable owner; one canonical GitHub outcome; explicit
+dependencies; a current acceptance gate; an active or explicitly blocked disposition;
+evidence requirements; and no contradictory closed public mirror.
+
+## Outcome mapping
+
+The table below is the canonical Bead ↔ GitHub mapping (also available as JSON):
+
+<!-- BEGIN GENERATED:MAPPING-TABLE v1 -- regenerate with: node docs/roadmaps/drift-check.mjs --render (do not edit by hand) -->
+| Outcome | GitHub | Priority | Bead label | Bead ID | Dependencies | Disposition |
+| --- | --- | --- | --- | --- | --- | --- |
+| program | [OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854) | P0 | `automations-v1/program` | (pending provisioning) | (none) | active:release-gate-ownership |
+| foundation | [OpenCoven/coven#816](https://github.com/OpenCoven/coven/issues/816) | P0 | `automations-v1/foundation` | (pending provisioning) | (none) | active:reconciling-landed-evidence |
+| authority | [OpenCoven/coven#857](https://github.com/OpenCoven/coven/issues/857) | P0 | `automations-v1/authority` | (pending provisioning) | foundation, protocol | blocked:pending-foundation-reconciliation-and-bead-provisioning |
+| certification | [OpenCoven/coven#858](https://github.com/OpenCoven/coven/issues/858) | P0 | `automations-v1/certification` | (pending provisioning) | protocol, scheduler, authority | blocked:pending-p0-workstreams-and-bead-provisioning |
+| protocol | [OpenCoven/coven#855](https://github.com/OpenCoven/coven/issues/855) | P0 | `automations-v1/protocol` | (pending provisioning) | foundation | blocked:pending-foundation-reconciliation-and-bead-provisioning |
+| scheduler | [OpenCoven/coven#856](https://github.com/OpenCoven/coven/issues/856) | P0 | `automations-v1/scheduler` | (pending provisioning) | foundation, protocol | blocked:pending-foundation-reconciliation-and-bead-provisioning |
+
+_Cross-repository child outcomes: none created yet. One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome under the program is mapped here one-to-one as each is created._
+<!-- END GENERATED:MAPPING-TABLE -->
+
+Bead IDs are pending until provisioning lands through
+[OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220) — the
+mapping records the contract (`surface:shared`, exact GitHub links, one-to-one outcomes)
+and the drift check reports the gap (`W010`) until IDs are declared.
+
+## Dependency graph
+
+Minimum canonical P0 graph (from OpenCoven/coven#859):
+
+```text
+#816 foundation
+  ├─ #855 protocol
+  ├─ #856 scheduler reliability
+  └─ #857 identity + authority
+
+#855 ─┬─> #856
+      └─> #857
+
+#855 + #856 + #857 -> #858 certification
+#858 -> v1 release gate
+
+#855 -> SDK read/types/changefeed          (P1)
+#855 + #857 -> SDK mutations/approvals     (P1)
+#855 + #856 + #857 -> Cave oversight/recovery (P1)
+#855 + #857 -> Psyche adapter              (P1)
+upstream Familiar/Threads profiles -> #857 (cross-repo, when created)
+```
+
+Exact dependencies are recorded per outcome in the mapping file
+(`depends_on` slugs; `depends_on_external` for cross-repository outcomes). P1 ecosystem
+beads must declare their exact dependencies rather than inheriting them from the broad
+program parent.
+
+## Release gates
+
+1. **Foundation reconciled** — #816 evidence checklist complete (landed series linked,
+   clean-clone test verification, migration/rollback proof, daemon wiring proof, unified
+   manual/scheduled run path, stale-lease recovery, delivery-failure non-success,
+   compatibility facade reconciled with
+   [OpenCoven/coven-cave#4990](https://github.com/OpenCoven/coven-cave/issues/4990)).
+2. **Protocol specified** — #855 schemas/state machines/idempotency/changefeed reviewed
+   and test-covered.
+3. **Scheduler hardened** — #856 time/retry/cancel/fencing/recovery behaviors proven,
+   including no duplicate execution.
+4. **Authority bound** — #857 principal/familiar/authority/approval/receipt binding with
+   fail-closed negative tests.
+5. **Certification** — #858 conformance/chaos/SLO/operator-diagnostics suites run without
+   ambient production credentials; the v1 release gate report is generated from them.
+6. **Program rollup** — the final #854 release rollup can be generated from reconciled
+   tracker state and exact evidence; no P2 work has leaked onto the critical path.
+
+## Active blockers
+
+- **Bead provisioning pending** — the Automations v1 delivery epic and its
+  `surface:shared` beads do not exist yet in Cave's canonical Beads/Dolt graph;
+  [OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220)
+  owns creation, dependency verification (`bd dep list`, `bd ready --json`), bounded
+  `pnpm beads:sync` evidence, and before/after `refs/dolt/data` OIDs. No competing Beads
+  database may be initialized in `OpenCoven/coven`.
+- **Foundation evidence reconciliation** —
+  [#816](https://github.com/OpenCoven/coven/issues/816) implementation landed on main
+  (2026-08-28) but its evidence checklist (clean-clone verification, migration proof,
+  daemon wiring proof, run-path proof) is still open.
+- **Cross-repository profiles** — the Familiar Contract and Threads profile outcomes that
+  #857 must depend on do not exist yet; `depends_on_external` stays empty and explicit
+  until they are created.
+
+## Evidence and completion semantics
+
+A bead may close only when the corresponding GitHub acceptance criteria are satisfied or
+the outcome is explicitly cancelled/superseded with rationale. Required evidence includes,
+as applicable: PR/merge commit and exact source revision; exact verification
+commands/results; schema/vector/conformance artifact revisions; migration/rollback proof;
+cross-repository canaries; security/privacy/authority impact; release artifact digest and
+certification report; remaining known limitations. A GitHub issue is not closed merely
+because a bead has no active assignee or a partial implementation landed.
+
+## Drift detection
+
+```sh
+# verify the committed mapping, the generated roadmap block, and (optionally) an export
+node docs/roadmaps/drift-check.mjs
+node docs/roadmaps/drift-check.mjs --beads-export .beads/issues.jsonl   # coven-cave checkout
+node docs/roadmaps/drift-check.mjs --strict                             # pending provisioning also fails
+node docs/roadmaps/drift-check.mjs --selftest                           # verify detection rules
+```
+
+The check reports identifiers, statuses, priorities, links, and evidence references only,
+requires no network or credentials, and flags: state disagreement (bead closed while the
+GitHub outcome is open and vice versa), priority disagreement, P0 beads without an active
+P0 outcome (owner/gate/disposition missing), outcomes without exactly one bead mapping,
+unknown/ambiguous parent or dependency mappings, dependency cycles, completed work
+lacking PR/test/release evidence, generated mirror bodies edited outside the generator
+contract, and tracker output containing secrets or sensitive payloads. Severity policy:
+`error` fails CI; `warning` (currently the pending-provisioning `W010`) is reported
+without failing until provisioning is declared, after which the missing-mapping class
+escalates to `error`.

--- a/docs/roadmaps/drift-check.mjs
+++ b/docs/roadmaps/drift-check.mjs
@@ -1,0 +1,727 @@
+#!/usr/bin/env node
+// Drift check for the Coven Automations v1 tracker mapping (OpenCoven/coven#859).
+//
+// Verifies that the machine-readable Bead <-> GitHub mapping
+// (docs/roadmaps/coven-automations-v1.mapping.json), the generated mapping table
+// inside docs/roadmaps/coven-automations-v1.md, and an optional Beads public
+// export (.beads/issues.jsonl from OpenCoven/coven-cave) agree.
+//
+// Design constraints (from OpenCoven/coven#859):
+//   - runnable locally and in CI without ambient production credentials;
+//   - no network access; the optional Beads export is a local file;
+//   - reports identifiers, statuses, priorities, links, and evidence references only;
+//   - tracker data is never treated as production automation state.
+//
+// Usage:
+//   node docs/roadmaps/drift-check.mjs                       # verify committed state (exit 1 on error-severity drift)
+//   node docs/roadmaps/drift-check.mjs --strict              # pending-provisioning warnings also fail
+//   node docs/roadmaps/drift-check.mjs --beads-export PATH   # cross-check a Beads issues.jsonl export
+//   node docs/roadmaps/drift-check.mjs --render              # regenerate the roadmap mapping table in place
+//   node docs/roadmaps/drift-check.mjs --selftest            # run built-in detection fixtures
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROADMAPS_DIR = path.resolve(SCRIPT_DIR);
+const MAPPING_PATH = path.join(ROADMAPS_DIR, "coven-automations-v1.mapping.json");
+const ROADMAP_PATH = path.join(ROADMAPS_DIR, "coven-automations-v1.md");
+
+const BLOCK_BEGIN =
+  "<!-- BEGIN GENERATED:MAPPING-TABLE v1 -- regenerate with: node docs/roadmaps/drift-check.mjs --render (do not edit by hand) -->";
+const BLOCK_END = "<!-- END GENERATED:MAPPING-TABLE -->";
+
+const PRIORITIES = new Set(["P0", "P1", "P2"]);
+const BEAD_PRIORITY_BY_NUMBER = { 0: "P0", 1: "P1", 2: "P2" };
+
+// ---------------------------------------------------------------------------
+// Sensitive-payload detection. Patterns are assembled from fragments so that
+// this source file never itself contains a string matching the repo privacy
+// guard or the detector below.
+// ---------------------------------------------------------------------------
+
+function frag(...parts) {
+  return parts.join("");
+}
+
+const SENSITIVE_PATTERNS = [
+  {
+    name: "coven_session_key",
+    pattern: new RegExp(
+      frag("agent:[A-Za-z0-9_-]+:(?:telegram|imessage|discord|whatsapp|", "signal|webchat):[a-z]+:\\S"),
+    ),
+  },
+  {
+    name: "messenger_chat_id",
+    pattern: new RegExp(
+      frag("(?:telegram|imessage|discord|whatsapp|", "signal):(?:direct:)?\\d{6,}"),
+    ),
+  },
+  {
+    name: "absolute_personal_path",
+    pattern: new RegExp(frag("/", "(?:Users|home)/[A-Za-z0-9._-]+/")),
+  },
+  {
+    name: "runtime_internal_path",
+    pattern: new RegExp(frag("~/", "\\.(?:openclaw|coven)/(?:agents|workspaces|credentials|sessions)")),
+  },
+  {
+    name: "phone_number",
+    pattern: new RegExp(frag("\\+[1-9]\\d{1,14}", "(?!\\d)")),
+  },
+  {
+    name: "credential_bearing_url",
+    pattern: new RegExp(frag("ht", "tps?://\\S*(?:invite|handoff|ts\\.net)\\S*to", "ken\\S*")),
+  },
+];
+
+function findSensitivePayloads(text) {
+  const hits = [];
+  for (const { name, pattern } of SENSITIVE_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match !== null) {
+      hits.push({ rule: name, excerpt: "<redacted: sensitive pattern matched>" });
+    }
+  }
+  return hits;
+}
+
+// ---------------------------------------------------------------------------
+// Analysis core (pure; exercised by --selftest)
+// ---------------------------------------------------------------------------
+
+function outcomeGithubRef(outcome) {
+  return `${outcome.github.repo}#${outcome.github.issue}`;
+}
+
+function buildSlugIndex(mapping) {
+  const bySlug = new Map();
+  for (const outcome of mapping.outcomes ?? []) {
+    bySlug.set(outcome.slug, outcome);
+  }
+  return bySlug;
+}
+
+function findDependencyErrors(mapping) {
+  const findings = [];
+  const bySlug = buildSlugIndex(mapping);
+  const edges = new Map();
+
+  for (const outcome of mapping.outcomes ?? []) {
+    for (const dep of outcome.depends_on ?? []) {
+      if (!bySlug.has(dep)) {
+        findings.push({
+          code: "E003",
+          severity: "error",
+          slug: outcome.slug,
+          message: `unknown dependency mapping: ${outcomeGithubRef(outcome)} depends on unknown slug '${dep}'`,
+        });
+      }
+    }
+    edges.set(outcome.slug, [...(outcome.depends_on ?? [])]);
+  }
+
+  const state = new Map();
+  const stack = new Map();
+  const visit = (slug) => {
+    if (state.get(slug) === "done") return true;
+    if (state.get(slug) === "visiting") {
+      findings.push({
+        code: "E004",
+        severity: "error",
+        slug,
+        message: `dependency cycle involving '${slug}'`,
+      });
+      return false;
+    }
+    state.set(slug, "visiting");
+    for (const dep of edges.get(slug) ?? []) {
+      if (!visit(dep)) return false;
+    }
+    state.set(slug, "done");
+    return true;
+  };
+  for (const slug of edges.keys()) visit(slug);
+
+  return findings;
+}
+
+function findMappingErrors(mapping) {
+  const findings = [];
+  const seenRefs = new Map();
+  const seenSlugs = new Set();
+  const seenLabels = new Set();
+
+  for (const outcome of mapping.outcomes ?? []) {
+    const ref = outcomeGithubRef(outcome);
+    if (seenRefs.has(ref)) {
+      findings.push({
+        code: "E001",
+        severity: "error",
+        slug: outcome.slug,
+        message: `GitHub outcome ${ref} maps to more than one bead ('${seenRefs.get(ref)}' and '${outcome.slug}')`,
+      });
+    } else {
+      seenRefs.set(ref, outcome.slug);
+    }
+
+    if (seenSlugs.has(outcome.slug)) {
+      findings.push({
+        code: "E002",
+        severity: "error",
+        slug: outcome.slug,
+        message: `duplicate outcome slug '${outcome.slug}'`,
+      });
+    }
+    seenSlugs.add(outcome.slug);
+
+    const label = outcome.bead?.label;
+    if (label) {
+      if (seenLabels.has(label)) {
+        findings.push({
+          code: "E002",
+          severity: "error",
+          slug: outcome.slug,
+          message: `duplicate bead label '${label}'`,
+        });
+      }
+      seenLabels.add(label);
+    }
+
+    const priority = outcome.github?.priority;
+    if (!PRIORITIES.has(priority)) {
+      findings.push({
+        code: "E005",
+        severity: "error",
+        slug: outcome.slug,
+        message: `invalid or missing priority '${priority}' for ${ref} (expected one of ${[...PRIORITIES].join(", ")})`,
+      });
+    }
+
+    if (priority === "P0") {
+      const missing = [];
+      if (!outcome.github?.owner) missing.push("owner");
+      if (!outcome.bead?.gate) missing.push("acceptance gate");
+      if (!outcome.bead?.disposition) missing.push("disposition");
+      if (missing.length > 0) {
+        findings.push({
+          code: "E006",
+          severity: "error",
+          slug: outcome.slug,
+          message: `P0 outcome ${ref} is missing: ${missing.join(", ")}`,
+        });
+      }
+    }
+
+    const closedMirror =
+      outcome.github?.state === "closed" ||
+      /^(complete|done|closed)/i.test(outcome.bead?.disposition ?? "");
+    if (closedMirror && (outcome.bead?.evidence ?? []).length === 0) {
+      findings.push({
+        code: "E007",
+        severity: "error",
+        slug: outcome.slug,
+        message: `completed work for ${ref} lacks PR/test/release evidence references`,
+      });
+    }
+  }
+
+  findings.push(...findDependencyErrors(mapping));
+  return findings;
+}
+
+function findPendingProvisioning(mapping) {
+  const findings = [];
+  for (const outcome of mapping.outcomes ?? []) {
+    if (outcome.bead?.id === null || outcome.bead?.id === undefined) {
+      const ref = outcomeGithubRef(outcome);
+      const provisioning = outcome.bead?.provisioning ?? "unrecorded";
+      findings.push({
+        code: "W010",
+        severity: "warning",
+        slug: outcome.slug,
+        message: `${ref} has no provisioned bead id yet (provisioning: ${provisioning})`,
+      });
+    }
+  }
+  return findings;
+}
+
+function renderMappingTable(mapping) {
+  const lines = [
+    "| Outcome | GitHub | Priority | Bead label | Bead ID | Dependencies | Disposition |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+  ];
+  const order = { program: 0, "p0-foundation": 1, "p0-workstream": 2 };
+  const outcomes = [...(mapping.outcomes ?? [])].sort(
+    (a, b) => (order[a.role] ?? 9) - (order[b.role] ?? 9) || a.slug.localeCompare(b.slug),
+  );
+  for (const outcome of outcomes) {
+    const ref = outcomeGithubRef(outcome);
+    const deps = (outcome.depends_on ?? []).join(", ") || "(none)";
+    lines.push(
+      `| ${outcome.slug} | [${ref}](${outcome.github.url}) | ${outcome.github.priority} | \`${outcome.bead.label}\` | ${
+        outcome.bead.id ?? "(pending provisioning)"
+      } | ${deps} | ${outcome.bead.disposition} |`,
+    );
+  }
+  if ((mapping.cross_repository_children ?? []).length === 0) {
+    lines.push("");
+    lines.push(
+      "_Cross-repository child outcomes: none created yet. One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome under the program is mapped here one-to-one as each is created._",
+    );
+  }
+  return lines.join("\n");
+}
+
+function extractGeneratedBlock(roadmapText) {
+  const begin = roadmapText.indexOf(BLOCK_BEGIN);
+  const end = roadmapText.indexOf(BLOCK_END);
+  if (begin === -1 || end === -1 || end < begin) return null;
+  const start = begin + BLOCK_BEGIN.length;
+  return roadmapText.slice(start, end).replace(/^\n/, "").replace(/\n\s*$/, "\n");
+}
+
+function findGeneratedBlockDrift(mapping, roadmapText) {
+  const committed = extractGeneratedBlock(roadmapText);
+  if (committed === null) {
+    return [
+      {
+        code: "E008",
+        severity: "error",
+        slug: null,
+        message: "generated mapping table block missing from docs/roadmaps/coven-automations-v1.md",
+      },
+    ];
+  }
+  const expected = renderMappingTable(mapping);
+  if (committed.trimEnd() !== expected.trimEnd()) {
+    return [
+      {
+        code: "E008",
+        severity: "error",
+        slug: null,
+        message:
+          "generated mapping table in docs/roadmaps/coven-automations-v1.md was edited outside the generator contract (run: node docs/roadmaps/drift-check.mjs --render)",
+      },
+    ];
+  }
+  return [];
+}
+
+function beadPriorityLabel(priority) {
+  if (typeof priority === "number") return BEAD_PRIORITY_BY_NUMBER[priority] ?? `P${priority}`;
+  return String(priority ?? "unknown");
+}
+
+function collectBeadGithubRefs(bead) {
+  const haystack = [
+    bead.external_ref,
+    bead.notes,
+    bead.design,
+    bead.acceptance_criteria,
+    ...(bead.comments ?? []).map((comment) => comment?.text ?? ""),
+  ]
+    .filter((value) => typeof value === "string")
+    .join("\n");
+  const refs = new Set();
+  for (const match of haystack.matchAll(/https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)/g)) {
+    refs.add(`${match[1]}#${match[2]}`);
+  }
+  for (const match of haystack.matchAll(/\b([\w.-]+\/[\w.-]+)#(\d+)\b/g)) {
+    refs.add(`${match[1]}#${match[2]}`);
+  }
+  return refs;
+}
+
+function findExportDrift(mapping, exportText) {
+  const findings = [];
+  const beads = [];
+  for (const [index, line] of exportText.split("\n").entries()) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let bead;
+    try {
+      bead = JSON.parse(trimmed);
+    } catch {
+      findings.push({
+        code: "E100",
+        severity: "error",
+        slug: null,
+        message: `beads export line ${index + 1} is not valid JSON`,
+      });
+      continue;
+    }
+    beads.push({ line: index + 1, bead });
+  }
+
+  for (const { line, bead } of beads) {
+    for (const hit of findSensitivePayloads(JSON.stringify(bead))) {
+      findings.push({
+        code: "E009",
+        severity: "error",
+        slug: bead.id ?? null,
+        message: `tracker output contains sensitive payload (rule: ${hit.rule}) at export line ${line}`,
+      });
+    }
+  }
+
+  const byRef = new Map();
+  for (const outcome of mapping.outcomes ?? []) {
+    byRef.set(outcomeGithubRef(outcome), outcome);
+  }
+
+  const beadRefs = new Map();
+  for (const { line, bead } of beads) {
+    for (const ref of collectBeadGithubRefs(bead)) {
+      if (!byRef.has(ref)) continue;
+      if (!beadRefs.has(ref)) beadRefs.set(ref, []);
+      beadRefs.get(ref).push({ line, bead });
+    }
+  }
+
+  for (const [ref, outcome] of byRef) {
+    if (outcome.bead?.id !== null && outcome.bead?.id !== undefined) {
+      const linked = beadRefs.get(ref) ?? [];
+      if (linked.length === 0) {
+        findings.push({
+          code: "E101",
+          severity: "error",
+          slug: outcome.slug,
+          message: `GitHub outcome ${ref} has no bead referencing it in the export (expected exactly one)`,
+        });
+      } else if (linked.length > 1) {
+        findings.push({
+          code: "E101",
+          severity: "error",
+          slug: outcome.slug,
+          message: `GitHub outcome ${ref} is referenced by ${linked.length} beads in the export (expected exactly one)`,
+        });
+      }
+    }
+  }
+
+  for (const [ref, entries] of beadRefs) {
+    const outcome = byRef.get(ref);
+    for (const { bead } of entries) {
+      const beadOpen = bead.status !== undefined && !["closed", "done"].includes(bead.status);
+      const githubOpen = outcome.github?.state === "open";
+      if (beadOpen !== githubOpen) {
+        findings.push({
+          code: "E102",
+          severity: "error",
+          slug: outcome.slug,
+          message: `state drift for ${ref}: bead '${bead.id}' status '${bead.status}' vs GitHub state '${outcome.github?.state}'`,
+        });
+      }
+      const expectedPriority = outcome.github?.priority;
+      const actualPriority = beadPriorityLabel(bead.priority);
+      if (PRIORITIES.has(expectedPriority) && actualPriority !== expectedPriority) {
+        findings.push({
+          code: "E103",
+          severity: "error",
+          slug: outcome.slug,
+          message: `priority drift for ${ref}: bead '${bead.id}' is ${actualPriority}, mapping says ${expectedPriority}`,
+        });
+      }
+      const labels = bead.labels ?? [];
+      if (!labels.includes("surface:shared")) {
+        findings.push({
+          code: "E104",
+          severity: "error",
+          slug: outcome.slug,
+          message: `bead '${bead.id}' mapped to ${ref} lacks the surface:shared label (has: ${
+            labels.length > 0 ? labels.join(", ") : "(none)"
+          })`,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+function analyze(mapping, roadmapText, exportText) {
+  const findings = [
+    ...findMappingErrors(mapping),
+    ...findGeneratedBlockDrift(mapping, roadmapText),
+    ...findPendingProvisioning(mapping),
+  ];
+  if (typeof roadmapText === "string") {
+    for (const hit of findSensitivePayloads(roadmapText)) {
+      findings.push({
+        code: "E009",
+        severity: "error",
+        slug: null,
+        message: `roadmap artifact contains sensitive payload (rule: ${hit.rule})`,
+      });
+    }
+  }
+  const mappingText = JSON.stringify(mapping, null, 2);
+  for (const hit of findSensitivePayloads(mappingText)) {
+    findings.push({
+      code: "E009",
+      severity: "error",
+      slug: null,
+      message: `mapping file contains sensitive payload (rule: ${hit.rule})`,
+    });
+  }
+  if (exportText !== undefined) {
+    findings.push(...findExportDrift(mapping, exportText));
+  }
+  return findings;
+}
+
+function printFindings(findings) {
+  if (findings.length === 0) {
+    console.log("drift-check: no findings");
+    return;
+  }
+  for (const finding of findings) {
+    const scope = finding.slug ? ` [${finding.slug}]` : "";
+    console.log(`${finding.code}${scope} ${finding.severity}: ${finding.message}`);
+  }
+}
+
+function loadMapping() {
+  return JSON.parse(fs.readFileSync(MAPPING_PATH, "utf8"));
+}
+
+function writeRenderedBlock(mapping) {
+  let roadmap = fs.readFileSync(ROADMAP_PATH, "utf8");
+  const begin = roadmap.indexOf(BLOCK_BEGIN);
+  const end = roadmap.indexOf(BLOCK_END);
+  if (begin === -1 || end === -1 || end < begin) {
+    console.error("drift-check: generated block markers missing from roadmap; cannot render");
+    process.exitCode = 2;
+    return false;
+  }
+  const replacement = `${BLOCK_BEGIN}\n${renderMappingTable(mapping)}\n${BLOCK_END}`;
+  roadmap = roadmap.slice(0, begin) + replacement + roadmap.slice(end + BLOCK_END.length);
+  fs.writeFileSync(ROADMAP_PATH, roadmap);
+  return true;
+}
+
+function runSelftest() {
+  const failures = [];
+  const expectFinding = (findings, code, label) => {
+    if (!findings.some((finding) => finding.code === code)) {
+      failures.push(`selftest: expected ${code} (${label}) to be detected`);
+    }
+  };
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+
+  const baseMapping = loadMapping();
+  const baseRoadmap = fs.readFileSync(ROADMAP_PATH, "utf8");
+  const pristine = analyze(baseMapping, baseRoadmap, undefined);
+  const pristineErrors = pristine.filter((finding) => finding.severity === "error");
+  if (pristineErrors.length > 0) {
+    failures.push(`selftest: committed state has error-severity findings: ${JSON.stringify(pristineErrors)}`);
+  }
+  if (!pristine.some((finding) => finding.code === "W010")) {
+    failures.push("selftest: expected W010 pending-provisioning warnings on the committed mapping");
+  }
+
+  const duplicateRef = clone(baseMapping);
+  duplicateRef.outcomes[1].github.issue = duplicateRef.outcomes[2].github.issue;
+  expectFinding(analyze(duplicateRef, baseRoadmap, undefined), "E001", "duplicate GitHub mapping");
+
+  const unknownDep = clone(baseMapping);
+  unknownDep.outcomes[2].depends_on.push("does-not-exist");
+  expectFinding(analyze(unknownDep, baseRoadmap, undefined), "E003", "unknown dependency");
+
+  const cycle = clone(baseMapping);
+  cycle.outcomes[0].depends_on.push("certification");
+  cycle.outcomes[5].depends_on.push("program");
+  expectFinding(analyze(cycle, baseRoadmap, undefined), "E004", "dependency cycle");
+
+  const badPriority = clone(baseMapping);
+  badPriority.outcomes[2].github.priority = "P9";
+  expectFinding(analyze(badPriority, baseRoadmap, undefined), "E005", "invalid priority");
+
+  const noOwner = clone(baseMapping);
+  noOwner.outcomes[2].github.owner = null;
+  expectFinding(analyze(noOwner, baseRoadmap, undefined), "E006", "P0 without owner");
+
+  const closedNoEvidence = clone(baseMapping);
+  closedNoEvidence.outcomes[2].github.state = "closed";
+  expectFinding(analyze(closedNoEvidence, baseRoadmap, undefined), "E007", "closed without evidence");
+
+  const tamperedBlock = baseRoadmap.replace(
+    /\| program \| \[/,
+    "| program (edited outside the generator contract) | [",
+  );
+  expectFinding(analyze(baseMapping, tamperedBlock, undefined), "E008", "mirror edit");
+  expectFinding(
+    analyze(clone(baseMapping), "no markers here", undefined),
+    "E008",
+    "missing generated block",
+  );
+
+  const sensitiveMapping = clone(baseMapping);
+  sensitiveMapping.outcomes[0].notes = [
+    "operator note: ",
+    frag("agent:", "demo", ":telegram:", "direct", ":SECRETVALUE"),
+  ].join("");
+  expectFinding(analyze(sensitiveMapping, baseRoadmap, undefined), "E009", "sensitive payload in mapping");
+
+  const exportFixtures = [
+    {
+      label: "closed bead vs open outcome (E102)",
+      line: JSON.stringify({
+        _type: "issue",
+        id: "automations-v1.1",
+        title: "protocol",
+        status: "closed",
+        priority: 0,
+        labels: ["surface:shared"],
+        external_ref: "https://github.com/OpenCoven/coven/issues/855",
+      }),
+      codes: ["E102"],
+    },
+    {
+      label: "priority drift (E103)",
+      line: JSON.stringify({
+        _type: "issue",
+        id: "automations-v1.1",
+        title: "protocol",
+        status: "open",
+        priority: 1,
+        labels: ["surface:shared"],
+        external_ref: "https://github.com/OpenCoven/coven/issues/855",
+      }),
+      codes: ["E103"],
+    },
+    {
+      label: "missing surface:shared label (E104)",
+      line: JSON.stringify({
+        _type: "issue",
+        id: "automations-v1.1",
+        title: "protocol",
+        status: "open",
+        priority: 0,
+        labels: ["surface:api"],
+        external_ref: "https://github.com/OpenCoven/coven/issues/855",
+      }),
+      codes: ["E104"],
+    },
+    {
+      label: "sensitive payload in export (E009)",
+      line: JSON.stringify({
+        _type: "issue",
+        id: "automations-v1.9",
+        title: "leaky",
+        status: "open",
+        priority: 0,
+        labels: ["surface:shared"],
+        notes: frag("session ", "agent:x", ":telegram:bot:", "SECRET"),
+      }),
+      codes: ["E009"],
+    },
+  ];
+
+  const emptyOutcomeMapping = clone(baseMapping);
+  for (const outcome of emptyOutcomeMapping.outcomes) {
+    outcome.bead.id = null;
+    outcome.bead.provisioning = "selftest";
+  }
+
+  for (const fixture of exportFixtures) {
+    const findings = analyze(emptyOutcomeMapping, baseRoadmap, fixture.line);
+    for (const code of fixture.codes) {
+      expectFinding(findings, code, fixture.label);
+    }
+  }
+
+  const duplicateBeadExport = [
+    JSON.stringify({
+      _type: "issue",
+      id: "automations-v1.1",
+      status: "open",
+      priority: 0,
+      labels: ["surface:shared"],
+      external_ref: "https://github.com/OpenCoven/coven/issues/855",
+    }),
+    JSON.stringify({
+      _type: "issue",
+      id: "automations-v1.2",
+      status: "open",
+      priority: 0,
+      labels: ["surface:shared"],
+      external_ref: "OpenCoven/coven#855",
+    }),
+  ].join("\n");
+  const dupFindings = analyze(emptyOutcomeMapping, baseRoadmap, duplicateBeadExport);
+  if (!dupFindings.some((finding) => finding.code === "E101")) {
+    // Provisioning is pending, so E101 only fires for outcomes with declared ids.
+    const declared = clone(baseMapping);
+    declared.outcomes[2].bead.id = "automations-v1.1";
+    const declaredFindings = analyze(declared, baseRoadmap, duplicateBeadExport);
+    expectFinding(declaredFindings, "E101", "duplicate bead references for one outcome");
+  }
+
+  if (failures.length > 0) {
+    console.error(failures.join("\n"));
+    return false;
+  }
+  console.log(`drift-check: selftest passed (${SENSITIVE_PATTERNS.length} sensitive-payload rules, 11 drift fixtures)`);
+  return true;
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  if (args.includes("--selftest")) {
+    process.exitCode = runSelftest() ? 0 : 1;
+    return;
+  }
+
+  let mapping;
+  try {
+    mapping = loadMapping();
+  } catch (error) {
+    console.error(`drift-check: cannot parse mapping: ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (args.includes("--render")) {
+    const ok = writeRenderedBlock(mapping);
+    if (ok) console.log("drift-check: regenerated the roadmap mapping table");
+    return;
+  }
+
+  let roadmapText;
+  try {
+    roadmapText = fs.readFileSync(ROADMAP_PATH, "utf8");
+  } catch (error) {
+    console.error(`drift-check: cannot read roadmap: ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  let exportText;
+  const exportIndex = args.indexOf("--beads-export");
+  if (exportIndex !== -1) {
+    const exportPath = args[exportIndex + 1];
+    if (!exportPath) {
+      console.error("drift-check: --beads-export requires a path");
+      process.exitCode = 2;
+      return;
+    }
+    exportText = fs.readFileSync(path.resolve(exportPath), "utf8");
+  }
+
+  const findings = analyze(mapping, roadmapText, exportText);
+  printFindings(findings);
+
+  const strict = args.includes("--strict");
+  const hasErrors = findings.some((finding) => finding.severity === "error");
+  const hasWarnings = findings.some((finding) => finding.severity === "warning");
+  if (hasErrors || (strict && hasWarnings)) {
+    process.exitCode = 1;
+  }
+}
+
+main(process.argv);

--- a/docs/superpowers/plans/2026-08-30-issue-859-coven-automations-v1-tracker-operationalization.md
+++ b/docs/superpowers/plans/2026-08-30-issue-859-coven-automations-v1-tracker-operationalization.md
@@ -1,0 +1,203 @@
+# Issue #859 Status/Decision Record — Operationalize Coven Automations v1 in Beads and GitHub roadmap mirrors
+
+**Date:** 2026-08-30
+**Author:** Timothy Wayne Gregg
+**Scope:** Investigation and reviewed tracker-setup deliverables for
+[OpenCoven/coven#859](https://github.com/OpenCoven/coven/issues/859) ("P0 control:
+Operationalize Coven Automations v1 through Cave's canonical Beads graph and GitHub
+mirrors"). Facts only; each claim carries an evidence link or exact command.
+
+---
+
+## 1. What was inspected
+
+- Upstream `OpenCoven/coven` `main` at `1364cec` (`1364cec9dbaf1e2aca2e4544dec0e1ce807d859c`), cloned 2026-08-30.
+- GitHub issues [OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854) (opened 2026-08-30T13:36:04Z), [#816](https://github.com/OpenCoven/coven/issues/816) (2026-08-24T15:32:52Z), [#855](https://github.com/OpenCoven/coven/issues/855), [#856](https://github.com/OpenCoven/coven/issues/856), [#857](https://github.com/OpenCoven/coven/issues/857), [#858](https://github.com/OpenCoven/coven/issues/858) (all opened 2026-08-30T13:37–13:41Z), and [#859](https://github.com/OpenCoven/coven/issues/859) (2026-08-30T13:41:50Z); all open, all assigned to `BunsDev`, no labels, no milestones.
+- The single comment on #859 (BunsDev, 2026-08-30T14:05:44Z,
+  [comment 5469149789](https://github.com/OpenCoven/coven/issues/859#issuecomment-5469149789))
+  — the operational correction redirecting the canonical Beads store to Cave.
+- `OpenCoven/coven-cave` issues #5219 (roadmap/operating contract, opened 2026-08-30T14:03:02Z) and #5220 (Beads/Dolt seeding, opened 2026-08-30T14:04:34Z); both open.
+- `OpenCoven/coven-cave` local checkout `.beads/` directory: `issues.jsonl` (public-scrubbed export), `config.yaml` (sync remote `git+https://github.com/OpenCoven/coven-cave.git`), README, hooks.
+- Upstream CI state on the base SHA (see §4).
+- Search for existing work on #859: no open PRs reference 859 (`search/issues` and `repos/OpenCoven/coven/pulls?state=open`, 2026-08-30); no `859` branch on `CompleteDotTech/coven`.
+
+## 2. What exists on `main` today
+
+**The native automations foundation is implemented on `main`; the tracker graph is not.**
+
+- `crates/coven-cli/src/automations/` exists on main: 11 Rust files, 2,719 lines total
+  (`definition.rs`, `store.rs`, `occurrences.rs`, `rrule.rs`, `schedule.rs`, `runner.rs`,
+  `runs.rs`, `health.rs`, `import_legacy.rs`, `daemon_tick.rs`, `mod.rs`), plus daemon
+  integration in `crates/coven-cli/src/daemon.rs`.
+- The landed series is dated 2026-08-28 and is enumerated by
+  [#816's program-status section](https://github.com/OpenCoven/coven/issues/816)
+  (in the issue body, updated 2026-08-30): PR [#846](https://github.com/OpenCoven/coven/pull/846) (routine
+  definitions and control actions, part 1 — commit `882fc83`) and PR
+  [#847](https://github.com/OpenCoven/coven/pull/847) (legacy import — merge commit
+  `58bc547`), with parts 5–8 as commits `39b8618`, `bd3b47d`, `a4a71af`, `1de50a8`.
+  #816's comment enumerates what landed: versioned routine definitions; SQLite
+  definition/occurrence/lease/run storage; RRULE planning; unique occurrence fencing and
+  bounded claim leases; expired-lease recovery, latest-only misfire, overlap refusal;
+  daemon recurring tick and scheduled dispatch; shared manual/scheduled launch path;
+  familiar ID propagation; bounded logs and atomic output delivery; health and run-history
+  projections; source-preserving paused legacy import; `coven.automations.*` control
+  actions; Cave's migration away from direct Codex ownership
+  ([OpenCoven/coven-cave#4990](https://github.com/OpenCoven/coven-cave/issues/4990)).
+- #816 itself states it "remains open for **foundation reconciliation and exact
+  evidence**, not because the original architecture is still absent", and lists the
+  evidence required before closing (linked commit/PR series with exact final revision,
+  clean-clone test verification, migration/rollback proof, daemon wiring proof on
+  supported platforms, unified run-path proof, stale-lease proof, delivery-failure
+  non-success proof, criterion-by-criterion reconciliation).
+- **No Beads store exists in `OpenCoven/coven`** — no `.beads/` directory on `main`.
+  Per the #859 operational correction this is correct: the canonical Beads graph is Cave's
+  embedded-Dolt database `cave` in `OpenCoven/coven-cave`; a competing Beads database must
+  not be initialized in `OpenCoven/coven`.
+- The Automations v1 delivery epic and its `surface:shared` beads **do not exist yet**:
+  the `coven-cave` public-scrubbed export (`.beads/issues.jsonl`, 4 entries checked
+  2026-08-30) contains only the `cave-hlv` Beads-operating epic (`cave-hlv`,
+  `cave-hlv.1` in_progress, `cave-hlv.2`/`.3` deferred); no bead references
+  `OpenCoven/coven` issues #854/#816/#855–#858. Provisioning is owned by
+  [OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220).
+  The live Dolt database could not be read from this environment (no `bd`/`dolt` binary
+  available); the export is the review-visible state.
+- `docs/roadmaps/` did not exist on `main`; the repo's record location is
+  `docs/superpowers/plans/<date>-<slug>.md` (47 existing records, 2026-05-04 → 2026-08-23).
+- No SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, or Threads child issues
+  existed under #854 at investigation time (issue-body search returned only #859 and the
+  P0 graph).
+- `docs/ROADMAP.md` is the public product roadmap (last updated 2026-05-26) and does not
+  cover the Automations v1 delivery graph.
+
+## 3. Issue state and the operational correction
+
+[#859](https://github.com/OpenCoven/coven/issues/859) was opened 2026-08-30T13:41:50Z.
+Its Phase 1 says to "inspect the current Coven Beads schema/version"; the
+[operational correction](https://github.com/OpenCoven/coven/issues/859#issuecomment-5469149789)
+(2026-08-30T14:05:44Z) resolves the ambiguity:
+
+- the canonical familiar execution queue is **Cave's embedded-Dolt Beads graph**;
+  references to inspecting "the current Coven Beads schema" mean inspecting Cave's
+  canonical Beads/Dolt schema and workflow through #5220;
+- roadmap and reviewed operating contract: OpenCoven/coven-cave issue #5219;
+- seeding, dependency verification (`bd dep` help, `bd dep list`, `bd ready --json`),
+  bounded `pnpm beads:sync`, and before/after `refs/dolt/data` OIDs: #5220;
+- `.beads/issues.jsonl` is a public-scrubbed review export, never canonical state;
+- do **not** initialize a competing Beads database in `OpenCoven/coven`; the original
+  tracker roles and acceptance gates remain valid.
+
+Consequently #859's GitHub-side deliverables (roadmap artifact, machine-readable mapping,
+drift detection, and this record) land in this repository through review, while bead
+creation stays with #5220 in `OpenCoven/coven-cave`.
+
+## 4. Pre-change integrity/status report (2026-08-30)
+
+| Check | Result |
+| --- | --- |
+| Working tree | clean before this change (only `docs/roadmaps/` additions by this branch) |
+| Base SHA | `1364cec9dbaf1e2aca2e4544dec0e1ce807d859c` (even with upstream `main` and fork `main`) |
+| `docs/superpowers/plans/` | 47 records present, latest `2026-08-23-maintenance-participant.md` |
+| `docs/roadmaps/` | absent on base (created by this branch per #859's suggested path) |
+| Upstream CI on base SHA | `CI` run 33309176793 (2026-08-30T11:32:21Z) **failed** at "Classify changes" — `scripts/classify-ci-changes.py` raised `ValueError: no paths provided` on the empty-diff `push` to `main` for commit `1364cec` ("chore: preserve consolidated branch ancestry"). This is a push-event classification edge case, not a PR-path failure: PR classification uses `PR_BASE_SHA...PR_HEAD_SHA`, which always contains paths. No other CI workflow run failed on the base SHA; the `Engine bump` workflow succeeded on the same SHA at 2026-08-30T13:48:51Z. |
+| Upstream open PRs touching this area | none found for issue #859 |
+| Fork (`CompleteDotTech/coven`) branch state | `main` mirrors upstream `main` at the same SHA; no `859` branch existed before this work |
+| Beads export cross-check | `node docs/roadmaps/drift-check.mjs --beads-export .beads/issues.jsonl` (run against the `coven-cave` checkout export) → no errors; confirms zero Automations v1 beads and no sensitive payloads in the export |
+
+## 5. Decisions
+
+- **D1 — one canonical writer.** Exactly one checkout/process is designated schema
+  migrator and canonical writer for this setup; persisted tracker changes land only
+  through reviewed PRs (this branch/PR for GitHub-side artifacts; #5220's checkout for
+  Bead-side provisioning). Concurrent independent migrations and direct writes from
+  unrelated worktrees are refused. The `coven claim` registry could not be used here
+  (no Rust toolchain in this environment to build the CLI); REST deconfliction (§1) plus
+  a dedicated clone and branch satisfy the anti-duplication intent.
+- **D2 — reuse, don't duplicate.** No bead mapping #816 was found in the review-visible
+  export, so nothing is duplicated: #816's mapping entry is declared once in the mapping
+  file with `provisioning` pointing at #5220, which owns the reuse-check against the live
+  Dolt store before creating anything.
+- **D3 — no competing Beads store.** No `.beads/` is initialized in `OpenCoven/coven`;
+  the operational correction is honored verbatim.
+- **D4 — mapping lives in both worlds correctly.** GitHub owns the public roadmap
+  artifact and the machine-readable mapping contract (this PR); Beads owns the
+  implementation dependency graph and execution state once provisioned. The mapping file
+  is the reconciliation contract; Bead IDs stay `null` (warn-level `W010`) until #5220
+  declares them, after which a one-line reviewed change flips provisioning to `done` and
+  missing-mapping drift escalates to `error`.
+- **D5 — drift detection without credentials.** `docs/roadmaps/drift-check.mjs` is
+  dependency-free, offline, and CI-safe; it verifies mapping-internal invariants, the
+  generated roadmap block (generator-contract enforcement), and an optional local Beads
+  export, and scans tracker output for sensitive payloads. `--selftest` proves every
+  detection class with fixtures (all 11 fixtures and 6 sensitive-payload rules pass).
+- **D6 — severity policy.** `error` findings fail CI; `warning` findings (today: pending
+  provisioning) report without failing. This keeps the check honest (it reports the real
+  gap) without keeping CI red on work owned by another repository.
+- **D7 — no premature closure.** This PR references #859 without `Closes`; the issue's
+  own completion semantics (#816 stays open until its evidence checklist is done; #859
+  spans provisioning in `coven-cave`) mean nothing is closed by tracker work alone.
+
+## 6. Verdict against #859's acceptance criteria
+
+| # | Criterion | Verdict |
+| --- | --- | --- |
+| 1 | #854, #816, #855–#858 each map to exactly one Bead | **PARTIAL** — the one-to-one contract is committed (mapping file: 6 outcomes, unique slugs/labels/refs, enforced by `E001`/`E002`), but bead IDs are `null` until #5220 provisions them; drift check reports `W010` per outcome. |
+| 2 | Cross-repository child outcomes map one-to-one as created | **SATISFIED (vacuously today)** — no child outcomes existed at sync time; `cross_repository_children` is empty and the policy + `E101` enforcement are in place. |
+| 3 | Dependencies and P0/P1/P2 priorities match the canonical roadmap | **SATISFIED** — mapping `depends_on` mirrors #859's minimum graph; the roadmap table is generated from the same file, and any hand edit is flagged `E008`. |
+| 4 | One writer/schema owner and reviewed change path documented | **SATISFIED** — D1 above; also recorded in the roadmap sync metadata. |
+| 5 | Roadmap artifact and machine-readable mapping committed through review | **SATISFIED BY THIS PR** — `docs/roadmaps/coven-automations-v1.md` + `coven-automations-v1.mapping.json` + `drift-check.mjs`. |
+| 6 | Drift detection catches state, priority, parent, evidence, generated-mirror disagreement | **SATISFIED** — classes `E001`–`E009` (plus `E100`–`E104` in export mode) cover state, priority, parent/dependency, evidence, generated-mirror, and sensitive payloads; proven by `--selftest`. |
+| 7 | No tracker data treated as automation runtime truth | **SATISFIED (documented)** — canonical tracker roles in the roadmap and mapping invariants state it; the Coven runtime owns occurrences/runs/leases/approvals/receipts. |
+| 8 | Final #854 release rollup generable from reconciled state and exact evidence | **PENDING** — the mapping carries evidence links and gates so the rollup is generable in principle, but certification evidence does not exist yet (no #855–#858 outcomes started; #816's evidence checklist open). |
+
+## 7. What remains
+
+1. Provision the Automations v1 delivery epic and six `surface:shared` beads in Cave's
+   canonical Beads/Dolt graph with dependency verification and bounded
+   `pnpm beads:sync`, recording before/after `refs/dolt/data` OIDs —
+   OpenCoven/coven-cave issue #5220
+   (P0, on the critical path for criterion 1).
+2. Land Cave's reviewed operating contract — OpenCoven/coven-cave issue #5219.
+3. Fill #816's evidence checklist (criterion 1's "close only after" condition and the
+   foundation release gate).
+4. After provisioning: set the real bead IDs in
+   `docs/roadmaps/coven-automations-v1.mapping.json` (one reviewed change; `W010` clears;
+   `E101` escalation arms).
+5. Wire `node docs/roadmaps/drift-check.mjs` into relevant PR CI and the weekly program
+   rollup cadence once provisioning exists (the check itself needs no credentials).
+6. Create the P1 cross-repository outcomes (SDK, Cave, Psyche, docs,
+   organization-canary, Familiar Contract, Threads) under #854 and map them one-to-one as
+   they appear, with explicit `depends_on`/`depends_on_external` edges.
+7. #855–#858 implementation work per the graph below.
+
+## 8. Critical path (before/after P0 dependency graph)
+
+**Before this PR:** no recorded graph in this repository — the P0 ordering existed only
+in #859's prose; the bead side did not exist at all.
+
+**After this PR (GitHub side recorded; bead provisioning pending → #5220):**
+
+```text
+#854 program (P0 control — release gates, rollup)
+  └─ gate 1: #816 foundation (P0 — landed 2026-08-28, evidence reconciliation open)
+       ├─ #855 protocol (P0, depends: foundation)
+       │    ├─ #856 scheduler (P0, depends: foundation, protocol)
+       │    └─ #857 authority (P0, depends: foundation, protocol; + upstream Familiar/Threads profiles when created)
+       └─ #858 certification (P0, depends: protocol, scheduler, authority)
+            └─ v1 release gate (owned by #854)
+```
+
+## 9. Initial evidence packet
+
+- Pre-change tracker report: §4 above plus the `drift-check` export cross-check (no
+  Automations v1 beads; export contains only the `cave-hlv` operating epic).
+- Created/reused bead IDs: none created by this repository (forbidden by the operational
+  correction); provisioning delegated to OpenCoven/coven-cave#5220 (D2/D3).
+- Beads version/schema: Beads 1.2.2, schema v53, as recorded in
+  [2026-08-20-coven-v0.4.1-release-program.md](./2026-08-20-coven-v0.4.1-release-program.md);
+  live verification owned by #5220.
+- Reviewed PR: this branch —
+  `agent/issue-859-p0-control-operationalize-coven-automations-v1` based on `1364cec`.
+- Drift report: `node docs/roadmaps/drift-check.mjs` → 0 errors, 6 × `W010` (pending
+  provisioning); `--selftest` → pass.
+- Final mapping: `docs/roadmaps/coven-automations-v1.mapping.json` (schema version 1).
+- Before/after P0 dependency graph: §8.


### PR DESCRIPTION
## Summary

- Operationalizes the GitHub-side half of the OpenCoven/coven#859 operational delivery graph for **Coven Automations v1** (#854): one reviewed roadmap artifact, one machine-readable Bead↔GitHub mapping, one credential-free drift check, and one dated status/decision record.
- Follows the operational correction on #859 (comment 5469149789, 2026-08-30): the canonical Beads graph is Cave's embedded-Dolt database `cave` (`OpenCoven/coven-cave`), `.beads/issues.jsonl` there is a public-scrubbed review export, and **no competing Beads store is initialized in OpenCoven/coven**. Bead provisioning itself is delegated to OpenCoven/coven-cave#5220; bead IDs stay `null` (warn-level `W010`) in the mapping until #5220 declares them.

### Files changed (4 files, +1318)

- `docs/roadmaps/coven-automations-v1.md` — roadmap artifact: canonical tracker roles (Beads / GitHub / Coven runtime), sync metadata (last sync, source branch, writer designation), P0/P1/P2 policy, generated outcome-mapping table, dependency graph, release gates, active blockers, drift-check usage; carries a generated-content warning and does not duplicate mutable run status.
- `docs/roadmaps/coven-automations-v1.mapping.json` — machine-readable one-to-one mapping for #854, #816, #855, #856, #857, #858: explicit `depends_on` edges matching #859's minimum graph, acceptance gates, dispositions, evidence links, cross-repository child policy, and P2 exclusions.
- `docs/roadmaps/drift-check.mjs` — offline, dependency-free drift check (no network, no credentials): mapping invariants (duplicate/missing mapping, unknown deps, cycles, priority validity, P0 owner/gate/disposition, completed-work-without-evidence), generated-mirror contract enforcement (the roadmap table block is regenerated by `--render` and verified on every run), optional `--beads-export <issues.jsonl>` cross-check (state/priority/`surface:shared` label/1:1 linkage), sensitive-payload scan of tracker output, and `--selftest` proving every detection class with fixtures. Severity policy: `error` fails CI; `warning` (pending provisioning) does not, keeping CI honest without staying red on work owned by another repository.
- `docs/superpowers/plans/2026-08-30-issue-859-coven-automations-v1-tracker-operationalization.md` — dated status/decision record: what exists on `main` today (automations series landed 2026-08-28 via PRs #846/#847, commits `882fc83`…`1de50a8`; no Beads store in this repo), pre-change integrity report (including the pre-existing push-only `Classify changes` CI failure on the base SHA), decisions D1–D7, criterion-by-criterion verdict, remaining work, critical path, and the initial evidence packet.

## Issue

Refs OpenCoven/coven#859.

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#859.

Deliberately **not** `Closes`: the issue's own completion semantics keep #816 open until its evidence checklist is done, and #859 spans bead provisioning in OpenCoven/coven-cave#5220 (outside this repository). Closing on merge would close work that is only partially established; per #859, a GitHub issue is not closed merely because partial implementation landed.

## Test plan

Checked = ran locally in this checkout (node v24.16.0, no Rust toolchain, no python3):

- [x] `node docs/roadmaps/drift-check.mjs --selftest` — all 11 drift fixtures and 6 sensitive-payload rules detected (exit 0)
- [x] `node docs/roadmaps/drift-check.mjs` — 0 errors; 6 × `W010` pending-provisioning warnings, exit 0
- [x] `node docs/roadmaps/drift-check.mjs --beads-export .beads/issues.jsonl` run against the `OpenCoven/coven-cave` checkout export — 0 errors; confirms zero Automations v1 beads exist and no sensitive payloads in the export
- [x] `node docs/roadmaps/drift-check.mjs --render` — regenerated block is byte-identical to the committed one (idempotent)
- [x] `node --check docs/roadmaps/drift-check.mjs`; JSON parse of the mapping file
- [x] Secret scan + privacy guard mirrored locally in JS over the four changed files using the exact rule set from `scripts/check-secrets.py` / `scripts/check-coven-privacy.py` (python3 is unavailable locally) — clean
- [ ] `python3 scripts/check-secrets.py` + `python3 scripts/check-coven-privacy.py --range` — deferred to CI (policy-guard runs them on this PR)
- [ ] `cargo fmt --check` / `cargo clippy` / `cargo test` — deferred to CI; not applicable locally (no Rust toolchain) and not exercised by a docs-only diff (CI classification keeps Rust jobs skipped)

## Risk and Rollback

- Risk level: low — docs-only change (all paths under `docs/`); no code, no workflow changes, no tracker state mutated (bead state untouched; provisioning explicitly delegated to OpenCoven/coven-cave#5220).
- Rollback plan: revert this single commit; the mapping and roadmap are additive and nothing outside the PR consumes them yet.

## Agent Handoff

- Current state: single commit on `agent/issue-859-p0-control-operationalize-coven-automations-v1`, based on upstream `main` at `1364cec`; DCO signed-off.
- Follow-ups: (1) provision the Automations v1 epic + six `surface:shared` beads via OpenCoven/coven-cave#5220, then set real bead IDs in the mapping (one-line reviewed change; `W010` clears, missing-mapping drift escalates to `error`); (2) wire `node docs/roadmaps/drift-check.mjs` into relevant PR CI and the weekly rollup cadence; (3) fill the #816 evidence checklist; (4) map cross-repository child outcomes one-to-one as they are created.
- Known gaps: live Dolt database not readable from this environment (no `bd`/`dolt` binary) — bead reuse-check against live state is owned by #5220; the `coven claim` registry could not be used (no Rust toolchain to build the CLI) — REST deconfliction (no open PR or branch for #859) plus a dedicated clone/branch covers the anti-duplication intent.

## CI note (checkless repository, draft→ready provenance)

- No CI exists on `CompleteDotTech/coven`: the repository has never run a GitHub Actions workflow (0 total workflow runs, confirmed 2026-08-30 via the Actions API) and the head SHA `83ba34a8a8d368d408c6637a424a0dfa4c8e0ca7` reports `check-runs total_count: 0`. Per the draft-until-green contract for a checkless repository, there is no CI verdict to report; upstream `OpenCoven/coven` checks (policy-guard: secret scan, privacy guard; docs-only classification skips Rust jobs) will run when this branch is re-targeted upstream.
- Ladder provenance: the upstream PR attempt (`gh pr create --repo OpenCoven/coven ...`, 2026-08-30T15:24Z) failed with `GraphQL: Resource not accessible by personal access token (createPullRequest)`; this fork PR is the working CI vehicle.
- Draft→ready provenance: the PR was created as a **draft** at 2026-08-30T15:25:09Z; a `ready_for_review` event was recorded at 2026-08-30T15:26:16Z by actor `CompleteDotTech` — the shared token identity used by concurrent sweeps — before any check could report. This session did not merge the PR and did not use GraphQL to change draft state; the REST API cannot convert a PR back to draft. End state (ready, unmerged) matches the checkless-repo contract outcome.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/3], preserving source head `83ba34a8a8d368d408c6637a424a0dfa4c8e0ca7` and branch `agent/issue-859-p0-control-operationalize-coven-automations-v1`.