### PR TITLE
refactor: extract route/version authority gate from coven-cli api

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, HashSet},
     fs,
     io::Write,
@@ -17,6 +16,7 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{
+    api_routes::{normalize_api_route, split_path_query, ApiRoute},
     control_plane,
     daemon::DaemonStatus,
     encrypted_artifacts::SensitiveArtifactStore,
@@ -28,10 +28,8 @@ use crate::{
 const MAX_EVENTS_LIMIT: i64 = 1_000;
 const EVENT_CANDIDATE_BATCH_LIMIT: usize = 16;
 const MAX_EVENT_CANDIDATE_BYTES: usize = coven_client::MAX_RESPONSE_BODY_BYTES;
-pub const COVEN_API_ROUTE_VERSION: &str = "v1";
 pub const COVEN_API_NAMED_VERSION: &str = "coven.daemon.v1";
 pub const COVEN_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const SUPPORTED_API_ROUTE_VERSIONS: [&str; 1] = [COVEN_API_ROUTE_VERSION];
 
 fn proposal_decision_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -528,7 +526,7 @@ pub(crate) fn handle_request_with_runtime_and_authority(
                 "Unsupported API version.",
                 Some(json!({
                     "apiVersion": version,
-                    "supportedApiVersions": SUPPORTED_API_ROUTE_VERSIONS,
+                    "supportedApiVersions": crate::api_routes::SUPPORTED_API_ROUTE_VERSIONS,
                 })),
             );
         }
@@ -540,8 +538,8 @@ pub(crate) fn handle_request_with_runtime_and_authority(
         ("GET", "/api-version") => json_response(
             200,
             &json!({
-                "apiVersion": COVEN_API_ROUTE_VERSION,
-                "supportedApiVersions": SUPPORTED_API_ROUTE_VERSIONS,
+                "apiVersion": crate::api_routes::COVEN_API_ROUTE_VERSION,
+                "supportedApiVersions": crate::api_routes::SUPPORTED_API_ROUTE_VERSIONS,
             }),
         ),
         ("GET", "/health") => json_response(
@@ -998,28 +996,6 @@ pub(crate) fn handle_request_with_runtime_and_authority(
         }
         _ => api_error(404, "not_found", "Route not found.", None),
     }
-}
-
-enum ApiRoute<'a> {
-    Route(Cow<'a, str>),
-    Unsupported(String),
-    Malformed,
-}
-
-fn normalize_api_route(route: &str) -> ApiRoute<'_> {
-    let Some(rest) = route.strip_prefix("/api/") else {
-        return ApiRoute::Route(Cow::Borrowed(route));
-    };
-    let Some((version, suffix)) = rest.split_once('/') else {
-        return ApiRoute::Malformed;
-    };
-    if version != COVEN_API_ROUTE_VERSION {
-        return ApiRoute::Unsupported(version.to_string());
-    }
-    if suffix.is_empty() {
-        return ApiRoute::Malformed;
-    }
-    ApiRoute::Route(Cow::Owned(format!("/{suffix}")))
 }
 
 pub(crate) fn store_path(coven_home: &Path) -> std::path::PathBuf {
@@ -8740,13 +8716,6 @@ pub(crate) fn parse_body(body: Option<&str>) -> Result<Value> {
     }
 }
 
-fn split_path_query(path: &str) -> (&str, Option<&str>) {
-    match path.split_once('?') {
-        Some((route, query)) => (route, Some(query)),
-        None => (path, None),
-    }
-}
-
 pub(crate) fn query_param<'a>(query: &'a str, key: &str) -> Option<&'a str> {
     query.split('&').find_map(|part| {
         let (candidate, value) = part.split_once('=')?;
@@ -8827,6 +8796,7 @@ pub(crate) fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiRe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api_routes::{COVEN_API_ROUTE_VERSION, SUPPORTED_API_ROUTE_VERSIONS};
 
     thread_local! {
         /// Backing storage for the parent-correlation failpoint (issue #728
@@ -10583,6 +10553,42 @@ mod tests {
 
         assert_eq!(response.status, 404);
         assert!(response.body.contains(r#""code":"invalid_request""#));
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_version_rejection_pins_full_envelope() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let response = handle_request("GET", "/api/v2/health", temp_dir.path(), None)?;
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+
+        assert_eq!(response.status, 404);
+        assert_eq!(body["error"]["code"], "invalid_request");
+        assert_eq!(body["error"]["message"], "Unsupported API version.");
+        assert_eq!(body["error"]["details"]["apiVersion"], "v2");
+        assert_eq!(
+            body["error"]["details"]["supportedApiVersions"],
+            json!(["v1"])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_malformed_api_route_prefixes() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        // The gate (and the router's fallback for non-API passthroughs) must
+        // answer every unrouteable shape with the same 404 envelope: callers
+        // cannot distinguish where the path was refused.
+        for path in ["/api/v1/", "/api/v1", "/api/", "/api"] {
+            let response = handle_request("GET", path, temp_dir.path(), None)?;
+            let body: serde_json::Value = serde_json::from_str(&response.body)?;
+
+            assert_eq!(response.status, 404, "path {path:?}");
+            assert_eq!(body["error"]["code"], "not_found", "path {path:?}");
+            assert_eq!(body["error"]["message"], "Route not found.", "path {path:?}");
+        }
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -10587,7 +10587,10 @@ mod tests {
 
             assert_eq!(response.status, 404, "path {path:?}");
             assert_eq!(body["error"]["code"], "not_found", "path {path:?}");
-            assert_eq!(body["error"]["message"], "Route not found.", "path {path:?}");
+            assert_eq!(
+                body["error"]["message"], "Route not found.",
+                "path {path:?}"
+            );
         }
         Ok(())
     }

--- a/crates/coven-cli/src/api_routes.rs
+++ b/crates/coven-cli/src/api_routes.rs
@@ -1,0 +1,158 @@
+//! Route/version authority gate for the Coven daemon HTTP API.
+//!
+//! Every API request enters through [`crate::api::handle_request`] (or its
+//! `_with_body` / `_with_runtime` / `_with_runtime_and_authority` variants),
+//! and the first thing that entry point does is split the raw path with
+//! [`split_path_query`] and classify the route with [`normalize_api_route`]
+//! here. This module is the single place that decides whether a request path
+//! carries a supported API version, so handlers below the gate never re-parse
+//! the `/api/<version>` prefix and cannot be reached under an unsupported
+//! version.
+//!
+//! Contract (pinned by the tests below and by the envelope tests in
+//! `crate::api`):
+//!
+//! - paths without the `/api/` prefix pass through unchanged (borrowed, no
+//!   allocation);
+//! - `/api/<supported-version>/<route>` is rewritten to `/<route>`;
+//! - any other `/api/...` shape is rejected before dispatch: an unsupported
+//!   version answers `404 invalid_request` with an `apiVersion` and
+//!   `supportedApiVersions` payload, and every other malformed shape answers
+//!   `404 not_found`;
+//! - the query string is split off the raw path before classification and is
+//!   never part of the classified route.
+//!
+//! New routes belong in the `crate::api` dispatch behind this gate — never in
+//! a helper that skips it. Route/version policy changes belong here;
+//! validation, persistence, and response mapping stay in their own seams (see
+//! `docs/authority-module-inventory.md`).
+
+use std::borrow::Cow;
+
+/// The only API route version this authority currently accepts.
+pub const COVEN_API_ROUTE_VERSION: &str = "v1";
+
+/// Route versions advertised to clients that send an unsupported version.
+pub const SUPPORTED_API_ROUTE_VERSIONS: [&str; 1] = [COVEN_API_ROUTE_VERSION];
+
+/// Classification of a raw request path after its query string was split off.
+#[derive(Debug)]
+pub(crate) enum ApiRoute<'a> {
+    /// A routable path: either a non-`/api/` path passed through unchanged, or
+    /// an `/api/<supported-version>/<route>` path with the version prefix
+    /// stripped. Never retains a version prefix or a `?query` suffix.
+    Route(Cow<'a, str>),
+    /// `/api/<version>/...` with a version this authority does not support.
+    Unsupported(String),
+    /// An `/api/...` path that does not carry a routable suffix.
+    Malformed,
+}
+
+/// Classify a raw request path (already split from its query string).
+pub(crate) fn normalize_api_route(route: &str) -> ApiRoute<'_> {
+    let Some(rest) = route.strip_prefix("/api/") else {
+        return ApiRoute::Route(Cow::Borrowed(route));
+    };
+    let Some((version, suffix)) = rest.split_once('/') else {
+        return ApiRoute::Malformed;
+    };
+    if version != COVEN_API_ROUTE_VERSION {
+        return ApiRoute::Unsupported(version.to_string());
+    }
+    if suffix.is_empty() {
+        return ApiRoute::Malformed;
+    }
+    ApiRoute::Route(Cow::Owned(format!("/{suffix}")))
+}
+
+/// Split the raw request path into its route part and optional query string.
+pub(crate) fn split_path_query(path: &str) -> (&str, Option<&str>) {
+    match path.split_once('?') {
+        Some((route, query)) => (route, Some(query)),
+        None => (path, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routes_supported_version_paths_to_stripped_route() {
+        match normalize_api_route("/api/v1/health") {
+            ApiRoute::Route(route) => assert_eq!(route, "/health"),
+            other => panic!("expected a route, got {other:?}"),
+        }
+        match normalize_api_route("/api/v1/sessions/session-1/input") {
+            ApiRoute::Route(route) => assert_eq!(route, "/sessions/session-1/input"),
+            other => panic!("expected a route, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn passes_non_api_paths_through_without_allocation() {
+        for path in ["/health", "", "/", "/api", "api/v1/health"] {
+            match normalize_api_route(path) {
+                ApiRoute::Route(Cow::Borrowed(passed)) => assert_eq!(passed, path),
+                other => panic!("expected a borrowed passthrough for {path:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_api_versions() {
+        for (path, version) in [
+            ("/api/v2/health", "v2"),
+            ("/api/V1/health", "V1"),
+            ("/api//health", ""),
+        ] {
+            match normalize_api_route(path) {
+                ApiRoute::Unsupported(unsupported) => assert_eq!(unsupported, version),
+                other => panic!("expected an unsupported version for {path:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_api_prefixes() {
+        for path in ["/api/", "/api/v1", "/api/v1/"] {
+            assert!(
+                matches!(normalize_api_route(path), ApiRoute::Malformed),
+                "expected a malformed classification for {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn stripped_routes_never_retain_version_prefix_or_query() {
+        for path in [
+            "/api/v1/health",
+            "/api/v1/health?refresh=1",
+            "/api/v1/sessions?limit=2&cursor=abc",
+            "/api/v1/events?sessionId=s-1",
+        ] {
+            let (route, _query) = split_path_query(path);
+            match normalize_api_route(route) {
+                ApiRoute::Route(stripped) => {
+                    assert!(!stripped.starts_with("/api/"), "{stripped:?}");
+                    assert!(!stripped.contains('?'), "{stripped:?}");
+                }
+                other => panic!("expected a route for {path:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn splits_path_and_query() {
+        assert_eq!(split_path_query("/health"), ("/health", None));
+        assert_eq!(
+            split_path_query("/events?sessionId=s-1"),
+            ("/events", Some("sessionId=s-1"))
+        );
+        assert_eq!(
+            split_path_query("/sessions?limit=2&cursor=a=b"),
+            ("/sessions", Some("limit=2&cursor=a=b"))
+        );
+        assert_eq!(split_path_query("/events?"), ("/events", Some("")));
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 mod afs;
 mod afs_mount;
 mod api;
+mod api_routes;
 mod capabilities;
 mod cockpit_sources;
 mod config_paths;

--- a/docs/authority-module-inventory.md
+++ b/docs/authority-module-inventory.md
@@ -1,0 +1,95 @@
+# Authority module inventory
+
+Status: living inventory for [OpenCoven/coven#806](https://github.com/OpenCoven/coven/issues/806)
+("reduce Coven authority-module concentration behind stable contracts"). It records
+where authority-bearing responsibility is concentrated, the prioritized extraction
+order, and where new route, policy, persistence, transport, and mapping changes
+belong. Update it when a slice lands or the concentration picture changes.
+
+## Method
+
+Rust modules ranked by lines (`git ls-files '*.rs' | xargs wc -l`), then classified
+by responsibility: parsing, validation, authorization/policy, domain service,
+persistence, process/PTY lifecycle, transport/API, mapping/serialization, telemetry.
+Priority is review risk (fan-in of the dispatch surface, shared mutable state,
+security sensitivity), not size alone. Counts include inline `#[cfg(test)]` tests.
+
+## Inventory (as of this writing)
+
+| Module (`crates/coven-cli/src` unless noted) | Lines | Responsibility classes | Review risk |
+| --- | --- | --- | --- |
+| `api.rs` | ~25.4k | transport/API route dispatch, request parsing, validation, launch policy, domain orchestration (sessions, travel, scheduler, threads, handoffs), persistence access, response/error mapping | Highest. The `handle_request_with_runtime_and_authority` match is the fan-in point of the whole crate (~80 route arms); handlers mix policy, store access, and mapping inline |
+| `daemon.rs` | ~12.1k | transport (local socket), request forwarding, process/PTY supervision, runtime ownership, health handshake, telemetry | High. Owns the daemon lifecycle and the only production dispatch call into `api.rs` |
+| `store.rs` | ~11.3k | persistence (SQLite schema, migrations, queries), storage health mapping | High. Every authority path funnels through it; queries and schema evolution share one module |
+| `pty_runner.rs` | ~9.7k | executor/process lifecycle, PTY I/O, platform transport | High. Security-sensitive process supervision |
+| `memory_import.rs` | ~8.9k | parsing of external memory formats, validation, persistence | Medium |
+| `tui/chat/app.rs` | ~8.6k | UI state machine, transport client, rendering inputs | Medium (presentation; not authority) |
+| `main.rs` | ~8.5k | CLI parsing, command dispatch, setup | Medium |
+| `harness.rs` | ~6.3k | adapter policy for supported harnesses, launch construction | High (policy) |
+| `ward.rs` | ~3.5k | authorization/policy gates, audit ledger | High (policy core) |
+| `hub.rs` | ~2.6k | multi-node registry domain service, persistence, health | Medium |
+| `threads_gate.rs` | ~1.6k | proposal adjudication policy | High (policy) |
+
+## Prioritized extraction order
+
+Each extraction must map to an existing contract/test surface and preserve it.
+The stable outer contracts are: the public HTTP API (`docs/API-CONTRACT.md`,
+`docs/API.md`), the daemon socket protocol (`docs/daemon/`), the SQLite store
+schema, and the integration suites (`tests/smoke.rs`,
+`tests/stream_json_integration.rs`, `tests/setup_cli.rs`) plus the inline
+characterization tests of each module.
+
+1. **Route/version authority gate — done (slice 1).** `ApiRoute`,
+   `normalize_api_route`, `split_path_query`, and the route-version constants
+   moved from `api.rs` to `api_routes.rs`. Pure parsing; rejection envelopes
+   (`404 invalid_request` with `apiVersion`/`supportedApiVersions`,
+   `404 not_found`) pinned by tests. No behavior change.
+2. **Response/error envelope mapping** (`api_error`, `json_response`,
+   `ApiResponse`, error-code precedence) — pure mapping, fan-in from every
+   handler; extract behind the same public envelopes.
+3. **Health/capability mapping and `RequestAuthority`** — the advertised
+   capability surface is an authority decision (`sessionLaunchPolicy` depends
+   on it); map it independently of session orchestration.
+4. **Sessions route family** — launch/complete/input/kill/handoff/events/log
+   handlers share process-lifecycle authority; extract as one bounded family
+   only with crash/restart characterization in place.
+5. **Threads proposal decision path** — decision locking, failpoints, and
+   recovery authorization (`recovery_authorization`, proposal failpoints) are
+   policy + persistence interleaved; extract behind the existing ward/threads
+   gate contracts.
+6. **Travel/scheduler handler groups** — large, mostly independent domains in
+   `api.rs`; lower risk, do after the shared seams above exist.
+7. **`store.rs` command/query vs. schema/migration split** — keep authority
+   decisions out of the persistence layer (no ORM-shaped bypass).
+8. **`daemon.rs` transport vs. supervision** — separate socket transport
+   plumbing from session supervision state machines.
+
+What will **not** change in any slice: route paths and versions, status codes,
+error codes/messages/payload precedence, response payload schemas, the SQLite
+schema, the socket protocol, CLI flags, and the fail-closed behavior of ward
+gates. Behavioral changes require a separate, separately approved PR.
+
+## Where new behavior belongs
+
+- **Route/version policy** (new route arm, version bump, gate rejection):
+  `api_routes.rs` for the gate, the `api.rs` dispatch match for the arm. Never
+  in a helper that bypasses the gate.
+- **Validation and domain policy**: the module that owns the domain
+  (`ward.rs`, `threads_gate.rs`, `harness.rs`, `session_launch.rs`) — not
+  inline in transport handlers where avoidable.
+- **Persistence**: `store.rs` commands/queries; schema changes stay in its
+  migration path. Policy decisions never move into the store layer.
+- **Executor/process lifecycle**: `pty_runner.rs` (and daemon supervision);
+  never coupled to API formatting.
+- **Response/event mapping**: `api.rs` mapping helpers until slice 2 gives
+  them their own module; mapping stays pure (no I/O, no policy).
+
+New cross-cutting responsibilities must justify staying inside a large module
+rather than joining the extracted contract.
+
+## Metrics
+
+Trends, not vanity LOC targets: largest authority module size; distinct
+responsibility classes per selected module; review diff size for
+security-sensitive changes; externally observable contracts covered by focused
+tests; escaped defects caused by cross-responsibility interactions.


### PR DESCRIPTION
## Summary

Slice 1 of #806 — extract the **route/version authority gate** (the first seam
of the request pipeline) out of the 25k-line `api.rs` monolith into a dedicated
`api_routes.rs` module, behind its existing stable contract, with
characterization tests. Pure parsing move; zero behavior change.

- `ApiRoute`, `normalize_api_route`, `split_path_query`, and the route-version
  constants (`COVEN_API_ROUTE_VERSION`, `SUPPORTED_API_ROUTE_VERSIONS`) move
  from `api.rs` to `api_routes.rs` — the single place that decides whether a
  request path carries a supported API version. The authority entry point
  (`handle_request_with_runtime_and_authority`, the crate's only route fan-in,
  ~80 arms) imports the gate; handlers below it never re-parse the
  `/api/<version>` prefix, so validation cannot be bypassed by choosing a
  lower-level helper.
- Visibility widens from module-private to `pub(crate)`; no signatures change.
- `docs/authority-module-inventory.md` (new) publishes the issue's Phase-1
  concentration inventory, the prioritized extraction order, and the
  where-new-behavior-belongs map (Phase 4).

**Preserved behavior/invariants:** public HTTP API contract
(`docs/API-CONTRACT.md`) including the unsupported-version
`404 invalid_request` envelope (`apiVersion`, `supportedApiVersions`) and the
uniform `404 not_found` envelope for unrouteable shapes; all route arms;
persistence, ward fail-closed behavior, SQLite schema, socket protocol, CLI
flags.

**Intentionally changed behavior:** none (structural extraction only).

**Focused tests proving the boundary:** `api_routes.rs` classifier
characterization (positive, malformed, unsupported, borrowed passthrough, query
splitting, version-prefix-never-retained property) plus two new `api.rs`
envelope tests (`unsupported_version_rejection_pins_full_envelope`,
`rejects_malformed_api_route_prefixes`) next to the existing
`rejects_unknown_api_version_prefixes`.

**Rollback strategy:** `git revert` of the single commit; no migration, no
state.

## Issue

Refs OpenCoven/coven#806

## Test plan

- [x] Full diff reviewed as a pure move; moved code byte-identical apart from the module doc, `#[derive(Debug)]`, and `pub(crate)` visibility required by the new seam
- [x] Verified by search that nothing else in the crate references the moved items; changed/added files manually scanned against the privacy-guard patterns
- [ ] `cargo fmt --check` (deferred to CI — no Rust toolchain in the authoring environment)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` (deferred to CI)
- [ ] `cargo test --workspace --locked` (deferred to CI)
- [ ] `python3 scripts/check-secrets.py` (deferred to CI — no Python locally)

---

## Context (PR template)

- Summary: route/version authority gate extracted from `api.rs` into
  `api_routes.rs` with characterization tests; inventory doc added.
- Files changed: `crates/coven-cli/src/api_routes.rs` (new),
  `crates/coven-cli/src/api.rs`, `crates/coven-cli/src/main.rs`,
  `docs/authority-module-inventory.md` (new)
- Closes # (none — slice 1 of N; see Refs above)

## Implementation (PR template)

- Approach: one extraction at a time, pure parsing first (issue Phase 2 → 3
  order). Characterization added with the move; the gate owns the full
  route/version rejection contract documented on the module.
- User-visible behavior: none.
- Compatibility notes: the moved constants keep their names and values;
  nothing outside `api.rs` referenced them (coven-cli is a binary crate).

## Risk and Rollback (PR template)

- Risk level: low — mechanical extraction of three pure functions, two
  constants, and one enum; dispatch and handlers untouched.
- Rollback plan: `git revert` the single commit.

## Agent Handoff (PR template)

- Current state: slice 1 of N. Gate extracted, characterized, documented.
- Follow-ups (inventory priority order): (2) response/error envelope mapping,
  (3) health/capability mapping + `RequestAuthority`, (4) sessions route
  family, (5) threads proposal decision path, then travel/scheduler,
  store command/query split, daemon transport vs supervision.
- Known gaps: full `cargo fmt`/`clippy`/`test` verification deferred to CI
  (no Rust toolchain in the authoring environment).

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#806.

> **CI note:** no CI exists on this fork vehicle — `gh api repos/CompleteDotTech/coven/commits/f00b9b1/check-runs` returns `total_count: 0` and the fork has no GitHub Actions runs at all, so no check has reported and none is expected. The upstream gates (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, secret/privacy/API-doc guards) are deferred to the upstream re-target. Refs OpenCoven/coven#806.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/5], preserving source head `f00b9b12886c27aeb894c926151eec06b8573b1c` and branch `agent/issue-806-p1-reduce-coven-authority-module-concentration`.