### PR TITLE
docs(automations): specify coven.automations.v1 schemas, state machines, and changefeed

### DIFF
--- a/docs/architecture/coven-automations-v1.md
+++ b/docs/architecture/coven-automations-v1.md
@@ -1,0 +1,288 @@
+# Coven Automations Protocol v1 (`coven.automations.v1`)
+
+Status: Proposed implementation contract
+
+Tracks: OpenCoven/coven#855 (this specification), OpenCoven/coven#854 (parent program), OpenCoven/coven#816 (landed foundation)
+
+Machine-readable artifacts: [`spec/coven-automations/v1/`](../../spec/coven-automations/v1/) — JSON Schemas, state machines, capability negotiation, compatibility matrix, golden vectors, and a pinned TypeScript projection.
+
+## Normative language
+
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are to be interpreted as normative requirements.
+
+## Purpose
+
+Turn the internal automation structs and control actions into a stable, independently testable protocol so Cave, the SDK, Psyche adapters, runtimes, and future implementations can consume automations without importing Coven internals or reproducing lifecycle semantics by hand. The protocol is one canonical truth for definitions, occurrences, runs, attempts, authority bindings, receipts, commands, events, and failures.
+
+This document specifies the contract. It does not change schedule authority, familiar identity, or authority semantics: those stay in their canonical layers (see [Implementation boundaries](#implementation-boundaries)).
+
+## Current gap, with code paths
+
+The #816 foundation is a valid v1 Rust implementation, but the public contract is still inferred from implementation. Each gap below cites the code as of this writing:
+
+1. **Definitions are schedule + prompt records.** `RoutineDefinition` (`crates/coven-cli/src/automations/definition.rs`) carries `schemaVersion`, `id`, `name`, `status` (`ACTIVE | PAUSED`), `rrule`, `timeoutMinutes`, `runtime`, `familiarId`, `prompt`, and little else. There is no revision counter, no integrity digest, no trigger/action unions, no lifecycle beyond two states, no provenance, and no retention policy.
+2. **JSON payloads are assembled inside the control action router.** Every wire shape is hand-built in `control_plane.rs` (`automation_list_payload`, `automation_create_payload`, `automation_runs_payload`, ... at `crates/coven-cli/src/control_plane.rs`), so the router is the only specification of the payloads.
+3. **Domain failures hide inside accepted responses.** `automation_event` (`control_plane.rs`) always returns `ok: true, accepted: true, status: completed`; when the store call fails, the error is embedded as a `{"error": ...}` payload (for example `automation_tick_payload`, `automation_run_payload`, `automation_update_payload`). A client that trusts `accepted` cannot see the failure.
+4. **No revision/adoption model.** `update_definition` (`crates/coven-cli/src/automations/store.rs`) mutates the row in place; nothing records which revision a caller expected, and `intentId` on control actions (`control_plane.rs`) is echoed, never adopted, stored, or replay-checked.
+5. **No versioned event envelope or replay reducer.** `ControlEvent` (`control_plane.rs`) has `kind/action/origin/intentId/payload` but no schema version, no event id, no per-stream sequence, and no timestamps; there is no changefeed at all — Cave polls list/get endpoints.
+6. **Lifecycle semantics are stringly typed and partial.** Occurrence states are free strings (`'planned'/'claimed'/'running'/'succeeded'/'failed'` in `crates/coven-cli/src/automations/occurrences.rs`), terminal states are exactly `[succeeded, failed]` (`OCCURRENCE_TERMINAL_STATES`), and lease recovery maps straight to `failed` with reason `lease expired` (`recover_expired_leases`). There are no eligible/dispatching/recovering/cancelled/timed_out/superseded states, no run state machine beyond `status` strings, and no attempt object at all — only an `attempt` counter incremented by claim (`claim_due_occurrence`).
+7. **No receipts, no digests, no integrity anywhere** in the automations module; run outcomes are ledger rows (`automation_runs.log_json`, `exit_code`) with no tamper-evident summary.
+8. **No capability negotiation.** `capabilities()` (`control_plane.rs`) lists action ids, but nothing lets a client ask which trigger/action/policy variants an implementation executes, and nothing forces a definition with an unsupported variant to fail explicitly.
+9. **Adoption-key gaps.** Run and occurrence ids are wall-clock derived (`fresh_id`, `crates/coven-cli/src/automations/runner.rs` — `format!("{prefix}-{millis}")`), so a retried `coven.automations.run` command can create a second occurrence/run rather than replaying the first outcome.
+
+## Contract profile and versioning
+
+- The wire contract profile is the string `coven.automations.v1`, carried as `schemaVersion` on every object (`spec/coven-automations/v1/protocol-version.json`).
+- Contract version is separate from implementation/release version: envelopes carry the producer's `implementationVersion` alongside the contract profile, and clients MUST NOT infer semantics from release versions.
+- Unknown profiles fail closed with `SCHEMA_VERSION_UNSUPPORTED` (`coven.automations.v0` and future `coven.automations.v2` are both refusals — golden vectors pin both).
+- Additive evolution rules and per-field change classes are machine-readable in `compatibility-matrix.json`; see [Compatibility and evolution](#compatibility-and-evolution).
+
+## Data model
+
+All objects are JSON per draft 2020-12 schemas under `spec/coven-automations/v1/`, with `additionalProperties: false`: unknown fields fail closed, and optional, non-semantic data travels only in the explicit `extensions` bag (keys `x-*` or reverse-DNS; preserved on round-trip, never interpreted until promoted by a new profile).
+
+### `AutomationDefinition`
+
+Specified by `automation-definition.schema.json`. Field groups (all required unless noted):
+
+- `automationId` — stable identity, charset `[A-Za-z0-9._-]`, 1..=96 chars, matching the #816 validator in `definition.rs` (`AUTOMATION_ID_MAX_CHARS`).
+- `revision` — monotonic integer, starts at 1, incremented by exactly one per accepted mutating command.
+- `integrity` — SHA-256 over the RFC 8785 (JCS) canonical serialization of the definition body with the `integrity` member removed (`common.schema.json#/$defs/digest`). The digest pins what a revision means; receipts and occurrences pin it so history stays verifiable even if the definition store is later revised or lost.
+- `schemaVersion` — the constant `coven.automations.v1`. The #816 numeric `schemaVersion: 1` is the pre-contract encoding (see [Migration](#migration-from-816)).
+- `lifecycleState` — `draft | paused | active | disabled | invalid` (tombstoning is a deletion marker, not a state; see below).
+- `display` — `name` (required, 1..=160), optional `description`, `tags`.
+- `trigger` — exactly one versioned union. v1 ratifies `schedule` only (scoped RRULE per `crates/coven-cli/src/automations/rrule.rs`: `FREQ=DAILY|WEEKLY`, optional `BYHOUR`, optional `BYDAY` for weekly; anything else is refused at validation). The union admits future variants as new branches in future profiles without redefining v1 fields, and consumers reject unknown variants via capability negotiation.
+- `conditions` — zero or more; v1 defines zero variants (the slot is a boolean-false schema), so any value fails validation until a future profile adds branches.
+- `action` — exactly one versioned union. v1 ratifies `familiarInvocation` (non-empty `prompt`, optional `cwd`), mirroring the #816 prompt requirement and the runner's no-cwd failure rule.
+- `binding` — `familiarBindingPolicy: "exact"` plus `familiarId` and the authority/approval policy reference. Exact binding is the only v1 policy: the familiar recorded at activation is the familiar every run binds; rebinding requires a new revision.
+- `runtimeRequirements` — `runtimeId` + capability keys + optional model (required for active/paused/disabled definitions; the #816 `runtime` field maps to `runtimeId`, default `coven-code`).
+- `policies` — `timeout.perRunMinutes` (1..=44640, as `definition.rs`), `retry` (max attempts 1..=10, backoff policy, retryable failure classes), `concurrency.overlap: forbid` (the #816 `RoutineOverlap::Forbid`), `misfire.disposition: latest` (the #816 `RoutineMisfire::Latest`), `delivery` (optional atomic `outputTarget` — commit only after a completed, verified run, per `definition.rs`), and `retention` classes for occurrence history, run logs, and receipts.
+- `provenance` — creator principal, creation/update timestamps, optional `importedFrom` marker (set to `codex.automation.toml` by the #816 importer in `import_legacy.rs`).
+- `activation` — optional `effectiveFrom`/`effectiveUntil` window; outside the window the definition behaves as paused without a lifecycle change.
+
+### `AutomationOccurrence`
+
+Specified by `automation-occurrence.schema.json`.
+
+- `occurrenceId`, `automationId`, `automationRevision` (exact revision pinned forever).
+- `triggerIdentity` (`schedule.slot` with `rruleRef`, or `manual.request` with requester) and the canonical `occurrenceKey`: `automationId@scheduledFor` for slots — this is the wire projection of the idempotent planning fence `UNIQUE(automation_id, scheduled_for)` (`crates/coven-cli/src/automations/occurrences.rs`), and `automationId@manual-<adoptionKey>` for manual runs.
+- `scheduledFor` / `observedAt` / `eligibleAt` timestamps.
+- `fence` — monotonic `generation` per occurrence plus claimant and lease expiry; the contract-level form of the lease columns and `attempt` counter in `occurrences.rs`.
+- `state` + `stateReason` — the occurrence state machine (below).
+- `misfireDisposition` — `collapsed_to_latest` records the #816 misfire-latest collapse (`plan_latest_due_occurrence` walks forward from the later of creation time and the latest fenced slot and fences exactly one slot; `occurrences.rs`).
+- `claimMetadata` (bounded lease 1..=1440 minutes, per `claim_due_occurrence`).
+- `activeRunRef` — present while exactly one accepted run owns the fence generation.
+- `cancellation` — request vs acknowledgment vs reconciliation timestamps (cancellation is a request until acknowledged or reconciled).
+- `recovery` — evidence class and resolved disposition for the recovering/recovery_required path.
+- `eventWindow` — first/last sequence of the occurrence's authoritative stream, so readers can resume without gaps.
+
+### `AutomationRun`
+
+Specified by `automation-run.schema.json`.
+
+- `runId`, occurrence correlation (`occurrenceId`, `automationId`, `automationRevision`).
+- `binding` — the exact familiar, the exact principal/authority/approval (references only; authority semantics live in the canonical authority layer), and the exact runtime descriptor/capabilities observed at dispatch. These are frozen at acceptance; retries change attempts, never the run's bindings.
+- `state` — `accepted | running | succeeded | failed | cancelled | timed_out | ambiguous`.
+- `attemptCount` (monotonic) and `currentAttemptId` while unsettled.
+- `terminalDisposition` (required when terminal) with outcome and failure class.
+- `delivery` (none/pending/committed/refused/rolled_back; `committed` only after a completed, verified run — the #816 atomic output rule), artifact references, `resultDigest`.
+- `receiptRef` — the receipt recording this run's disposition.
+- `startedAt` (required) and `finishedAt` (required when terminal — schema-enforced).
+
+### `AutomationAttempt`
+
+Specified by `automation-attempt.schema.json`.
+
+- `attemptId`, `runId`, `occurrenceId`, monotonic `attemptNumber` (never reused within a run).
+- `adoptionKey` — workers adopt by key; replays return the same attempt instead of creating a second one.
+- `priorDisposition` — required when `attemptNumber > 1`: every retry names the attempt and outcome it retries (`failed | timed_out | ambiguous | cancelled`).
+- `dispatchFence` — the occurrence fence generation plus a dispatch generation guarding double dispatch.
+- `workerCorrelation` — worker id and the single bound `sessionId`; a second session bind on one attempt is `ILLEGAL_TRANSITION`, never a silent overwrite.
+- `retryClassification` — initial / automatic_retry / operator_retry / operator_recovery, with the eligible-classes snapshot.
+- `leaseObservations` — heartbeat evidence; expired evidence moves work to recovery and can never be reinterpreted as success.
+- `outputCursors` — event/log cursors a resuming worker continues from without re-emitting.
+- `state` — `adopted → dispatching → started → observing → succeeded | failed | cancelled | timed_out | ambiguous`. `ambiguous` is terminal for the attempt (see state machines).
+
+### `AutomationReceipt`
+
+Specified by `automation-receipt.schema.json`. Immutable and versioned; written once, never revised.
+
+- Pins `definitionDigest` (the revision's digest), the occurrence fence generation, run, attempt, exact identity, authority/approval, and runtime.
+- `exercisedCapabilities` and `sideEffectClass` (`none → local_read → local_write → external_read → external_mutation → irreversible_external_mutation`), which drive whether ambiguous work can be resolved as `failed_deterministic`.
+- `outcome` with partial failures and recovery disposition; timestamps; `producer` identity.
+- `integrity` — digest over the canonical receipt body plus an `authentication` marker (`none | producer-hmac | cosign`); unauthenticated receipts are integrity-checked but not provenance-proof, and consumers MUST surface the distinction.
+- `privacy` — classification and retention.
+
+## Lifecycle semantics (state machines)
+
+Machine-readable source of truth: `spec/coven-automations/v1/state-machines.json`. Clients do not author state; transitions are committed by command handlers or the scheduler, never by arbitrary client writes.
+
+### Occurrence
+
+```text
+planned -> eligible -> claimed -> dispatching -> running
+    -> succeeded | failed | cancelled | timed_out | recovery_required
+
+planned/eligible -> skipped | superseded | cancelled
+claimed/dispatching with expired evidence -> recovering -> failed | recovery_required
+recovery_required -> failed | dispatching (explicit operator recovery only)
+```
+
+Terminal: `succeeded, failed, cancelled, timed_out, skipped, superseded`. Non-obvious ratifications:
+
+- `dispatching -> failed` exists for deterministic pre-side-effect launch refusals (`launch_refused`); without it, every refused launch would be ambiguous, which is wrong — the #816 runner already treats a launch error as a recorded failure with a reason (`runner.rs`).
+- `recovering` is automatic reconciliation in progress; `recovery_required` needs an explicit operator command. `recovery_required` is deliberately **not terminal**: its only exits are `failed` (operator determines no side effects were possible) or `dispatching` (operator-approved recovery attempt, which creates a new attempt carrying `priorDisposition: ambiguous`).
+- `skipped` vs `superseded`: skipped means policy disposed of the slot (overlap forbid, paused, invalid); superseded means a newer definition revision replaced this one before it was claimed.
+
+### Attempt
+
+```text
+adopted -> dispatching -> started -> observing
+    -> succeeded | failed | cancelled | timed_out | ambiguous
+```
+
+`ambiguous` is terminal for the attempt (dispatch sent but no deterministic ack, or evidence lost). The occurrence carries the recovery; the attempt never re-opens. `dispatching -> failed` covers deterministic launch refusal; `dispatching -> ambiguous` covers unconfirmed dispatch.
+
+### Run
+
+```text
+accepted -> running -> succeeded | failed | cancelled | timed_out | ambiguous
+```
+
+`accepted` commits before any consequential side effect. A run spans its attempts: retry/recover increments `attemptCount` and swaps `currentAttemptId`; terminal `terminalDisposition` is written exactly once.
+
+### Definition
+
+```text
+draft -> paused -> active -> paused | disabled | invalid | tombstoned
+disabled -> paused (explicit re-enable only)
+invalid -> paused (after a repairing revise) | tombstoned
+tombstoned (terminal)
+```
+
+`draft` replaces the #816 implicit "created PAUSED" default (every import lands in `draft` until validated and explicitly paused/activated). Tombstoning is a deletion marker on the definition plus retention of all history.
+
+### Invariants
+
+`state-machines.json` carries the machine-readable form. The ten normative invariants, each traceable to a current-code motivation:
+
+1. **Command adoption commits before consequential side effects** — closes the gap where `coven.automations.run` launches before any adoption record exists (`runner.rs` fences and launches in one call with no command record).
+2. **One occurrence fence cannot own two accepted runs** — generalizes the compare-and-set claim in `claim_due_occurrence` (`occurrences.rs`) from claiming to acceptance.
+3. **One attempt cannot bind two runtime sessions** — a second bind is `ILLEGAL_TRANSITION`, never an overwrite.
+4. **Terminal states do not regress** — #816 already enforces a weak form (`settle_occurrence` only settles claimed/running; `record_run_finish` only finishes `running` rows); the contract ratifies it for every state.
+5. **Absence of runtime evidence cannot become success** — #816's `run_routine_now` marks `succeeded` on a bare `launch_session` ack with no completion evidence (`runner.rs`); under the contract that launch ack is `dispatching -> started`, and settling `succeeded` requires verified evidence.
+6. **Cancellation is a request until acknowledged/reconciled** — typed `CANCEL_PENDING` while a running attempt has not acknowledged.
+7. **Retry creates a new attempt and never rewrites the prior attempt** — attempts are immutable after settling.
+8. **Ambiguous mutating work is not automatically retried** — only `occurrence.recover.v1` with an explicit operator determination opens work after `ambiguous`.
+9. **Definition revision changes never rewrite historical occurrences/runs** — every record pins `automationRevision` + definition digest.
+10. **Deleting a definition tombstones it without erasing required history** — replaces `delete_definition`'s hard `DELETE FROM automation_definitions` (`store.rs`), which erases identity while leaving orphan occurrences.
+
+## Commands, idempotency, and revision semantics
+
+Specified by `command-envelope.schema.json`. Every command is an envelope:
+
+```json
+{
+  "schemaVersion": "coven.automations.v1",
+  "command": "definition.revise.v1",
+  "adoptionKey": "adopt:revise-daily-notes-0002",
+  "expectedRevision": 2,
+  "origin": { "principal": { "principalId": "principal:tim" }, "channel": "sdk" },
+  "intent": { "statement": "Move the daily notes slot to 10:00." },
+  "payload": { "definition": { } }
+}
+```
+
+- **`adoptionKey` (required):** the stable request/adoption key. First commit wins; the key is stored with the committed outcome. A repeat with the same key returns the first committed outcome unchanged (`outcome: "replayed"` with `replay.firstCommittedAt`) — identical bytes, no second event, no second revision. A repeat with the same key but different command/payload is `ADOPTION_REPLAY_MISMATCH` (409) carrying what the key actually committed, so callers reconcile instead of guessing. Recommendation: keys are caller-chosen ULIDs; handlers may derive per-attempt keys deterministically (`adopt:<runId>:<attemptNumber>`).
+- **`expectedRevision`:** required for `definition.revise/activate/pause/disable/tombstone`, forbidden otherwise (schema-enforced). Commit happens only when the stored revision equals `expectedRevision`; mismatch returns `REVISION_CONFLICT` (409) with `currentRevision`, committing nothing.
+- **`origin`:** authenticated principal, channel, authentication class, requested-at, correlation id. Transports that cannot authenticate must refuse upstream; the envelope records, never decides.
+- **`intent.statement`:** explicit human-authored intent, recorded on events and receipts.
+
+Command catalog (all names versioned in the envelope): create, revise, activate, pause, disable, tombstone; run now; cancel occurrence/run/attempt; retry with explicit prior disposition; recover with explicit evidence determination; list/get/history/health; events read/subscribe; legacy import. The response is one of `committed`, `replayed`, `rejected` — with `result` only on committed/replayed and `error` only on rejected.
+
+**Idempotency storage note for implementers:** the adoption key must be persisted in the same transaction as the state change it drives (a `command_adoption` table keyed by adoption key storing the serialized committed response), so replays are answerable without recomputation.
+
+## Errors and status mapping
+
+Specified by `error-envelope.schema.json`. Domain failures are errors; a rejected or failed domain operation MUST NOT be wrapped as `accepted: true` merely because routing succeeded. This is the direct fix for the current `automation_event` behavior (`control_plane.rs`) that emits `ok/accepted/completed` around `{"error": ...}` payloads.
+
+Twenty typed codes with a frozen HTTP mapping (also machine-readable in the schema): validation and schema-version refusals → 400; not found → 404; tombstoned → 410; adoption/revision conflicts, cancel-pending, overlap, out-of-order stream → 409; capability, transition, retry-disposition, ambiguous-retry refusals → 422; authority/approval → 403; payload too large → 413; concurrency → 429; deadline → 504; internal → 500.
+
+Control-action transport mapping: `POST /api/v1/actions` (`crates/coven-cli/src/api.rs`, `route_action`) keeps its `ControlActionResponse` shape but the automations actions MUST surface domain failures as `ok: false, accepted: false, status: rejected` with the typed error envelope embedded, and the transport status MUST be the mapped one — exactly what `rejected_action` already does for routing failures. The same command handlers back both transports and return the same typed outcomes; the router stops assembling domain payloads (its current payload builders move into the shared handlers).
+
+## Event/changefeed
+
+Specified by `event-envelope.schema.json`.
+
+- **Envelope:** `schemaVersion`, `eventId` (globally unique), `stream {kind, id}`, gapless `sequence` per stream, `recordedAt`/`observedAt`, `producer`, optional `causation` (adoption key, cause event id, correlation id), object ids as applicable, `kind`, user-safe `summary` (no secrets, no prompts), typed `payload`, `privacy`, optional `integrity`.
+- **Streams:** `automation/{id}`, `occurrence/{id}`, `run/{id}`, plus a global `feed`. Stream-local sequences are gapless and append via compare-and-set; out-of-order appends are refused (`STREAM_OUT_OF_ORDER`), never reordered.
+- **Delivery:** at-least-once. Consumers deduplicate on `eventId` and refuse regressions against their cursor (the golden vectors pin both).
+- **Read:** `events.read.v1` with `after` (exclusive sequence) or `from` (timestamp, resolved to a concrete cursor in the response); `events.subscribe.v1` with an opaque `checkpoint`. Expired checkpoints return `CURSOR_EXPIRED` (410) with the expiry instant — never a silent rewind.
+- **Rehydration:** the read model is a fold: dedupe by eventId → apply strictly-increasing sequences → final state. Reconnection and duplicates converge to the same state (vector `event-replay-rehydrates-deterministically`). Occurrence records carry `eventWindow` so a reader knows the stream bounds it read.
+- **Compaction:** `feed.snapshot` events carry `throughSequence` plus compacted state; consumers fold the snapshot and apply strictly-later events. Retention may compact streams only behind a snapshot.
+
+## Capability negotiation
+
+`capabilities.json` lists supported v1 variants (trigger `schedule`, action `familiarInvocation`, policies `misfire.latest`, `overlap.forbid`, `timeout.required`, delivery `outputTarget.atomic`, retention `standard`), an empty `experimental` list, and explicit `refused` entries (`trigger.webhook`, `action.pipeline`, `misfire.backfill`) with reasons. Rules:
+
+- A definition referencing a variant absent from the producer's supported list MUST be refused with `CAPABILITY_UNSUPPORTED`, naming the variant. Nothing is guessed, defaulted, or silently downgraded — the same fail-closed stance as the #816 RRULE vocabulary gate (`rrule.rs` refuses unsupported frequencies instead of approximating).
+- Refusal is per-variant and additive: refusing one variant says nothing about others.
+- Unknown values inside a supported variant are still unknown variants.
+- The negative path is also a schema property: v1 unions are closed, so an unknown variant fails schema validation before negotiation is even needed; producers that relax schema validation in future profiles still refuse at the capability layer.
+
+## Canonicalization and digests
+
+Digests (definition integrity, receipts, event integrity where required) are SHA-256 over RFC 8785 (JCS) canonical JSON: UTF-8, recursively key-sorted, no whitespace, minimal escaping, ES6 number formatting. The golden vectors pin actual digest values computed this way over integer/ASCII-only fixtures, so any conformant JCS implementation reproduces them byte-for-byte. Producers MUST NOT digest ad-hoc serializations.
+
+## Migration from #816
+
+Non-destructive, no data loss, no rewritten history:
+
+1. **Definitions:** on first contract adoption, each stored `automation_definitions` row gains sidecar columns (`revision` = 1, `integrity` = digest over its existing `definition_json` bytes, lifecycle mapping `ACTIVE → active`, `PAUSED → paused`, default `draft` for import). `definition_json` bytes stay byte-identical — the digest is computed over them, not written into them — so pre-migration rows remain verifiable.
+2. **Occurrences:** every existing row pins `automationRevision: 1` plus the definition digest; `attempt` counter maps to fence `generation` (claim already increments it in `claim_due_occurrence`); state strings map 1:1 (`planned/claimed/running/succeeded/failed`) with `succeeded/failed` becoming the v1 terminals of the same names.
+3. **Runs:** `automation_runs` rows map to v1 runs with `state` from `status`; the ledger's `exit_code/log_json/output_commit` columns carry into `terminalDisposition`/`delivery` without backfilling receipts — receipts exist only for runs that produce them after adoption (receipts are never fabricated for history).
+4. **Wire compatibility:** the legacy control actions (`coven.automations.*`, `control_plane.rs`) continue to respond during migration, each response additionally carrying the contract profile; new commands are additive. `coven.automations.import` maps to `legacy.import.v1` (`source: codex-automation-toml`), keeping the non-destructive, created-PAUSED/draft semantics of `import_legacy.rs`.
+5. **Nothing is deleted:** no definitions, occurrences, or run history are erased at any step (acceptance criterion), and the migration is idempotent (re-running adopts nothing twice — the adoption table marks it).
+
+## Implementation boundaries
+
+- `crates/coven-cli/src/automations/**` may implement the contract but is not its specification; this directory plus `spec/coven-automations/v1/` is the specification.
+- Control actions and any HTTP routes delegate to the same command handlers and return the same typed outcomes; the router stops being a payload assembler.
+- Cave, SDK, and Psyche consume the pinned artifacts (`schemas`, `test-vectors.json`, `coven.automations.v1.d.ts`) as packed/released artifacts — never source-relative imports, never hand-maintained parallel types.
+- This protocol does not move schedule authority into Psyche or authority semantics into Cave: it binds references (`principalId`, `approvalPolicyRef`, `familiarId`) and defers semantics to their canonical layers.
+
+## Corresponding Rust types (pinned mapping, implementation deferred)
+
+The Rust projection is mechanical and lands in a follow-up implementation PR (this issue specifies; it does not implement): a `contract` module with serde types renamed to camelCase (`#[serde(rename_all = "camelCase")]`, the existing wire style in `definition.rs`), where each struct maps 1:1 to a schema (`AutomationDefinition`, `AutomationOccurrence`, `AutomationRun`, `AutomationAttempt`, `AutomationReceipt`, `CommandEnvelope`, `CommandResponse`, `ErrorEnvelope`, `EventEnvelope`), `#[serde(deny_unknown_fields)]` on every v1 struct to mirror `additionalProperties: false`, `serde_json::Value` for the extension bag, and round-trip tests generated from the golden vectors. Status enums map to the schemas' enums exactly; the schema files remain the source of truth.
+
+## Verification matrix
+
+| Issue requirement | Contract artifact | Required test suite |
+| --- | --- | --- |
+| Schema validation + Rust round-trip | all schemas | `schema-validation`, `rust-round-trip` |
+| State-machine invariant preservation | `state-machines.json` | `state-machine-property-tests` |
+| Adoption replay/conflict | command envelope semantics | `request-adoption-replay-and-conflict` |
+| Expected-revision conflict | command envelope | `expected-revision-conflict` |
+| Duplicate/out-of-order replay | event envelope + vectors | `duplicate-and-out-of-order-event-replay` |
+| Typed transport/domain error mapping | error envelope + status mapping | `typed-transport-domain-error-mapping` |
+| Golden vectors runnable outside the Coven crate | `test-vectors.json` (self-contained, digest recipe inline) | `golden-vectors-external-runners` |
+| Packed/released artifact tests + cross-repo canaries | pinned `.d.ts` + schemas + vectors | `packed-artifact-canaries` (Coven, SDK, Cave pin exact artifacts) |
+| #816 migration | migration section above | migration proof: pre/post digest equality, row counts, no deletes |
+
+All suites are enumerated with `releaseState: proposed` in `conformance-manifest.json`.
+
+## Alternatives considered (recommendations for the maintainer)
+
+1. **Tolerant reader vs fail-closed unknown fields.** Chosen: fail-closed (`additionalProperties: false`) with an explicit namespaced extension bag, matching `spec/device-pairing/v1` ("unknown required restrictions fail closed") and the security-first posture of the repo. Alternative considered: ignore unknown fields for additive ease — rejected because silent reinterpretation is exactly the drift this issue exists to end; additive fields still land via a minor profile with dual-emit.
+2. **`recovery_required` terminal vs non-terminal.** Chosen non-terminal with two explicit exits (`failed` or a new operator-approved attempt), because the issue requires retry/recover commands with explicit prior disposition while also requiring that ambiguous work is never auto-retried; a terminal `recovery_required` would make explicit recovery impossible without violating "retry creates a new attempt". Alternative considered: model recovery as a new occurrence — rejected because it forks the audit trail for one logical slot.
+3. **Revision integer vs content-addressed definition ids.** Chosen monotonic integer + digest (the digest already gives content addressing); integer revisions give callers a trivial compare-and-set and match the store's row model. Alternative considered: content-hash identity — rejected as the primary key (history joins become opaque), kept as the integrity layer.
+4. **RFC 8785 vs a Coven-private canonical form.** Chosen JCS: portable, implemented everywhere, and sufficient for v1's integer/ASCII digest fixtures. Alternative considered: a private canonicalization — rejected; it would force every canary to import Coven code, violating the independence requirement.
+5. **Attempt-level retry within a run vs run-per-attempt.** Chosen retries-within-a-run (`attemptCount`, `priorDisposition`), matching the issue's wording ("current attempt", "retry creates a new attempt"). Alternative considered: a new run per retry — rejected; it would fragment authority bindings the run is supposed to pin.
+6. **`cancelled` as request vs state.** Chosen: the request lives in `cancellation` metadata with `requestedAt`; `cancelled` is only committed on acknowledgment/reconciliation, keeping `CANCEL_PENDING` representable. Alternative considered: immediate cancelled state — rejected; it would let a client-authored transition lie about runtime state.
+
+## Non-goals
+
+- Implementing every future trigger or action variant (v1 ships `schedule` + `familiarInvocation` only).
+- A general-purpose workflow language (no pipelines, no step graphs).
+- Client-authored run state (clients issue commands; the authority commits transitions).
+- Defining familiar identity or authority semantics independently of their canonical layers (this protocol binds references only).

--- a/spec/coven-automations/v1/README.md
+++ b/spec/coven-automations/v1/README.md
@@ -1,0 +1,38 @@
+# Coven Automations v1 (`coven.automations.v1`)
+
+Machine-readable contract artifacts for the Coven automations protocol defined in [`docs/architecture/coven-automations-v1.md`](../../../docs/architecture/coven-automations-v1.md) (OpenCoven/coven issue #855, foundation #816).
+
+Cave, the SDK, Psyche adapters, runtimes, and future implementations consume these artifacts — never Coven internals, never hand-maintained parallel types.
+
+## Artifacts
+
+| File | Purpose |
+| --- | --- |
+| `protocol-version.json` | Contract profile registry; contract version is separate from implementation/release version. |
+| `capabilities.json` | Variant negotiation, including explicit negative negotiation (`refused`) — unknown variants fail closed with `CAPABILITY_UNSUPPORTED`. |
+| `common.schema.json` | Shared value definitions (ids, digests, principals, timestamps, extension bag). |
+| `automation-definition.schema.json` | `AutomationDefinition`: identity, monotonic revision + integrity digest, versioned trigger/condition/action unions, binding, policies, provenance. |
+| `automation-occurrence.schema.json` | `AutomationOccurrence`: occurrence key, exact definition revision pin, fence/lease, cancellation/recovery, event window. |
+| `automation-run.schema.json` | `AutomationRun`: exact familiar/principal/authority/runtime binding, attempts, terminal disposition, delivery, receipt reference. |
+| `automation-attempt.schema.json` | `AutomationAttempt`: adoption key, dispatch fence, worker correlation, retry classification, cursors, ambiguous disposition. |
+| `automation-receipt.schema.json` | `AutomationReceipt`: immutable versioned receipt with digests, side-effect class, integrity/authentication, privacy/retention. |
+| `command-envelope.schema.json` | Every command (create, revise, activate, pause, disable, tombstone, run now, cancel, retry/recover, list/get/history/health, events read/subscribe, legacy import) + response envelope with adoption-key semantics. |
+| `error-envelope.schema.json` | Typed error codes and the frozen HTTP/control-action status mapping. |
+| `event-envelope.schema.json` | Changefeed envelope: streams, gapless sequences, event ids, causation, compaction snapshots. |
+| `state-machines.json` | Authoritative lifecycle state machines (definition, occurrence, run, attempt) plus the ten normative invariants. |
+| `compatibility-matrix.json` | Machine-readable change classes, per-field status, and explicit incompatible-profile refusal rules. |
+| `test-vectors.json` | Golden vectors: valid, invalid, unknown-field, downgrade/upgrade, unknown-variant, adoption replay/conflict, revision conflict, duplicate/out-of-order event replay — with pinned RFC 8785 digests. |
+| `coven.automations.v1.d.ts` | Pinned TypeScript projection of the schemas for SDK/Cave canaries. |
+
+## Compatibility rules
+
+- Unknown schema versions fail closed: `SCHEMA_VERSION_UNSUPPORTED`, never approximation.
+- Unknown trigger/condition/action/policy variants fail closed: `CAPABILITY_UNSUPPORTED` naming the variant.
+- Unknown fields fail closed (`additionalProperties: false`); optional data travels only in the namespaced `extensions` bag, which is preserved and never interpreted until promoted by a new profile.
+- Digests are SHA-256 over RFC 8785 (JCS) canonical JSON — never over ad-hoc serialization.
+- Contract profile (`coven.automations.v1`) is independent of implementation release versions.
+- Historical records pin the exact definition revision and digest they were created and executed against, and are never reinterpreted by current definitions.
+
+## Conformance
+
+Required test suites and canary requirements (Coven, SDK, Cave — each against packed/released artifacts, not source-relative imports) are listed in `conformance-manifest.json`. Golden vectors are self-contained: any draft 2020-12 validator plus the digest recipe in `test-vectors.json` suffices to run them outside the Coven crate.

--- a/spec/coven-automations/v1/automation-attempt.schema.json
+++ b/spec/coven-automations/v1/automation-attempt.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/automation-attempt.schema.json",
+  "title": "Coven Automations v1 AutomationAttempt",
+  "description": "One dispatch unit of one run. Attempts are individually fenced and individually terminal: a retry always creates a new attempt and never rewrites a prior attempt. An attempt binds at most one runtime session.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "attemptId",
+    "runId",
+    "occurrenceId",
+    "attemptNumber",
+    "adoptionKey",
+    "dispatchFence",
+    "state"
+  ],
+  "properties": {
+    "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+    "attemptId": { "$ref": "common.schema.json#/$defs/attemptId" },
+    "runId": { "$ref": "common.schema.json#/$defs/runId" },
+    "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+    "attemptNumber": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic within the run, starting at 1. attemptNumber n is never reused within a run."
+    },
+    "adoptionKey": {
+      "$ref": "common.schema.json#/$defs/adoptionKey",
+      "description": "Request/adoption key for this dispatch. Workers adopt by key; replays of the same key return the same attempt rather than creating a second one. Derived deterministically from the run id and attempt number unless the caller supplies one."
+    },
+    "priorDisposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attemptNumber", "outcome"],
+      "properties": {
+        "attemptNumber": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The prior attempt this attempt retries, when applicable."
+        },
+        "outcome": {
+          "enum": ["failed", "timed_out", "ambiguous", "cancelled"],
+          "description": "Explicit prior disposition the retry is issued against. Retrying requires stating this; an ambiguous prior disposition forbids automatic retry and requires an explicit recover command."
+        }
+      },
+      "description": "Required when attemptNumber > 1: every retry names the disposition it retries."
+    },
+    "dispatchFence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["occurrenceFenceGeneration", "dispatchGeneration"],
+      "properties": {
+        "occurrenceFenceGeneration": { "$ref": "common.schema.json#/$defs/fenceToken" },
+        "dispatchGeneration": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Monotonic dispatch counter guarding double-dispatch of the same attempt."
+        }
+      }
+    },
+    "workerCorrelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workerId"],
+      "properties": {
+        "workerId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Dispatcher/worker instance that adopted this attempt."
+        },
+        "sessionId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Runtime session bound to this attempt. At most one session may bind to one attempt; a second bind is a typed error (ILLEGAL_TRANSITION), never a silent overwrite."
+        },
+        "adoptedAt": { "$ref": "common.schema.json#/$defs/timestamp" }
+      }
+    },
+    "retryClassification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "classification": {
+          "enum": ["initial", "automatic_retry", "operator_retry", "operator_recovery"]
+        },
+        "eligibleClasses": {
+          "type": "array",
+          "items": {
+            "enum": ["transient_dispatch", "lease_expired", "runtime_unavailable"]
+          },
+          "description": "Snapshot of retryable classes from the definition's retry policy when this attempt was opened."
+        }
+      }
+    },
+    "leaseObservations": {
+      "type": "array",
+      "maxItems": 1024,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["observedAt", "heartbeatOk"],
+        "properties": {
+          "observedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+          "heartbeatOk": { "type": "boolean" },
+          "note": { "type": "string", "maxLength": 200 }
+        }
+      },
+      "description": "Heartbeat/lease observations. Expired evidence moves work to recovery; it can never be reinterpreted as success."
+    },
+    "outputCursors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "eventCursor": { "$ref": "common.schema.json#/$defs/sequenceNumber" },
+        "logCursor": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Cursor into the bounded run log the worker has consumed."
+        }
+      },
+      "description": "Output/event cursors a resuming worker uses to continue observing without re-emitting."
+    },
+    "state": {
+      "enum": [
+        "adopted",
+        "dispatching",
+        "started",
+        "observing",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "timed_out",
+        "ambiguous"
+      ],
+      "description": "Attempt lifecycle per state-machines.json. ambiguous is terminal: absence of runtime evidence cannot become success, and ambiguous work is never automatically retried."
+    },
+    "stateReason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "openedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "settledAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "extensions": { "$ref": "common.schema.json#/$defs/extensionBag" }
+  }
+}

--- a/spec/coven-automations/v1/automation-definition.schema.json
+++ b/spec/coven-automations/v1/automation-definition.schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/automation-definition.schema.json",
+  "title": "Coven Automations v1 AutomationDefinition",
+  "description": "Durable, Coven-owned automation definition. The definition is the identity and intent anchor; execution state lives in occurrences, runs, and attempts. Unknown top-level fields fail closed; optional data travels only in `extensions`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "automationId",
+    "revision",
+    "integrity",
+    "lifecycleState",
+    "display",
+    "trigger",
+    "action",
+    "binding",
+    "policies"
+  ],
+  "properties": {
+    "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+    "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+    "revision": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic per-automation revision. Incremented by exactly one on every accepted mutating command. Occurrences and runs pin the revision they were created and executed against, and are never reinterpreted by later revisions."
+    },
+    "integrity": {
+      "$ref": "common.schema.json#/$defs/digest",
+      "description": "SHA-256 over the RFC 8785 canonical serialization of this object with the `integrity` member removed. Pins the exact definition body a revision means."
+    },
+    "lifecycleState": {
+      "enum": ["draft", "paused", "active", "disabled", "invalid"],
+      "description": "Definition lifecycle per state-machines.json. New definitions start in draft; nothing runs until an explicit activate commits active. Tombstoning is not a state here: it is recorded by the deletion marker and this object is retained for history."
+    },
+    "deletion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tombstoned", "requestedAt"],
+      "properties": {
+        "tombstoned": { "const": true },
+        "requestedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+        "requestedBy": { "$ref": "common.schema.json#/$defs/principalRef" },
+        "reason": { "type": "string", "maxLength": 500 }
+      },
+      "description": "Present if and only if the definition is tombstoned. A tombstoned definition never plans, claims, or runs; its historical occurrences, runs, attempts, and receipts are retained."
+    },
+    "display": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "description": { "type": "string", "maxLength": 2000 },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "maxItems": 64,
+          "uniqueItems": true
+        }
+      }
+    },
+    "trigger": {
+      "oneOf": [
+        { "$ref": "#/$defs/scheduleTrigger" }
+      ],
+      "description": "Exactly one versioned trigger union. v1 ships the schedule variant; the union admits future variants as new oneOf branches without redefining v1 fields. Consumers must fail closed on unrecognized variants (negative capability negotiation)."
+    },
+    "conditions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/condition" },
+      "maxItems": 16,
+      "default": [],
+      "description": "Zero or more versioned conditions. v1 defines none; the slot exists so future variants are additive."
+    },
+    "action": {
+      "oneOf": [
+        { "$ref": "#/$defs/familiarInvocationAction" }
+      ],
+      "description": "Exactly one versioned action union."
+    },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["familiarBindingPolicy", "authority"],
+      "properties": {
+        "familiarBindingPolicy": {
+          "enum": ["exact"],
+          "description": "v1 ratifies exact binding only: the familiar recorded at activation is the familiar every run binds. Rebinding requires a new revision and re-activation."
+        },
+        "familiarId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "description": "Required when familiarBindingPolicy is exact. This protocol references familiar identity; it never defines it."
+        },
+        "authority": {
+          "$ref": "common.schema.json#/$defs/approvalRef",
+          "description": "Authority/approval policy reference. Approval decisions live in the canonical authority layer."
+        }
+      }
+    },
+    "runtimeRequirements": {
+      "$ref": "common.schema.json#/$defs/runtimeDescriptor",
+      "description": "Runtime descriptor and capability requirements every run must satisfy. Required for active definitions."
+    },
+    "policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["timeout", "retry", "concurrency", "misfire", "retention"],
+      "properties": {
+        "timeout": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["perRunMinutes"],
+          "properties": {
+            "perRunMinutes": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 44640,
+              "description": "Bounded and required, matching the #816 validator (1..=44640 minutes)."
+            }
+          }
+        },
+        "retry": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["maxAttempts", "backoffPolicy"],
+          "properties": {
+            "maxAttempts": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 1,
+              "description": "Maximum attempts per run. Attempts are new, individually fenced units; the prior attempt is never rewritten. Ambiguous dispositions are never auto-retried."
+            },
+            "backoffPolicy": {
+              "enum": ["none", "fixed", "exponential"],
+              "description": "Retry classification consumed by the dispatcher. Fixed backoff requires backoffSeconds."
+            },
+            "backoffSeconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "retryableClasses": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "enum": ["transient_dispatch", "lease_expired", "runtime_unavailable"]
+              },
+              "description": "Failure classes eligible for an automatic next attempt. Everything else, especially ambiguous, requires an explicit recover command."
+            }
+          }
+        },
+        "concurrency": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["overlap"],
+          "properties": {
+            "overlap": {
+              "enum": ["forbid"],
+              "description": "v1 ratifies forbid only: a run is skipped when the previous occurrence has not settled (#816 semantic)."
+            }
+          }
+        },
+        "misfire": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["disposition"],
+          "properties": {
+            "disposition": {
+              "enum": ["latest"],
+              "description": "v1 ratifies latest only: on recovery, exactly the latest missed slot is fenced; earlier slots collapse and are recorded with misfireDisposition collapsed_to_latest."
+            }
+          }
+        },
+        "delivery": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "outputTarget": {
+              "type": "string",
+              "maxLength": 1024,
+              "description": "Optional atomic output path. Delivery commits there only on a completed, verified run."
+            },
+            "mode": {
+              "enum": ["atomic"],
+              "description": "Required when outputTarget is present. v1 supports atomic writes only."
+            }
+          }
+        },
+        "retention": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["occurrenceHistory"],
+          "properties": {
+            "occurrenceHistory": { "$ref": "common.schema.json#/$defs/retentionClass" },
+            "runLogs": { "$ref": "common.schema.json#/$defs/retentionClass" },
+            "receipts": { "$ref": "common.schema.json#/$defs/retentionClass" }
+          }
+        }
+      }
+    },
+    "provenance": {
+      "$ref": "common.schema.json#/$defs/provenance"
+    },
+    "activation": {
+      "$ref": "common.schema.json#/$defs/activationWindow"
+    },
+    "extensions": { "$ref": "common.schema.json#/$defs/extensionBag" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "lifecycleState": { "enum": ["active", "paused", "disabled"] } } },
+      "then": {
+        "required": ["runtimeRequirements"],
+        "properties": {
+          "binding": { "required": ["familiarBindingPolicy", "familiarId", "authority"] }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "policies": {
+            "properties": {
+              "delivery": { "required": ["outputTarget"] }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "policies": {
+            "properties": {
+              "delivery": { "required": ["outputTarget", "mode"] }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "policies": {
+            "properties": {
+              "retry": {
+                "properties": { "backoffPolicy": { "const": "fixed" } }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "policies": {
+            "properties": {
+              "retry": { "required": ["maxAttempts", "backoffPolicy", "backoffSeconds"] }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "scheduleTrigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["variant", "version", "schedule"],
+      "properties": {
+        "variant": { "const": "schedule" },
+        "version": { "const": 1 },
+        "schedule": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["rrule", "timezone"],
+          "properties": {
+            "rrule": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 512,
+              "description": "Scoped RRULE text per the #816 scheduler vocabulary: FREQ=DAILY|WEEKLY, optional BYHOUR list, optional BYDAY list for weekly. Anything else is refused at validation."
+            },
+            "timezone": {
+              "enum": ["local", "utc"]
+            }
+          }
+        }
+      }
+    },
+    "condition": {
+      "$comment": "v1 defines zero condition variants. The boolean-false schema matches nothing, so any value in `conditions` fails validation until a future profile adds branches here additively.",
+      "not": {}
+    },
+    "familiarInvocationAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["variant", "version", "prompt"],
+      "properties": {
+        "variant": { "const": "familiarInvocation" },
+        "version": { "const": 1 },
+        "prompt": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100000,
+          "description": "Non-empty prompt executed verbatim; mirrors the #816 prompt requirement."
+        },
+        "cwd": {
+          "type": "string",
+          "maxLength": 1024,
+          "description": "Working directory for the invocation. Runs without a resolvable cwd fail with a recorded reason rather than guessing a project (#816 runner semantic)."
+        }
+      }
+    }
+  }
+}

--- a/spec/coven-automations/v1/automation-occurrence.schema.json
+++ b/spec/coven-automations/v1/automation-occurrence.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/automation-occurrence.schema.json",
+  "title": "Coven Automations v1 AutomationOccurrence",
+  "description": "One scheduled or requested execution slot of one exact definition revision. Occurrences are immutable history anchors: their automationRevision never changes, and terminal states never regress. State transitions are governed by state-machines.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "occurrenceId",
+    "automationId",
+    "automationRevision",
+    "triggerIdentity",
+    "occurrenceKey",
+    "scheduledFor",
+    "state",
+    "stateReason",
+    "fence",
+    "createdAt",
+    "updatedAt"
+  ],
+  "properties": {
+    "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+    "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+    "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+    "automationRevision": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Exact definition revision this occurrence executes against. Never rewritten when the definition is revised; historical occurrences are never reinterpreted by current definitions."
+    },
+    "triggerIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["schedule.slot", "manual.request"]
+        },
+        "rruleRef": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Required for schedule.slot: the RRULE the slot was computed from."
+        },
+        "requestedBy": { "$ref": "common.schema.json#/$defs/principalRef" }
+      }
+    },
+    "occurrenceKey": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 320,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._@:-]*$",
+      "description": "Canonical occurrence key: `automationId@scheduledFor` for schedule slots (scheduledFor in RFC 3339 millis), `automationId@manual-<adoptionKey>` for manual requests. The store fence UNIQUE(automation_id, scheduled_for) of #816 is the implementation of this key."
+    },
+    "scheduledFor": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "observedAt": {
+      "$ref": "common.schema.json#/$defs/timestamp",
+      "description": "When the trigger was observed by the planner; may differ from scheduledFor by misfire disposition."
+    },
+    "eligibleAt": {
+      "$ref": "common.schema.json#/$defs/timestamp",
+      "description": "When the occurrence passed eligibility (conditions and policies) and became claimable."
+    },
+    "state": {
+      "enum": [
+        "planned",
+        "eligible",
+        "claimed",
+        "dispatching",
+        "running",
+        "recovering",
+        "recovery_required",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "timed_out",
+        "skipped",
+        "superseded"
+      ],
+      "description": "Occurrence lifecycle state per state-machines.json."
+    },
+    "stateReason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500,
+      "description": "Machine-readable reason the current state was entered, for example lease_expired, launch_refused, overlap_forbid, superseded_by_revision_3."
+    },
+    "fence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generation"],
+      "properties": {
+        "generation": { "$ref": "common.schema.json#/$defs/fenceToken" },
+        "claimedBy": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "Claimant identity (scheduler or dispatcher instance)."
+        },
+        "leaseExpiresAt": { "$ref": "common.schema.json#/$defs/timestamp" }
+      }
+    },
+    "misfireDisposition": {
+      "$ref": "common.schema.json#/$defs/misfireDisposition",
+      "default": "none"
+    },
+    "createdAt": {
+      "$ref": "common.schema.json#/$defs/timestamp",
+      "description": "When the occurrence was fenced; mirrors the #816 store column."
+    },
+    "updatedAt": {
+      "$ref": "common.schema.json#/$defs/timestamp",
+      "description": "When the occurrence row last changed; mirrors the #816 store column."
+    },
+    "claimMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claimedAt", "leaseMinutes"],
+      "properties": {
+        "claimedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+        "leaseMinutes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1440,
+          "description": "Bounded lease per #816 claim semantics (1..=1440 minutes)."
+        }
+      }
+    },
+    "activeRunRef": {
+      "$ref": "common.schema.json#/$defs/runId",
+      "description": "Present while exactly one accepted run owns this occurrence fence. At most one run may be accepted per fence generation."
+    },
+    "cancellation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestedAt"],
+      "properties": {
+        "requestedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+        "requestedBy": { "$ref": "common.schema.json#/$defs/principalRef" },
+        "acknowledgedAt": {
+          "$ref": "common.schema.json#/$defs/timestamp",
+          "description": "Cancellation is a request until acknowledged or reconciled; this field records the acknowledgment, not the intent."
+        },
+        "reconciledAt": { "$ref": "common.schema.json#/$defs/timestamp" }
+      }
+    },
+    "recovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enteredAt"],
+      "properties": {
+        "enteredAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+        "evidence": {
+          "enum": ["lease_expired", "dispatch_unconfirmed", "runtime_lost"],
+          "description": "Expired or missing runtime evidence that moved this occurrence into recovering/recovery_required."
+        },
+        "resolvedDisposition": {
+          "enum": ["failed_deterministic", "failed_ambiguous"],
+          "description": "Set when recovery resolves. failed_deterministic means no side effects were possible; failed_ambiguous means side effects cannot be ruled out and no automatic retry may occur."
+        }
+      }
+    },
+    "eventWindow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["firstSequence", "lastSequence"],
+      "properties": {
+        "firstSequence": { "$ref": "common.schema.json#/$defs/sequenceNumber" },
+        "lastSequence": {
+          "$ref": "common.schema.json#/$defs/sequenceNumber",
+          "description": "Inclusive upper bound of this occurrence's stream events at the time this representation was read."
+        }
+      },
+      "description": "Event sequence boundaries in the occurrence's authoritative stream, enabling clients to resume change reading without gaps."
+    },
+    "extensions": { "$ref": "common.schema.json#/$defs/extensionBag" }
+  }
+}

--- a/spec/coven-automations/v1/automation-receipt.schema.json
+++ b/spec/coven-automations/v1/automation-receipt.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/automation-receipt.schema.json",
+  "title": "Coven Automations v1 AutomationReceipt",
+  "description": "Immutable, versioned proof of what one attempt actually did. A receipt is written once, never revised, and binds digests of everything that determined the outcome. Receipts are the audit anchor for ambiguous-evidence questions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "receiptId",
+    "automationId",
+    "automationRevision",
+    "occurrenceId",
+    "runId",
+    "attemptId",
+    "identity",
+    "outcome",
+    "sideEffectClass",
+    "producedAt",
+    "producer",
+    "integrity",
+    "privacy"
+  ],
+  "properties": {
+    "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+    "receiptId": { "$ref": "common.schema.json#/$defs/receiptId" },
+    "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+    "automationRevision": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Exact definition revision executed; the receipt also carries the definition digest so the meaning of that revision is pinned even if the definition store is lost."
+    },
+    "definitionDigest": { "$ref": "common.schema.json#/$defs/digest" },
+    "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+    "occurrenceFenceGeneration": { "$ref": "common.schema.json#/$defs/fenceToken" },
+    "runId": { "$ref": "common.schema.json#/$defs/runId" },
+    "attemptId": { "$ref": "common.schema.json#/$defs/attemptId" },
+    "attemptNumber": { "type": "integer", "minimum": 1 },
+    "identity": {
+      "$ref": "common.schema.json#/$defs/familiarRef",
+      "description": "Exact familiar identity that executed."
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principal"],
+      "properties": {
+        "principal": { "$ref": "common.schema.json#/$defs/principalRef" },
+        "approval": { "$ref": "common.schema.json#/$defs/approvalRef" }
+      }
+    },
+    "runtime": {
+      "$ref": "common.schema.json#/$defs/runtimeDescriptor",
+      "description": "Runtime descriptor and capabilities actually exercised."
+    },
+    "deliveryDigest": { "$ref": "common.schema.json#/$defs/digest" },
+    "resultDigest": { "$ref": "common.schema.json#/$defs/digest" },
+    "exercisedCapabilities": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1, "maxLength": 96 },
+      "uniqueItems": true,
+      "maxItems": 128,
+      "description": "Capability keys the run actually exercised, as observed by the runtime."
+    },
+    "sideEffectClass": {
+      "enum": [
+        "none",
+        "local_read",
+        "local_write",
+        "external_read",
+        "external_mutation",
+        "irreversible_external_mutation"
+      ],
+      "description": "Most severe side-effect class the attempt reached. Drives whether an ambiguous disposition may be resolved as failed_deterministic."
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disposition"],
+      "properties": {
+        "disposition": {
+          "enum": ["succeeded", "failed", "cancelled", "timed_out", "ambiguous"]
+        },
+        "failureClass": { "type": "string", "maxLength": 96 },
+        "detail": { "type": "string", "maxLength": 2000 },
+        "partialFailures": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["step", "reason"],
+            "properties": {
+              "step": { "type": "string", "minLength": 1, "maxLength": 128 },
+              "reason": { "type": "string", "minLength": 1, "maxLength": 1000 },
+              "recovered": { "type": "boolean" }
+            }
+          },
+          "description": "Per-step partial failures with recovery disposition."
+        },
+        "recoveryDisposition": {
+          "enum": ["not_required", "recovered_inline", "deferred_to_operator"]
+        }
+      }
+    },
+    "producedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "producer": { "$ref": "common.schema.json#/$defs/producerIdentity" },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "canonicalization", "value"],
+      "properties": {
+        "algorithm": { "const": "sha256" },
+        "canonicalization": { "const": "jcs-rfc8785" },
+        "value": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "authentication": {
+          "enum": ["none", "producer-hmac", "cosign"],
+          "description": "Authentication applied over the digest by the producing deployment. Receipts without authentication are integrity-checked but not provenance-proof; consumers must surface the distinction."
+        }
+      },
+      "description": "SHA-256 over the RFC 8785 canonical serialization of this receipt with the `integrity` member removed. The immutable body plus this field is the receipt's integrity/authentication story in v1."
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["classification", "retention"],
+      "properties": {
+        "classification": { "$ref": "common.schema.json#/$defs/privacyClassification" },
+        "retention": { "$ref": "common.schema.json#/$defs/retentionClass" },
+        "notes": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Privacy-relevant facts a reviewer must know, for example whether the prompt body is retained."
+        }
+      }
+    }
+  }
+}

--- a/spec/coven-automations/v1/automation-run.schema.json
+++ b/spec/coven-automations/v1/automation-run.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/automation-run.schema.json",
+  "title": "Coven Automations v1 AutomationRun",
+  "description": "One accepted execution of one occurrence, binding the exact familiar, principal/authority, and runtime used. A run owns a sequence of attempts; retries create new attempts and never rewrite the run's recorded bindings.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "runId",
+    "occurrenceId",
+    "automationId",
+    "automationRevision",
+    "binding",
+    "state",
+    "attemptCount",
+    "startedAt"
+  ],
+  "properties": {
+    "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+    "runId": { "$ref": "common.schema.json#/$defs/runId" },
+    "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+    "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+    "automationRevision": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Exact definition revision the run was accepted under."
+    },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["familiar", "authority", "runtime"],
+      "properties": {
+        "familiar": {
+          "$ref": "common.schema.json#/$defs/familiarRef",
+          "description": "Exact familiar identity at dispatch time."
+        },
+        "authority": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["principal"],
+          "properties": {
+            "principal": { "$ref": "common.schema.json#/$defs/principalRef" },
+            "approval": { "$ref": "common.schema.json#/$defs/approvalRef" },
+            "authenticationClass": {
+              "type": "string",
+              "maxLength": 64,
+              "description": "Authentication class presented at dispatch, recorded verbatim from the authority layer."
+            }
+          },
+          "description": "Exact principal/authority/approval binding. This protocol records the binding; authority semantics live in their canonical layer."
+        },
+        "runtime": {
+          "$ref": "common.schema.json#/$defs/runtimeDescriptor",
+          "description": "Exact runtime descriptor and capabilities observed at dispatch."
+        }
+      }
+    },
+    "state": {
+      "enum": [
+        "accepted",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "timed_out",
+        "ambiguous"
+      ],
+      "description": "Run lifecycle per state-machines.json. accepted commits before any consequential side effect; terminal states never regress."
+    },
+    "stateReason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "attemptCount": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "Total attempts opened under this run, including retries. Monotonic."
+    },
+    "currentAttemptId": {
+      "$ref": "common.schema.json#/$defs/attemptId",
+      "description": "Present while the run is accepted/running: the attempt that may still settle."
+    },
+    "terminalDisposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome"],
+      "properties": {
+        "outcome": {
+          "enum": ["succeeded", "failed", "cancelled", "timed_out", "ambiguous"]
+        },
+        "failureClass": {
+          "enum": [
+            "launch_refused",
+            "runtime_error",
+            "timeout",
+            "cancelled_by_request",
+            "lease_expired",
+            "ambiguous_evidence"
+          ]
+        },
+        "detail": { "type": "string", "maxLength": 2000 }
+      }
+    },
+    "delivery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "enum": ["none", "pending", "committed", "refused", "rolled_back"],
+          "description": "Output-target delivery state. committed may be recorded only after a completed, verified run (#816 atomic delivery rule)."
+        },
+        "target": { "type": "string", "maxLength": 1024 },
+        "artifactRefs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ref"],
+            "properties": {
+              "ref": { "type": "string", "minLength": 1, "maxLength": 512 },
+              "digest": { "$ref": "common.schema.json#/$defs/digest" }
+            }
+          },
+          "maxItems": 64
+        }
+      }
+    },
+    "resultDigest": { "$ref": "common.schema.json#/$defs/digest" },
+    "receiptRef": {
+      "$ref": "common.schema.json#/$defs/receiptId",
+      "description": "Receipt recording this run's terminal disposition, if one has been produced."
+    },
+    "startedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+    "finishedAt": {
+      "$ref": "common.schema.json#/$defs/timestamp",
+      "description": "Required once the run reaches a terminal state; absent otherwise."
+    },
+    "extensions": { "$ref": "common.schema.json#/$defs/extensionBag" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "state": { "enum": ["succeeded", "failed", "cancelled", "timed_out", "ambiguous"] }
+        }
+      },
+      "then": {
+        "required": ["finishedAt", "terminalDisposition"]
+      }
+    }
+  ]
+}

--- a/spec/coven-automations/v1/capabilities.json
+++ b/spec/coven-automations/v1/capabilities.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "contractProfile": "coven.automations.v1",
+  "description": "Machine-readable variant negotiation for coven.automations.v1. A producer lists the trigger, condition, action, and policy variants it executes. A definition referencing a variant absent from `supported` (and, where explicitly flagged, `experimental`) MUST be refused with the typed error `CAPABILITY_UNSUPPORTED`; the error payload names the unsupported variant. This is the negative negotiation path: nothing about an unknown variant is guessed, defaulted, or silently downgraded.",
+  "supported": {
+    "triggers": [
+      {
+        "variant": "schedule",
+        "profile": "coven.automations.v1",
+        "notes": "RRULE vocabulary per the #816 scheduler: FREQ=DAILY|WEEKLY, optional BYHOUR list, optional BYDAY list for weekly."
+      }
+    ],
+    "conditions": [],
+    "actions": [
+      {
+        "variant": "familiarInvocation",
+        "profile": "coven.automations.v1",
+        "notes": "One prompt, one familiar, one runtime descriptor per definition; dispatch through the shared SessionLaunch path."
+      }
+    ],
+    "triggerPolicies": [
+      { "variant": "misfire.latest", "notes": "On recovery only the latest missed slot runs; earlier slots collapse, never backfill." },
+      { "variant": "overlap.forbid", "notes": "A run is skipped when the previous occurrence has not settled." },
+      { "variant": "timeout.required", "notes": "Every definition carries a bounded per-run timeout, 1..=44640 minutes." }
+    ],
+    "deliveryPolicies": [
+      { "variant": "outputTarget.atomic", "notes": "Optional atomic output path; commits only after a completed, verified run." }
+    ],
+    "retentionPolicies": [
+      { "variant": "retention.standard" }
+    ]
+  },
+  "experimental": [],
+  "refused": [
+    {
+      "variant": "trigger.webhook",
+      "reason": "Not defined in v1; refuse with CAPABILITY_UNSUPPORTED rather than approximating with schedule."
+    },
+    {
+      "variant": "action.pipeline",
+      "reason": "Multi-step pipelines are out of scope (issue non-goal: not a general-purpose workflow language)."
+    },
+    {
+      "variant": "misfire.backfill",
+      "reason": "v1 misfire semantics collapse missed slots; backfill would change occurrence-key identity."
+    }
+  ],
+  "negotiationRules": [
+    "Producers advertise this file (or a generated equivalent) on the capability surface; consumers read it before authoring definitions.",
+    "Refusal is per-variant and additive: refusing `trigger.webhook` says nothing about `action.familiarInvocation`.",
+    "Unknown policy values inside a supported variant are still unknown variants and fail closed.",
+    "A consumer must treat `experimental` entries as unavailable unless it explicitly opts in; opting in is a local decision and never changes wire semantics."
+  ]
+}

--- a/spec/coven-automations/v1/command-envelope.schema.json
+++ b/spec/coven-automations/v1/command-envelope.schema.json
@@ -1,0 +1,362 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/command-envelope.schema.json",
+  "title": "Coven Automations v1 command and response envelopes",
+  "description": "Every mutating automations operation is one command envelope with a stable adoptionKey (idempotency), an expectedRevision where applicable, authenticated origin context, and explicit intent. Queries use the same envelope; only their semantics differ. A rejected or failed domain operation MUST produce outcome=rejected with a typed error — never an accepted wrapper around a failure. This document validates either a commandEnvelope or a commandResponse; consumers address each shape directly via the $defs pointer.",
+  "oneOf": [
+    { "$ref": "#/$defs/commandEnvelope" },
+    { "$ref": "#/$defs/commandResponse" }
+  ],
+  "$defs": {
+    "commandEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "command", "adoptionKey", "origin", "intent", "payload"],
+      "properties": {
+        "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+        "command": { "$ref": "#/$defs/commandName" },
+        "adoptionKey": { "$ref": "common.schema.json#/$defs/adoptionKey" },
+        "expectedRevision": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Required for definition-scoped mutating commands. The revision the caller believes is current; a mismatch commits nothing and returns REVISION_CONFLICT with the current revision."
+        },
+        "origin": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["principal", "channel"],
+          "properties": {
+            "principal": { "$ref": "common.schema.json#/$defs/principalRef" },
+            "channel": {
+              "enum": ["daemon-ipc", "http", "control-action", "cli", "sdk", "cave"],
+              "description": "Authenticated transport the command arrived on. Transports that cannot authenticate the principal must be refused upstream; this field records, not decides."
+            },
+            "authenticationClass": { "type": "string", "maxLength": 64 },
+            "requestedAt": { "$ref": "common.schema.json#/$defs/timestamp" },
+            "correlationId": { "$ref": "common.schema.json#/$defs/correlationId" }
+          }
+        },
+        "intent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["statement"],
+          "properties": {
+            "statement": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 1000,
+              "description": "Human-authored description of what this command intends. Recorded on events and receipts."
+            }
+          }
+        },
+        "payload": {
+          "$comment": "Shape is pinned normatively by the per-command correlation branches under allOf below — the union of payload shapes is deliberately not expressed here because definition.create.v1 and definition.revise.v1 payloads are shape-identical and a union would double-match.",
+          "type": "object"
+        }
+      },
+      "allOf": [
+        { "if": { "properties": { "command": { "const": "definition.create.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionCreate" } } } },
+        { "if": { "properties": { "command": { "const": "definition.revise.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionRevise" } } } },
+        { "if": { "properties": { "command": { "const": "definition.activate.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionTarget" } } } },
+        { "if": { "properties": { "command": { "const": "definition.pause.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionTarget" } } } },
+        { "if": { "properties": { "command": { "const": "definition.disable.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionTarget" } } } },
+        { "if": { "properties": { "command": { "const": "definition.tombstone.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionTarget" } } } },
+        { "if": { "properties": { "command": { "const": "occurrence.runNow.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/runNow" } } } },
+        { "if": { "properties": { "command": { "const": "occurrence.cancel.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/occurrenceCancel" } } } },
+        { "if": { "properties": { "command": { "const": "run.cancel.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/runCancel" } } } },
+        { "if": { "properties": { "command": { "const": "attempt.cancel.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/attemptCancel" } } } },
+        { "if": { "properties": { "command": { "const": "attempt.retry.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/attemptRetry" } } } },
+        { "if": { "properties": { "command": { "const": "occurrence.recover.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/occurrenceRecover" } } } },
+        { "if": { "properties": { "command": { "const": "definition.list.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionList" } } } },
+        { "if": { "properties": { "command": { "const": "definition.get.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionGet" } } } },
+        { "if": { "properties": { "command": { "const": "run.history.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/runHistory" } } } },
+        { "if": { "properties": { "command": { "const": "definition.health.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/definitionHealth" } } } },
+        { "if": { "properties": { "command": { "const": "events.read.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/eventsRead" } } } },
+        { "if": { "properties": { "command": { "const": "events.subscribe.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/eventsSubscribe" } } } },
+        { "if": { "properties": { "command": { "const": "legacy.import.v1" } } }, "then": { "properties": { "payload": { "$ref": "#/$defs/legacyImport" } } } },
+        { "if": { "properties": { "command": { "enum": ["definition.revise.v1", "definition.activate.v1", "definition.pause.v1", "definition.disable.v1", "definition.tombstone.v1"] } } }, "then": { "required": ["expectedRevision"] }, "else": { "not": { "required": ["expectedRevision"] } } }
+      ]
+    },
+    "commandName": {
+      "enum": [        "definition.create.v1",
+        "definition.revise.v1",
+        "definition.activate.v1",
+        "definition.pause.v1",
+        "definition.disable.v1",
+        "definition.tombstone.v1",
+        "occurrence.runNow.v1",
+        "occurrence.cancel.v1",
+        "run.cancel.v1",
+        "attempt.cancel.v1",
+        "attempt.retry.v1",
+        "occurrence.recover.v1",
+        "definition.list.v1",
+        "definition.get.v1",
+        "run.history.v1",
+        "definition.health.v1",
+        "events.read.v1",
+        "events.subscribe.v1",
+        "legacy.import.v1"
+      ]
+    },
+    "definitionCreate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["definition"],
+      "properties": {
+        "definition": { "$ref": "automation-definition.schema.json" }
+      }
+    },
+    "definitionRevise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["definition"],
+      "properties": {
+        "definition": {
+          "$ref": "automation-definition.schema.json",
+          "description": "The full next-revision definition body. The command's expectedRevision is the revision being replaced; the accepted response carries revision = expectedRevision + 1."
+        }
+      }
+    },
+    "definitionTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automationId"],
+      "properties": {
+        "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+        "reason": { "type": "string", "maxLength": 500 }
+      },
+      "description": "Payload for activate, pause, disable, and tombstone."
+    },
+    "runNow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automationId"],
+      "properties": {
+        "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+        "note": { "type": "string", "maxLength": 500 },
+        "bypassEligibility": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true the occurrence is planned and claimed immediately without condition evaluation; lifecycle state and policy (timeout, overlap) still apply."
+        }
+      }
+    },
+    "occurrenceCancel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["occurrenceId"],
+      "properties": {
+        "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+        "reason": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "runCancel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runId"],
+      "properties": {
+        "runId": { "$ref": "common.schema.json#/$defs/runId" },
+        "reason": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "attemptCancel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attemptId"],
+      "properties": {
+        "attemptId": { "$ref": "common.schema.json#/$defs/attemptId" },
+        "reason": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "attemptRetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runId", "priorAttemptNumber", "priorDisposition"],
+      "properties": {
+        "runId": { "$ref": "common.schema.json#/$defs/runId" },
+        "priorAttemptNumber": { "type": "integer", "minimum": 1 },
+        "priorDisposition": {
+          "enum": ["failed", "timed_out", "cancelled"],
+          "description": "Explicit prior disposition the retry is issued against. `ambiguous` is deliberately absent here: retrying ambiguous work requires occurrence.recover.v1 with an operator's explicit statement."
+        },
+        "note": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "occurrenceRecover": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["occurrenceId", "evidenceDetermination"],
+      "properties": {
+        "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+        "evidenceDetermination": {
+          "enum": ["failed_deterministic", "retry_with_new_attempt"],
+          "description": "The operator's explicit determination of the ambiguous work. failed_deterministic settles the occurrence failed; retry_with_new_attempt opens a new attempt carrying the ambiguous prior disposition."
+        },
+        "statement": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000,
+          "description": "Operator's signed-off rationale; recorded on the event and any receipt."
+        }
+      }
+    },
+    "definitionList": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lifecycleState": {
+          "enum": ["draft", "paused", "active", "disabled", "invalid", "tombstoned", "all"]
+        },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "cursor": { "type": "string", "maxLength": 256 }
+      }
+    },
+    "definitionGet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automationId"],
+      "properties": {
+        "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+        "revision": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Omit for the current revision; supply to read a historical revision, which is served immutable."
+        }
+      }
+    },
+    "runHistory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automationId"],
+      "properties": {
+        "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+        "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
+        "cursor": { "type": "string", "maxLength": 256 }
+      }
+    },
+    "definitionHealth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automationId"],
+      "properties": {
+        "automationId": { "$ref": "common.schema.json#/$defs/automationId" }
+      }
+    },
+    "eventsRead": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stream"],
+      "properties": {
+        "stream": { "$ref": "#/$defs/streamRef" },
+        "after": {
+          "$ref": "common.schema.json#/$defs/sequenceNumber",
+          "description": "Exclusive lower sequence bound. Omit with `from` to start from the stream beginning."
+        },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 1000, "default": 100 },
+        "from": {
+          "$ref": "common.schema.json#/$defs/timestamp",
+          "description": "Alternative entry: replay from the first event recorded at or after this instant, resolving to a concrete cursor in the response."
+        }
+      }
+    },
+    "eventsSubscribe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stream"],
+      "properties": {
+        "stream": { "$ref": "#/$defs/streamRef" },
+        "after": { "$ref": "common.schema.json#/$defs/sequenceNumber" },
+        "checkpoint": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Opaque cursor from a prior read/subscribe response. Expired checkpoints yield CURSOR_EXPIRED with the expiry instant, never a silent rewind."
+        }
+      }
+    },
+    "legacyImport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source"],
+      "properties": {
+        "source": {
+          "enum": ["codex-automation-toml"],
+          "description": "v1 supports the #816 non-destructive Codex import; imported definitions are created PAUSED (draft in v1 lifecycle terms) with provenance.importedFrom set."
+        },
+        "dryRun": {
+          "type": "boolean",
+          "default": false,
+          "description": "Report what would import, skip, and fail without writing."
+        }
+      }
+    },
+    "streamRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "enum": ["automation", "occurrence", "run", "feed"]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 320,
+          "description": "automationId / occurrenceId / runId; empty string for the global feed."
+        }
+      }
+    },
+    "commandResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "command", "adoptionKey", "outcome"],
+      "properties": {
+        "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+        "command": { "$ref": "#/$defs/commandName" },
+        "adoptionKey": { "$ref": "common.schema.json#/$defs/adoptionKey" },
+        "outcome": {
+          "enum": ["committed", "replayed", "rejected"],
+          "description": "committed: first time this adoptionKey committed. replayed: this exact adoptionKey committed before; the original committed result is returned unchanged and idempotent. rejected: nothing committed; see error. There is no accepted-but-failed shape: a domain failure is always outcome=rejected."
+        },
+        "replay": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["firstCommittedAt"],
+          "properties": {
+            "firstCommittedAt": { "$ref": "common.schema.json#/$defs/timestamp" }
+          },
+          "description": "Present if and only if outcome=replayed."
+        },
+        "revision": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Definition revision after a committed or replayed definition-scoped mutation."
+        },
+        "result": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Command-specific committed result: definition/occurrence/run/attempt projections, health snapshot, event page, or import report. Present only for committed/replayed outcomes."
+        },
+        "error": {
+          "$ref": "error-envelope.schema.json#/$defs/errorEnvelope",
+          "description": "Present if and only if outcome=rejected."
+        },
+        "receiptRef": {
+          "$ref": "common.schema.json#/$defs/receiptId",
+          "description": "Receipt produced by this command, when one exists."
+        },
+        "eventRef": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["stream", "sequence"],
+          "properties": {
+            "stream": { "type": "string", "minLength": 1, "maxLength": 400 },
+            "sequence": { "$ref": "common.schema.json#/$defs/sequenceNumber" }
+          },
+          "description": "Position of the event this command appended, for clients that follow the changefeed."
+        }
+      }
+    }
+  }
+}

--- a/spec/coven-automations/v1/common.schema.json
+++ b/spec/coven-automations/v1/common.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/common.schema.json",
+  "title": "Coven Automations v1 shared definitions",
+  "description": "Shared value definitions for coven.automations.v1. Schemas in this directory reference these via relative $ref. Unknown-field rule: v1 objects set additionalProperties=false and carry optional data only through the explicit extensionBag.",
+  "$defs": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "coven.automations.v1"
+    },
+    "automationId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 96,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "description": "Stable automation identifier; charset and bound match the #816 definition validator."
+    },
+    "occurrenceId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "attemptId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "receiptId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "adoptionKey": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 200,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+      "description": "Stable request/adoption (idempotency) key supplied by the caller. Replays of the same command with the same key return the first committed outcome unchanged."
+    },
+    "correlationId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{3})?Z$",
+      "description": "RFC 3339 UTC, millisecond precision, matching the #816 store encoding (chrono SecondsFormat::Millis)."
+    },
+    "digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "canonicalization", "value"],
+      "properties": {
+        "algorithm": { "const": "sha256" },
+        "canonicalization": { "const": "jcs-rfc8785" },
+        "value": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Lowercase hex SHA-256 over the RFC 8785 canonical serialization of the covered object."
+        }
+      }
+    },
+    "fenceToken": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic per-occurrence generation. Incremented on every accepted claim; a fence token owns at most one accepted run."
+    },
+    "sequenceNumber": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "principalRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principalId"],
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$",
+          "description": "Canonical principal identifier from the authority layer. This protocol binds but does not define principal semantics."
+        },
+        "displayName": { "type": "string", "maxLength": 160 }
+      }
+    },
+    "familiarRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["familiarId"],
+      "properties": {
+        "familiarId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "description": "Exact familiar identity binding; resolved and owned by the familiar identity layer."
+        }
+      }
+    },
+    "runtimeDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtimeId", "capabilities"],
+      "properties": {
+        "runtimeId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "description": "Harness/runtime identifier, for example coven-code."
+        },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 96 },
+          "uniqueItems": true,
+          "description": "Capability requirement keys the run depends on; advertised by the runtime descriptor layer."
+        },
+        "model": { "type": "string", "maxLength": 128 }
+      }
+    },
+    "approvalRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approvalPolicyRef"],
+      "properties": {
+        "approvalPolicyRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Reference into the authority/approval policy layer; this protocol records the binding, never the decision."
+        },
+        "approvalRecordRef": { "type": "string", "maxLength": 200 }
+      }
+    },
+    "extensionBag": {
+      "type": "object",
+      "additionalProperties": { "$comment": "Extension values are opaque JSON; producers must keep them small and consumers must preserve but never interpret them until understood.", "type": ["object", "string", "number", "boolean", "array", "null"] },
+      "propertyNames": {
+        "pattern": "^(x-[a-z0-9-]+|[a-z0-9.-]+\\.[a-z0-9-]+\\.[a-z0-9-]+)$",
+        "description": "Keys are either x-prefixed (vendor-local) or reverse-DNS namespaced (example com.acme.lift). Untyped keys are rejected."
+      },
+      "description": "Explicit extension bag. Extensions are preserved on round-trip, never required, never influence state, digests, or authorization until they are promoted into a new contract profile."
+    },
+    "misfireDisposition": {
+      "enum": ["none", "collapsed_to_latest", "skipped_overlap", "skipped_paused", "skipped_invalid"],
+      "description": "How planning disposed of this slot relative to the misfire policy. collapsed_to_latest is the #816 misfire-latest semantic."
+    },
+    "privacyClassification": {
+      "enum": ["public", "operational", "sensitive", "restricted"]
+    },
+    "retentionClass": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["classification"],
+      "properties": {
+        "classification": { "enum": ["ephemeral", "standard", "extended"] },
+        "deleteAfter": { "$ref": "#/$defs/timestamp" }
+      }
+    },
+    "producerIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component", "instanceId"],
+      "properties": {
+        "component": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 96,
+          "description": "Producing component, for example coven-daemon."
+        },
+        "instanceId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Stable instance identifier of the producer."
+        },
+        "implementationVersion": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Release version of the producing implementation. Never confused with the contract profile."
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["createdBy"],
+      "properties": {
+        "createdBy": { "$ref": "#/$defs/principalRef" },
+        "createdAt": { "$ref": "#/$defs/timestamp" },
+        "updatedBy": { "$ref": "#/$defs/principalRef" },
+        "updatedAt": { "$ref": "#/$defs/timestamp" },
+        "importedFrom": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Legacy source marker for imported definitions, for example codex.automation.toml."
+        }
+      }
+    },
+    "activationWindow": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "effectiveFrom": { "$ref": "#/$defs/timestamp" },
+        "effectiveUntil": { "$ref": "#/$defs/timestamp" }
+      },
+      "description": "Optional activation window. Outside the window the definition behaves as paused without changing lifecycle state."
+    }
+  }
+}

--- a/spec/coven-automations/v1/compatibility-matrix.json
+++ b/spec/coven-automations/v1/compatibility-matrix.json
@@ -1,0 +1,100 @@
+{
+  "contractProfile": "coven.automations.v1",
+  "version": 1,
+  "notes": [
+    "Machine-readable compatibility matrix for coven.automations.v1.",
+    "changeClass defines what a future change to any field or variant is, and what a v1 consumer/producer must do when it meets it.",
+    "Consumers and producers must refuse incompatible profiles explicitly with SCHEMA_VERSION_UNSUPPORTED; they never approximate or degrade silently."
+  ],
+  "changeClasses": [
+    {
+      "id": "additive-variant",
+      "definition": "A new trigger/condition/action variant or policy value is added to a union.",
+      "v1ConsumerBehavior": "fail-closed per variant: refuse with CAPABILITY_UNSUPPORTED naming the variant. Unions are open in future profiles, closed in v1 readers.",
+      "profileImpact": "none; same major profile, consumers negotiate via capabilities.json"
+    },
+    {
+      "id": "additive-extension",
+      "definition": "A new key inside `extensions`.",
+      "v1ConsumerBehavior": "preserve, never interpret; round-trip verbatim.",
+      "profileImpact": "none"
+    },
+    {
+      "id": "additive-optional-field",
+      "definition": "A new optional top-level or nested field is introduced.",
+      "v1ConsumerBehavior": "v1 readers reject unknown fields (additionalProperties=false). Producers introduce such fields only under a new minor profile (for example coven.automations.v1.1) and dual-emit while consumers migrate.",
+      "profileImpact": "minor profile bump"
+    },
+    {
+      "id": "incompatible-field-change",
+      "definition": "A field changes meaning, type, requirement, or is removed/renamed.",
+      "v1ConsumerBehavior": "refuse the profile explicitly with SCHEMA_VERSION_UNSUPPORTED.",
+      "profileImpact": "new major profile (coven.automations.v2); v1 is frozen"
+    },
+    {
+      "id": "state-machine-change",
+      "definition": "A state, transition, guard, or invariant in state-machines.json changes.",
+      "v1ConsumerBehavior": "refuse; lifecycle semantics are the contract's core and are never evolved additively.",
+      "profileImpact": "new major profile"
+    }
+  ],
+  "objectFields": [
+    { "object": "AutomationDefinition", "field": "schemaVersion", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationDefinition", "field": "automationId", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationDefinition", "field": "revision", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationDefinition", "field": "integrity", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationDefinition", "field": "lifecycleState", "status": "required-since-v1", "changeClass": "state-machine-change" },
+    { "object": "AutomationDefinition", "field": "deletion", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationDefinition", "field": "display", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationDefinition", "field": "trigger", "status": "required-since-v1", "changeClass": "additive-variant" },
+    { "object": "AutomationDefinition", "field": "conditions", "status": "optional-since-v1", "changeClass": "additive-variant" },
+    { "object": "AutomationDefinition", "field": "action", "status": "required-since-v1", "changeClass": "additive-variant" },
+    { "object": "AutomationDefinition", "field": "binding", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationDefinition", "field": "runtimeRequirements", "status": "required-for-active", "changeClass": "additive-optional-field" },
+    { "object": "AutomationDefinition", "field": "policies", "status": "required-since-v1", "changeClass": "additive-variant" },
+    { "object": "AutomationDefinition", "field": "provenance", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationDefinition", "field": "activation", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationDefinition", "field": "extensions", "status": "optional-since-v1", "changeClass": "additive-extension" },
+    { "object": "AutomationOccurrence", "field": "occurrenceKey", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationOccurrence", "field": "automationRevision", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationOccurrence", "field": "state", "status": "required-since-v1", "changeClass": "state-machine-change" },
+    { "object": "AutomationOccurrence", "field": "fence", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationOccurrence", "field": "misfireDisposition", "status": "optional-since-v1", "changeClass": "additive-variant" },
+    { "object": "AutomationOccurrence", "field": "activeRunRef", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationOccurrence", "field": "cancellation", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationOccurrence", "field": "recovery", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationOccurrence", "field": "eventWindow", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationRun", "field": "binding", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationRun", "field": "state", "status": "required-since-v1", "changeClass": "state-machine-change" },
+    { "object": "AutomationRun", "field": "attemptCount", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationRun", "field": "terminalDisposition", "status": "required-when-terminal", "changeClass": "additive-optional-field" },
+    { "object": "AutomationRun", "field": "delivery", "status": "optional-since-v1", "changeClass": "additive-variant" },
+    { "object": "AutomationRun", "field": "receiptRef", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationAttempt", "field": "attemptNumber", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationAttempt", "field": "adoptionKey", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationAttempt", "field": "dispatchFence", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationAttempt", "field": "priorDisposition", "status": "required-for-retries", "changeClass": "additive-optional-field" },
+    { "object": "AutomationAttempt", "field": "workerCorrelation", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationAttempt", "field": "leaseObservations", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationAttempt", "field": "outputCursors", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "AutomationAttempt", "field": "state", "status": "required-since-v1", "changeClass": "state-machine-change" },
+    { "object": "AutomationReceipt", "field": "receiptId", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationReceipt", "field": "integrity", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "AutomationReceipt", "field": "sideEffectClass", "status": "required-since-v1", "changeClass": "additive-variant" },
+    { "object": "AutomationReceipt", "field": "privacy", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "EventEnvelope", "field": "eventId", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "EventEnvelope", "field": "stream", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "EventEnvelope", "field": "sequence", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "EventEnvelope", "field": "kind", "status": "required-since-v1", "changeClass": "additive-variant" },
+    { "object": "EventEnvelope", "field": "causation", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "EventEnvelope", "field": "integrity", "status": "optional-since-v1", "changeClass": "additive-optional-field" },
+    { "object": "CommandEnvelope", "field": "adoptionKey", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "CommandEnvelope", "field": "expectedRevision", "status": "required-for-definition-mutations", "changeClass": "incompatible-field-change" },
+    { "object": "CommandEnvelope", "field": "origin", "status": "required-since-v1", "changeClass": "incompatible-field-change" },
+    { "object": "CommandEnvelope", "field": "intent", "status": "required-since-v1", "changeClass": "incompatible-field-change" }
+  ],
+  "profileRefusal": {
+    "rule": "A consumer that receives a schemaVersion it does not implement refuses the object with SCHEMA_VERSION_UNSUPPORTED and stops; it must not skip unknown versions, must not coerce, and must not reinterpret.",
+    "negotiation": "Producers advertise implemented profiles via protocol-version.json; callers pin the profile at session start."
+  }
+}

--- a/spec/coven-automations/v1/conformance-manifest.json
+++ b/spec/coven-automations/v1/conformance-manifest.json
@@ -1,0 +1,47 @@
+{
+  "protocol": "Coven Automations",
+  "contractProfile": "coven.automations.v1",
+  "objects": [
+    "AutomationDefinition",
+    "AutomationOccurrence",
+    "AutomationRun",
+    "AutomationAttempt",
+    "AutomationReceipt",
+    "CommandEnvelope",
+    "CommandResponse",
+    "ErrorEnvelope",
+    "EventEnvelope"
+  ],
+  "schemas": [
+    "common.schema.json",
+    "automation-definition.schema.json",
+    "automation-occurrence.schema.json",
+    "automation-run.schema.json",
+    "automation-attempt.schema.json",
+    "automation-receipt.schema.json",
+    "command-envelope.schema.json",
+    "error-envelope.schema.json",
+    "event-envelope.schema.json"
+  ],
+  "stateMachines": "state-machines.json",
+  "compatibilityMatrix": "compatibility-matrix.json",
+  "goldenVectors": "test-vectors.json",
+  "requiredSuites": [
+    "schema-validation",
+    "rust-round-trip",
+    "state-machine-property-tests",
+    "request-adoption-replay-and-conflict",
+    "expected-revision-conflict",
+    "duplicate-and-out-of-order-event-replay",
+    "typed-transport-domain-error-mapping",
+    "golden-vectors-external-runners",
+    "packed-artifact-canaries"
+  ],
+  "releaseState": "proposed",
+  "productionReady": false,
+  "canaryRequirements": {
+    "coven": "Consumes the schemas and vectors from this directory through a packed/released artifact, not source-relative imports.",
+    "sdk": "Consumes the pinned TypeScript declarations and golden vectors against the exact released artifact version.",
+    "cave": "Consumes the event envelope and read-model reducer vectors against the exact released artifact version."
+  }
+}

--- a/spec/coven-automations/v1/coven.automations.v1.d.ts
+++ b/spec/coven-automations/v1/coven.automations.v1.d.ts
@@ -1,0 +1,619 @@
+/**
+ * coven.automations.v1 — pinned TypeScript contract types.
+ *
+ * SPEC ARTIFACT, NOT A PACKAGE MODULE. This file is the portable,
+ * hand-pinned type projection of the JSON Schemas in this directory
+ * (draft 2020-12). SDK and Cave canaries consume it as a pinned artifact
+ * — never as a source-relative import of Coven internals — and must pair
+ * it with test-vectors.json for behavioral conformance.
+ *
+ * Regeneration: any change here requires a contract-profile decision per
+ * compatibility-matrix.json. Field shapes mirror the schemas exactly;
+ * descriptions are omitted here and live in the schemas.
+ *
+ * Consumers must treat unknown variants (trigger, action, condition,
+ * policy values, event kinds) as failures per the negative negotiation
+ * rules in capabilities.json — TS unions here are closed.
+ */
+
+export type SchemaVersion = "coven.automations.v1";
+
+/** RFC 3339 UTC, millisecond precision (matches the #816 store encoding). */
+export type Timestamp = string;
+
+export interface Digest {
+  algorithm: "sha256";
+  canonicalization: "jcs-rfc8785";
+  /** Lowercase hex SHA-256 over the RFC 8785 canonical serialization of the covered object. */
+  value: string;
+}
+
+export type AdoptionKey = string;
+export type CorrelationId = string;
+
+export interface PrincipalRef {
+  principalId: string;
+  displayName?: string;
+}
+
+export interface FamiliarRef {
+  familiarId: string;
+}
+
+export interface RuntimeDescriptor {
+  runtimeId: string;
+  capabilities: string[];
+  model?: string;
+}
+
+export interface ApprovalRef {
+  approvalPolicyRef: string;
+  approvalRecordRef?: string;
+}
+
+/** Keys are `x-prefixed` or reverse-DNS namespaced; values opaque; preserve, never interpret. */
+export type ExtensionBag = Record<string, unknown>;
+
+export type PrivacyClassification = "public" | "operational" | "sensitive" | "restricted";
+
+export interface RetentionClass {
+  classification: "ephemeral" | "standard" | "extended";
+  deleteAfter?: Timestamp;
+}
+
+export interface ProducerIdentity {
+  component: string;
+  instanceId: string;
+  implementationVersion?: string;
+}
+
+export interface Provenance {
+  createdBy: PrincipalRef;
+  createdAt?: Timestamp;
+  updatedBy?: PrincipalRef;
+  updatedAt?: Timestamp;
+  importedFrom?: string;
+}
+
+// ---------------------------------------------------------------------------
+// AutomationDefinition
+// ---------------------------------------------------------------------------
+
+export type DefinitionLifecycleState = "draft" | "paused" | "active" | "disabled" | "invalid";
+
+export interface AutomationDefinition {
+  schemaVersion: SchemaVersion;
+  automationId: string;
+  /** Monotonic per automation; incremented by exactly one per accepted mutation. */
+  revision: number;
+  integrity: Digest;
+  lifecycleState: DefinitionLifecycleState;
+  deletion?: {
+    tombstoned: true;
+    requestedAt: Timestamp;
+    requestedBy?: PrincipalRef;
+    reason?: string;
+  };
+  display: {
+    name: string;
+    description?: string;
+    tags?: string[];
+  };
+  trigger: ScheduleTrigger; // v1 union: exactly this variant; future variants extend the union in later profiles
+  conditions?: Condition[]; // v1 defines zero condition variants; any value fails validation
+  action: FamiliarInvocationAction; // v1 union: exactly this variant
+  binding: {
+    familiarBindingPolicy: "exact";
+    familiarId: string;
+    authority: ApprovalRef;
+  };
+  runtimeRequirements?: RuntimeDescriptor; // required for active/paused/disabled
+  policies: {
+    timeout: { perRunMinutes: number }; // 1..=44640
+    retry: {
+      maxAttempts: number; // 1..=10
+      backoffPolicy: "none" | "fixed" | "exponential";
+      backoffSeconds?: number; // required when backoffPolicy is "fixed"
+      retryableClasses?: Array<"transient_dispatch" | "lease_expired" | "runtime_unavailable">;
+    };
+    concurrency: { overlap: "forbid" };
+    misfire: { disposition: "latest" };
+    delivery?: {
+      outputTarget: string;
+      mode?: "atomic"; // required when outputTarget is present
+    };
+    retention: {
+      occurrenceHistory: RetentionClass;
+      runLogs?: RetentionClass;
+      receipts?: RetentionClass;
+    };
+  };
+  provenance?: Provenance;
+  activation?: {
+    effectiveFrom?: Timestamp;
+    effectiveUntil?: Timestamp;
+  };
+  extensions?: ExtensionBag;
+}
+
+export interface ScheduleTrigger {
+  variant: "schedule";
+  version: 1;
+  schedule: {
+    /** Scoped RRULE: FREQ=DAILY|WEEKLY, optional BYHOUR list, optional BYDAY list for weekly. */
+    rrule: string;
+    timezone: "local" | "utc";
+  };
+}
+
+/** v1 has zero condition variants; this type is intentionally uninhabited. */
+export type Condition = never;
+
+export interface FamiliarInvocationAction {
+  variant: "familiarInvocation";
+  version: 1;
+  prompt: string;
+  cwd?: string;
+}
+
+// ---------------------------------------------------------------------------
+// AutomationOccurrence / AutomationRun / AutomationAttempt / AutomationReceipt
+// ---------------------------------------------------------------------------
+
+export type OccurrenceState =
+  | "planned"
+  | "eligible"
+  | "claimed"
+  | "dispatching"
+  | "running"
+  | "recovering"
+  | "recovery_required"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "timed_out"
+  | "skipped"
+  | "superseded";
+
+export type MisfireDisposition =
+  | "none"
+  | "collapsed_to_latest"
+  | "skipped_overlap"
+  | "skipped_paused"
+  | "skipped_invalid";
+
+export interface AutomationOccurrence {
+  schemaVersion: SchemaVersion;
+  occurrenceId: string;
+  automationId: string;
+  /** Exact definition revision executed against; never rewritten. */
+  automationRevision: number;
+  triggerIdentity:
+    | { kind: "schedule.slot"; rruleRef: string }
+    | { kind: "manual.request"; requestedBy?: PrincipalRef };
+  /** `automationId@scheduledFor` or `automationId@manual-<adoptionKey>`. */
+  occurrenceKey: string;
+  scheduledFor: Timestamp;
+  observedAt?: Timestamp;
+  eligibleAt?: Timestamp;
+  state: OccurrenceState;
+  stateReason: string;
+  fence: {
+    generation: number; // monotonic, >= 1
+    claimedBy?: string;
+    leaseExpiresAt?: Timestamp;
+  };
+  misfireDisposition?: MisfireDisposition;
+  claimMetadata?: {
+    claimedAt: Timestamp;
+    leaseMinutes: number; // 1..=1440
+  };
+  activeRunRef?: string;
+  cancellation?: {
+    requestedAt: Timestamp;
+    requestedBy?: PrincipalRef;
+    acknowledgedAt?: Timestamp;
+    reconciledAt?: Timestamp;
+  };
+  recovery?: {
+    enteredAt: Timestamp;
+    evidence?: "lease_expired" | "dispatch_unconfirmed" | "runtime_lost";
+    resolvedDisposition?: "failed_deterministic" | "failed_ambiguous";
+  };
+  createdAt?: Timestamp;
+  updatedAt?: Timestamp;
+  eventWindow?: {
+    firstSequence: number;
+    lastSequence: number;
+  };
+  extensions?: ExtensionBag;
+}
+
+export type RunState =
+  | "accepted"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "timed_out"
+  | "ambiguous";
+
+export type RunOutcome =
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "timed_out"
+  | "ambiguous";
+
+export interface AutomationRun {
+  schemaVersion: SchemaVersion;
+  runId: string;
+  occurrenceId: string;
+  automationId: string;
+  automationRevision: number;
+  binding: {
+    familiar: FamiliarRef;
+    authority: {
+      principal: PrincipalRef;
+      approval?: ApprovalRef;
+      authenticationClass?: string;
+    };
+    runtime: RuntimeDescriptor;
+  };
+  state: RunState;
+  stateReason?: string;
+  attemptCount: number;
+  currentAttemptId?: string;
+  terminalDisposition?: {
+    outcome: RunOutcome;
+    failureClass?:
+      | "launch_refused"
+      | "runtime_error"
+      | "timeout"
+      | "cancelled_by_request"
+      | "lease_expired"
+      | "ambiguous_evidence";
+    detail?: string;
+  };
+  delivery?: {
+    status: "none" | "pending" | "committed" | "refused" | "rolled_back";
+    target?: string;
+    artifactRefs?: Array<{ ref: string; digest?: Digest }>;
+  };
+  resultDigest?: Digest;
+  receiptRef?: string;
+  startedAt: Timestamp;
+  finishedAt?: Timestamp; // required when state is terminal
+  extensions?: ExtensionBag;
+}
+
+export type AttemptState =
+  | "adopted"
+  | "dispatching"
+  | "started"
+  | "observing"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "timed_out"
+  | "ambiguous";
+
+export interface AutomationAttempt {
+  schemaVersion: SchemaVersion;
+  attemptId: string;
+  runId: string;
+  occurrenceId: string;
+  /** Monotonic within the run, starting at 1; never reused. */
+  attemptNumber: number;
+  adoptionKey: AdoptionKey;
+  priorDisposition?: {
+    attemptNumber: number;
+    outcome: "failed" | "timed_out" | "ambiguous" | "cancelled";
+  };
+  dispatchFence: {
+    occurrenceFenceGeneration: number;
+    dispatchGeneration: number;
+  };
+  workerCorrelation?: {
+    workerId: string;
+    sessionId?: string; // at most one session binds to one attempt
+    adoptedAt?: Timestamp;
+  };
+  retryClassification?: {
+    classification?: "initial" | "automatic_retry" | "operator_retry" | "operator_recovery";
+    eligibleClasses?: Array<"transient_dispatch" | "lease_expired" | "runtime_unavailable">;
+  };
+  leaseObservations?: Array<{
+    observedAt: Timestamp;
+    heartbeatOk: boolean;
+    note?: string;
+  }>;
+  outputCursors?: {
+    eventCursor?: number;
+    logCursor?: number;
+  };
+  state: AttemptState;
+  stateReason?: string;
+  openedAt?: Timestamp;
+  settledAt?: Timestamp;
+  extensions?: ExtensionBag;
+}
+
+export type SideEffectClass =
+  | "none"
+  | "local_read"
+  | "local_write"
+  | "external_read"
+  | "external_mutation"
+  | "irreversible_external_mutation";
+
+export interface AutomationReceipt {
+  schemaVersion: SchemaVersion;
+  receiptId: string;
+  automationId: string;
+  automationRevision: number;
+  definitionDigest: Digest;
+  occurrenceId: string;
+  occurrenceFenceGeneration: number;
+  runId: string;
+  attemptId: string;
+  attemptNumber: number;
+  identity: FamiliarRef;
+  authority?: {
+    principal: PrincipalRef;
+    approval?: ApprovalRef;
+  };
+  runtime: RuntimeDescriptor;
+  deliveryDigest?: Digest;
+  resultDigest?: Digest;
+  exercisedCapabilities?: string[];
+  sideEffectClass: SideEffectClass;
+  outcome: {
+    disposition: RunOutcome;
+    failureClass?: string;
+    detail?: string;
+    partialFailures?: Array<{
+      step: string;
+      reason: string;
+      recovered?: boolean;
+    }>;
+    recoveryDisposition?: "not_required" | "recovered_inline" | "deferred_to_operator";
+  };
+  producedAt: Timestamp;
+  producer: ProducerIdentity;
+  integrity: Digest & {
+    authentication: "none" | "producer-hmac" | "cosign";
+  };
+  privacy: {
+    classification: PrivacyClassification;
+    retention: RetentionClass;
+    notes?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+export type CommandName =
+  | "definition.create.v1"
+  | "definition.revise.v1"
+  | "definition.activate.v1"
+  | "definition.pause.v1"
+  | "definition.disable.v1"
+  | "definition.tombstone.v1"
+  | "occurrence.runNow.v1"
+  | "occurrence.cancel.v1"
+  | "run.cancel.v1"
+  | "attempt.cancel.v1"
+  | "attempt.retry.v1"
+  | "occurrence.recover.v1"
+  | "definition.list.v1"
+  | "definition.get.v1"
+  | "run.history.v1"
+  | "definition.health.v1"
+  | "events.read.v1"
+  | "events.subscribe.v1"
+  | "legacy.import.v1";
+
+export interface CommandOrigin {
+  principal: PrincipalRef;
+  channel: "daemon-ipc" | "http" | "control-action" | "cli" | "sdk" | "cave";
+  authenticationClass?: string;
+  requestedAt?: Timestamp;
+  correlationId?: CorrelationId;
+}
+
+/** Payload shapes per command; see command-envelope.schema.json for the normative pin. */
+export interface CommandPayloadByCommand {
+  "definition.create.v1": { definition: AutomationDefinition };
+  "definition.revise.v1": { definition: AutomationDefinition };
+  "definition.activate.v1": { automationId: string; reason?: string };
+  "definition.pause.v1": { automationId: string; reason?: string };
+  "definition.disable.v1": { automationId: string; reason?: string };
+  "definition.tombstone.v1": { automationId: string; reason?: string };
+  "occurrence.runNow.v1": { automationId: string; note?: string; bypassEligibility?: boolean };
+  "occurrence.cancel.v1": { occurrenceId: string; reason?: string };
+  "run.cancel.v1": { runId: string; reason?: string };
+  "attempt.cancel.v1": { attemptId: string; reason?: string };
+  "attempt.retry.v1": {
+    runId: string;
+    priorAttemptNumber: number;
+    priorDisposition: "failed" | "timed_out" | "cancelled";
+    note?: string;
+  };
+  "occurrence.recover.v1": {
+    occurrenceId: string;
+    evidenceDetermination: "failed_deterministic" | "retry_with_new_attempt";
+    statement: string;
+  };
+  "definition.list.v1": {
+    lifecycleState?: "draft" | "paused" | "active" | "disabled" | "invalid" | "tombstoned" | "all";
+    limit?: number;
+    cursor?: string;
+  };
+  "definition.get.v1": { automationId: string; revision?: number };
+  "run.history.v1": {
+    automationId: string;
+    occurrenceId?: string;
+    limit?: number;
+    cursor?: string;
+  };
+  "definition.health.v1": { automationId: string };
+  "events.read.v1": {
+    stream: StreamRef;
+    after?: number;
+    limit?: number;
+    from?: Timestamp;
+  };
+  "events.subscribe.v1": {
+    stream: StreamRef;
+    after?: number;
+    checkpoint?: string;
+  };
+  "legacy.import.v1": { source: "codex-automation-toml"; dryRun?: boolean };
+}
+
+export interface StreamRef {
+  kind: "automation" | "occurrence" | "run" | "feed";
+  id: string;
+}
+
+export interface CommandEnvelope<C extends CommandName = CommandName> {
+  schemaVersion: SchemaVersion;
+  command: C;
+  adoptionKey: AdoptionKey;
+  /** Required for definition.revise/activate/pause/disable/tombstone; forbidden otherwise. */
+  expectedRevision?: number;
+  origin: CommandOrigin;
+  intent: { statement: string };
+  payload: CommandPayloadByCommand[C];
+}
+
+export type ErrorCode =
+  | "SCHEMA_VERSION_UNSUPPORTED"
+  | "VALIDATION_FAILED"
+  | "ADOPTION_REPLAY_MISMATCH"
+  | "REVISION_CONFLICT"
+  | "NOT_FOUND"
+  | "GONE_TOMBSTONED"
+  | "CAPABILITY_UNSUPPORTED"
+  | "ILLEGAL_TRANSITION"
+  | "AUTHORITY_REQUIRED"
+  | "APPROVAL_REQUIRED"
+  | "CANCEL_PENDING"
+  | "OVERLAP_FORBIDDEN"
+  | "RETRY_DISPOSITION_INVALID"
+  | "AMBIGUOUS_RETRY_FORBIDDEN"
+  | "CURSOR_EXPIRED"
+  | "STREAM_OUT_OF_ORDER"
+  | "PAYLOAD_TOO_LARGE"
+  | "DEADLINE_EXCEEDED"
+  | "CONCURRENCY_LIMIT"
+  | "INTERNAL";
+
+export interface ErrorEnvelope {
+  code: ErrorCode;
+  httpStatus: number;
+  message: string;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+  adoption?: {
+    key: AdoptionKey;
+    conflictOutcome?: "committed" | "rejected";
+  };
+  currentRevision?: number;
+}
+
+export interface CommandResponse<C extends CommandName = CommandName> {
+  schemaVersion: SchemaVersion;
+  command: C;
+  adoptionKey: AdoptionKey;
+  outcome: "committed" | "replayed" | "rejected";
+  replay?: { firstCommittedAt: Timestamp };
+  revision?: number;
+  result?: Record<string, unknown>;
+  error?: ErrorEnvelope;
+  receiptRef?: string;
+  eventRef?: { stream: string; sequence: number };
+}
+
+// ---------------------------------------------------------------------------
+// Events / changefeed
+// ---------------------------------------------------------------------------
+
+export type EventKind =
+  | "definition.created"
+  | "definition.revised"
+  | "definition.activated"
+  | "definition.paused"
+  | "definition.disabled"
+  | "definition.invalidated"
+  | "definition.tombstoned"
+  | "definition.imported"
+  | "occurrence.transitioned"
+  | "occurrence.misfire_recorded"
+  | "run.transitioned"
+  | "attempt.transitioned"
+  | "receipt.recorded"
+  | "feed.snapshot";
+
+export type EventPayload =
+  | {
+      revision: number;
+      definitionDigest?: Digest;
+      lifecycleState?: DefinitionLifecycleState | "tombstoned";
+      importedFrom?: string;
+    }
+  | {
+      entity: "occurrence" | "run" | "attempt";
+      from: string;
+      to: string;
+      reason: string;
+      fenceGeneration?: number;
+      attemptNumber?: number;
+      commandAdoptionKey?: AdoptionKey;
+    }
+  | {
+      disposition: MisfireDisposition;
+      collapsedSlots: Timestamp[];
+    }
+  | {
+      receiptRef: string;
+      outcome: RunOutcome;
+      sideEffectClass?: SideEffectClass;
+    }
+  | {
+      throughSequence: number;
+      state: Record<string, unknown>;
+      reason?: "retention_compaction" | "manual_snapshot";
+    };
+
+export interface EventEnvelope {
+  schemaVersion: SchemaVersion;
+  /** Globally unique; duplicates of a delivered eventId are redeliveries: ignore, never re-apply. */
+  eventId: string;
+  stream: { kind: "automation" | "occurrence" | "run" | "feed"; id: string };
+  /** Monotonically increasing, gapless within `stream`. */
+  sequence: number;
+  recordedAt: Timestamp;
+  observedAt: Timestamp;
+  producer: ProducerIdentity;
+  causation?: {
+    adoptionKey?: AdoptionKey;
+    causeEventId?: string;
+    correlationId?: CorrelationId;
+  };
+  automationId?: string;
+  occurrenceId?: string;
+  runId?: string;
+  attemptId?: string;
+  kind: EventKind;
+  summary: string;
+  payload: EventPayload;
+  privacy: {
+    classification: PrivacyClassification;
+    retention: RetentionClass;
+  };
+  integrity?: Digest;
+}

--- a/spec/coven-automations/v1/error-envelope.schema.json
+++ b/spec/coven-automations/v1/error-envelope.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/error-envelope.schema.json",
+  "title": "Coven Automations v1 typed error envelope",
+  "description": "Typed errors for every automations failure, with the HTTP and control-action status mapping. Domain failures are errors — they are never wrapped in an accepted/completed outer response merely because routing succeeded. The document root validates an errorEnvelope; the frozen statusMapping remains addressable at #/$defs/statusMapping.",
+  "$ref": "#/$defs/errorEnvelope",
+  "$defs": {
+    "errorCode": {
+      "enum": [
+        "SCHEMA_VERSION_UNSUPPORTED",
+        "VALIDATION_FAILED",
+        "ADOPTION_REPLAY_MISMATCH",
+        "REVISION_CONFLICT",
+        "NOT_FOUND",
+        "GONE_TOMBSTONED",
+        "CAPABILITY_UNSUPPORTED",
+        "ILLEGAL_TRANSITION",
+        "AUTHORITY_REQUIRED",
+        "APPROVAL_REQUIRED",
+        "CANCEL_PENDING",
+        "OVERLAP_FORBIDDEN",
+        "RETRY_DISPOSITION_INVALID",
+        "AMBIGUOUS_RETRY_FORBIDDEN",
+        "CURSOR_EXPIRED",
+        "STREAM_OUT_OF_ORDER",
+        "PAYLOAD_TOO_LARGE",
+        "DEADLINE_EXCEEDED",
+        "CONCURRENCY_LIMIT",
+        "INTERNAL"
+      ]
+    },
+    "errorEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "httpStatus", "message", "retryable"],
+      "properties": {
+        "code": { "$ref": "#/$defs/errorCode" },
+        "httpStatus": {
+          "type": "integer",
+          "minimum": 400,
+          "maximum": 599,
+          "description": "Canonical HTTP status for this error class when surfaced over HTTP or a control-action response."
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000,
+          "description": "Human-readable, safe-to-display description."
+        },
+        "retryable": {
+          "type": "boolean",
+          "description": "Whether an identical retry (same adoptionKey for mutations) could succeed after delay."
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Structured specifics: the failing JSON-Schema path for VALIDATION_FAILED, the current revision for REVISION_CONFLICT, the unsupported variant for CAPABILITY_UNSUPPORTED, the expired instant for CURSOR_EXPIRED, and so on."
+        },
+        "adoption": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["key"],
+          "properties": {
+            "key": { "$ref": "common.schema.json#/$defs/adoptionKey" },
+            "conflictOutcome": {
+              "enum": ["committed", "rejected"],
+              "description": "For ADOPTION_REPLAY_MISMATCH: what the key actually committed, so callers can reconcile instead of guessing."
+            }
+          },
+          "description": "Present when the error concerns the caller's adoption key."
+        },
+        "currentRevision": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "For REVISION_CONFLICT: the revision the caller must re-read before re-submitting."
+        }
+      }
+    },
+    "statusMapping": {
+      "type": "object",
+      "additionalProperties": { "type": "integer" },
+      "required": [
+        "SCHEMA_VERSION_UNSUPPORTED",
+        "VALIDATION_FAILED",
+        "ADOPTION_REPLAY_MISMATCH",
+        "REVISION_CONFLICT",
+        "NOT_FOUND",
+        "GONE_TOMBSTONED",
+        "CAPABILITY_UNSUPPORTED",
+        "ILLEGAL_TRANSITION",
+        "AUTHORITY_REQUIRED",
+        "APPROVAL_REQUIRED",
+        "CANCEL_PENDING",
+        "OVERLAP_FORBIDDEN",
+        "RETRY_DISPOSITION_INVALID",
+        "AMBIGUOUS_RETRY_FORBIDDEN",
+        "CURSOR_EXPIRED",
+        "STREAM_OUT_OF_ORDER",
+        "PAYLOAD_TOO_LARGE",
+        "DEADLINE_EXCEEDED",
+        "CONCURRENCY_LIMIT",
+        "INTERNAL"
+      ],
+      "properties": {
+        "SCHEMA_VERSION_UNSUPPORTED": { "const": 400 },
+        "VALIDATION_FAILED": { "const": 400 },
+        "ADOPTION_REPLAY_MISMATCH": { "const": 409 },
+        "REVISION_CONFLICT": { "const": 409 },
+        "NOT_FOUND": { "const": 404 },
+        "GONE_TOMBSTONED": { "const": 410 },
+        "CAPABILITY_UNSUPPORTED": { "const": 422 },
+        "ILLEGAL_TRANSITION": { "const": 422 },
+        "AUTHORITY_REQUIRED": { "const": 403 },
+        "APPROVAL_REQUIRED": { "const": 403 },
+        "CANCEL_PENDING": { "const": 409 },
+        "OVERLAP_FORBIDDEN": { "const": 409 },
+        "RETRY_DISPOSITION_INVALID": { "const": 422 },
+        "AMBIGUOUS_RETRY_FORBIDDEN": { "const": 422 },
+        "CURSOR_EXPIRED": { "const": 410 },
+        "STREAM_OUT_OF_ORDER": { "const": 409 },
+        "PAYLOAD_TOO_LARGE": { "const": 413 },
+        "DEADLINE_EXCEEDED": { "const": 504 },
+        "CONCURRENCY_LIMIT": { "const": 429 },
+        "INTERNAL": { "const": 500 }
+      },
+      "description": "Frozen mapping from typed code to HTTP status. Control-action responses surface the same code in the rejected envelope; the /actions transport maps 400/403/404/409/410/413/422/429/500/504 onto its existing status passthrough (api.rs json_response(status, ...))."
+    }
+  }
+}

--- a/spec/coven-automations/v1/event-envelope.schema.json
+++ b/spec/coven-automations/v1/event-envelope.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/event-envelope.schema.json",
+  "title": "Coven Automations v1 event/changefeed envelope",
+  "description": "Durable event envelope for the automations changefeed. Events are at-least-once, per-stream gaplessly sequenced, and the sole input to read-model rehydration. Consumers deduplicate on eventId, reject sequence regressions against their cursor, and resume from checkpoints that can expire (typed CURSOR_EXPIRED, never a silent rewind).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "eventId",
+    "stream",
+    "sequence",
+    "recordedAt",
+    "observedAt",
+    "producer",
+    "kind",
+    "summary",
+    "payload",
+    "privacy"
+  ],
+  "properties": {
+    "schemaVersion": { "$ref": "common.schema.json#/$defs/schemaVersion" },
+    "eventId": {
+      "type": "string",
+      "minLength": 20,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z0-9]+$",
+      "description": "Globally unique, case-sensitive; duplicates of a delivered eventId are redeliveries and must be ignored, not re-applied."
+    },
+    "stream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": { "enum": ["automation", "occurrence", "run", "feed"] },
+        "id": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 320,
+          "description": "automationId / occurrenceId / runId; the global feed uses kind=feed and a composite id (feed.<recordedAtMillis>)."
+        }
+      }
+    },
+    "sequence": {
+      "$ref": "common.schema.json#/$defs/sequenceNumber",
+      "description": "Monotonically increasing, gapless within `stream`. Stream-local, starting at 0. Append is a compare-and-set on the stream head: out-of-order appends are refused (STREAM_OUT_OF_ORDER) rather than reordered."
+    },
+    "recordedAt": {
+      "$ref": "common.schema.json#/$defs/timestamp",
+      "description": "When the authoritative store recorded the event. Read-model ordering uses (sequence, recordedAt), never observedAt."
+    },
+    "observedAt": {
+      "$ref": "common.schema.json#/$defs/timestamp",
+      "description": "When the producing component observed the cause (may precede recordedAt)."
+    },
+    "producer": { "$ref": "common.schema.json#/$defs/producerIdentity" },
+    "causation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "adoptionKey": { "$ref": "common.schema.json#/$defs/adoptionKey" },
+        "causeEventId": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "eventId that caused this event, for chains."
+        },
+        "correlationId": { "$ref": "common.schema.json#/$defs/correlationId" }
+      },
+      "description": "Idempotency/causation/correlation context. adoptionKey ties the event to the command that committed it; replay consumers use it to prove command adoption happened exactly once."
+    },
+    "automationId": { "$ref": "common.schema.json#/$defs/automationId" },
+    "occurrenceId": { "$ref": "common.schema.json#/$defs/occurrenceId" },
+    "runId": { "$ref": "common.schema.json#/$defs/runId" },
+    "attemptId": { "$ref": "common.schema.json#/$defs/attemptId" },
+    "kind": { "$ref": "#/$defs/eventKind" },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 300,
+      "description": "User-safe summary for UI surfaces; must not contain secrets, prompts, or raw payloads."
+    },
+    "payload": {
+      "oneOf": [
+        { "$ref": "#/$defs/definitionLifecyclePayload" },
+        { "$ref": "#/$defs/transitionPayload" },
+        { "$ref": "#/$defs/misfirePayload" },
+        { "$ref": "#/$defs/receiptPayload" },
+        { "$ref": "#/$defs/snapshotPayload" }
+      ]
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["classification", "retention"],
+      "properties": {
+        "classification": { "$ref": "common.schema.json#/$defs/privacyClassification" },
+        "retention": { "$ref": "common.schema.json#/$defs/retentionClass" }
+      }
+    },
+    "integrity": {
+      "$ref": "common.schema.json#/$defs/digest",
+      "description": "Required where the deployment requires tamper evidence (for example receipt.recorded events): digest over the canonical envelope with this member removed."
+    }
+  },
+  "$defs": {
+    "eventKind": {
+      "enum": [
+        "definition.created",
+        "definition.revised",
+        "definition.activated",
+        "definition.paused",
+        "definition.disabled",
+        "definition.invalidated",
+        "definition.tombstoned",
+        "definition.imported",
+        "occurrence.transitioned",
+        "occurrence.misfire_recorded",
+        "run.transitioned",
+        "attempt.transitioned",
+        "receipt.recorded",
+        "feed.snapshot"
+      ]
+    },
+    "definitionLifecyclePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["revision"],
+      "properties": {
+        "revision": { "type": "integer", "minimum": 1 },
+        "definitionDigest": { "$ref": "common.schema.json#/$defs/digest" },
+        "lifecycleState": {
+          "enum": ["draft", "paused", "active", "disabled", "invalid", "tombstoned"]
+        },
+        "importedFrom": { "type": "string", "maxLength": 200 }
+      }
+    },
+    "transitionPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["entity", "from", "to", "reason"],
+      "properties": {
+        "entity": { "enum": ["occurrence", "run", "attempt"] },
+        "from": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "description": "Prior state; the literal `none` marks creation."
+        },
+        "to": { "type": "string", "minLength": 1, "maxLength": 32 },
+        "reason": { "type": "string", "minLength": 1, "maxLength": 500 },
+        "fenceGeneration": { "$ref": "common.schema.json#/$defs/fenceToken" },
+        "attemptNumber": { "type": "integer", "minimum": 1 },
+        "commandAdoptionKey": { "$ref": "common.schema.json#/$defs/adoptionKey" }
+      }
+    },
+    "misfirePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disposition", "collapsedSlots"],
+      "properties": {
+        "disposition": { "$ref": "common.schema.json#/$defs/misfireDisposition" },
+        "collapsedSlots": {
+          "type": "array",
+          "items": { "$ref": "common.schema.json#/$defs/timestamp" },
+          "maxItems": 4096,
+          "description": "Missed slots this event accounts for (collapsed_to_latest). Recorded, never backfilled as occurrences."
+        }
+      }
+    },
+    "receiptPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receiptRef", "outcome"],
+      "properties": {
+        "receiptRef": { "$ref": "common.schema.json#/$defs/receiptId" },
+        "outcome": {
+          "enum": ["succeeded", "failed", "cancelled", "timed_out", "ambiguous"]
+        },
+        "sideEffectClass": {
+          "enum": [
+            "none",
+            "local_read",
+            "local_write",
+            "external_read",
+            "external_mutation",
+            "irreversible_external_mutation"
+          ]
+        }
+      }
+    },
+    "snapshotPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["throughSequence", "state"],
+      "properties": {
+        "throughSequence": {
+          "$ref": "common.schema.json#/$defs/sequenceNumber",
+          "description": "All events of the stream up to and including this sequence are compacted into `state`; a rehydrating consumer folds the snapshot then applies events strictly after it."
+        },
+        "state": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Compacted read-model state for the stream, itself schema-validated per object type."
+        },
+        "reason": {
+          "enum": ["retention_compaction", "manual_snapshot"]
+        }
+      }
+    }
+  }
+}

--- a/spec/coven-automations/v1/protocol-version.json
+++ b/spec/coven-automations/v1/protocol-version.json
@@ -1,0 +1,25 @@
+{
+  "protocol": "Coven Automations",
+  "contractProfile": "coven.automations.v1",
+  "version": 1,
+  "status": "proposed",
+  "canonicalization": "jcs-rfc8785",
+  "digestAlgorithm": "sha256",
+  "profiles": [
+    "coven.automations.v1"
+  ],
+  "refusedProfiles": [
+    "coven.automations.v0"
+  ],
+  "unknownProfileBehavior": "fail-closed",
+  "contractVersionVsRelease": {
+    "contractProfile": "Identifies the wire contract only. Changes if and only if the published schema, state machine, or compatibility rules change.",
+    "implementationVersion": "Carried by the producing implementation (for example the Coven daemon release) and is independent of the contract profile. Clients must never infer contract semantics from an implementation version.",
+    "producerIdentity": "Event and receipt envelopes carry the producing implementation's identity and version alongside the contract profile."
+  },
+  "wireNotes": [
+    "All objects in this profile are JSON per draft 2020-12 schemas in this directory.",
+    "Digests and any future signatures are computed over RFC 8785 (JCS) canonical JSON, never over ad-hoc serialization.",
+    "Timestamps are RFC 3339 UTC with millisecond precision (for example 2026-08-30T09:00:00.000Z), matching the #816 store encoding."
+  ]
+}

--- a/spec/coven-automations/v1/state-machines.json
+++ b/spec/coven-automations/v1/state-machines.json
@@ -1,0 +1,186 @@
+{
+  "contractProfile": "coven.automations.v1",
+  "version": 1,
+  "notes": [
+    "Authoritative state machines for coven.automations.v1. Clients do not author state: transitions are committed by command handlers or the scheduler, never by arbitrary client writes.",
+    "`on` names the cause class; `actor` names who may commit the transition; `guard` names the condition that must hold. Property tests consume this file to prove invariant preservation."
+  ],
+  "machines": [
+    {
+      "id": "occurrence.v1",
+      "entity": "occurrence",
+      "initial": "planned",
+      "terminalStates": ["succeeded", "failed", "cancelled", "timed_out", "skipped", "superseded"],
+      "states": [
+        { "name": "planned", "terminal": false },
+        { "name": "eligible", "terminal": false },
+        { "name": "claimed", "terminal": false },
+        { "name": "dispatching", "terminal": false },
+        { "name": "running", "terminal": false },
+        { "name": "recovering", "terminal": false },
+        { "name": "recovery_required", "terminal": false },
+        { "name": "succeeded", "terminal": true },
+        { "name": "failed", "terminal": true },
+        { "name": "cancelled", "terminal": true },
+        { "name": "timed_out", "terminal": true },
+        { "name": "skipped", "terminal": true },
+        { "name": "superseded", "terminal": true }
+      ],
+      "transitions": [
+        { "from": "planned", "to": "eligible", "on": "eligibility_passed", "actor": "scheduler" },
+        { "from": "planned", "to": "skipped", "on": "misfire", "actor": "scheduler", "guard": "misfire policy disposes this slot (e.g. overlap_forbid, paused, invalid)" },
+        { "from": "planned", "to": "superseded", "on": "definition_superseded", "actor": "scheduler", "guard": "a newer revision replaced the definition before this slot was claimed" },
+        { "from": "planned", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler", "guard": "cancellation command committed before any claim" },
+        { "from": "eligible", "to": "claimed", "on": "claim", "actor": "scheduler", "guard": "compare-and-set on state='eligible' or 'planned' with lease set; increments fence generation" },
+        { "from": "eligible", "to": "skipped", "on": "misfire", "actor": "scheduler" },
+        { "from": "eligible", "to": "superseded", "on": "definition_superseded", "actor": "scheduler" },
+        { "from": "eligible", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler" },
+        { "from": "claimed", "to": "dispatching", "on": "attempt_adopted", "actor": "dispatcher", "guard": "attempt created with adoptionKey; fence generation matches the claim" },
+        { "from": "claimed", "to": "recovering", "on": "lease_expired", "actor": "scheduler", "guard": "leaseExpiresAt < now and no runtime evidence recorded" },
+        { "from": "claimed", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler", "guard": "cancellation reconciled before dispatch" },
+        { "from": "dispatching", "to": "running", "on": "runtime_started", "actor": "dispatcher", "guard": "runtime acknowledged the session start (attempt started)" },
+        { "from": "dispatching", "to": "failed", "on": "launch_refused", "actor": "dispatcher", "guard": "launch failed deterministically before any side effect; occurrence settles failed with reason launch_refused" },
+        { "from": "dispatching", "to": "recovering", "on": "lease_expired", "actor": "scheduler", "guard": "no runtime evidence before lease expiry" },
+        { "from": "dispatching", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler", "guard": "no attempt reached started; otherwise cancellation waits for reconciliation" },
+        { "from": "running", "to": "succeeded", "on": "run_settled", "actor": "dispatcher", "guard": "runtime evidence proves completion; receipt recorded" },
+        { "from": "running", "to": "failed", "on": "run_settled", "actor": "dispatcher", "guard": "runtime evidence proves failure" },
+        { "from": "running", "to": "timed_out", "on": "timeout", "actor": "scheduler", "guard": "perRunMinutes elapsed without settled evidence" },
+        { "from": "running", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler", "guard": "cancellation acknowledged by runtime or reconciled by recovery" },
+        { "from": "running", "to": "recovery_required", "on": "evidence_lost", "actor": "scheduler", "guard": "runtime lost mid-run: outcome cannot be determined automatically" },
+        { "from": "recovering", "to": "failed", "on": "recovery_determined", "actor": "scheduler", "guard": "no side effects were possible (sideEffectClass bounds proven)" },
+        { "from": "recovering", "to": "recovery_required", "on": "recovery_ambiguous", "actor": "scheduler", "guard": "side effects cannot be ruled out; requires explicit operator recovery" },
+        { "from": "recovery_required", "to": "failed", "on": "operator_recovery_failed", "actor": "command_handler", "guard": "occurrence.recover.v1 with evidenceDetermination=failed_deterministic" },
+        { "from": "recovery_required", "to": "dispatching", "on": "operator_recovery_attempt", "actor": "command_handler", "guard": "occurrence.recover.v1 with evidenceDetermination=retry_with_new_attempt; opens a new attempt carrying priorDisposition=ambiguous" }
+      ]
+    },
+    {
+      "id": "attempt.v1",
+      "entity": "attempt",
+      "initial": "adopted",
+      "terminalStates": ["succeeded", "failed", "cancelled", "timed_out", "ambiguous"],
+      "states": [
+        { "name": "adopted", "terminal": false },
+        { "name": "dispatching", "terminal": false },
+        { "name": "started", "terminal": false },
+        { "name": "observing", "terminal": false },
+        { "name": "succeeded", "terminal": true },
+        { "name": "failed", "terminal": true },
+        { "name": "cancelled", "terminal": true },
+        { "name": "timed_out", "terminal": true },
+        { "name": "ambiguous", "terminal": true }
+      ],
+      "transitions": [
+        { "from": "adopted", "to": "dispatching", "on": "dispatch", "actor": "dispatcher", "guard": "dispatch generation incremented; exactly one dispatch in flight per attempt" },
+        { "from": "adopted", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler", "guard": "cancellation committed before dispatch" },
+        { "from": "dispatching", "to": "started", "on": "runtime_started", "actor": "dispatcher", "guard": "runtime session bound; a second session bind is ILLEGAL_TRANSITION" },
+        { "from": "dispatching", "to": "failed", "on": "launch_refused", "actor": "dispatcher", "guard": "deterministic pre-side-effect refusal" },
+        { "from": "dispatching", "to": "ambiguous", "on": "dispatch_unconfirmed", "actor": "dispatcher", "guard": "dispatch sent but no deterministic ack before lease expiry; terminal for the attempt" },
+        { "from": "dispatching", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler", "guard": "cancellation acknowledged before runtime start" },
+        { "from": "started", "to": "observing", "on": "evidence_stream_open", "actor": "worker", "guard": "output/event cursors established" },
+        { "from": "started", "to": "succeeded", "on": "run_settled", "actor": "worker", "guard": "terminal evidence without an observing phase" },
+        { "from": "started", "to": "ambiguous", "on": "evidence_lost", "actor": "scheduler", "guard": "session vanished before evidence" },
+        { "from": "observing", "to": "succeeded", "on": "run_settled", "actor": "worker", "guard": "verified completion evidence" },
+        { "from": "observing", "to": "failed", "on": "run_settled", "actor": "worker", "guard": "verified failure evidence" },
+        { "from": "observing", "to": "timed_out", "on": "timeout", "actor": "scheduler", "guard": "perRunMinutes elapsed" },
+        { "from": "observing", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler", "guard": "cancellation acknowledged by runtime" },
+        { "from": "observing", "to": "ambiguous", "on": "evidence_lost", "actor": "scheduler", "guard": "heartbeat/lease evidence expired mid-observation" }
+      ]
+    },
+    {
+      "id": "run.v1",
+      "entity": "run",
+      "initial": "accepted",
+      "terminalStates": ["succeeded", "failed", "cancelled", "timed_out", "ambiguous"],
+      "states": [
+        { "name": "accepted", "terminal": false },
+        { "name": "running", "terminal": false },
+        { "name": "succeeded", "terminal": true },
+        { "name": "failed", "terminal": true },
+        { "name": "cancelled", "terminal": true },
+        { "name": "timed_out", "terminal": true },
+        { "name": "ambiguous", "terminal": true }
+      ],
+      "transitions": [
+        { "from": "accepted", "to": "running", "on": "attempt_started", "actor": "dispatcher", "guard": "command adoption committed before any side effect; currentAttemptId set" },
+        { "from": "accepted", "to": "failed", "on": "launch_refused", "actor": "dispatcher", "guard": "every attempt failed deterministically before evidence" },
+        { "from": "accepted", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler" },
+        { "from": "running", "to": "succeeded", "on": "attempt_settled", "actor": "dispatcher", "guard": "an attempt settled succeeded; receipt recorded" },
+        { "from": "running", "to": "failed", "on": "attempt_settled", "actor": "dispatcher", "guard": "an attempt settled failed and retry policy opens no further attempt" },
+        { "from": "running", "to": "timed_out", "on": "timeout", "actor": "scheduler" },
+        { "from": "running", "to": "cancelled", "on": "cancel_acknowledged", "actor": "command_handler" },
+        { "from": "running", "to": "ambiguous", "on": "attempt_ambiguous", "actor": "dispatcher", "guard": "the current attempt settled ambiguous and no operator recovery has resolved it" }
+      ]
+    },
+    {
+      "id": "definition.v1",
+      "entity": "definition",
+      "initial": "draft",
+      "terminalStates": ["tombstoned"],
+      "states": [
+        { "name": "draft", "terminal": false },
+        { "name": "paused", "terminal": false },
+        { "name": "active", "terminal": false },
+        { "name": "disabled", "terminal": false },
+        { "name": "invalid", "terminal": false },
+        { "name": "tombstoned", "terminal": true }
+      ],
+      "transitions": [
+        { "from": "draft", "to": "paused", "on": "definition_revise_committed", "actor": "command_handler", "guard": "definition validated; revision incremented" },
+        { "from": "draft", "to": "tombstoned", "on": "definition_tombstoned", "actor": "command_handler" },
+        { "from": "paused", "to": "active", "on": "definition_activated", "actor": "command_handler", "guard": "familiar, authority, and runtime requirements validated" },
+        { "from": "paused", "to": "disabled", "on": "definition_disabled", "actor": "command_handler" },
+        { "from": "paused", "to": "tombstoned", "on": "definition_tombstoned", "actor": "command_handler" },
+        { "from": "active", "to": "paused", "on": "definition_paused", "actor": "command_handler" },
+        { "from": "active", "to": "disabled", "on": "definition_disabled", "actor": "command_handler" },
+        { "from": "active", "to": "invalid", "on": "definition_invalidated", "actor": "command_handler", "guard": "a revise committed an invalid body or dependencies (familiar/runtime/authority) became unsatisfiable" },
+        { "from": "active", "to": "tombstoned", "on": "definition_tombstoned", "actor": "command_handler" },
+        { "from": "disabled", "to": "paused", "on": "definition_reenabled", "actor": "command_handler", "guard": "explicit re-enable; disabled never auto-reactivates" },
+        { "from": "disabled", "to": "tombstoned", "on": "definition_tombstoned", "actor": "command_handler" },
+        { "from": "invalid", "to": "paused", "on": "definition_revise_committed", "actor": "command_handler", "guard": "a revise repaired the body and validation passed" },
+        { "from": "invalid", "to": "tombstoned", "on": "definition_tombstoned", "actor": "command_handler" }
+      ]
+    }
+  ],
+  "invariants": [
+    {
+      "id": "adoption-before-side-effects",
+      "statement": "Command adoption commits before any consequential side effect is issued; a run is accepted (run.v1 accepted) before dispatch begins."
+    },
+    {
+      "id": "one-fence-one-run",
+      "statement": "One occurrence fence generation cannot own two accepted runs: acceptance requires a compare-and-set on the occurrence fence generation, and a second acceptance with the same generation is a typed conflict."
+    },
+    {
+      "id": "one-attempt-one-session",
+      "statement": "One attempt cannot bind two runtime sessions; a second session bind on the same attempt is ILLEGAL_TRANSITION and commits nothing."
+    },
+    {
+      "id": "terminal-no-regress",
+      "statement": "Terminal states never regress; no transition in any machine above leaves a terminal state."
+    },
+    {
+      "id": "no-evidence-no-success",
+      "statement": "Absence of runtime evidence can never become success; the only transitions out of evidence loss are failed, recovery paths, ambiguous, or timed_out."
+    },
+    {
+      "id": "cancellation-is-a-request",
+      "statement": "Cancellation is a request until acknowledged or reconciled; CANCEL_PENDING is returned while a running attempt has not acknowledged, and the occurrence settles cancelled only after acknowledgment or reconciliation."
+    },
+    {
+      "id": "retry-new-attempt",
+      "statement": "Retry creates a new attempt with attemptNumber incremented and priorDisposition set; the prior attempt's record is never rewritten."
+    },
+    {
+      "id": "ambiguous-never-auto-retried",
+      "statement": "Ambiguous mutating work is not automatically retried; only occurrence.recover.v1 with an explicit operator determination can open work after an ambiguous disposition."
+    },
+    {
+      "id": "revision-pins-history",
+      "statement": "Definition revision changes never rewrite historical occurrences, runs, attempts, or receipts; each pins the automationRevision and definition digest it was created and executed against."
+    },
+    {
+      "id": "tombstone-preserves-history",
+      "statement": "Deleting a definition tombstones it without erasing required history; tombstoned definitions never plan, claim, or run, and their records remain readable."
+    }
+  ]
+}

--- a/spec/coven-automations/v1/test-vectors.json
+++ b/spec/coven-automations/v1/test-vectors.json
@@ -1,0 +1,2085 @@
+{
+  "contractProfile": "coven.automations.v1",
+  "version": 1,
+  "status": "proposed",
+  "digestRecipe": {
+    "canonicalization": "RFC 8785 (JCS): UTF-8, key-sorted, no whitespace, minimal escaping.",
+    "digest": "SHA-256, lowercase hex, over the canonical serialization of the object with every `integrity` member removed.",
+    "fixtureScope": "All fixtures use integers and ASCII strings only, so any conformant JCS implementation reproduces the pinned byte strings exactly.",
+    "verification": "A runner recomputes the pinned digests before trusting the vectors; a mismatch means the vector bytes were altered and the file must not be used."
+  },
+  "caseKinds": {
+    "schema": "Validate `object` against `targetSchema` (draft 2020-12, with sibling schemas from this directory loaded). accept/reject is the whole verdict.",
+    "stateMachine": "Consult state-machines.json. `attemptedTransition` must be refused because no transition leaves the terminal state `fromState`.",
+    "adoption": "Consult command-envelope semantics. The case pins what a conformant command handler commits or refuses, independent of transport.",
+    "changefeed": "Consult event-envelope semantics. The case pins duplicate handling, ordering, and deterministic read-model rehydration."
+  },
+  "fixtures": {
+    "definition.golden": {
+      "schemaVersion": "coven.automations.v1",
+      "automationId": "daily-notes",
+      "revision": 1,
+      "lifecycleState": "active",
+      "display": {
+        "name": "Daily notes",
+        "description": "Write the daily reflection into the notes target.",
+        "tags": [
+          "notes",
+          "daily"
+        ]
+      },
+      "trigger": {
+        "variant": "schedule",
+        "version": 1,
+        "schedule": {
+          "rrule": "FREQ=DAILY;BYHOUR=9",
+          "timezone": "utc"
+        }
+      },
+      "conditions": [],
+      "action": {
+        "variant": "familiarInvocation",
+        "version": 1,
+        "prompt": "Write the daily reflection.",
+        "cwd": "~/projects/notes"
+      },
+      "binding": {
+        "familiarBindingPolicy": "exact",
+        "familiarId": "charm",
+        "authority": {
+          "approvalPolicyRef": "policy://authority/familiars/charm"
+        }
+      },
+      "runtimeRequirements": {
+        "runtimeId": "coven-code",
+        "capabilities": [
+          "sessions.launch"
+        ]
+      },
+      "policies": {
+        "timeout": {
+          "perRunMinutes": 30
+        },
+        "retry": {
+          "maxAttempts": 3,
+          "backoffPolicy": "exponential",
+          "retryableClasses": [
+            "transient_dispatch"
+          ]
+        },
+        "concurrency": {
+          "overlap": "forbid"
+        },
+        "misfire": {
+          "disposition": "latest"
+        },
+        "delivery": {
+          "outputTarget": "~/projects/notes/today.md",
+          "mode": "atomic"
+        },
+        "retention": {
+          "occurrenceHistory": {
+            "classification": "standard"
+          },
+          "runLogs": {
+            "classification": "standard"
+          },
+          "receipts": {
+            "classification": "extended"
+          }
+        }
+      },
+      "provenance": {
+        "createdBy": {
+          "principalId": "principal:tim"
+        },
+        "createdAt": "2026-08-30T09:00:00.000Z"
+      },
+      "activation": {
+        "effectiveFrom": "2026-08-30T09:00:00.000Z"
+      },
+      "extensions": {},
+      "integrity": {
+        "algorithm": "sha256",
+        "canonicalization": "jcs-rfc8785",
+        "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+      }
+    },
+    "occurrence.golden": {
+      "schemaVersion": "coven.automations.v1",
+      "occurrenceId": "daily-notes-1756544400000",
+      "automationId": "daily-notes",
+      "automationRevision": 1,
+      "triggerIdentity": {
+        "kind": "schedule.slot",
+        "rruleRef": "FREQ=DAILY;BYHOUR=9"
+      },
+      "occurrenceKey": "daily-notes@2026-08-30T09:00:00.000Z",
+      "scheduledFor": "2026-08-30T09:00:00.000Z",
+      "observedAt": "2026-08-30T09:00:00.000Z",
+      "eligibleAt": "2026-08-30T09:00:01.000Z",
+      "state": "claimed",
+      "stateReason": "claimed_by_daemon",
+      "fence": {
+        "generation": 1,
+        "claimedBy": "daemon@host-a",
+        "leaseExpiresAt": "2026-08-30T09:30:00.000Z"
+      },
+      "misfireDisposition": "none",
+      "claimMetadata": {
+        "claimedAt": "2026-08-30T09:00:01.000Z",
+        "leaseMinutes": 60
+      },
+      "activeRunRef": "run-daily-notes-0001",
+      "createdAt": "2026-08-30T09:00:00.000Z",
+      "updatedAt": "2026-08-30T09:00:02.000Z",
+      "eventWindow": {
+        "firstSequence": 0,
+        "lastSequence": 3
+      },
+      "extensions": {}
+    },
+    "run.golden": {
+      "schemaVersion": "coven.automations.v1",
+      "runId": "run-daily-notes-0001",
+      "occurrenceId": "daily-notes-1756544400000",
+      "automationId": "daily-notes",
+      "automationRevision": 1,
+      "binding": {
+        "familiar": {
+          "familiarId": "charm"
+        },
+        "authority": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "approval": {
+            "approvalPolicyRef": "policy://authority/familiars/charm",
+            "approvalRecordRef": "approval-2026-08-30-0001"
+          },
+          "authenticationClass": "devicekey"
+        },
+        "runtime": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        }
+      },
+      "state": "succeeded",
+      "stateReason": "attempt_settled_succeeded",
+      "attemptCount": 1,
+      "terminalDisposition": {
+        "outcome": "succeeded",
+        "detail": "verified completion evidence"
+      },
+      "delivery": {
+        "status": "committed",
+        "target": "~/projects/notes/today.md"
+      },
+      "receiptRef": "receipt-daily-notes-0001",
+      "startedAt": "2026-08-30T09:00:02.000Z",
+      "finishedAt": "2026-08-30T09:00:05.000Z",
+      "extensions": {}
+    },
+    "attempt.golden": {
+      "schemaVersion": "coven.automations.v1",
+      "attemptId": "att-daily-notes-0001-1",
+      "runId": "run-daily-notes-0001",
+      "occurrenceId": "daily-notes-1756544400000",
+      "attemptNumber": 1,
+      "adoptionKey": "adopt:run-daily-notes-0001:1",
+      "dispatchFence": {
+        "occurrenceFenceGeneration": 1,
+        "dispatchGeneration": 1
+      },
+      "workerCorrelation": {
+        "workerId": "dispatcher@host-a",
+        "sessionId": "session-coven-code-7",
+        "adoptedAt": "2026-08-30T09:00:01.000Z"
+      },
+      "retryClassification": {
+        "classification": "initial",
+        "eligibleClasses": [
+          "transient_dispatch"
+        ]
+      },
+      "leaseObservations": [
+        {
+          "observedAt": "2026-08-30T09:00:03.000Z",
+          "heartbeatOk": true
+        }
+      ],
+      "outputCursors": {
+        "eventCursor": 3,
+        "logCursor": 128
+      },
+      "state": "succeeded",
+      "stateReason": "verified completion evidence",
+      "openedAt": "2026-08-30T09:00:01.000Z",
+      "settledAt": "2026-08-30T09:00:05.000Z",
+      "extensions": {}
+    },
+    "receipt.golden": {
+      "schemaVersion": "coven.automations.v1",
+      "receiptId": "receipt-daily-notes-0001",
+      "automationId": "daily-notes",
+      "automationRevision": 1,
+      "definitionDigest": {
+        "algorithm": "sha256",
+        "canonicalization": "jcs-rfc8785",
+        "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+      },
+      "occurrenceId": "daily-notes-1756544400000",
+      "occurrenceFenceGeneration": 1,
+      "runId": "run-daily-notes-0001",
+      "attemptId": "att-daily-notes-0001-1",
+      "attemptNumber": 1,
+      "identity": {
+        "familiarId": "charm"
+      },
+      "authority": {
+        "principal": {
+          "principalId": "principal:tim"
+        },
+        "approval": {
+          "approvalPolicyRef": "policy://authority/familiars/charm"
+        }
+      },
+      "runtime": {
+        "runtimeId": "coven-code",
+        "capabilities": [
+          "sessions.launch"
+        ]
+      },
+      "exercisedCapabilities": [
+        "sessions.launch"
+      ],
+      "sideEffectClass": "local_write",
+      "outcome": {
+        "disposition": "succeeded",
+        "recoveryDisposition": "not_required"
+      },
+      "producedAt": "2026-08-30T09:00:05.000Z",
+      "producer": {
+        "component": "coven-daemon",
+        "instanceId": "daemon@host-a",
+        "implementationVersion": "0.9.0"
+      },
+      "privacy": {
+        "classification": "operational",
+        "retention": {
+          "classification": "standard"
+        }
+      },
+      "integrity": {
+        "algorithm": "sha256",
+        "canonicalization": "jcs-rfc8785",
+        "value": "3b278869178dc3a8461a0cae5a1c671e77085e468261d651460ccf6822300418",
+        "authentication": "none"
+      }
+    },
+    "command.create.golden": {
+      "schemaVersion": "coven.automations.v1",
+      "command": "definition.create.v1",
+      "adoptionKey": "adopt:create-daily-notes-0001",
+      "origin": {
+        "principal": {
+          "principalId": "principal:tim"
+        },
+        "channel": "sdk",
+        "authenticationClass": "devicekey",
+        "requestedAt": "2026-08-30T09:00:00.000Z",
+        "correlationId": "corr-create-0001"
+      },
+      "intent": {
+        "statement": "Create the daily notes routine."
+      },
+      "payload": {
+        "definition": {
+          "schemaVersion": "coven.automations.v1",
+          "automationId": "daily-notes",
+          "revision": 1,
+          "lifecycleState": "active",
+          "display": {
+            "name": "Daily notes",
+            "description": "Write the daily reflection into the notes target.",
+            "tags": [
+              "notes",
+              "daily"
+            ]
+          },
+          "trigger": {
+            "variant": "schedule",
+            "version": 1,
+            "schedule": {
+              "rrule": "FREQ=DAILY;BYHOUR=9",
+              "timezone": "utc"
+            }
+          },
+          "conditions": [],
+          "action": {
+            "variant": "familiarInvocation",
+            "version": 1,
+            "prompt": "Write the daily reflection.",
+            "cwd": "~/projects/notes"
+          },
+          "binding": {
+            "familiarBindingPolicy": "exact",
+            "familiarId": "charm",
+            "authority": {
+              "approvalPolicyRef": "policy://authority/familiars/charm"
+            }
+          },
+          "runtimeRequirements": {
+            "runtimeId": "coven-code",
+            "capabilities": [
+              "sessions.launch"
+            ]
+          },
+          "policies": {
+            "timeout": {
+              "perRunMinutes": 30
+            },
+            "retry": {
+              "maxAttempts": 3,
+              "backoffPolicy": "exponential",
+              "retryableClasses": [
+                "transient_dispatch"
+              ]
+            },
+            "concurrency": {
+              "overlap": "forbid"
+            },
+            "misfire": {
+              "disposition": "latest"
+            },
+            "delivery": {
+              "outputTarget": "~/projects/notes/today.md",
+              "mode": "atomic"
+            },
+            "retention": {
+              "occurrenceHistory": {
+                "classification": "standard"
+              },
+              "runLogs": {
+                "classification": "standard"
+              },
+              "receipts": {
+                "classification": "extended"
+              }
+            }
+          },
+          "provenance": {
+            "createdBy": {
+              "principalId": "principal:tim"
+            },
+            "createdAt": "2026-08-30T09:00:00.000Z"
+          },
+          "activation": {
+            "effectiveFrom": "2026-08-30T09:00:00.000Z"
+          },
+          "extensions": {},
+          "integrity": {
+            "algorithm": "sha256",
+            "canonicalization": "jcs-rfc8785",
+            "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+          }
+        }
+      }
+    },
+    "event.occurrence.sequence": [
+      {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtocc00a7c3e9d24b6f8051",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 0,
+        "recordedAt": "2026-08-30T09:00:00.000Z",
+        "observedAt": "2026-08-30T09:00:00.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "occurrence.transitioned",
+        "summary": "occurrence occurrence none -> planned",
+        "payload": {
+          "entity": "occurrence",
+          "from": "none",
+          "to": "planned",
+          "reason": "slot_fenced",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      },
+      {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtocc01a7c3e9d24b6f8051",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 1,
+        "recordedAt": "2026-08-30T09:00:01.000Z",
+        "observedAt": "2026-08-30T09:00:01.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "occurrence.transitioned",
+        "summary": "occurrence occurrence planned -> eligible",
+        "payload": {
+          "entity": "occurrence",
+          "from": "planned",
+          "to": "eligible",
+          "reason": "eligibility_passed",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      },
+      {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtocc02a7c3e9d24b6f8051",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 2,
+        "recordedAt": "2026-08-30T09:00:02.000Z",
+        "observedAt": "2026-08-30T09:00:02.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "occurrence.transitioned",
+        "summary": "occurrence occurrence eligible -> claimed",
+        "payload": {
+          "entity": "occurrence",
+          "from": "eligible",
+          "to": "claimed",
+          "reason": "claim",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      },
+      {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtocc03a7c3e9d24b6f8051",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 3,
+        "recordedAt": "2026-08-30T09:00:03.000Z",
+        "observedAt": "2026-08-30T09:00:03.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "occurrence.transitioned",
+        "summary": "occurrence occurrence claimed -> dispatching",
+        "payload": {
+          "entity": "occurrence",
+          "from": "claimed",
+          "to": "dispatching",
+          "reason": "attempt_adopted",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      },
+      {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtocc04a7c3e9d24b6f8051",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 4,
+        "recordedAt": "2026-08-30T09:00:04.000Z",
+        "observedAt": "2026-08-30T09:00:04.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "occurrence.transitioned",
+        "summary": "occurrence occurrence dispatching -> running",
+        "payload": {
+          "entity": "occurrence",
+          "from": "dispatching",
+          "to": "running",
+          "reason": "runtime_started",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      },
+      {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtocc05a7c3e9d24b6f8051",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 5,
+        "recordedAt": "2026-08-30T09:00:05.000Z",
+        "observedAt": "2026-08-30T09:00:05.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "occurrence.transitioned",
+        "summary": "occurrence occurrence running -> succeeded",
+        "payload": {
+          "entity": "occurrence",
+          "from": "running",
+          "to": "succeeded",
+          "reason": "run_settled",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      }
+    ]
+  },
+  "cases": [
+    {
+      "name": "definition-golden-valid",
+      "kind": "schema",
+      "targetSchema": "automation-definition.schema.json",
+      "expected": "accept",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "automationId": "daily-notes",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "schedule",
+          "version": 1,
+          "schedule": {
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "prompt": "Write the daily reflection.",
+          "cwd": "~/projects/notes"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        }
+      }
+    },
+    {
+      "name": "definition-rejects-unknown-field",
+      "kind": "schema",
+      "targetSchema": "automation-definition.schema.json",
+      "expected": "reject",
+      "reason": "additionalProperties=false; unknown fields fail closed (extensions bag is the only optional channel).",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "automationId": "no-unknown-fields",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "schedule",
+          "version": 1,
+          "schedule": {
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "prompt": "Write the daily reflection.",
+          "cwd": "~/projects/notes"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        },
+        "autoRetry": true
+      }
+    },
+    {
+      "name": "definition-rejects-unknown-trigger-variant",
+      "kind": "schema",
+      "targetSchema": "automation-definition.schema.json",
+      "expected": "reject",
+      "reason": "v1 unions are closed; trigger.webhook is not a v1 variant. Producers that pass validation through must still refuse with CAPABILITY_UNSUPPORTED.",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "automationId": "no-unknown-variants",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "webhook",
+          "version": 1,
+          "webhook": {
+            "url": "https://example.invalid/hook"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "prompt": "Write the daily reflection.",
+          "cwd": "~/projects/notes"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        }
+      }
+    },
+    {
+      "name": "definition-rejects-downgrade",
+      "kind": "schema",
+      "targetSchema": "automation-definition.schema.json",
+      "expected": "reject",
+      "reason": "schemaVersion const coven.automations.v1; v0 is a refused profile.",
+      "object": {
+        "schemaVersion": "coven.automations.v0",
+        "automationId": "downgrade-refused",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "schedule",
+          "version": 1,
+          "schedule": {
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "prompt": "Write the daily reflection.",
+          "cwd": "~/projects/notes"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        }
+      }
+    },
+    {
+      "name": "definition-rejects-upgrade",
+      "kind": "schema",
+      "targetSchema": "automation-definition.schema.json",
+      "expected": "reject",
+      "reason": "Unknown future profile fails closed; consumers never approximate v2 objects with v1 semantics.",
+      "object": {
+        "schemaVersion": "coven.automations.v2",
+        "automationId": "upgrade-refused",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "schedule",
+          "version": 1,
+          "schedule": {
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "prompt": "Write the daily reflection.",
+          "cwd": "~/projects/notes"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        }
+      }
+    },
+    {
+      "name": "definition-rejects-missing-prompt",
+      "kind": "schema",
+      "targetSchema": "automation-definition.schema.json",
+      "expected": "reject",
+      "reason": "familiarInvocation requires a non-empty prompt.",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "automationId": "missing-prompt-refused",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "schedule",
+          "version": 1,
+          "schedule": {
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "cwd": "~/x"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        }
+      }
+    },
+    {
+      "name": "occurrence-golden-valid",
+      "kind": "schema",
+      "targetSchema": "automation-occurrence.schema.json",
+      "expected": "accept",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "occurrenceId": "daily-notes-1756544400000",
+        "automationId": "daily-notes",
+        "automationRevision": 1,
+        "triggerIdentity": {
+          "kind": "schedule.slot",
+          "rruleRef": "FREQ=DAILY;BYHOUR=9"
+        },
+        "occurrenceKey": "daily-notes@2026-08-30T09:00:00.000Z",
+        "scheduledFor": "2026-08-30T09:00:00.000Z",
+        "observedAt": "2026-08-30T09:00:00.000Z",
+        "eligibleAt": "2026-08-30T09:00:01.000Z",
+        "state": "claimed",
+        "stateReason": "claimed_by_daemon",
+        "fence": {
+          "generation": 1,
+          "claimedBy": "daemon@host-a",
+          "leaseExpiresAt": "2026-08-30T09:30:00.000Z"
+        },
+        "misfireDisposition": "none",
+        "claimMetadata": {
+          "claimedAt": "2026-08-30T09:00:01.000Z",
+          "leaseMinutes": 60
+        },
+        "activeRunRef": "run-daily-notes-0001",
+        "createdAt": "2026-08-30T09:00:00.000Z",
+        "updatedAt": "2026-08-30T09:00:02.000Z",
+        "eventWindow": {
+          "firstSequence": 0,
+          "lastSequence": 3
+        },
+        "extensions": {}
+      }
+    },
+    {
+      "name": "run-golden-valid",
+      "kind": "schema",
+      "targetSchema": "automation-run.schema.json",
+      "expected": "accept",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "runId": "run-daily-notes-0001",
+        "occurrenceId": "daily-notes-1756544400000",
+        "automationId": "daily-notes",
+        "automationRevision": 1,
+        "binding": {
+          "familiar": {
+            "familiarId": "charm"
+          },
+          "authority": {
+            "principal": {
+              "principalId": "principal:tim"
+            },
+            "approval": {
+              "approvalPolicyRef": "policy://authority/familiars/charm",
+              "approvalRecordRef": "approval-2026-08-30-0001"
+            },
+            "authenticationClass": "devicekey"
+          },
+          "runtime": {
+            "runtimeId": "coven-code",
+            "capabilities": [
+              "sessions.launch"
+            ]
+          }
+        },
+        "state": "succeeded",
+        "stateReason": "attempt_settled_succeeded",
+        "attemptCount": 1,
+        "terminalDisposition": {
+          "outcome": "succeeded",
+          "detail": "verified completion evidence"
+        },
+        "delivery": {
+          "status": "committed",
+          "target": "~/projects/notes/today.md"
+        },
+        "receiptRef": "receipt-daily-notes-0001",
+        "startedAt": "2026-08-30T09:00:02.000Z",
+        "finishedAt": "2026-08-30T09:00:05.000Z",
+        "extensions": {}
+      }
+    },
+    {
+      "name": "attempt-golden-valid",
+      "kind": "schema",
+      "targetSchema": "automation-attempt.schema.json",
+      "expected": "accept",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "attemptId": "att-daily-notes-0001-1",
+        "runId": "run-daily-notes-0001",
+        "occurrenceId": "daily-notes-1756544400000",
+        "attemptNumber": 1,
+        "adoptionKey": "adopt:run-daily-notes-0001:1",
+        "dispatchFence": {
+          "occurrenceFenceGeneration": 1,
+          "dispatchGeneration": 1
+        },
+        "workerCorrelation": {
+          "workerId": "dispatcher@host-a",
+          "sessionId": "session-coven-code-7",
+          "adoptedAt": "2026-08-30T09:00:01.000Z"
+        },
+        "retryClassification": {
+          "classification": "initial",
+          "eligibleClasses": [
+            "transient_dispatch"
+          ]
+        },
+        "leaseObservations": [
+          {
+            "observedAt": "2026-08-30T09:00:03.000Z",
+            "heartbeatOk": true
+          }
+        ],
+        "outputCursors": {
+          "eventCursor": 3,
+          "logCursor": 128
+        },
+        "state": "succeeded",
+        "stateReason": "verified completion evidence",
+        "openedAt": "2026-08-30T09:00:01.000Z",
+        "settledAt": "2026-08-30T09:00:05.000Z",
+        "extensions": {}
+      }
+    },
+    {
+      "name": "receipt-golden-valid",
+      "kind": "schema",
+      "targetSchema": "automation-receipt.schema.json",
+      "expected": "accept",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "receiptId": "receipt-daily-notes-0001",
+        "automationId": "daily-notes",
+        "automationRevision": 1,
+        "definitionDigest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        },
+        "occurrenceId": "daily-notes-1756544400000",
+        "occurrenceFenceGeneration": 1,
+        "runId": "run-daily-notes-0001",
+        "attemptId": "att-daily-notes-0001-1",
+        "attemptNumber": 1,
+        "identity": {
+          "familiarId": "charm"
+        },
+        "authority": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "approval": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtime": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "exercisedCapabilities": [
+          "sessions.launch"
+        ],
+        "sideEffectClass": "local_write",
+        "outcome": {
+          "disposition": "succeeded",
+          "recoveryDisposition": "not_required"
+        },
+        "producedAt": "2026-08-30T09:00:05.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a",
+          "implementationVersion": "0.9.0"
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        },
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "3b278869178dc3a8461a0cae5a1c671e77085e468261d651460ccf6822300418",
+          "authentication": "none"
+        }
+      }
+    },
+    {
+      "name": "command-create-golden-valid",
+      "kind": "schema",
+      "targetSchema": "command-envelope.schema.json",
+      "expected": "accept",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "command": "definition.create.v1",
+        "adoptionKey": "adopt:create-daily-notes-0001",
+        "origin": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "channel": "sdk",
+          "authenticationClass": "devicekey",
+          "requestedAt": "2026-08-30T09:00:00.000Z",
+          "correlationId": "corr-create-0001"
+        },
+        "intent": {
+          "statement": "Create the daily notes routine."
+        },
+        "payload": {
+          "definition": {
+            "schemaVersion": "coven.automations.v1",
+            "automationId": "daily-notes",
+            "revision": 1,
+            "lifecycleState": "active",
+            "display": {
+              "name": "Daily notes",
+              "description": "Write the daily reflection into the notes target.",
+              "tags": [
+                "notes",
+                "daily"
+              ]
+            },
+            "trigger": {
+              "variant": "schedule",
+              "version": 1,
+              "schedule": {
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "utc"
+              }
+            },
+            "conditions": [],
+            "action": {
+              "variant": "familiarInvocation",
+              "version": 1,
+              "prompt": "Write the daily reflection.",
+              "cwd": "~/projects/notes"
+            },
+            "binding": {
+              "familiarBindingPolicy": "exact",
+              "familiarId": "charm",
+              "authority": {
+                "approvalPolicyRef": "policy://authority/familiars/charm"
+              }
+            },
+            "runtimeRequirements": {
+              "runtimeId": "coven-code",
+              "capabilities": [
+                "sessions.launch"
+              ]
+            },
+            "policies": {
+              "timeout": {
+                "perRunMinutes": 30
+              },
+              "retry": {
+                "maxAttempts": 3,
+                "backoffPolicy": "exponential",
+                "retryableClasses": [
+                  "transient_dispatch"
+                ]
+              },
+              "concurrency": {
+                "overlap": "forbid"
+              },
+              "misfire": {
+                "disposition": "latest"
+              },
+              "delivery": {
+                "outputTarget": "~/projects/notes/today.md",
+                "mode": "atomic"
+              },
+              "retention": {
+                "occurrenceHistory": {
+                  "classification": "standard"
+                },
+                "runLogs": {
+                  "classification": "standard"
+                },
+                "receipts": {
+                  "classification": "extended"
+                }
+              }
+            },
+            "provenance": {
+              "createdBy": {
+                "principalId": "principal:tim"
+              },
+              "createdAt": "2026-08-30T09:00:00.000Z"
+            },
+            "activation": {
+              "effectiveFrom": "2026-08-30T09:00:00.000Z"
+            },
+            "extensions": {},
+            "integrity": {
+              "algorithm": "sha256",
+              "canonicalization": "jcs-rfc8785",
+              "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "command-revise-requires-expected-revision",
+      "kind": "schema",
+      "targetSchema": "command-envelope.schema.json",
+      "expected": "reject",
+      "reason": "definition.revise.v1 requires expectedRevision; without it nothing may commit.",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "command": "definition.revise.v1",
+        "adoptionKey": "adopt:revise-daily-notes-0002",
+        "origin": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "channel": "sdk",
+          "requestedAt": "2026-08-30T09:00:01.000Z"
+        },
+        "intent": {
+          "statement": "Move the daily notes slot to 10:00."
+        },
+        "payload": {
+          "definition": {
+            "schemaVersion": "coven.automations.v1",
+            "automationId": "daily-notes",
+            "revision": 3,
+            "lifecycleState": "active",
+            "display": {
+              "name": "Daily notes",
+              "description": "Write the daily reflection into the notes target.",
+              "tags": [
+                "notes",
+                "daily"
+              ]
+            },
+            "trigger": {
+              "variant": "schedule",
+              "version": 1,
+              "schedule": {
+                "rrule": "FREQ=DAILY;BYHOUR=10",
+                "timezone": "utc"
+              }
+            },
+            "conditions": [],
+            "action": {
+              "variant": "familiarInvocation",
+              "version": 1,
+              "prompt": "Write the daily reflection.",
+              "cwd": "~/projects/notes"
+            },
+            "binding": {
+              "familiarBindingPolicy": "exact",
+              "familiarId": "charm",
+              "authority": {
+                "approvalPolicyRef": "policy://authority/familiars/charm"
+              }
+            },
+            "runtimeRequirements": {
+              "runtimeId": "coven-code",
+              "capabilities": [
+                "sessions.launch"
+              ]
+            },
+            "policies": {
+              "timeout": {
+                "perRunMinutes": 30
+              },
+              "retry": {
+                "maxAttempts": 3,
+                "backoffPolicy": "exponential",
+                "retryableClasses": [
+                  "transient_dispatch"
+                ]
+              },
+              "concurrency": {
+                "overlap": "forbid"
+              },
+              "misfire": {
+                "disposition": "latest"
+              },
+              "delivery": {
+                "outputTarget": "~/projects/notes/today.md",
+                "mode": "atomic"
+              },
+              "retention": {
+                "occurrenceHistory": {
+                  "classification": "standard"
+                },
+                "runLogs": {
+                  "classification": "standard"
+                },
+                "receipts": {
+                  "classification": "extended"
+                }
+              }
+            },
+            "provenance": {
+              "createdBy": {
+                "principalId": "principal:tim"
+              },
+              "createdAt": "2026-08-30T09:00:00.000Z"
+            },
+            "activation": {
+              "effectiveFrom": "2026-08-30T09:00:00.000Z"
+            },
+            "extensions": {},
+            "integrity": {
+              "algorithm": "sha256",
+              "canonicalization": "jcs-rfc8785",
+              "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "definition-terminal-state-never-regresses",
+      "kind": "stateMachine",
+      "machine": "occurrence.v1",
+      "fromState": "succeeded",
+      "attemptedTransition": {
+        "to": "running",
+        "on": "runtime_started"
+      },
+      "expected": "reject",
+      "reason": "No transition in state-machines.json leaves a terminal state."
+    },
+    {
+      "name": "definition-revision-conflict-commits-nothing",
+      "kind": "adoption",
+      "given": {
+        "automationId": "daily-notes",
+        "currentRevision": 5,
+        "previouslyCommittedAdoptionKeys": [
+          "adopt:create-daily-notes-0001"
+        ]
+      },
+      "command": {
+        "schemaVersion": "coven.automations.v1",
+        "command": "definition.revise.v1",
+        "adoptionKey": "adopt:revise-daily-notes-0002",
+        "expectedRevision": 2,
+        "origin": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "channel": "sdk",
+          "requestedAt": "2026-08-30T09:00:01.000Z"
+        },
+        "intent": {
+          "statement": "Move the daily notes slot to 10:00."
+        },
+        "payload": {
+          "definition": {
+            "schemaVersion": "coven.automations.v1",
+            "automationId": "daily-notes",
+            "revision": 3,
+            "lifecycleState": "active",
+            "display": {
+              "name": "Daily notes",
+              "description": "Write the daily reflection into the notes target.",
+              "tags": [
+                "notes",
+                "daily"
+              ]
+            },
+            "trigger": {
+              "variant": "schedule",
+              "version": 1,
+              "schedule": {
+                "rrule": "FREQ=DAILY;BYHOUR=10",
+                "timezone": "utc"
+              }
+            },
+            "conditions": [],
+            "action": {
+              "variant": "familiarInvocation",
+              "version": 1,
+              "prompt": "Write the daily reflection.",
+              "cwd": "~/projects/notes"
+            },
+            "binding": {
+              "familiarBindingPolicy": "exact",
+              "familiarId": "charm",
+              "authority": {
+                "approvalPolicyRef": "policy://authority/familiars/charm"
+              }
+            },
+            "runtimeRequirements": {
+              "runtimeId": "coven-code",
+              "capabilities": [
+                "sessions.launch"
+              ]
+            },
+            "policies": {
+              "timeout": {
+                "perRunMinutes": 30
+              },
+              "retry": {
+                "maxAttempts": 3,
+                "backoffPolicy": "exponential",
+                "retryableClasses": [
+                  "transient_dispatch"
+                ]
+              },
+              "concurrency": {
+                "overlap": "forbid"
+              },
+              "misfire": {
+                "disposition": "latest"
+              },
+              "delivery": {
+                "outputTarget": "~/projects/notes/today.md",
+                "mode": "atomic"
+              },
+              "retention": {
+                "occurrenceHistory": {
+                  "classification": "standard"
+                },
+                "runLogs": {
+                  "classification": "standard"
+                },
+                "receipts": {
+                  "classification": "extended"
+                }
+              }
+            },
+            "provenance": {
+              "createdBy": {
+                "principalId": "principal:tim"
+              },
+              "createdAt": "2026-08-30T09:00:00.000Z"
+            },
+            "activation": {
+              "effectiveFrom": "2026-08-30T09:00:00.000Z"
+            },
+            "extensions": {},
+            "integrity": {
+              "algorithm": "sha256",
+              "canonicalization": "jcs-rfc8785",
+              "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+            }
+          }
+        }
+      },
+      "expected": "reject",
+      "errorCode": "REVISION_CONFLICT",
+      "httpStatus": 409,
+      "detailsMustInclude": [
+        "currentRevision"
+      ],
+      "reason": "expectedRevision=2 but the definition is currently at revision 5: the handler commits nothing, leaves history untouched, and returns currentRevision=5 in the error details. The payload's revision (3) also exposes a stale-belief write; both mismatch paths resolve to REVISION_CONFLICT."
+    },
+    {
+      "name": "definition-adoption-replay-returns-first-outcome",
+      "kind": "adoption",
+      "given": {
+        "automationId": "daily-notes",
+        "previouslyCommittedAdoptionKeys": {
+          "adopt:create-daily-notes-0001": {
+            "command": "definition.create.v1",
+            "committedAt": "2026-08-30T09:00:00.000Z",
+            "revision": 1
+          }
+        }
+      },
+      "command": {
+        "schemaVersion": "coven.automations.v1",
+        "command": "definition.create.v1",
+        "adoptionKey": "adopt:create-daily-notes-0001",
+        "origin": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "channel": "sdk",
+          "authenticationClass": "devicekey",
+          "requestedAt": "2026-08-30T09:00:00.000Z",
+          "correlationId": "corr-create-0001"
+        },
+        "intent": {
+          "statement": "Create the daily notes routine."
+        },
+        "payload": {
+          "definition": {
+            "schemaVersion": "coven.automations.v1",
+            "automationId": "daily-notes",
+            "revision": 1,
+            "lifecycleState": "active",
+            "display": {
+              "name": "Daily notes",
+              "description": "Write the daily reflection into the notes target.",
+              "tags": [
+                "notes",
+                "daily"
+              ]
+            },
+            "trigger": {
+              "variant": "schedule",
+              "version": 1,
+              "schedule": {
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "utc"
+              }
+            },
+            "conditions": [],
+            "action": {
+              "variant": "familiarInvocation",
+              "version": 1,
+              "prompt": "Write the daily reflection.",
+              "cwd": "~/projects/notes"
+            },
+            "binding": {
+              "familiarBindingPolicy": "exact",
+              "familiarId": "charm",
+              "authority": {
+                "approvalPolicyRef": "policy://authority/familiars/charm"
+              }
+            },
+            "runtimeRequirements": {
+              "runtimeId": "coven-code",
+              "capabilities": [
+                "sessions.launch"
+              ]
+            },
+            "policies": {
+              "timeout": {
+                "perRunMinutes": 30
+              },
+              "retry": {
+                "maxAttempts": 3,
+                "backoffPolicy": "exponential",
+                "retryableClasses": [
+                  "transient_dispatch"
+                ]
+              },
+              "concurrency": {
+                "overlap": "forbid"
+              },
+              "misfire": {
+                "disposition": "latest"
+              },
+              "delivery": {
+                "outputTarget": "~/projects/notes/today.md",
+                "mode": "atomic"
+              },
+              "retention": {
+                "occurrenceHistory": {
+                  "classification": "standard"
+                },
+                "runLogs": {
+                  "classification": "standard"
+                },
+                "receipts": {
+                  "classification": "extended"
+                }
+              }
+            },
+            "provenance": {
+              "createdBy": {
+                "principalId": "principal:tim"
+              },
+              "createdAt": "2026-08-30T09:00:00.000Z"
+            },
+            "activation": {
+              "effectiveFrom": "2026-08-30T09:00:00.000Z"
+            },
+            "extensions": {},
+            "integrity": {
+              "algorithm": "sha256",
+              "canonicalization": "jcs-rfc8785",
+              "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+            }
+          }
+        }
+      },
+      "expected": "replayed",
+      "resultMustEqual": "the result recorded when adoptionKey adopt:create-daily-notes-0001 first committed, including revision 1 and the original eventRef",
+      "reason": "A repeated command with the same adoptionKey is a redelivery: the first committed outcome is returned unchanged and idempotent; no second definition, event, or revision is created."
+    },
+    {
+      "name": "definition-adoption-replay-mismatch-is-a-conflict",
+      "kind": "adoption",
+      "given": {
+        "automationId": "daily-notes",
+        "previouslyCommittedAdoptionKeys": {
+          "adopt:create-daily-notes-0001": {
+            "command": "definition.create.v1",
+            "committedAt": "2026-08-30T09:00:00.000Z",
+            "revision": 1
+          }
+        }
+      },
+      "command": {
+        "schemaVersion": "coven.automations.v1",
+        "command": "definition.create.v1",
+        "adoptionKey": "adopt:create-daily-notes-0001",
+        "origin": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "channel": "sdk",
+          "authenticationClass": "devicekey",
+          "requestedAt": "2026-08-30T09:00:00.000Z",
+          "correlationId": "corr-create-0001"
+        },
+        "intent": {
+          "statement": "Create a different routine under a reused key."
+        },
+        "payload": {
+          "definition": {
+            "schemaVersion": "coven.automations.v1",
+            "automationId": "weekly-notes",
+            "revision": 1,
+            "lifecycleState": "active",
+            "display": {
+              "name": "Daily notes",
+              "description": "Write the daily reflection into the notes target.",
+              "tags": [
+                "notes",
+                "daily"
+              ]
+            },
+            "trigger": {
+              "variant": "schedule",
+              "version": 1,
+              "schedule": {
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "utc"
+              }
+            },
+            "conditions": [],
+            "action": {
+              "variant": "familiarInvocation",
+              "version": 1,
+              "prompt": "Write the daily reflection.",
+              "cwd": "~/projects/notes"
+            },
+            "binding": {
+              "familiarBindingPolicy": "exact",
+              "familiarId": "charm",
+              "authority": {
+                "approvalPolicyRef": "policy://authority/familiars/charm"
+              }
+            },
+            "runtimeRequirements": {
+              "runtimeId": "coven-code",
+              "capabilities": [
+                "sessions.launch"
+              ]
+            },
+            "policies": {
+              "timeout": {
+                "perRunMinutes": 30
+              },
+              "retry": {
+                "maxAttempts": 3,
+                "backoffPolicy": "exponential",
+                "retryableClasses": [
+                  "transient_dispatch"
+                ]
+              },
+              "concurrency": {
+                "overlap": "forbid"
+              },
+              "misfire": {
+                "disposition": "latest"
+              },
+              "delivery": {
+                "outputTarget": "~/projects/notes/today.md",
+                "mode": "atomic"
+              },
+              "retention": {
+                "occurrenceHistory": {
+                  "classification": "standard"
+                },
+                "runLogs": {
+                  "classification": "standard"
+                },
+                "receipts": {
+                  "classification": "extended"
+                }
+              }
+            },
+            "provenance": {
+              "createdBy": {
+                "principalId": "principal:tim"
+              },
+              "createdAt": "2026-08-30T09:00:00.000Z"
+            },
+            "activation": {
+              "effectiveFrom": "2026-08-30T09:00:00.000Z"
+            },
+            "extensions": {},
+            "integrity": {
+              "algorithm": "sha256",
+              "canonicalization": "jcs-rfc8785",
+              "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+            }
+          }
+        }
+      },
+      "expected": "reject",
+      "errorCode": "ADOPTION_REPLAY_MISMATCH",
+      "httpStatus": 409,
+      "detailsMustInclude": [
+        "adoption.conflictOutcome"
+      ],
+      "reason": "Same adoptionKey with a different command/payload is never silently re-executed; the caller learns what the key actually committed."
+    },
+    {
+      "name": "event-golden-valid",
+      "kind": "schema",
+      "targetSchema": "event-envelope.schema.json",
+      "expected": "accept",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtocc05a7c3e9d24b6f8051",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 5,
+        "recordedAt": "2026-08-30T09:00:05.000Z",
+        "observedAt": "2026-08-30T09:00:05.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "occurrence.transitioned",
+        "summary": "occurrence occurrence running -> succeeded",
+        "payload": {
+          "entity": "occurrence",
+          "from": "running",
+          "to": "succeeded",
+          "reason": "run_settled",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      }
+    },
+    {
+      "name": "event-duplicate-delivery-is-ignored",
+      "kind": "changefeed",
+      "stream": {
+        "kind": "occurrence",
+        "id": "daily-notes-1756544400000"
+      },
+      "deliveries": [
+        "event.occurrence.sequence[0]",
+        "event.occurrence.sequence[1]",
+        "event.occurrence.sequence[1]",
+        "event.occurrence.sequence[2]"
+      ],
+      "expected": "read model equals the fold of [0,1,2]; the redelivered eventId at index 2 is recognized and ignored, not re-applied",
+      "reason": "Delivery is at-least-once; consumers deduplicate on eventId."
+    },
+    {
+      "name": "event-out-of-order-is-rejected-not-reordered",
+      "kind": "changefeed",
+      "stream": {
+        "kind": "occurrence",
+        "id": "daily-notes-1756544400000"
+      },
+      "consumerCursor": 2,
+      "deliveries": [
+        "event.occurrence.sequence[1]"
+      ],
+      "expected": "reject",
+      "errorCode": "STREAM_OUT_OF_ORDER",
+      "reason": "sequence 1 is not strictly after the consumer cursor 2; consumers refuse regression against their cursor instead of re-applying history."
+    },
+    {
+      "name": "event-replay-rehydrates-deterministically",
+      "kind": "changefeed",
+      "stream": {
+        "kind": "occurrence",
+        "id": "daily-notes-1756544400000"
+      },
+      "reductions": [
+        {
+          "label": "from-empty",
+          "cursor": -1,
+          "deliveries": "event.occurrence.sequence[0..5]"
+        },
+        {
+          "label": "from-empty-with-duplicate",
+          "cursor": -1,
+          "deliveries": "event.occurrence.sequence[0..5] plus a duplicate of [3]"
+        },
+        {
+          "label": "resume-after-cursor-2",
+          "cursor": 2,
+          "deliveries": "event.occurrence.sequence[3..5]"
+        }
+      ],
+      "expected": "all three reductions yield the identical read model: occurrence state succeeded with eventWindow.lastSequence 5",
+      "reason": "Duplicate delivery and reconnect (checkpoint resume) must rehydrate the same state; the occurrence's eventWindow.firstSequence/lastSequence bound the stream. cursor is the consumer's last applied sequence (-1 = empty); deliveries with sequence <= cursor are already folded."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Specifies the `coven.automations.v1` protocol — schemas, state machines, idempotency, and changefeed — as spec artifacts plus a normative design document. No runtime code changes: schemas, vectors, and docs only.

**Artifacts** (following the `spec/device-pairing/v1` precedent for versioned protocol directories):

- `spec/coven-automations/v1/` — draft 2020-12 JSON Schemas for the five normative objects (`AutomationDefinition`, `AutomationOccurrence`, `AutomationRun`, `AutomationAttempt`, `AutomationReceipt`) with monotonic revisions + RFC 8785 integrity digests, exact-revision pinning, versioned trigger/condition/action unions (v1 executes `schedule` + `familiarInvocation` only), and fail-closed unknown-field behavior through an explicit namespaced extension bag
- `command-envelope.schema.json` — every mutating command (create, revise, activate, pause, disable, tombstone, run now, cancel, retry/recover, plus list/get/history/health, events read/subscribe, legacy import) carries a stable **adoption key** (first-commit-wins replay; `ADOPTION_REPLAY_MISMATCH` on key reuse with a different payload) and **`expectedRevision`** where applicable (`REVISION_CONFLICT` commits nothing). Responses are `committed | replayed | rejected` only — a domain failure can never be wrapped as accepted
- `error-envelope.schema.json` — 20 typed error codes with a frozen HTTP/control-action status mapping
- `event-envelope.schema.json` — versioned changefeed: per-stream gapless sequences, globally unique event ids, causation/idempotency keys, cursor expiry (`CURSOR_EXPIRED`, never a silent rewind), duplicate delivery, out-of-order rejection, compaction snapshots
- `state-machines.json` — authoritative definition/occurrence/run/attempt machines + the ten normative invariants (adoption-before-side-effects, one-fence-one-run, terminal-no-regress, no-evidence-no-success, ambiguous-never-auto-retried, revision-pins-history, …)
- `capabilities.json` — positive + explicit **negative** variant negotiation (unknown variants fail closed with `CAPABILITY_UNSUPPORTED`)
- `compatibility-matrix.json` — machine-readable change classes, per-field status, incompatible-profile refusal
- `test-vectors.json` — golden valid/invalid/unknown-field/downgrade/upgrade/unknown-variant vectors, adoption replay + revision-conflict cases, duplicate and out-of-order event replay; **pinned RFC 8785 (JCS) digests**, self-contained so any draft 2020-12 validator can run them outside the Coven crate
- `coven.automations.v1.d.ts` — pinned TypeScript projection for SDK/Cave canaries
- `docs/architecture/coven-automations-v1.md` — the design document: cites the current #816 code paths for every gap it closes, ratifies lifecycle semantics and the non-destructive #816 migration, maps the corresponding Rust types, and records alternatives considered for the maintainer-owned decisions

## Issue

Refs OpenCoven/coven#855

## Context

- Summary: the `coven.automations.v1` contract published as machine-readable spec artifacts + design doc (above).
- Files changed: 18 files, +5303/−0 — `spec/coven-automations/v1/*` (16 files) and `docs/architecture/coven-automations-v1.md`. No `crates/` or npm code touched.
- Closes: none on this vehicle (fork PR). Refs OpenCoven/coven#855.

## Implementation

- Approach: spec-first. JSON Schemas are the source of truth for every object; state machines, capability negotiation, compatibility classes, and golden vectors are machine-readable siblings; the design doc in `docs/architecture/` is the normative narrative with per-claim code citations and alternatives considered.
- User-visible behavior: none yet — this PR specifies the contract; implementations follow in their own PRs. Clients can already consume the schemas/vectors as pinned artifacts.
- Compatibility notes: additive-only going forward per `compatibility-matrix.json`; unknown profiles/fields/variants fail closed; digests are RFC 8785 (JCS); the #816 migration is non-destructive and pins `definition_json` bytes byte-identically.

## Verification

- [x] All 9 schemas compile under a draft 2020-12 validator (ajv 8, 2020 mode) with cross-file `$ref` resolution
- [x] All 51 golden-vector/state-machine/compat checks pass: 15 schema accept/reject cases, digest pinning re-verified by recomputation (definition + receipt), 4 state machines statically proven (no transition leaves a terminal state, endpoints exist, no dead ends, terminal lists consistent), adoption cases schema-validate, changefeed rehydration deterministic across duplicate delivery and checkpoint resume
- [x] `coven.automations.v1.d.ts` typechecks clean under `tsc --strict`
- [x] Privacy + secret guard rule replica over the changed files: clean
- [ ] `cargo fmt --check` — deferred to CI; no cargo on the authoring host; this PR changes no Rust code, so the rust jobs are expected to classify as skipped
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — deferred to CI (same)
- [ ] `cargo test --workspace --locked` — deferred to CI (same)
- [ ] `python3 scripts/check-secrets.py` — deferred to CI (no python locally; rule replica clean)
- [ ] Additional manual checks: command catalog cross-checked against the issue's required command list (19/19 present); every sibling schema `$ref` target resolves; vector event kinds covered by the envelope enum

## Risk and Rollback

- Risk level: low — docs + spec artifacts only; no runtime code, no schema-of-record changes, no npm/Rust surfaces touched. The CI change classifier treats the JSON as non-docs, so `cargo-deny` may run; it checks unchanged lockfiles and should pass.
- Rollback plan: revert the single commit; no data, store, or wire format depends on these files.

## Agent Handoff

- Current state: draft PR opened in the fork as the CI vehicle; awaiting CI verdict.
- Follow-ups: implement the contract module in `crates/coven-cli/src/automations/` (Rust types mapped in the design doc); wire command handlers behind the existing control actions; SDK/Cave canaries against the pinned artifacts; the P0 bead packet with evidence (schema artifacts, vectors, test commands/results, canaries, migration proof, open decisions).
- Known gaps: cross-repository canaries (SDK, Cave) and Rust round-trip/property tests are implementation-stage work enumerated in `conformance-manifest.json`; they cannot be delivered by a spec-only PR. The bead entry itself is not created here (bead state is out of this task's write scope).

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#855.

> **CI note:** this repository (the CompleteDotTech/coven fork CI vehicle) reported no checks: 0 check-runs and 0 workflow runs on the head SHA after the watch interval, and no workflow is registered on the fork (Actions requires one-time owner activation in the UI; there is no REST endpoint). No CI exists here, so the draft-to-ready gate is vacuous for this vehicle. The checks that would run upstream — policy-guard and cargo-deny (rust and npm jobs classify as skipped for this docs+spec change) — are enumerated in the Verification section and were replicated locally where possible.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/6], preserving source head `abda74eeca3271ff6a69523b62cf00fa27c1718b` and branch `agent/issue-855-p0-specify-coven-automations-v1-schemas`.