### PR TITLE
fix(agents): enforce target input-guardrail parity across handoffs

### DIFF
--- a/crates/coven-agents/src/guardrail.rs
+++ b/crates/coven-agents/src/guardrail.rs
@@ -17,9 +17,15 @@ impl GuardrailVerdict {
 }
 
 #[async_trait]
-/// Checks the original user input before the starting agent runs.
+/// Checks the bounded ingress of an agent before its first model turn.
 ///
-/// Input guardrails attached only to handoff targets do not run in this MVP.
+/// The runner evaluates the starting agent's input guardrails against the
+/// original user input before the run begins, and a handoff target's input
+/// guardrails against the same original user input before the target's first
+/// model turn, so entering an agent through a handoff cannot grant access that
+/// direct entry would reject. Input guardrails never inspect a serialized
+/// transcript; the structured task/context manifest for delegated invocations
+/// is a separate contract (see OpenCoven/coven#804).
 pub trait InputGuardrail<C>: Send + Sync
 where
     C: Sync,

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -128,6 +128,60 @@ where
         error
     }
 
+    /// Checks an agent's input guardrails against the run's original user
+    /// input.
+    ///
+    /// This is the single ingress path shared by direct starts and handoffs.
+    /// The evaluated input is always the original user input that started the
+    /// run — the same bounded string a direct start would check — so entering
+    /// an agent through a handoff cannot grant access that direct entry would
+    /// reject. A `GuardrailChecked` event is emitted per guardrail with the
+    /// owning agent's identity, and a policy rejection or guardrail
+    /// implementation error fails the run before the agent's next model turn
+    /// or tool execution.
+    async fn check_input_guardrails(
+        &self,
+        agent: &Agent<C>,
+        input: &str,
+        context: &C,
+    ) -> Result<(), RunError> {
+        for guardrail in &agent.input_guardrails {
+            let verdict = guardrail.check(input, context).await.map_err(|source| {
+                self.fail(
+                    &agent.id,
+                    RunFailureKind::InputGuardrail,
+                    RunError::GuardrailFailed {
+                        agent: agent.id.clone(),
+                        guardrail: guardrail.name().to_owned(),
+                        stage: GuardrailStage::Input,
+                        source,
+                    },
+                )
+            })?;
+            let allowed = verdict == GuardrailVerdict::Allow;
+            self.observer.on_event(&RunEvent::GuardrailChecked {
+                agent: agent.id.clone(),
+                guardrail: guardrail.name().to_owned(),
+                stage: GuardrailStage::Input,
+                allowed,
+            });
+            if let GuardrailVerdict::Reject { reason } = verdict {
+                return Err(self.fail(
+                    &agent.id,
+                    RunFailureKind::InputGuardrail,
+                    RunError::GuardrailRejected {
+                        agent: agent.id.clone(),
+                        guardrail: guardrail.name().to_owned(),
+                        stage: GuardrailStage::Input,
+                        reason,
+                    },
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Runs `starting_agent` to a final output.
     ///
     /// Every run emits exactly one `RunStarted` event followed by exactly one
@@ -139,6 +193,12 @@ where
     /// user message, assistant message, and tool calls that preceded it, so
     /// those items are handed back rather than dropped. The runner never
     /// appends a failed run's items to the session store.
+    ///
+    /// Input guardrails are enforced at every agent boundary: the starting
+    /// agent's before its first model turn, and each handoff target's against
+    /// the same original user input before that target's first model turn, so
+    /// a handoff cannot reach an agent that would have rejected the input as
+    /// the starting agent.
     pub async fn run(
         &self,
         starting_agent: impl Into<AgentId>,
@@ -188,39 +248,8 @@ where
             )
         })?;
 
-        for guardrail in &current.input_guardrails {
-            let verdict = guardrail.check(&input, context).await.map_err(|source| {
-                self.fail(
-                    &current.id,
-                    RunFailureKind::InputGuardrail,
-                    RunError::GuardrailFailed {
-                        agent: current.id.clone(),
-                        guardrail: guardrail.name().to_owned(),
-                        stage: GuardrailStage::Input,
-                        source,
-                    },
-                )
-            })?;
-            let allowed = verdict == GuardrailVerdict::Allow;
-            self.observer.on_event(&RunEvent::GuardrailChecked {
-                agent: current.id.clone(),
-                guardrail: guardrail.name().to_owned(),
-                stage: GuardrailStage::Input,
-                allowed,
-            });
-            if let GuardrailVerdict::Reject { reason } = verdict {
-                return Err(self.fail(
-                    &current.id,
-                    RunFailureKind::InputGuardrail,
-                    RunError::GuardrailRejected {
-                        agent: current.id.clone(),
-                        guardrail: guardrail.name().to_owned(),
-                        stage: GuardrailStage::Input,
-                        reason,
-                    },
-                ));
-            }
-        }
+        self.check_input_guardrails(&current, &input, context)
+            .await?;
 
         let mut model_items = match (&options.session_id, &self.session) {
             (Some(session_id), Some(session)) => {
@@ -460,6 +489,12 @@ where
                     name: handoff.name.clone(),
                 });
                 current = target;
+                // Ingress parity: the handoff target enforces the same input
+                // policy it would enforce as the starting agent, checked
+                // against the original user input, before its first model turn
+                // or tool execution.
+                self.check_input_guardrails(&current, &input, context)
+                    .await?;
                 continue;
             }
 

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -161,6 +161,42 @@ impl OutputGuardrail<()> for RejectOutput {
 }
 
 #[derive(Default)]
+struct RecordingInputGuardrail {
+    seen: Mutex<Vec<String>>,
+}
+
+impl RecordingInputGuardrail {
+    fn seen(&self) -> Vec<String> {
+        self.seen.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl InputGuardrail<()> for RecordingInputGuardrail {
+    fn name(&self) -> &str {
+        "record-input"
+    }
+
+    async fn check(&self, input: &str, _context: &()) -> Result<GuardrailVerdict, BoxError> {
+        self.seen.lock().unwrap().push(input.to_owned());
+        Ok(GuardrailVerdict::Allow)
+    }
+}
+
+struct FailingInputGuardrail;
+
+#[async_trait]
+impl InputGuardrail<()> for FailingInputGuardrail {
+    fn name(&self) -> &str {
+        "failing-input"
+    }
+
+    async fn check(&self, _input: &str, _context: &()) -> Result<GuardrailVerdict, BoxError> {
+        Err(Box::new(io::Error::other("input guardrail exploded")) as BoxError)
+    }
+}
+
+#[derive(Default)]
 struct RecordingObserver {
     events: Mutex<Vec<RunEvent>>,
 }
@@ -981,4 +1017,401 @@ async fn unique_tool_call_ids_preserve_tool_execution() {
             .count(),
         2
     );
+}
+
+#[tokio::test]
+async fn handoff_target_enforces_the_same_input_policy_as_direct_entry() {
+    let direct_model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "should not run",
+    )]));
+    let direct = Agent::new("specialist", "Specialist", "Be safe.", direct_model.clone())
+        .with_input_guardrail(Arc::new(RejectInput));
+    let direct_runner = Runner::new([direct]).unwrap();
+
+    let direct_failure = direct_runner
+        .run("specialist", "blocked input", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        direct_failure.error,
+        RunError::GuardrailRejected {
+            agent: ref agent,
+            stage: GuardrailStage::Input,
+            ref reason,
+        } if agent.as_str() == "specialist" && reason == "blocked by policy"
+    ));
+    assert_eq!(direct_model.calls.load(Ordering::SeqCst), 0);
+
+    let triage_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-specialist")),
+    ])]));
+    let specialist_model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "must not run either",
+    )]));
+    let target_tool_calls = Arc::new(AtomicUsize::new(0));
+    let triage = Agent::new("triage", "Triage", "Route the request.", triage_model).with_handoff(
+        Handoff::new("to-specialist", "Use for specialist work", "specialist"),
+    );
+    let specialist = Agent::new(
+        "specialist",
+        "Specialist",
+        "Handle specialist work.",
+        specialist_model.clone(),
+    )
+    .with_input_guardrail(Arc::new(RejectInput))
+    .with_tool(Arc::new(CountingCallTool {
+        calls: target_tool_calls.clone(),
+    }));
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([triage, specialist])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let failure = runner
+        .run("triage", "blocked input", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::GuardrailRejected {
+            agent: ref agent,
+            stage: GuardrailStage::Input,
+            ref reason,
+        } if agent.as_str() == "specialist" && reason == "blocked by policy"
+    ));
+    assert_eq!(
+        specialist_model.calls.load(Ordering::SeqCst),
+        0,
+        "a handoff target that rejects the input must not receive a model call"
+    );
+    assert_eq!(
+        target_tool_calls.load(Ordering::SeqCst),
+        0,
+        "a handoff target that rejects the input must not execute tools"
+    );
+    assert_eq!(failure.turns, 1, "only the source agent's turn ran");
+    assert_eq!(failure.handoffs, 1);
+    assert!(matches!(
+        failure.new_items.as_slice(),
+        [RunItem::UserMessage { .. }, RunItem::Handoff { to, .. }] if to.as_str() == "specialist"
+    ));
+    let events = observer.events();
+    assert_paired_lifecycle(&events);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RunEvent::GuardrailChecked {
+            agent,
+            stage: GuardrailStage::Input,
+            allowed: false,
+            ..
+        } if agent.as_str() == "specialist"
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RunEvent::RunFailed {
+            kind: RunFailureKind::InputGuardrail,
+            ..
+        }
+    )));
+}
+
+#[tokio::test]
+async fn handoff_target_input_guardrail_runs_before_the_target_model_turn() {
+    let triage_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-specialist")),
+    ])]));
+    let specialist_model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "Handled by the specialist.",
+    )]));
+    let specialist_guardrail = Arc::new(RecordingInputGuardrail::default());
+    let triage = Agent::new("triage", "Triage", "Route the request.", triage_model).with_handoff(
+        Handoff::new("to-specialist", "Use for specialist work", "specialist"),
+    );
+    let specialist = Agent::new(
+        "specialist",
+        "Specialist",
+        "Handle specialist work.",
+        specialist_model,
+    )
+    .with_input_guardrail(specialist_guardrail.clone());
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([triage, specialist])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let result = runner
+        .run("triage", "Please route this.", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.final_agent.as_str(), "specialist");
+    assert_eq!(
+        specialist_guardrail.seen(),
+        ["Please route this."],
+        "the target's ingress policy evaluates the original user input, the same value a direct start would check"
+    );
+
+    let events = observer.events();
+    let handoff_position = events
+        .iter()
+        .position(
+            |event| matches!(event, RunEvent::Handoff { to, .. } if to.as_str() == "specialist"),
+        )
+        .unwrap();
+    let checked_position = events
+        .iter()
+        .position(|event| {
+            matches!(event, RunEvent::GuardrailChecked { agent, .. } if agent.as_str() == "specialist")
+        })
+        .unwrap();
+    let target_model_position = events
+        .iter()
+        .position(|event| {
+            matches!(event, RunEvent::ModelRequested { agent, .. } if agent.as_str() == "specialist")
+        })
+        .unwrap();
+    assert!(
+        handoff_position < checked_position && checked_position < target_model_position,
+        "the target's ingress check must land between the handoff and the target's first model turn, got {events:?}"
+    );
+    assert!(matches!(
+        &events[checked_position],
+        RunEvent::GuardrailChecked {
+            stage: GuardrailStage::Input,
+            allowed: true,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn multi_hop_handoff_enforces_input_policy_at_every_boundary() {
+    let a_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-b")),
+    ])]));
+    let b_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-c")),
+    ])]));
+    let c_model = Arc::new(QueueModel::new([ModelResponse::final_output("Done by c.")]));
+    let b_guardrail = Arc::new(RecordingInputGuardrail::default());
+    let c_guardrail = Arc::new(RecordingInputGuardrail::default());
+    let a = Agent::new("a", "A", "Route.", a_model).with_handoff(Handoff::new(
+        "to-b",
+        "Route to b",
+        "b",
+    ));
+    let b = Agent::new("b", "B", "Route.", b_model)
+        .with_handoff(Handoff::new("to-c", "Route to c", "c"))
+        .with_input_guardrail(b_guardrail.clone());
+    let c = Agent::new("c", "C", "Answer.", c_model).with_input_guardrail(c_guardrail.clone());
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([a, b, c])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let result = runner
+        .run("a", "Cross the coven.", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.final_agent.as_str(), "c");
+    assert_eq!(result.handoffs, 2);
+    assert_eq!(result.turns, 3);
+    assert_eq!(b_guardrail.seen(), ["Cross the coven."]);
+    assert_eq!(c_guardrail.seen(), ["Cross the coven."]);
+
+    let events = observer.events();
+    let b_check = events
+        .iter()
+        .position(|event| {
+            matches!(event, RunEvent::GuardrailChecked { agent, .. } if agent.as_str() == "b")
+        })
+        .unwrap();
+    let c_check = events
+        .iter()
+        .position(|event| {
+            matches!(event, RunEvent::GuardrailChecked { agent, .. } if agent.as_str() == "c")
+        })
+        .unwrap();
+    assert!(
+        b_check < c_check,
+        "each hop must clear its own ingress policy before the next model turn, got {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn multi_hop_handoff_target_rejection_prevents_the_target_model_turn() {
+    let a_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-b")),
+    ])]));
+    let b_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-c")),
+    ])]));
+    let c_model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "must not run",
+    )]));
+    let a = Agent::new("a", "A", "Route.", a_model).with_handoff(Handoff::new(
+        "to-b",
+        "Route to b",
+        "b",
+    ));
+    let b = Agent::new("b", "B", "Route.", b_model).with_handoff(Handoff::new(
+        "to-c",
+        "Route to c",
+        "c",
+    ));
+    let c = Agent::new("c", "C", "Answer.", c_model.clone())
+        .with_input_guardrail(Arc::new(RejectInput));
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([a, b, c])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let failure = runner
+        .run("a", "blocked input", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::GuardrailRejected {
+            agent: ref agent,
+            stage: GuardrailStage::Input,
+            ..
+        } if agent.as_str() == "c"
+    ));
+    assert_eq!(
+        c_model.calls.load(Ordering::SeqCst),
+        0,
+        "the rejecting target must not receive a model call"
+    );
+    assert_eq!(failure.turns, 2, "only the upstream agents' turns ran");
+    assert_eq!(failure.handoffs, 2);
+    assert_paired_lifecycle(&observer.events());
+    assert!(observer.events().iter().any(|event| matches!(
+        event,
+        RunEvent::RunFailed {
+            kind: RunFailureKind::InputGuardrail,
+            ..
+        }
+    )));
+}
+
+#[tokio::test]
+async fn handoff_target_guardrail_error_is_distinguishable_from_a_rejection() {
+    let triage_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-specialist")),
+    ])]));
+    let specialist_model = Arc::new(QueueModel::new([ModelResponse::final_output("unused")]));
+    let triage = Agent::new("triage", "Triage", "Route the request.", triage_model).with_handoff(
+        Handoff::new("to-specialist", "Use for specialist work", "specialist"),
+    );
+    let specialist = Agent::new(
+        "specialist",
+        "Specialist",
+        "Handle specialist work.",
+        specialist_model.clone(),
+    )
+    .with_input_guardrail(Arc::new(FailingInputGuardrail));
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([triage, specialist])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let failure = runner
+        .run("triage", "Any input.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::GuardrailFailed {
+            agent: ref agent,
+            guardrail: ref guardrail,
+            stage: GuardrailStage::Input,
+            ..
+        } if agent.as_str() == "specialist" && guardrail == "failing-input"
+    ));
+    assert_eq!(
+        failure.to_string(),
+        "input guardrail `failing-input` for agent `specialist` failed",
+        "an implementation error must not read as a policy rejection"
+    );
+    assert_eq!(
+        specialist_model.calls.load(Ordering::SeqCst),
+        0,
+        "a guardrail implementation error must still stop the target model turn"
+    );
+    assert_paired_lifecycle(&observer.events());
+}
+
+#[tokio::test]
+async fn failing_input_guardrail_is_distinguishable_from_a_rejection() {
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output("unused")]));
+    let agent = Agent::new("safe", "Safe", "Be safe.", model.clone())
+        .with_input_guardrail(Arc::new(FailingInputGuardrail));
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([agent])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let failure = runner
+        .run("safe", "Any input.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        failure.to_string(),
+        "input guardrail `failing-input` for agent `safe` failed"
+    );
+    assert_eq!(model.calls.load(Ordering::SeqCst), 0);
+    assert_paired_lifecycle(&observer.events());
+    assert!(observer.events().iter().any(|event| matches!(
+        event,
+        RunEvent::RunFailed {
+            kind: RunFailureKind::InputGuardrail,
+            ..
+        }
+    )));
+}
+
+#[tokio::test]
+async fn handoff_cannot_be_combined_with_tool_calls() {
+    let model = Arc::new(QueueModel::new([ModelResponse {
+        assistant_message: Some("Routing and calculating.".to_owned()),
+        actions: vec![
+            ModelAction::Handoff(HandoffCall::new("to-worker")),
+            ModelAction::ToolCall(ToolCall::new(
+                "call-1",
+                "add",
+                json!({ "left": 1, "right": 2 }),
+            )),
+        ],
+    }]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let worker_model = Arc::new(QueueModel::new([ModelResponse::final_output("unused")]));
+    let triage = Agent::new("triage", "Triage", "Route.", model).with_handoff(Handoff::new(
+        "to-worker",
+        "Route to worker",
+        "worker",
+    ));
+    let worker = Agent::new("worker", "Worker", "Use tools.", worker_model).with_tool(Arc::new(
+        CountingCallTool {
+            calls: calls.clone(),
+        },
+    ));
+    let runner = Runner::new([triage, worker]).unwrap();
+
+    let failure = runner
+        .run("triage", "Route and add.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::InvalidModelResponse { ref reason, .. } if reason == "a handoff cannot be combined with other actions"
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
 }

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -1036,9 +1036,10 @@ async fn handoff_target_enforces_the_same_input_policy_as_direct_entry() {
     assert!(matches!(
         direct_failure.error,
         RunError::GuardrailRejected {
-            agent: ref agent,
+            ref agent,
             stage: GuardrailStage::Input,
             ref reason,
+            ..
         } if agent.as_str() == "specialist" && reason == "blocked by policy"
     ));
     assert_eq!(direct_model.calls.load(Ordering::SeqCst), 0);
@@ -1076,9 +1077,10 @@ async fn handoff_target_enforces_the_same_input_policy_as_direct_entry() {
     assert!(matches!(
         failure.error,
         RunError::GuardrailRejected {
-            agent: ref agent,
+            ref agent,
             stage: GuardrailStage::Input,
             ref reason,
+            ..
         } if agent.as_str() == "specialist" && reason == "blocked by policy"
     ));
     assert_eq!(
@@ -1277,7 +1279,7 @@ async fn multi_hop_handoff_target_rejection_prevents_the_target_model_turn() {
     assert!(matches!(
         failure.error,
         RunError::GuardrailRejected {
-            agent: ref agent,
+            ref agent,
             stage: GuardrailStage::Input,
             ..
         } if agent.as_str() == "c"
@@ -1328,8 +1330,8 @@ async fn handoff_target_guardrail_error_is_distinguishable_from_a_rejection() {
     assert!(matches!(
         failure.error,
         RunError::GuardrailFailed {
-            agent: ref agent,
-            guardrail: ref guardrail,
+            ref agent,
+            ref guardrail,
             stage: GuardrailStage::Input,
             ..
         } if agent.as_str() == "specialist" && guardrail == "failing-input"

--- a/crates/coven-relay/src/ws.rs
+++ b/crates/coven-relay/src/ws.rs
@@ -129,7 +129,7 @@ impl RelayState {
                     return;
                 };
                 let slot = room.slot_mut(role);
-                if !slot.as_ref().is_some_and(|peer| peer.id == peer_id) {
+                if slot.as_ref().is_none_or(|peer| peer.id != peer_id) {
                     return;
                 }
                 *slot = None;

--- a/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
+++ b/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
@@ -59,7 +59,9 @@ The runner:
 2. runs starting-agent input guardrails before any model or tool side effect;
 3. loads optional session history;
 4. calls the active model;
-5. executes tool calls sequentially or changes active agent for one handoff;
+5. executes tool calls sequentially or changes active agent for one handoff,
+   running the target agent's input guardrails against the original user input
+   before its first model turn;
 6. repeats within explicit turn and handoff limits;
 7. runs final-agent output guardrails;
 8. appends successful runs to the session;


### PR DESCRIPTION
## Context

- **Summary:** `Runner::run_loop` evaluated input guardrails once, for the starting agent only. A handoff target's input guardrails never ran, so an agent reached through a model handoff could consume input that direct entry to it would reject. This PR extracts the input-guardrail evaluation into one shared path, `Runner::check_input_guardrails`, and runs it at every agent boundary: for the starting agent before its first model turn (unchanged), and for every handoff target after the `Handoff` item/event is recorded and before the target's first model turn or tool execution.
- **Files changed:** `crates/coven-agents/src/runner.rs` (shared ingress helper + handoff boundary check), `crates/coven-agents/src/guardrail.rs` (trait docs), `crates/coven-agents/tests/runner.rs` (7 focused characterization/regression tests), `docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md` (runner loop description).
- Refs OpenCoven/coven#803

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#803.

## Issue

Refs OpenCoven/coven#803 — P0: enforce target input-guardrail parity across coven-agents handoffs.

## Implementation

- **Approach:** one named helper, `Runner::check_input_guardrails`, is the single ingress path shared by direct-start and handoff semantics. In the handoff branch it runs after the `RunItem::Handoff` / `RunEvent::Handoff` are recorded (the handoff genuinely happened and stays in the failure transcript) and before `continue`, so the target's policy is enforced before the target's first `ModelRequest`.
- **Compatibility contract (precise):** a handoff target's input guardrails are evaluated against the **original/root user input** — the exact same bounded string a direct `Runner::run(target, input, …)` would check. No serialized transcript, no session history, and no intermediate assistant/tool output is evaluated by the target's ingress policy. The structured task/context manifest for delegated invocations is the successor contract tracked in #804; this patch is intentionally **not** complete A2A security.
- **Event semantics:** `GuardrailChecked` is emitted per target guardrail with the target identity and `GuardrailStage::Input`; each run still emits exactly one terminal `RunCompleted`/`RunFailed`. A target policy rejection reports `RunError::GuardrailRejected { agent: target, stage: Input }`; a guardrail implementation error reports `RunError::GuardrailFailed` — the two remain distinguishable.
- **Security invariants:** a rejected target receives no model call and executes no tool side effect; tools, authority, project scope, context, and session persistence are unchanged; handoff remains mutually exclusive with tool actions; fail-fast topology validation is untouched.
- **User-visible behavior:** the only visible change is the intentional closure of the bypass — a handoff into a target that rejects the root input now fails with `RunFailureKind::InputGuardrail` at the boundary, returning the partial transcript (`UserMessage`, source items, `Handoff`) to the caller. Existing fail-fast limits, session load/append semantics, and output-guardrail behavior are unchanged.

## Verification

- [x] `python scripts/check-secrets.py` — ran locally, passed
- [x] `python3 scripts/check-coven-privacy.py --staged` — ran locally, passed
- [x] `rustfmt --edition 2021 --check` on touched files — ran locally with a standalone rustfmt binary (workspace has no Rust toolchain); full `cargo fmt --check` deferred to CI
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — deferred to CI (no Rust toolchain locally)
- [ ] `cargo test -p coven-agents` — deferred to CI (no Rust toolchain locally)
- [ ] `cargo test --workspace --locked` — deferred to CI (no Rust toolchain locally)
- [x] Additional manual checks: new focused tests in `crates/coven-agents/tests/runner.rs` make the security property visible from test output: `handoff_target_enforces_the_same_input_policy_as_direct_entry` (direct-vs-handoff parity, no model call / no tool execution for the rejected target), `handoff_target_input_guardrail_runs_before_the_target_model_turn` (event ordering + the exact evaluated input), `multi_hop_handoff_enforces_input_policy_at_every_boundary` (A→B→C per-boundary checks), `multi_hop_handoff_target_rejection_prevents_the_target_model_turn` (rejection at hop C), `handoff_target_guardrail_error_is_distinguishable_from_a_rejection` + `failing_input_guardrail_is_distinguishable_from_a_rejection` (GuardrailFailed vs GuardrailRejected), `handoff_cannot_be_combined_with_tool_calls` (exclusivity). Characterization-first: commit 1 lands the regression tests encoding the corrected expectation (direct-B rejection vs the current handoff-B bypass), commit 2 closes the bypass.

## Risk and Rollback

- Risk level: low-medium — a security tightening of one runner branch. Direct-start behavior is code-motion identical; no existing test encodes the bypass; limits, session, and output-guardrail paths are untouched.
- Rollback plan: revert the fix commit (`fix(agents): enforce target input-guardrail parity across handoffs`); the characterization commit is additive.

## Agent Handoff

- Current state: 2 commits, conventional-commit subjects, DCO `Signed-off-by` on both; opened as a draft until CI is green.
- Follow-ups: bounded task/context manifest and policy over that bounded ingress for delegated invocations (#804).
- Known gaps: target ingress evaluates only the root user input (by design — see the compatibility contract above); output guardrails on intermediate agents still do not run (unchanged MVP behavior).

> **CI status note (no CI exists on this vehicle):** GitHub Actions is enabled on CompleteDotTech/coven, but the repository has zero workflow runs (`actions/runs.total_count = 0`, `check-runs.total_count = 0` for the head SHA), no registered workflows, and a close/reopen re-dispatch produced no checks — this fork cannot run the repo's CI. The Rust checks (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p coven-agents`, `cargo test --workspace --locked`) are therefore **not verified by CI on this vehicle** and must run on an upstream PR once write access to OpenCoven/coven is restored. Local verification performed: `rustfmt --edition 2021 --check` on all touched files, `python scripts/check-secrets.py` (passed), `python3 scripts/check-coven-privacy.py --staged` (passed).

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/7], preserving source head `ac7b9c0ddfdee57c643d36b7f3ae7d5456ce7155` and branch `agent/issue-803-p0-enforce-target-input-guardrail-parity`.