### PR TITLE
docs(cli): document the deterministic JSON help contract

### DIFF
--- a/docs/development/cli-core-functionality.md
+++ b/docs/development/cli-core-functionality.md
@@ -46,6 +46,43 @@ Progressive help is part of that parser contract:
 - `coven help <command>` should stay equivalent in useful content to `coven <command> --help`.
 - Hidden/internal entrypoints such as `process-supervisor` and `coven daemon serve` stay absent from the public help surfaces and JSON catalog.
 
+## JSON help contract
+
+`coven help --all --json` prints the public command catalog as a single deterministic JSON document on stdout. Automation parses this document instead of scraping human help output. The example below is abbreviated; the real document lists every public command across all six groups.
+
+```json
+{
+  "schemaVersion": 1,
+  "groups": [
+    {
+      "id": "start-and-launch",
+      "title": "Start and launch",
+      "commands": [
+        {
+          "name": "doctor",
+          "summary": "Check local setup and print next steps (exits 1 when a blocking problem is found)",
+          "docsUrl": "https://docs.opencoven.ai/docs/cli/doctor"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The contract to preserve:
+
+- `schemaVersion` is a number, currently `1`. The key set of a given schema version is exact: no missing fields and no extras. Changing the shape or field semantics means shipping a new schema version, not mutating this one.
+- `groups` is a non-empty array. Group ids are lowercase kebab-case and fixed in this order: `start-and-launch`, `configure-and-extend`, `session-lifecycle`, `observe-your-coven`, `coordinate-parallel-work`, `repair-and-administer`.
+- Each command carries a kebab-case `name`, a one-line `summary`, and an absolute `docsUrl` on the stable `https://docs.opencoven.ai/docs/` origin with no query parameters and a lowercase kebab-case fragment when one is present.
+- Output is byte-identical across runs and machines: fixed group and command ordering, no ANSI escapes even under `--color=always`, no machine-specific paths, and no dependence on locale, clock, or environment. stderr stays empty on success.
+- Coverage is complete and leak-free: every public top-level command appears exactly once, and internal entrypoints such as `process-supervisor` and `coven daemon serve` never appear.
+
+Drift fails loudly instead of silently: `crates/coven-cli/src/help.rs` errors at render time when a public command lacks catalog metadata or when the catalog names an unknown command, so adding, renaming, or hiding a public command requires updating `HELP_GROUPS` in the same change. `scripts/export-cli-help-contract.mjs` validates a catalog snapshot's shape, leak checks, and URL constraints from a built binary, which keeps packaged consumers and CI honest:
+
+```sh
+node scripts/export-cli-help-contract.mjs --binary target/debug/coven --output help-contract.json
+```
+
 ## Access paths developers should exercise
 
 Run these from a clean, representative project directory. They are ordered from read-only inspection to daemon activation; the final launch is intentionally opt-in.

--- a/docs/guides/automation-json.md
+++ b/docs/guides/automation-json.md
@@ -45,6 +45,14 @@ coven sessions --json | jq '.sessions[] | { id, harness, status, title }'
 
 Use `coven sessions --all --json` only when archived history is relevant. Treat ids as opaque strings and do not record session titles or event content in public logs without a privacy review.
 
+## Discover the command inventory without scraping help
+
+```sh
+coven help --all --json | jq -r '.groups[] | .title, (.commands[] | "  \(.name)  \(.summary)")'
+```
+
+The catalog is a deterministic, versioned JSON contract (`schemaVersion: 1`): fixed ordering, no ANSI escapes, and one entry per public command. Parse it instead of scraping `--help` output, and gate on `schemaVersion` before trusting new fields. The full field reference lives in the [developer core-functionality guide](/development/cli-core-functionality).
+
 ## Pick the right integration boundary
 
 - Use the CLI JSON commands for local shell automation and maintainer checks.

--- a/scripts/cli-docs-test.mjs
+++ b/scripts/cli-docs-test.mjs
@@ -5,7 +5,16 @@ import test from 'node:test';
 const coreGuideDocs = [
   {
     path: 'docs/development/cli-core-functionality.md',
-    required: ['Command ownership', 'Access contract', 'coven doctor --json', 'coven daemon status --json']
+    required: [
+      'Command ownership',
+      'Access contract',
+      'coven doctor --json',
+      'coven daemon status --json',
+      'coven help --all --json',
+      '"schemaVersion": 1',
+      'docsUrl',
+      'scripts/export-cli-help-contract.mjs'
+    ]
   },
   {
     path: 'docs/guides/index.md',
@@ -21,7 +30,7 @@ const coreGuideDocs = [
   },
   {
     path: 'docs/guides/automation-json.md',
-    required: ['coven doctor --json', 'coven daemon status --json', 'coven sessions --json']
+    required: ['coven doctor --json', 'coven daemon status --json', 'coven sessions --json', 'coven help --all --json', 'schemaVersion']
   },
   {
     path: 'docs/guides/multi-agent-worktrees.md',


### PR DESCRIPTION
## Context

- Summary: Documents the deterministic JSON help contract (`coven help --all --json`) that #834 shipped, and guards the contract documentation in the CLI docs discovery test.
- Files changed: `docs/development/cli-core-functionality.md` (+37), `docs/guides/automation-json.md` (+8), `scripts/cli-docs-test.mjs` (+11/−2)

## Issue

Refs OpenCoven/coven#774

Issue #774 ("feat(cli): add progressive help disclosure and help contract") asks for three things: make default help concise, preserve all commands through a complete grouped view, and expose a deterministic JSON help contract. The executable side of that scope is already on `main` via #834 (concise curated `coven --help`, grouped `coven help --all` inventory, the `coven help --all --json` contract, `scripts/export-cli-help-contract.mjs`, and `crates/coven-cli/tests/help_disclosure.rs`), but the contract itself was documented nowhere, so automation had no stable field reference. This PR completes that remaining "expose" requirement. No Rust code changes are needed or included.

## Implementation

- Approach: add a "JSON help contract" section to `docs/development/cli-core-functionality.md` covering the `schemaVersion: 1` payload shape, fixed group ordering, `docsUrl` constraints, byte-identical output guarantees, leak-free coverage, and the drift-fails-loudly rule enforced by `crates/coven-cli/src/help.rs`; surface the catalog to script authors in `docs/guides/automation-json.md`; extend `scripts/cli-docs-test.mjs` so the docs guard fails when the contract documentation regresses.
- User-visible behavior: none at runtime; documentation and docs-guard only.
- Compatibility notes: docs plus one test script; no runtime, API, or packaging changes. CI classification routes this to the npm/docs surface (no Rust lane).

## Test plan

Ran locally (node v24, no Rust toolchain in the authoring environment):

- [x] `node --test scripts/cli-docs-test.mjs` (7 pass)
- [x] `node --test scripts/export-cli-help-contract-test.mjs` (8 pass)
- [x] `node scripts/onboarding-docs-test.mjs`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged` (3 staged files)
- [x] `git diff --check`

Deferred to CI:

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace --locked` (exercises the untouched `crates/coven-cli/tests/help_disclosure.rs`)
- [ ] `npm onboarding smoke` lanes (ubuntu/windows) that build the CLI and run `scripts/test-cli-prepublish.mjs` (which includes `cli-docs-test.mjs` and `export-cli-help-contract-test.mjs`)

## Risk and Rollback

- Risk level: low. Documentation and a test-guard extension only; no executable code paths change.
- Rollback plan: revert the single commit.

## Agent Handoff

- Current state: one signed commit, `docs(cli): document the deterministic JSON help contract`, on `agent/issue-774-feat-cli-add-progressive-help-disclosure` (base `OpenCoven:main` at `1364cec`).
- Follow-ups: none for this slice; #774's broader acceptance tracking lives under umbrella #670.
- Known gaps: the contract doc describes the schema enforced by the test suite; a checked-in snapshot artifact was deliberately not added because generating one requires a built binary.

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#774.

> **CI note:** treated as a checkless PR per the CI contract: more than 10 minutes after opening, this PR head (`8095b52`) has zero check runs and zero workflow runs in `CompleteDotTech/coven` (Actions enabled on the fork, `pull_request` trigger present in `.github/workflows/ci.yml`, and the fork has no Actions run history at all). No CI verdict is claimed; the checked local checks above are the only executed validation, and the Rust compile proof remains deferred to the upstream re-target.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/9], preserving source head `8095b5232643779f129ea07e582e978cac186772` and branch `agent/issue-774-feat-cli-add-progressive-help-disclosure`.