### PR TITLE
feat(automations): truthful run settlement and output delivery (coven#816, part 9)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -575,7 +575,8 @@ pub(crate) fn handle_request_with_runtime_and_authority(
                     );
                 }
             };
-            let (status, response) = control_plane::route_action(payload, &conn, runtime);
+            let (status, response) =
+                control_plane::route_action(payload, coven_home, &conn, runtime);
             json_response(status, &response)
         }
         ("POST", "/cast") => submit_cast(coven_home, body, runtime),
@@ -2106,7 +2107,6 @@ fn launch_session(
     // up, i.e. a child binding — an unbound or root-bound launch must not
     // create any store side effect ahead of the maintenance gate below, per
     // the existing maintenance-before-store-open precedence (§5.1).
-    let mut opened_conn: Option<rusqlite::Connection> = None;
     if let Some(binding) = execution_binding.as_ref() {
         let Some(familiar) = familiar_ctx.as_ref() else {
             return api_error(
@@ -2139,7 +2139,6 @@ fn launch_session(
             {
                 return Ok(response);
             }
-            opened_conn = Some(conn);
             // Test-only failpoint (issue #728 BLOCKER 1, final review): a
             // no-op in every non-test build. Deterministic concurrency tests
             // hook this to run a real concurrent write — e.g. sacrificing
@@ -2152,6 +2151,93 @@ fn launch_session(
             parent_correlation_advisory_check_completed_failpoint();
         }
     }
+    // The shared durable-launch primitive (coven#816): every launch —
+    // interactive `/sessions` and automation runs alike — persists the
+    // session row before spawn, and a runtime rejection terminally settles
+    // that row to `failed`.
+    let durable = DurableLaunch {
+        familiar_id: familiar_ctx.as_ref().map(|familiar| familiar.id.clone()),
+        execution_binding,
+        raw_caller_familiar_id: raw_caller_familiar_id.as_str(),
+    };
+    let record = match launch_session_durable(coven_home, &launch, durable, runtime) {
+        Ok(record) => record,
+        Err(DurableLaunchError::MaintenanceGate {
+            status,
+            code,
+            message,
+            session_id,
+            owner,
+        }) => {
+            let mut details = json!({ "sessionId": session_id });
+            if let Some(owner) = owner {
+                details["owner"] = json!(owner);
+            }
+            return api_error(status, code, &message, Some(details));
+        }
+        Err(DurableLaunchError::Rejected(response)) => return Ok(response),
+        Err(DurableLaunchError::Store(error)) => return Err(error),
+        Err(DurableLaunchError::LaunchRejected {
+            session_id,
+            message,
+        }) => {
+            return api_error(
+                500,
+                "launch_failed",
+                &message,
+                Some(json!({ "sessionId": session_id })),
+            );
+        }
+    };
+    json_response(201, &record)
+}
+
+/// The caller-specific durable-launch inputs each entry route resolves
+/// before the shared primitive runs. Automation runs resolve the familiar
+/// the definition pins; `/sessions` additionally resolves execution
+/// bindings and their raw caller identity.
+pub(crate) struct DurableLaunch<'a> {
+    pub familiar_id: Option<String>,
+    pub execution_binding: Option<crate::execution_binding::ExecutionBinding>,
+    pub raw_caller_familiar_id: Option<&'a str>,
+}
+
+/// The durable-launch failure modes. `MaintenanceGate` and `Rejected` mean
+/// nothing durable was written; `LaunchRejected` means the session row
+/// exists and has already been terminally settled to `failed`.
+pub(crate) enum DurableLaunchError {
+    /// The maintenance gate refused the launch before any row was written.
+    MaintenanceGate {
+        status: u16,
+        code: &'static str,
+        message: String,
+        session_id: String,
+        owner: Option<String>,
+    },
+    /// A request-level rejection surfaced after the gate (child/parent
+    /// correlation for bound launches): carries the structured response.
+    Rejected(ApiResponse),
+    /// The store could not be opened or the durable row could not be
+    /// written; nothing durable was created.
+    Store(anyhow::Error),
+    /// The runtime rejected the launch after the durable row existed; the
+    /// row has been terminally settled to `failed` unless a concurrent
+    /// terminal transition (kill/cancel) had already won that row.
+    LaunchRejected { session_id: String, message: String },
+}
+
+/// The one durable session-launch primitive shared by `POST /sessions` and
+/// automation run dispatch (coven#816 finding 1). Persists the session row
+/// before spawn, spawns through the caller's runtime, and terminally
+/// settles the row when the runtime rejects the launch — so every launch
+/// failure is durable and visible, and no launch bypasses the maintenance
+/// gate or familiar admission that `/sessions` applies.
+pub(crate) fn launch_session_durable(
+    coven_home: &Path,
+    launch: &SessionLaunch,
+    durable: DurableLaunch<'_>,
+    runtime: &dyn SessionRuntime,
+) -> Result<crate::store::SessionRecord, DurableLaunchError> {
     let writer = match crate::maintenance_gate::MaintenanceGate::discover_optional(Path::new(
         &launch.project_root,
     ))
@@ -2164,21 +2250,20 @@ fn launch_session(
         Ok(writer) => writer,
         Err(error) => {
             let gate_error = error.downcast_ref::<crate::maintenance_gate::GateError>();
-            let (code, details) = match gate_error {
-                Some(crate::maintenance_gate::GateError::OwnerHeld(owner)) => (
-                    "maintenance_locked",
-                    Some(json!({ "owner": owner, "sessionId": launch.id })),
-                ),
-                Some(_) => (
-                    "maintenance_state_invalid",
-                    Some(json!({ "sessionId": launch.id })),
-                ),
-                None => (
-                    "maintenance_gate_unavailable",
-                    Some(json!({ "sessionId": launch.id })),
-                ),
+            let (code, owner) = match gate_error {
+                Some(crate::maintenance_gate::GateError::OwnerHeld(owner)) => {
+                    ("maintenance_locked", Some(owner.owner_id.clone()))
+                }
+                Some(_) => ("maintenance_state_invalid", None),
+                None => ("maintenance_gate_unavailable", None),
             };
-            return api_error(423, code, &error.to_string(), details);
+            return Err(DurableLaunchError::MaintenanceGate {
+                status: 423,
+                code,
+                message: error.to_string(),
+                session_id: launch.id.clone(),
+                owner,
+            });
         }
     };
     let now = current_timestamp();
@@ -2190,21 +2275,15 @@ fn launch_session(
         status: "running".to_string(),
         now,
         conversation_id: launch.conversation_id.clone(),
-        familiar_id: familiar_ctx.as_ref().map(|familiar| familiar.id.clone()),
-        execution_binding,
+        familiar_id: durable.familiar_id,
+        execution_binding: durable.execution_binding,
         labels: Vec::new(),
         visibility: None,
     });
-    // Reuse the connection opened for a child binding's parent lookup, if
-    // any; otherwise open (and thereby initialize) the store only now, after
-    // the maintenance gate has already admitted this launch. Root/unbound
-    // launches take the `None` arm here and below, preserving the existing
-    // maintenance-before-store-open precedence unchanged: no parent to
-    // revalidate means no reason to pay for a transaction.
-    let mut conn = match opened_conn {
-        Some(conn) => conn,
-        None => store::open_store(&store_path(coven_home))?,
-    };
+    // Open (and thereby initialize) the store only now, after the
+    // maintenance gate has already admitted this launch, preserving the
+    // existing maintenance-before-store-open precedence (§5.1).
+    let mut conn = store::open_store(&store_path(coven_home)).map_err(DurableLaunchError::Store)?;
     match record
         .execution_binding
         .as_ref()
@@ -2220,46 +2299,49 @@ fn launch_session(
             // admission a single atomic unit against concurrent writers,
             // with no persistent FK/uniqueness constraint added to the
             // schema.
-            let caller_familiar_id = raw_caller_familiar_id.as_str();
-            let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-            if let Err(response) = correlate_child_parent(&tx, parent, caller_familiar_id)? {
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .map_err(|error| DurableLaunchError::Store(error.into()))?;
+            let correlated = correlate_child_parent(&tx, parent, durable.raw_caller_familiar_id)
+                .map_err(DurableLaunchError::Store)?;
+            if let Err(response) = correlated {
                 // Dropping `tx` without calling `commit()` rolls it back:
                 // no child row is ever inserted on a revalidation failure.
-                return Ok(response);
+                return Err(DurableLaunchError::Rejected(response));
             }
-            store::insert_session(&tx, &record)?;
-            tx.commit()?;
+            store::insert_session(&tx, &record).map_err(DurableLaunchError::Store)?;
+            tx.commit()
+                .map_err(|error| DurableLaunchError::Store(error.into()))?;
         }
         None => {
-            store::insert_session(&conn, &record)?;
+            store::insert_session(&conn, &record).map_err(DurableLaunchError::Store)?;
         }
     }
     if let Err(error) = match writer {
-        Some(writer) => runtime.launch_session_with_writer(&launch, writer),
-        None => runtime.launch_session(&launch),
+        Some(writer) => runtime.launch_session_with_writer(launch, writer),
+        None => runtime.launch_session(launch),
     } {
         // Don't propagate to the accept loop — that crashes the daemon.
         // Runtime launch failures are user-facing (missing harness CLI,
         // missing auth, child closed stdin during stream-mode init):
-        // mark the session row failed and return a structured response
-        // so the client surfaces the cause and the daemon stays up.
+        // mark the session row failed so the failure is durable and the
+        // caller surfaces the cause.
         // Cancellation can win while a large launch-time stdin prompt is
         // still being delivered. Preserve that terminal decision: only a row
         // that is still owned by the failing launch may transition to failed.
-        let _ = store::update_session_status_if_current(
+        store::update_session_status_if_current(
             &conn,
             &record.id,
             "running",
             "failed",
             None,
             &current_timestamp(),
-        )?;
-        return api_error(
-            500,
-            "launch_failed",
-            &error.to_string(),
-            Some(json!({ "sessionId": record.id })),
-        );
+        )
+        .map_err(DurableLaunchError::Store)?;
+        return Err(DurableLaunchError::LaunchRejected {
+            session_id: record.id,
+            message: error.to_string(),
+        });
     }
     // Record the inter-familiar delegation in cave-coven-calls.json so the
     // Coven Calls graph in coven-cave has data to render. Best-effort: a
@@ -2275,7 +2357,7 @@ fn launch_session(
             eprintln!("[coven-calls] warn: failed to record delegation: {_err}");
         }
     }
-    json_response(201, &record)
+    Ok(record)
 }
 
 fn validate_adopted_launch_structure(payload: &Value) -> Result<()> {
@@ -10748,6 +10830,12 @@ mod tests {
     #[test]
     fn control_action_runs_a_routine_through_the_ledger() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
+        // Run-now dispatch resolves the familiar through the shared
+        // admission path (coven#816 finding 1), so the roster must exist.
+        std::fs::write(
+            temp_dir.path().join("familiars.toml"),
+            "[[familiar]]\nid = \"charm\"\ndisplay_name = \"Charm\"\nrole = \"Code\"\ndescription = \"Does the thing.\"\n",
+        )?;
         let create_body = json!({
             "action": "coven.automations.create",
             "definition": {
@@ -10813,26 +10901,13 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        crate::store::insert_session(
-            &conn,
-            &crate::store::SessionRecord {
-                id: session_id,
-                project_root: "/work/project".to_string(),
-                harness: "coven-code".to_string(),
-                title: "Daily notes".to_string(),
-                status: "completed".to_string(),
-                exit_code: Some(0),
-                archived_at: None,
-                created_at: "2026-08-28T09:00:00Z".to_string(),
-                updated_at: "2026-08-28T09:05:00Z".to_string(),
-                conversation_id: None,
-                familiar_id: Some("charm".to_string()),
-                execution_binding: None,
-                labels: Vec::new(),
-                visibility: "private".to_string(),
-                external: false,
-                transcript_path: None,
-            },
+        // The durable launch primitive persisted the session row before
+        // spawn (coven#816 finding 1); the PTY writer only flips it
+        // terminal.
+        conn.execute(
+            "UPDATE sessions SET status = 'completed', exit_code = 0,
+                    updated_at = '2026-08-28T09:05:00Z' WHERE id = ?1",
+            rusqlite::params![session_id],
         )
         .unwrap();
         drop(conn);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -10789,13 +10789,65 @@ mod tests {
             Some(&run_body),
         )?;
         assert_eq!(response.status, 200);
+        // Run-now dispatches through the shared launch path and leaves the
+        // run in flight; the ledger settles from the session store.
         assert!(
-            response.body.contains(r#""status":"succeeded""#),
+            response.body.contains(r#""status":"dispatched""#),
             "{}",
             response.body
         );
         assert!(
             response.body.contains(r#""sessionId":"session-"#),
+            "{}",
+            response.body
+        );
+
+        // The dispatched session then finishes (as the PTY writer would
+        // record); the automations tick settles the ledger from the session
+        // store.
+        let conn = crate::store::open_store(&store_path(temp_dir.path()))?;
+        let session_id: String = conn
+            .query_row(
+                "SELECT session_id FROM automation_runs WHERE automation_id = 'daily-notes'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        crate::store::insert_session(
+            &conn,
+            &crate::store::SessionRecord {
+                id: session_id,
+                project_root: "/work/project".to_string(),
+                harness: "coven-code".to_string(),
+                title: "Daily notes".to_string(),
+                status: "completed".to_string(),
+                exit_code: Some(0),
+                archived_at: None,
+                created_at: "2026-08-28T09:00:00Z".to_string(),
+                updated_at: "2026-08-28T09:05:00Z".to_string(),
+                conversation_id: None,
+                familiar_id: Some("charm".to_string()),
+                execution_binding: None,
+                labels: Vec::new(),
+                visibility: "private".to_string(),
+                external: false,
+                transcript_path: None,
+            },
+        )
+        .unwrap();
+        drop(conn);
+
+        let tick_body = json!({ "action": "coven.automations.tick" }).to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&tick_body),
+        )?;
+        assert_eq!(response.status, 200);
+        assert!(
+            response.body.contains(r#""settledSucceeded":1"#),
             "{}",
             response.body
         );
@@ -10816,6 +10868,11 @@ mod tests {
         assert!(response.body.contains(r#""runs":[{""#), "{}", response.body);
         assert!(
             response.body.contains(r#""status":"succeeded""#),
+            "{}",
+            response.body
+        );
+        assert!(
+            response.body.contains(r#""exitCode":0"#),
             "{}",
             response.body
         );

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -1,10 +1,11 @@
 //! Daemon-side automations tick (coven#816).
 //!
-//! The daemon runs the planning/recovery/claim tick on a 60-second cadence.
-//! Dispatch of claimed occurrences is intentionally NOT wired into this tick
-//! yet: the tick fences and claims so the ledger reflects reality, and the
-//! dispatch path (part 4's run_routine_now) currently serves manual runs
-//! while occurrence execution lands behind the same SessionLaunch seam.
+//! The daemon runs the full ownership loop on a 60-second cadence: plan due
+//! occurrences, recover expired leases, claim work, dispatch claimed
+//! occurrences through the shared session-launch runtime, then settle
+//! finished runs (terminal status, bounded log, output delivery) from the
+//! Coven session store. Coven owns every step; the runtime is a replaceable
+//! worker.
 
 use std::path::Path;
 use std::time::Duration;
@@ -12,9 +13,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 
 /// One automations pass: open the store, run the full tick (plan, recover,
-/// claim), then dispatch every claimed occurrence through the shared
-/// session-launch runtime. Failures land in the daemon recovery log via the
-/// caller.
+/// claim), dispatch every claimed occurrence through the shared
+/// session-launch runtime, then reconcile running runs. Failures land in the
+/// daemon recovery log via the caller.
 pub fn process_automations_tick(
     coven_home: &Path,
     runtime: &dyn crate::api::SessionRuntime,
@@ -26,6 +27,14 @@ pub fn process_automations_tick(
     if !report.claimed.is_empty() {
         let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime, now)
             .map_err(anyhow::Error::msg)?;
+    }
+    let settlement =
+        super::delivery::settle_finished_runs(&conn, now).map_err(anyhow::Error::msg)?;
+    for failure in &settlement.failures {
+        crate::daemon::append_daemon_recovery_log(
+            coven_home,
+            &format!("automations run failed: {failure}"),
+        );
     }
     Ok(report)
 }
@@ -77,7 +86,7 @@ mod tests {
     }
 
     #[test]
-    fn tick_plans_and_claims_against_the_daemon_store() {
+    fn tick_plans_claims_dispatches_and_settles() {
         let temp = tempfile::tempdir().unwrap();
         let home = temp.path();
         crate::store::initialize_store(&home.join("coven.sqlite3")).unwrap();
@@ -105,11 +114,67 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        // The tick claims and then dispatches through the (noop) runtime, so
-        // the occurrence settles as succeeded and the ledger records the run.
-        assert_eq!(state, "succeeded");
+        // The tick dispatched the claimed occurrence through the (noop)
+        // runtime: the run is in flight, never instantly "successful".
+        assert_eq!(state, "running");
         let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "running");
+        let session_id = runs[0].session_id.clone().unwrap();
+        drop(conn);
+
+        // The session then finishes (the PTY writer flips the sessions row
+        // and records the normalized stream); the next tick settles the run
+        // from that store.
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        crate::store::insert_session(
+            &conn,
+            &crate::store::SessionRecord {
+                id: session_id.clone(),
+                project_root: "/work/project".to_string(),
+                harness: "coven-code".to_string(),
+                title: "daily".to_string(),
+                status: "completed".to_string(),
+                exit_code: Some(0),
+                archived_at: None,
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+                conversation_id: None,
+                familiar_id: Some("charm".to_string()),
+                execution_binding: None,
+                labels: Vec::new(),
+                visibility: "private".to_string(),
+                external: false,
+                transcript_path: None,
+            },
+        )
+        .unwrap();
+        crate::store::insert_event(
+            &conn,
+            &crate::store::EventRecord {
+                seq: 0,
+                id: "event-final".to_string(),
+                session_id: session_id,
+                kind: "output".to_string(),
+                payload_json: serde_json::json!({ "data": "done" }).to_string(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+        drop(conn);
+
+        process_automations_tick(home, &crate::api::NoopSessionRuntime).unwrap();
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "succeeded");
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs[0].status, "succeeded");
+        assert_eq!(runs[0].exit_code, Some(0));
     }
 }

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -154,7 +154,7 @@ mod tests {
             &crate::store::EventRecord {
                 seq: 0,
                 id: "event-final".to_string(),
-                session_id: session_id,
+                session_id,
                 kind: "output".to_string(),
                 payload_json: serde_json::json!({ "data": "done" }).to_string(),
                 created_at: chrono::Utc::now().to_rfc3339(),

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -25,8 +25,9 @@ pub fn process_automations_tick(
     let now = chrono::Utc::now();
     let report = super::occurrences::tick(&conn, now)?;
     if !report.claimed.is_empty() {
-        let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime, now)
-            .map_err(anyhow::Error::msg)?;
+        let _dispatch =
+            super::runner::dispatch_claimed_occurrences(coven_home, &conn, runtime, now)
+                .map_err(anyhow::Error::msg)?;
     }
     let settlement =
         super::delivery::settle_finished_runs(&conn, now).map_err(anyhow::Error::msg)?;
@@ -125,28 +126,13 @@ mod tests {
 
         // The session then finishes (the PTY writer flips the sessions row
         // and records the normalized stream); the next tick settles the run
-        // from that store.
+        // from that store. The durable launch primitive already persisted
+        // the session row before spawn — the writer only flips it terminal.
         let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
-        crate::store::insert_session(
-            &conn,
-            &crate::store::SessionRecord {
-                id: session_id.clone(),
-                project_root: "/work/project".to_string(),
-                harness: "coven-code".to_string(),
-                title: "daily".to_string(),
-                status: "completed".to_string(),
-                exit_code: Some(0),
-                archived_at: None,
-                created_at: chrono::Utc::now().to_rfc3339(),
-                updated_at: chrono::Utc::now().to_rfc3339(),
-                conversation_id: None,
-                familiar_id: Some("charm".to_string()),
-                execution_binding: None,
-                labels: Vec::new(),
-                visibility: "private".to_string(),
-                external: false,
-                transcript_path: None,
-            },
+        conn.execute(
+            "UPDATE sessions SET status = 'completed', exit_code = 0, updated_at = ?2
+             WHERE id = ?1",
+            rusqlite::params![session_id, chrono::Utc::now().to_rfc3339()],
         )
         .unwrap();
         crate::store::insert_event(

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -12,10 +12,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
-/// One automations pass: open the store, run the full tick (plan, recover,
-/// claim), dispatch every claimed occurrence through the shared
-/// session-launch runtime, then reconcile running runs. Failures land in the
-/// daemon recovery log via the caller.
+/// One automations pass: the shared full tick (`automations::full_tick`) —
+/// plan, recover, claim, dispatch every valid existing claim, and settle
+/// finished runs. Failures land in the daemon recovery log via the caller.
 pub fn process_automations_tick(
     coven_home: &Path,
     runtime: &dyn crate::api::SessionRuntime,
@@ -23,21 +22,14 @@ pub fn process_automations_tick(
     let store_path = crate::api::store_path(coven_home);
     let conn = crate::store::open_store(&store_path)?;
     let now = chrono::Utc::now();
-    let report = super::occurrences::tick(&conn, now)?;
-    if !report.claimed.is_empty() {
-        let _dispatch =
-            super::runner::dispatch_claimed_occurrences(coven_home, &conn, runtime, now)
-                .map_err(anyhow::Error::msg)?;
-    }
-    let settlement =
-        super::delivery::settle_finished_runs(&conn, now).map_err(anyhow::Error::msg)?;
-    for failure in &settlement.failures {
+    let report = super::full_tick(coven_home, &conn, runtime, now).map_err(anyhow::Error::msg)?;
+    for failure in &report.settlement.failures {
         crate::daemon::append_daemon_recovery_log(
             coven_home,
             &format!("automations run failed: {failure}"),
         );
     }
-    Ok(report)
+    Ok(report.tick)
 }
 
 /// Starts the automations scheduler thread on the daemon's 60s cadence.
@@ -162,5 +154,45 @@ mod tests {
         let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs[0].status, "succeeded");
         assert_eq!(runs[0].exit_code, Some(0));
+    }
+
+    #[test]
+    fn tick_dispatches_a_valid_pre_existing_claim() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+        crate::store::initialize_store(&home.join("coven.sqlite3")).unwrap();
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        // A claim a previous process made and never dispatched (crash gap):
+        // live lease, state claimed, nothing new planned this tick.
+        let now = chrono::Utc::now();
+        let millis = chrono::SecondsFormat::Millis;
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, lease_owner, lease_expires_at,
+                 attempt, created_at, updated_at)
+             VALUES ('daily-stuck', 'daily', ?2, 'claimed', 'daemon-a', ?3, 1, ?2, ?2)",
+            rusqlite::params![
+                "daily-stuck",
+                (now - chrono::Duration::hours(1)).to_rfc3339_opts(millis, true),
+                (now + chrono::Duration::hours(1)).to_rfc3339_opts(millis, true),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        process_automations_tick(home, &crate::api::NoopSessionRuntime).unwrap();
+
+        // The pre-existing claim is dispatched by this pass — never left
+        // stuck (coven#816 finding 2).
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = 'daily-stuck'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
     }
 }

--- a/crates/coven-cli/src/automations/definition.rs
+++ b/crates/coven-cli/src/automations/definition.rs
@@ -16,33 +16,43 @@ pub const AUTOMATION_SCHEMA_VERSION: u32 = 1;
 /// scheduler key occurrences by this id.
 pub const AUTOMATION_ID_MAX_CHARS: usize = 96;
 
-/// Accepted `status` values. New definitions default to PAUSED so nothing
-/// runs until a human opts in (coven#816 acceptance: "default PAUSED").
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum RoutineStatus {
-    Active,
-    Paused,
+/// Wire default for `runtime`: Coven's native runtime executes routine work
+/// unless a definition explicitly selects another adapter (coven#816).
+fn default_runtime() -> String {
+    "coven-code".to_string()
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Accepted `status` values. New definitions default to PAUSED so nothing
+/// runs until a human opts in (coven#816 acceptance: "default PAUSED").
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum RoutineStatus {
+    #[default]
+    Paused,
+    Active,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RoutineTimezone {
+    #[default]
     Local,
     Utc,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RoutineMisfire {
     /// On recovery, only the latest missed occurrence runs.
+    #[default]
     Latest,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RoutineOverlap {
     /// A run is skipped when the previous occurrence has not settled.
+    #[default]
     Forbid,
 }
 
@@ -54,15 +64,29 @@ pub struct RoutineDefinition {
     pub schema_version: u32,
     pub id: String,
     pub name: String,
+    /// Omitted on the wire this defaults to PAUSED: nothing runs until a
+    /// human activates the routine (coven#816 fail-closed default).
+    #[serde(default)]
     pub status: RoutineStatus,
     /// RRULE text, e.g. `FREQ=DAILY;BYHOUR=9,17`.
     pub rrule: String,
+    /// Omitted on the wire this defaults to `local` (coven#816 import parity).
+    #[serde(default)]
     pub timezone: RoutineTimezone,
+    /// Omitted on the wire this defaults to `latest`: after a restart only
+    /// the latest missed occurrence runs (coven#816 default misfire).
+    #[serde(default)]
     pub misfire: RoutineMisfire,
+    /// Omitted on the wire this defaults to `forbid`: a routine never runs
+    /// over its own unsettled previous occurrence (coven#816 overlap rule).
+    #[serde(default)]
     pub overlap: RoutineOverlap,
     /// Per-run wall-clock timeout in minutes. Bounded and required.
     pub timeout_minutes: u32,
-    /// Runtime identifier (harness), default `coven-code`.
+    /// Runtime identifier (harness). Omitted on the wire this defaults to
+    /// `coven-code`, Coven's native runtime; Codex/Claude/Copilot remain
+    /// selectable workers but none may own the schedule (coven#816).
+    #[serde(default = "default_runtime")]
     pub runtime: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub familiar_id: Option<String>,
@@ -213,5 +237,23 @@ mod tests {
             .insert("timeoutMinutes".to_string(), json!(0));
         let error = RoutineDefinition::from_json(&value).unwrap_err();
         assert!(error.contains("timeoutMinutes"), "{error}");
+    }
+
+    #[test]
+    fn wire_defaults_are_fail_closed_and_coven_native() {
+        let value = json!({
+            "schemaVersion": 1,
+            "id": "defaults",
+            "name": "Defaults",
+            "rrule": "FREQ=DAILY;BYHOUR=9,17",
+            "timeoutMinutes": 30,
+            "prompt": "Twice daily."
+        });
+        let definition = RoutineDefinition::from_json(&value).unwrap();
+        assert_eq!(definition.status, RoutineStatus::Paused);
+        assert_eq!(definition.runtime, "coven-code");
+        assert_eq!(definition.misfire, RoutineMisfire::Latest);
+        assert_eq!(definition.overlap, RoutineOverlap::Forbid);
+        assert_eq!(definition.timezone, RoutineTimezone::Local);
     }
 }

--- a/crates/coven-cli/src/automations/delivery.rs
+++ b/crates/coven-cli/src/automations/delivery.rs
@@ -15,7 +15,7 @@ use rusqlite::{params, Connection};
 use serde_json::{json, Value};
 
 use super::occurrences::settle_occurrence;
-use super::runs::{record_run_finish, LOG_ENTRY_MAX_CHARS, RunFinish};
+use super::runs::{record_run_finish, RunFinish, LOG_ENTRY_MAX_CHARS};
 
 /// How many trailing normalized-stream events a bounded log captures. The
 /// budget keeps the newest events; older entries are replaced by a marker.
@@ -24,7 +24,12 @@ const BOUNDED_LOG_EVENT_LIMIT: usize = 200;
 /// Terminal session statuses, mirroring
 /// `store::update_session_terminal_if_active`.
 const SESSION_TERMINAL_STATUSES: [&str; 6] = [
-    "completed", "failed", "cancelled", "killed", "idle", "orphaned",
+    "completed",
+    "failed",
+    "cancelled",
+    "killed",
+    "idle",
+    "orphaned",
 ];
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -70,8 +75,8 @@ fn read_stream_tail(
         .map_err(|error| format!("failed to read session stream: {error}"))?;
     let mut events = Vec::new();
     for row in rows {
-        let (kind, payload_json, created_at) = row
-            .map_err(|error| format!("failed to read session stream: {error}"))?;
+        let (kind, payload_json, created_at) =
+            row.map_err(|error| format!("failed to read session stream: {error}"))?;
         let payload = serde_json::from_str(&payload_json).unwrap_or(Value::Null);
         events.push(StreamEvent {
             kind,
@@ -158,7 +163,10 @@ pub fn deliver_output(target: &str, payload: &str) -> Result<(), String> {
         _ => PathBuf::from("."),
     };
     std::fs::create_dir_all(&parent).map_err(|error| {
-        format!("output commit failed: cannot create {}: {error}", parent.display())
+        format!(
+            "output commit failed: cannot create {}: {error}",
+            parent.display()
+        )
     })?;
     let file_name = target_path
         .file_name()
@@ -176,7 +184,10 @@ pub fn deliver_output(target: &str, payload: &str) -> Result<(), String> {
 
 fn write_atomically(temp: &Path, target: &Path, payload: &str) -> Result<(), String> {
     std::fs::write(temp, payload).map_err(|error| {
-        format!("output commit failed: cannot write {}: {error}", temp.display())
+        format!(
+            "output commit failed: cannot write {}: {error}",
+            temp.display()
+        )
     })?;
     std::fs::rename(temp, target).map_err(|error| {
         format!(
@@ -636,7 +647,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(status, "failed", "a failed delivery must not report success");
+        assert_eq!(
+            status, "failed",
+            "a failed delivery must not report success"
+        );
         let reason: String = conn
             .query_row(
                 "SELECT failure_reason FROM automation_occurrences WHERE automation_id = 'daily'",

--- a/crates/coven-cli/src/automations/delivery.rs
+++ b/crates/coven-cli/src/automations/delivery.rs
@@ -1,0 +1,722 @@
+//! Routine run delivery and settlement (coven#816).
+//!
+//! Dispatch records that a run *started*; this module finishes it. The
+//! reconciliation pass watches every running ledger row, reads the terminal
+//! outcome from the Coven session store (the same normalized stream every
+//! session produces), captures a bounded log, and — when the definition
+//! configures an output target — atomically commits the final assistant
+//! payload. Coven, not the model, performs the delivery, and a failed output
+//! commit fails the run visibly instead of reporting success.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+use serde_json::{json, Value};
+
+use super::occurrences::settle_occurrence;
+use super::runs::{record_run_finish, LOG_ENTRY_MAX_CHARS, RunFinish};
+
+/// How many trailing normalized-stream events a bounded log captures. The
+/// budget keeps the newest events; older entries are replaced by a marker.
+const BOUNDED_LOG_EVENT_LIMIT: usize = 200;
+
+/// Terminal session statuses, mirroring
+/// `store::update_session_terminal_if_active`.
+const SESSION_TERMINAL_STATUSES: [&str; 6] = [
+    "completed", "failed", "cancelled", "killed", "idle", "orphaned",
+];
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ReconcileReport {
+    pub settled_succeeded: usize,
+    pub settled_failed: usize,
+    pub still_running: usize,
+    pub failures: Vec<String>,
+}
+
+fn is_terminal_session_status(status: &str) -> bool {
+    SESSION_TERMINAL_STATUSES.contains(&status)
+}
+
+struct StreamEvent {
+    kind: String,
+    payload: Value,
+    created_at: String,
+}
+
+/// Reads the trailing normalized stream for one session, newest last.
+fn read_stream_tail(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<StreamEvent>, String> {
+    let mut statement = conn
+        .prepare(
+            "SELECT kind, payload_json, created_at FROM events
+             WHERE session_id = ?1
+             ORDER BY rowid DESC
+             LIMIT ?2",
+        )
+        .map_err(|error| format!("failed to read session stream: {error}"))?;
+    let rows = statement
+        .query_map(params![session_id, limit as i64], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|error| format!("failed to read session stream: {error}"))?;
+    let mut events = Vec::new();
+    for row in rows {
+        let (kind, payload_json, created_at) = row
+            .map_err(|error| format!("failed to read session stream: {error}"))?;
+        let payload = serde_json::from_str(&payload_json).unwrap_or(Value::Null);
+        events.push(StreamEvent {
+            kind,
+            payload,
+            created_at,
+        });
+    }
+    events.reverse();
+    Ok(events)
+}
+
+/// Captures a bounded JSON log of the session's normalized stream: the newest
+/// entries that fit the ledger's per-run budget, prefixed by a truncation
+/// marker when older entries were dropped. `None` when the session recorded
+/// nothing.
+pub fn capture_bounded_log(conn: &Connection, session_id: &str) -> Option<String> {
+    let events = read_stream_tail(conn, session_id, BOUNDED_LOG_EVENT_LIMIT).ok()?;
+    if events.is_empty() {
+        return None;
+    }
+    let entries: Vec<Value> = events
+        .iter()
+        .map(|event| {
+            json!({
+                "kind": event.kind,
+                "createdAt": event.created_at,
+                "payload": event.payload,
+            })
+        })
+        .collect();
+
+    // Keep the tail within the character budget: walk newest-first and stop
+    // at the first entry that no longer fits.
+    let mut kept: Vec<&Value> = Vec::new();
+    let mut budget = LOG_ENTRY_MAX_CHARS;
+    for entry in entries.iter().rev() {
+        let entry_chars = entry.to_string().chars().count() + 1;
+        if entry_chars > budget {
+            break;
+        }
+        budget -= entry_chars;
+        kept.push(entry);
+    }
+    kept.reverse();
+    let dropped = entries.len() - kept.len();
+
+    let mut log_entries = Vec::with_capacity(kept.len() + 1);
+    if dropped > 0 {
+        log_entries.push(json!({
+            "kind": "logTruncated",
+            "droppedEntries": dropped,
+        }));
+    }
+    if kept.is_empty() && dropped == 0 {
+        return None;
+    }
+    for entry in &kept {
+        log_entries.push((*entry).clone());
+    }
+    serde_json::to_string(&log_entries).ok()
+}
+
+/// The final assistant payload of a session: the text of its last `output`
+/// event. `None` when the session produced no output.
+pub fn final_output_text(conn: &Connection, session_id: &str) -> Option<String> {
+    let events = read_stream_tail(conn, session_id, BOUNDED_LOG_EVENT_LIMIT).ok()?;
+    events
+        .iter()
+        .rev()
+        .find(|event| event.kind == "output")
+        .and_then(|event| event.payload.get("data"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .filter(|text| !text.is_empty())
+}
+
+/// Atomically commits `payload` to `target`: the bytes land in a temp file in
+/// the target's directory and are renamed into place, so readers never see a
+/// partial file. Every failure is reported as `output commit failed: …`.
+pub fn deliver_output(target: &str, payload: &str) -> Result<(), String> {
+    let target_path = Path::new(target);
+    let parent = match target_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+    std::fs::create_dir_all(&parent).map_err(|error| {
+        format!("output commit failed: cannot create {}: {error}", parent.display())
+    })?;
+    let file_name = target_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_owned())
+        .ok_or_else(|| "output commit failed: output target has no file name".to_string())?;
+    let pid = std::process::id();
+    let millis = chrono::Utc::now().timestamp_millis();
+    let temp = parent.join(format!(".coven-delivery-{pid}-{millis}-{file_name}"));
+    let result = write_atomically(&temp, target_path, payload);
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
+}
+
+fn write_atomically(temp: &Path, target: &Path, payload: &str) -> Result<(), String> {
+    std::fs::write(temp, payload).map_err(|error| {
+        format!("output commit failed: cannot write {}: {error}", temp.display())
+    })?;
+    std::fs::rename(temp, target).map_err(|error| {
+        format!(
+            "output commit failed: cannot rename {} → {}: {error}",
+            temp.display(),
+            target.display()
+        )
+    })
+}
+
+struct Settlement {
+    status: &'static str,
+    exit_code: Option<i64>,
+    log: Option<String>,
+    output_commit: Option<String>,
+    reason: Option<String>,
+}
+
+struct RunningLedgerRow {
+    run_id: String,
+    automation_id: String,
+    session_id: Option<String>,
+    occurrence_id: Option<String>,
+    occurrence_state: Option<String>,
+    occurrence_failure: Option<String>,
+}
+
+fn running_ledger_rows(conn: &Connection) -> Result<Vec<RunningLedgerRow>, String> {
+    let mut statement = conn
+        .prepare(
+            "SELECT r.id, r.automation_id, r.session_id, r.occurrence_id,
+                    o.state, o.failure_reason
+             FROM automation_runs AS r
+             LEFT JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+             WHERE r.status = 'running'",
+        )
+        .map_err(|error| format!("failed to list running runs: {error}"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(RunningLedgerRow {
+                run_id: row.get(0)?,
+                automation_id: row.get(1)?,
+                session_id: row.get(2)?,
+                occurrence_id: row.get(3)?,
+                occurrence_state: row.get(4)?,
+                occurrence_failure: row.get(5)?,
+            })
+        })
+        .map_err(|error| format!("failed to list running runs: {error}"))?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|error| format!("failed to read running run: {error}"))?);
+    }
+    Ok(out)
+}
+
+/// Builds the settlement for a run whose session exists, or `None` while the
+/// session is still live (or has no sessions row yet — the occurrence lease
+/// bounds how long that can block the routine).
+fn session_settlement(
+    conn: &Connection,
+    automation_id: &str,
+    session_id: &str,
+) -> Result<Option<Settlement>, String> {
+    let session = crate::store::get_session(conn, session_id)
+        .map_err(|error| format!("failed to read session {session_id}: {error:#}"))?;
+    let Some(session) = session else {
+        return Ok(None);
+    };
+    if !is_terminal_session_status(&session.status) {
+        return Ok(None);
+    }
+
+    let log = capture_bounded_log(conn, session_id);
+    let exit_zero = session.exit_code.unwrap_or(0) == 0;
+    let succeeded = matches!(session.status.as_str(), "completed" | "idle") && exit_zero;
+    if !succeeded {
+        let reason = match session.exit_code {
+            Some(code) => format!("session {} (exit code {code})", session.status),
+            None => format!("session {}", session.status),
+        };
+        return Ok(Some(Settlement {
+            status: "failed",
+            exit_code: session.exit_code.map(i64::from),
+            log,
+            output_commit: None,
+            reason: Some(reason),
+        }));
+    }
+
+    // The run succeeded at the runtime. Delivery is Coven's job: commit the
+    // final assistant payload to the configured target, and a failed commit
+    // fails the run visibly (never reported as success).
+    let definition = super::runner::load_definition_for_run(conn, automation_id)
+        .map_err(|error| format!("failed to load routine {automation_id}: {error}"))?;
+    let output_target = definition.and_then(|routine| routine.output_target);
+    let (status, reason, output_commit) = match output_target.as_deref() {
+        None => ("succeeded", None, None),
+        Some(target) => match final_output_text(conn, session_id) {
+            None => (
+                "failed",
+                Some(format!(
+                    "output commit failed: no assistant output captured for session {session_id}"
+                )),
+                None,
+            ),
+            Some(payload) => match deliver_output(target, &payload) {
+                Ok(()) => ("succeeded", None, Some(target.to_string())),
+                Err(error) => ("failed", Some(error), None),
+            },
+        },
+    };
+    Ok(Some(Settlement {
+        status,
+        exit_code: session.exit_code.map(i64::from),
+        log,
+        output_commit,
+        reason,
+    }))
+}
+
+/// Settles every running ledger row whose work has finished. A row settles
+/// when its session reached a terminal state, or when its occurrence already
+/// settled through lease recovery. The matching occurrence settles alongside
+/// the ledger row; nothing here ever reports a run success that did not
+/// actually happen.
+pub fn settle_finished_runs(
+    conn: &Connection,
+    now: DateTime<Utc>,
+) -> Result<ReconcileReport, String> {
+    let mut report = ReconcileReport::default();
+
+    for row in running_ledger_rows(conn)? {
+        let RunningLedgerRow {
+            run_id,
+            automation_id,
+            session_id,
+            occurrence_id,
+            occurrence_state,
+            occurrence_failure,
+        } = row;
+
+        let mut settlement = match session_id.as_deref() {
+            Some(session_id) => session_settlement(conn, &automation_id, session_id)?,
+            None => None,
+        };
+        if settlement.is_none() {
+            if occurrence_state.as_deref() == Some("failed") {
+                let reason = occurrence_failure
+                    .filter(|reason| !reason.trim().is_empty())
+                    .unwrap_or_else(|| "lease expired".to_string());
+                settlement = Some(Settlement {
+                    status: "failed",
+                    exit_code: None,
+                    log: None,
+                    output_commit: None,
+                    reason: Some(reason),
+                });
+            } else if occurrence_state.as_deref() == Some("succeeded") {
+                // Defensive: an occurrence cannot legitimately settle success
+                // before its run does. Record a visible failure rather than
+                // inventing a result.
+                settlement = Some(Settlement {
+                    status: "failed",
+                    exit_code: None,
+                    log: None,
+                    output_commit: None,
+                    reason: Some("occurrence settled without a run result".to_string()),
+                });
+            }
+        }
+
+        let Some(settlement) = settlement else {
+            report.still_running += 1;
+            continue;
+        };
+
+        if let Some(occurrence_id) = occurrence_id.as_deref() {
+            let _ = settle_occurrence(
+                conn,
+                occurrence_id,
+                settlement.status,
+                settlement.reason.as_deref(),
+                now,
+            );
+        }
+        let _ = record_run_finish(
+            conn,
+            &run_id,
+            RunFinish {
+                status: settlement.status,
+                exit_code: settlement.exit_code,
+                session_id: session_id.clone(),
+                log_json: settlement.log,
+                output_commit: settlement.output_commit,
+            },
+            now,
+        );
+        if settlement.status == "succeeded" {
+            report.settled_succeeded += 1;
+        } else {
+            report.settled_failed += 1;
+            if let Some(reason) = settlement.reason {
+                report.failures.push(format!("{automation_id}: {reason}"));
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automations::definition::RoutineDefinition;
+    use crate::automations::store::insert_definition;
+    use crate::store::{initialize_store, insert_event, insert_session, SessionRecord};
+    use serde_json::json;
+
+    fn temp_store() -> (tempfile::TempDir, Connection) {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_store(&path).unwrap();
+        (temp, conn)
+    }
+
+    fn definition(id: &str, output_target: Option<&str>) -> RoutineDefinition {
+        let mut value = json!({
+            "schemaVersion": 1,
+            "id": id,
+            "name": id,
+            "status": "ACTIVE",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "cwd": "/work/project",
+            "prompt": "Do the thing."
+        });
+        if let Some(output_target) = output_target {
+            let object = value.as_object_mut().unwrap();
+            object.insert("outputTarget".to_string(), json!(output_target));
+        }
+        RoutineDefinition::from_json(&value).unwrap()
+    }
+
+    fn session_record(conn: &Connection, id: &str, status: &str, exit_code: Option<i32>) {
+        insert_session(
+            conn,
+            &SessionRecord {
+                id: id.to_string(),
+                project_root: "/work/project".to_string(),
+                harness: "coven-code".to_string(),
+                title: "routine run".to_string(),
+                status: status.to_string(),
+                exit_code,
+                archived_at: None,
+                created_at: "2026-08-28T09:00:00Z".to_string(),
+                updated_at: "2026-08-28T09:05:00Z".to_string(),
+                conversation_id: None,
+                familiar_id: None,
+                execution_binding: None,
+                labels: Vec::new(),
+                visibility: "private".to_string(),
+                external: false,
+                transcript_path: None,
+            },
+        )
+        .unwrap();
+    }
+
+    fn event(conn: &Connection, session_id: &str, kind: &str, data: &str) {
+        static EVENT_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let event_number = EVENT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        insert_event(
+            conn,
+            &crate::store::EventRecord {
+                seq: 0,
+                id: format!("event-{event_number}"),
+                session_id: session_id.to_string(),
+                kind: kind.to_string(),
+                payload_json: json!({ "data": data }).to_string(),
+                created_at: "2026-08-28T09:01:00Z".to_string(),
+            },
+        )
+        .unwrap();
+    }
+
+    /// Seeds a live run: claimed occurrence + running ledger row, as dispatch
+    /// leaves them before reconciliation.
+    fn live_run(conn: &Connection, automation_id: &str, session_id: &str) -> String {
+        let now = "2026-08-28T09:00:00.000Z";
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, lease_owner, lease_expires_at,
+                 attempt, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'running', 'daemon', '2026-08-28T10:00:00.000Z', 1, ?3, ?3)",
+            rusqlite::params![format!("occ-{session_id}"), automation_id, now],
+        )
+        .unwrap();
+        let run_id = format!("run-{session_id}");
+        record_run_start_raw(conn, &run_id, automation_id, session_id, now);
+        run_id
+    }
+
+    fn record_run_start_raw(
+        conn: &Connection,
+        run_id: &str,
+        automation_id: &str,
+        session_id: &str,
+        now: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO automation_runs
+                (id, automation_id, occurrence_id, session_id, familiar_id, runtime,
+                 status, started_at)
+             VALUES (?1, ?2, ?3, ?4, 'charm', 'coven-code', 'running', ?5)",
+            rusqlite::params![
+                run_id,
+                automation_id,
+                format!("occ-{session_id}"),
+                session_id,
+                now
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deliver_output_replaces_atomically_without_temp_litter() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("out").join("payload.md");
+        deliver_output(target.to_str().unwrap(), "first").unwrap();
+        deliver_output(target.to_str().unwrap(), "second version").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "second version");
+        let entries: Vec<_> = std::fs::read_dir(temp.path().join("out"))
+            .unwrap()
+            .collect();
+        assert_eq!(entries.len(), 1, "no temp files may remain");
+    }
+
+    #[test]
+    fn deliver_output_failure_is_visible() {
+        let temp = tempfile::tempdir().unwrap();
+        let blocker = temp.path().join("blocker");
+        std::fs::write(&blocker, "a file, not a directory").unwrap();
+        let target = blocker.join("payload.md");
+
+        let error = deliver_output(target.to_str().unwrap(), "payload").unwrap_err();
+        assert!(error.contains("output commit failed"), "{error}");
+    }
+
+    #[test]
+    fn bounded_log_keeps_the_tail_within_the_budget() {
+        let (_temp, conn) = temp_store();
+        session_record(&conn, "session-1", "completed", Some(0));
+        let huge = "x".repeat(50 * 1024);
+        event(&conn, "session-1", "output", &huge);
+        event(&conn, "session-1", "output", &huge);
+        event(&conn, "session-1", "output", "final answer");
+
+        let log = capture_bounded_log(&conn, "session-1").unwrap();
+        assert!(
+            log.chars().count() <= LOG_ENTRY_MAX_CHARS,
+            "log is bounded: {}",
+            log.chars().count()
+        );
+        assert!(log.contains("logTruncated"), "{log}");
+        assert!(log.contains("final answer"), "tail is kept: {log}");
+    }
+
+    #[test]
+    fn final_output_text_picks_the_last_output_event() {
+        let (_temp, conn) = temp_store();
+        session_record(&conn, "session-1", "completed", Some(0));
+        event(&conn, "session-1", "output", "draft");
+        event(&conn, "session-1", "input", "keep going");
+        event(&conn, "session-1", "output", "final answer");
+
+        assert_eq!(
+            final_output_text(&conn, "session-1").as_deref(),
+            Some("final answer")
+        );
+        assert_eq!(final_output_text(&conn, "session-missing"), None);
+    }
+
+    #[test]
+    fn settle_delivers_output_and_records_success() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("out").join("payload.md");
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", Some(target.to_str().unwrap()))).unwrap();
+        live_run(&conn, "daily", "session-1");
+        session_record(&conn, "session-1", "completed", Some(0));
+        event(&conn, "session-1", "output", "the delivered payload");
+
+        let report = settle_finished_runs(&conn, Utc::now()).unwrap();
+        assert_eq!(report.settled_succeeded, 1);
+        assert_eq!(report.settled_failed, 0);
+
+        let run: (String, Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT status, exit_code, output_commit FROM automation_runs WHERE id = 'run-session-1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(run.0, "succeeded");
+        assert_eq!(run.1, Some(0));
+        assert_eq!(run.2.as_deref(), Some(target.to_str().unwrap()));
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "the delivered payload"
+        );
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "succeeded");
+    }
+
+    #[test]
+    fn failed_output_commit_fails_the_run_visibly() {
+        let temp = tempfile::tempdir().unwrap();
+        let blocker = temp.path().join("blocker");
+        std::fs::write(&blocker, "a file, not a directory").unwrap();
+        let target = blocker.join("payload.md");
+
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", Some(target.to_str().unwrap()))).unwrap();
+        live_run(&conn, "daily", "session-1");
+        session_record(&conn, "session-1", "completed", Some(0));
+        event(&conn, "session-1", "output", "the delivered payload");
+
+        let report = settle_finished_runs(&conn, Utc::now()).unwrap();
+        assert_eq!(report.settled_failed, 1);
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|failure| failure.contains("output commit failed")),
+            "{report:?}"
+        );
+
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM automation_runs WHERE id = 'run-session-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "failed", "a failed delivery must not report success");
+        let reason: String = conn
+            .query_row(
+                "SELECT failure_reason FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(reason.contains("output commit failed"), "{reason}");
+    }
+
+    #[test]
+    fn failed_session_fails_the_run_without_delivery() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("payload.md");
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", Some(target.to_str().unwrap()))).unwrap();
+        live_run(&conn, "daily", "session-1");
+        session_record(&conn, "session-1", "failed", Some(1));
+        event(&conn, "session-1", "output", "partial output");
+
+        let report = settle_finished_runs(&conn, Utc::now()).unwrap();
+        assert_eq!(report.settled_failed, 1);
+
+        let (status, exit_code, output_commit): (String, Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT status, exit_code, output_commit FROM automation_runs WHERE id = 'run-session-1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "failed");
+        assert_eq!(exit_code, Some(1));
+        assert_eq!(output_commit, None);
+        assert!(!target.exists(), "nothing is delivered for a failed run");
+    }
+
+    #[test]
+    fn recovered_occurrence_settles_the_ledger_as_failed() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", None)).unwrap();
+        live_run(&conn, "daily", "session-1");
+        // Lease recovery already failed the occurrence (no sessions row was
+        // ever written — the daemon died mid-run).
+        conn.execute(
+            "UPDATE automation_occurrences SET state = 'failed',
+                 failure_reason = 'lease expired'",
+            [],
+        )
+        .unwrap();
+
+        let report = settle_finished_runs(&conn, Utc::now()).unwrap();
+        assert_eq!(report.settled_failed, 1);
+
+        let (status, log): (String, Option<String>) = conn
+            .query_row(
+                "SELECT status, log_json FROM automation_runs WHERE id = 'run-session-1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "failed");
+        assert!(log.is_none(), "no stream exists to capture");
+    }
+
+    #[test]
+    fn still_running_rows_are_left_alone() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", None)).unwrap();
+        live_run(&conn, "daily", "session-1");
+        session_record(&conn, "session-1", "running", None);
+
+        let report = settle_finished_runs(&conn, Utc::now()).unwrap();
+        assert_eq!(report.still_running, 1);
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM automation_runs WHERE id = 'run-session-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "running");
+    }
+}

--- a/crates/coven-cli/src/automations/delivery.rs
+++ b/crates/coven-cli/src/automations/delivery.rs
@@ -170,7 +170,7 @@ pub fn deliver_output(target: &str, payload: &str) -> Result<(), String> {
     })?;
     let file_name = target_path
         .file_name()
-        .map(|name| name.to_string_lossy().to_owned())
+        .map(|name| name.to_string_lossy().into_owned())
         .ok_or_else(|| "output commit failed: output target has no file name".to_string())?;
     let pid = std::process::id();
     let millis = chrono::Utc::now().timestamp_millis();

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -1,13 +1,17 @@
 //! Coven-native routine automations (coven#816).
 //!
 //! Routines replace harness-owned schedules with durable Coven definitions.
-//! This module owns definition parsing/validation, the RRULE vocabulary the
-//! scheduler understands, and definition persistence. Occurrence planning,
-//! claim/lease, and run delivery land in follow-up modules on the same
-//! seams.
+//! **Coven owns the schedule and the run ledger; runtimes are replaceable
+//! workers.** This module owns definition parsing/validation (stored under
+//! the Coven store, never a harness home), the RRULE vocabulary the
+//! scheduler understands, occurrence planning with a durable
+//! `UNIQUE(automation_id, scheduled_for)` fence, bounded claim/lease
+//! recovery, familiar-bound dispatch through the shared session-launch seam,
+//! the run ledger, and delivery of outputs.
 
 pub mod daemon_tick;
 pub mod definition;
+pub mod delivery;
 pub mod health;
 pub mod import_legacy;
 pub mod occurrences;

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -22,3 +22,40 @@ pub mod schedule;
 pub mod store;
 
 pub use definition::RoutineDefinition;
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+
+/// Everything one automations pass did, shared by the daemon cadence and
+/// the `coven.automations.tick` control-plane action.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct FullTickReport {
+    pub tick: occurrences::TickReport,
+    pub dispatch: runner::DispatchReport,
+    pub settlement: delivery::ReconcileReport,
+}
+
+/// The one full tick implementation: plan due slots, recover expired
+/// leases, claim due work, then dispatch every valid existing claim — not
+/// just freshly claimed ones — and settle finished runs. Both callers (the
+/// daemon cadence and the `coven.automations.tick` action) run this exact
+/// sequence, so control-plane claims and crash-interrupted claims always
+/// reach dispatch instead of waiting for some later tick (coven#816
+/// finding 2).
+pub fn full_tick(
+    coven_home: &Path,
+    conn: &Connection,
+    runtime: &dyn crate::api::SessionRuntime,
+    now: DateTime<Utc>,
+) -> Result<FullTickReport, String> {
+    let tick = occurrences::tick(conn, now).map_err(|error| format!("{error:#}"))?;
+    let dispatch = runner::dispatch_claimed_occurrences(coven_home, conn, runtime, now)?;
+    let settlement = delivery::settle_finished_runs(conn, now)?;
+    Ok(FullTickReport {
+        tick,
+        dispatch,
+        settlement,
+    })
+}

--- a/crates/coven-cli/src/automations/occurrences.rs
+++ b/crates/coven-cli/src/automations/occurrences.rs
@@ -669,7 +669,10 @@ mod tests {
         let first = claim_due_occurrence(&conn, "daily", "daemon-a", 60, real_now()).unwrap();
         assert!(first.is_some());
         let second = claim_due_occurrence(&conn, "daily", "daemon-b", 60, real_now()).unwrap();
-        assert!(second.is_none(), "overlap=forbid must reject a second claim");
+        assert!(
+            second.is_none(),
+            "overlap=forbid must reject a second claim"
+        );
 
         // Settling the live run unblocks the next claim.
         let claimed_id = first.unwrap();
@@ -695,14 +698,9 @@ mod tests {
             .unwrap();
 
         // Running keeps the lease alive, so recovery leaves it alone.
-        assert!(mark_occurrence_running(
-            &conn,
-            &occurrence_id,
-            "daemon-a",
-            60,
-            real_now()
-        )
-        .unwrap());
+        assert!(
+            mark_occurrence_running(&conn, &occurrence_id, "daemon-a", 60, real_now()).unwrap()
+        );
         let (state, owner): (String, Option<String>) = conn
             .query_row(
                 "SELECT state, lease_owner FROM automation_occurrences WHERE id = ?1",
@@ -739,9 +737,7 @@ mod tests {
         let (_temp, conn) = temp_store();
         assert!(mark_occurrence_running(&conn, "occ-x", "daemon-a", 0, real_now()).is_err());
         let too_long = 24 * 60 + 1;
-        assert!(
-            mark_occurrence_running(&conn, "occ-x", "daemon-a", too_long, real_now()).is_err()
-        );
+        assert!(mark_occurrence_running(&conn, "occ-x", "daemon-a", too_long, real_now()).is_err());
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/occurrences.rs
+++ b/crates/coven-cli/src/automations/occurrences.rs
@@ -68,12 +68,13 @@ pub struct TickReport {
 const OCCURRENCE_TERMINAL_STATES: [&str; 2] = ["succeeded", "failed"];
 
 /// Claims the earliest due PLANNED occurrence for a routine with a bounded
-/// lease. Returns the claimed occurrence id, or `None` when nothing is due.
-/// The compare-and-set WHERE clause makes claims race-safe across callers.
+/// lease. Returns the claimed occurrence id, or `None` when nothing is due
+/// — including when the routine already has a live claimed/running
+/// occurrence, which `overlap: forbid` keeps from racing a second run. The
+/// compare-and-set WHERE clause makes claims race-safe across callers.
 ///
-/// The runner (coven#816 part 4) is the production caller; until then tests
-/// and the daemon tick exercise the path directly.
-#[allow(dead_code)]
+/// The daemon tick claims through this path; manual run-now claims a specific
+/// fresh occurrence via `claim_occurrence_by_id`.
 pub fn claim_due_occurrence(
     conn: &Connection,
     automation_id: &str,
@@ -105,6 +106,11 @@ pub fn claim_due_occurrence(
                      AND scheduled_for <= ?2
                    ORDER BY scheduled_for ASC
                    LIMIT 1
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM automation_occurrences AS live
+                   WHERE live.automation_id = ?1
+                     AND live.state IN ('claimed', 'running')
                )",
             params![automation_id, now_iso, owner, expires_iso],
         )
@@ -120,6 +126,82 @@ pub fn claim_due_occurrence(
         )
         .map_err(|error| format!("failed to read claim: {error}"))?;
     Ok(Some(id))
+}
+
+/// Claims one specific occurrence (the manual run-now fence) with a bounded
+/// lease. Refused — returning `Ok(None)` — when the occurrence is not
+/// claimable, including when a sibling occurrence of the same routine is
+/// still live (`overlap: forbid`).
+pub fn claim_occurrence_by_id(
+    conn: &Connection,
+    occurrence_id: &str,
+    owner: &str,
+    lease_minutes: i64,
+    now: DateTime<Utc>,
+) -> Result<Option<String>, String> {
+    if lease_minutes <= 0 || lease_minutes > 24 * 60 {
+        return Err("lease minutes must be 1..=1440".to_string());
+    }
+    let expires = now + chrono::Duration::minutes(lease_minutes);
+    let now_iso = iso(now);
+    let expires_iso = iso(expires);
+    let changed = conn
+        .execute(
+            "UPDATE automation_occurrences
+             SET state = 'claimed',
+                 lease_owner = ?3,
+                 lease_expires_at = ?4,
+                 attempt = attempt + 1,
+                 updated_at = ?2
+             WHERE id = ?1
+               AND state = 'planned'
+               AND scheduled_for <= ?2
+               AND NOT EXISTS (
+                   SELECT 1 FROM automation_occurrences AS live
+                   WHERE live.automation_id = (
+                       SELECT automation_id FROM automation_occurrences WHERE id = ?1
+                   )
+                     AND live.state IN ('claimed', 'running')
+                     AND live.id != ?1
+             )",
+            params![occurrence_id, now_iso, owner, expires_iso],
+        )
+        .map_err(|error| format!("failed to claim occurrence: {error}"))?;
+    if changed == 0 {
+        return Ok(None);
+    }
+    Ok(Some(occurrence_id.to_string()))
+}
+
+/// Moves a claimed occurrence to `running` with a fresh bounded lease that
+/// outlives a healthy run of the routine (the definition timeout). A `running`
+/// row whose lease expires is recovered by `recover_expired_leases`, so a
+/// crashed dispatch never blocks the routine forever (coven#816).
+pub fn mark_occurrence_running(
+    conn: &Connection,
+    occurrence_id: &str,
+    owner: &str,
+    lease_minutes: i64,
+    now: DateTime<Utc>,
+) -> Result<bool, String> {
+    if lease_minutes <= 0 || lease_minutes > 24 * 60 {
+        return Err("lease minutes must be 1..=1440".to_string());
+    }
+    let expires = now + chrono::Duration::minutes(lease_minutes);
+    let now_iso = iso(now);
+    let expires_iso = iso(expires);
+    let changed = conn
+        .execute(
+            "UPDATE automation_occurrences
+             SET state = 'running',
+                 lease_owner = ?3,
+                 lease_expires_at = ?4,
+                 updated_at = ?2
+             WHERE id = ?1 AND state IN ('claimed', 'running')",
+            params![occurrence_id, now_iso, owner, expires_iso],
+        )
+        .map_err(|error| format!("failed to mark occurrence running: {error}"))?;
+    Ok(changed > 0)
 }
 
 /// Marks occurrences whose lease has expired as failed with a stale reason.
@@ -145,7 +227,6 @@ pub fn recover_expired_leases(conn: &Connection, now: DateTime<Utc>) -> Result<u
 
 /// Finalizes an occurrence into a terminal state. Releasing a PLANNED
 /// occurrence is refused — only claimed work can settle.
-#[allow(dead_code)]
 pub fn settle_occurrence(
     conn: &Connection,
     occurrence_id: &str,
@@ -551,6 +632,116 @@ mod tests {
             )
             .unwrap();
         assert_eq!(state, "failed");
+    }
+
+    #[test]
+    fn overlap_forbid_blocks_claims_while_a_run_is_live() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
+        let old_created = (real_now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+        // Two due slots: the collapse test's fence keeps only the latest, so
+        // insert a second, earlier planned occurrence by hand.
+        tick_planning(&conn, real_now()).unwrap();
+        let planned: String = conn
+            .query_row(
+                "SELECT id FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+             VALUES ('daily-earlier', 'daily', '2020-01-01T09:00:00.000Z', 'planned', 0,
+                     '2020-01-01T09:00:00.000Z', '2020-01-01T09:00:00.000Z')",
+            [],
+        )
+        .unwrap();
+
+        // First claim wins; the second must be refused while it stays live,
+        // even though another planned occurrence is due.
+        let first = claim_due_occurrence(&conn, "daily", "daemon-a", 60, real_now()).unwrap();
+        assert!(first.is_some());
+        let second = claim_due_occurrence(&conn, "daily", "daemon-b", 60, real_now()).unwrap();
+        assert!(second.is_none(), "overlap=forbid must reject a second claim");
+
+        // Settling the live run unblocks the next claim.
+        let claimed_id = first.unwrap();
+        assert!(settle_occurrence(&conn, &claimed_id, "succeeded", None, real_now()).unwrap());
+        let third = claim_occurrence_by_id(&conn, &planned, "daemon-b", 60, real_now()).unwrap();
+        assert!(third.is_some());
+    }
+
+    #[test]
+    fn running_occurrences_carry_a_bounded_recoverable_lease() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
+        let old_created = (real_now() - chrono::Duration::days(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "UPDATE automation_definitions SET created_at = ?1 WHERE id = 'daily'",
+            rusqlite::params![old_created],
+        )
+        .unwrap();
+        tick_planning(&conn, real_now()).unwrap();
+        let occurrence_id = claim_due_occurrence(&conn, "daily", "daemon-a", 60, real_now())
+            .unwrap()
+            .unwrap();
+
+        // Running keeps the lease alive, so recovery leaves it alone.
+        assert!(mark_occurrence_running(
+            &conn,
+            &occurrence_id,
+            "daemon-a",
+            60,
+            real_now()
+        )
+        .unwrap());
+        let (state, owner): (String, Option<String>) = conn
+            .query_row(
+                "SELECT state, lease_owner FROM automation_occurrences WHERE id = ?1",
+                rusqlite::params![occurrence_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
+        assert_eq!(owner.as_deref(), Some("daemon-a"));
+        let report = tick(&conn, real_now()).unwrap();
+        assert_eq!(report.recovered, 0);
+
+        // After the lease expires, recovery fails the row: a stale running
+        // record never blocks the routine forever (coven#816).
+        conn.execute(
+            "UPDATE automation_occurrences SET lease_expires_at = '2020-01-01T00:00:00.000Z'",
+            [],
+        )
+        .unwrap();
+        let report = tick(&conn, real_now()).unwrap();
+        assert_eq!(report.recovered, 1);
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = ?1",
+                rusqlite::params![occurrence_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "failed");
+    }
+
+    #[test]
+    fn rejects_an_out_of_range_lease() {
+        let (_temp, conn) = temp_store();
+        assert!(mark_occurrence_running(&conn, "occ-x", "daemon-a", 0, real_now()).is_err());
+        let too_long = 24 * 60 + 1;
+        assert!(
+            mark_occurrence_running(&conn, "occ-x", "daemon-a", too_long, real_now()).is_err()
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -1,12 +1,14 @@
 //! Routine run dispatch (coven#816).
 //!
-//! A run is a claimed occurrence dispatched through the exact session-launch
-//! path every other launch uses: the definition is re-read, the familiar and
-//! runtime are re-validated per run, a SessionLaunch is built, and the run
-//! goes in flight under a bounded lease. Coven (not a harness home) owns the
-//! record; terminal status, bounded log, and output delivery land through
-//! the delivery reconciliation pass.
+//! A run is a claimed occurrence dispatched through the one durable
+//! session-launch primitive `POST /sessions` uses
+//! (`api::launch_session_durable`): the definition is re-read, the familiar
+//! is admitted through the shared resolver, the maintenance gate is taken,
+//! and the session row is persisted before spawn. Coven (not a harness
+//! home) owns the record; terminal status, bounded log, and output delivery
+//! land through the delivery reconciliation pass.
 
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Utc};
@@ -15,7 +17,7 @@ use rusqlite::{params, Connection};
 use super::definition::RoutineDefinition;
 use super::occurrences::{claim_occurrence_by_id, mark_occurrence_running, settle_occurrence};
 use super::runs::{record_run_finish, record_run_session, record_run_start, RunFinish};
-use crate::api::{SessionLaunch, SessionRuntime};
+use crate::api::{DurableLaunch, DurableLaunchError, SessionLaunch, SessionRuntime};
 use crate::harness::HarnessLaunchMode;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,14 +57,106 @@ fn overlap_outcome(definition: &RoutineDefinition) -> RunOutcome {
     }
 }
 
+/// Resolves a routine's familiar through the same admission resolver
+/// `POST /sessions` uses. An automation launch must never bypass the
+/// familiar check (coven#816 finding 1).
+fn resolve_familiar_for_run(
+    coven_home: &Path,
+    familiar_id: Option<&str>,
+) -> Result<Option<crate::harness::FamiliarContext>, String> {
+    match crate::session_launch::resolve_familiar(coven_home, familiar_id) {
+        Ok(familiar) => Ok(familiar),
+        Err(crate::session_launch::FamiliarError::Unknown { error, .. }) => Err(format!("{error}")),
+        Err(crate::session_launch::FamiliarError::LookupFailed(error)) => {
+            Err(format!("familiar lookup failed: {error:#}"))
+        }
+    }
+}
+
+/// Launches through the shared durable primitive with the automation
+/// caller's fixed identity: no execution binding, no raw caller familiar.
+fn launch_durable(
+    coven_home: &Path,
+    launch: &SessionLaunch,
+    runtime: &dyn SessionRuntime,
+) -> Result<crate::store::SessionRecord, DurableLaunchError> {
+    crate::api::launch_session_durable(
+        coven_home,
+        launch,
+        DurableLaunch {
+            familiar_id: launch.familiar_id.clone(),
+            execution_binding: None,
+            raw_caller_familiar_id: None,
+        },
+        runtime,
+    )
+}
+
+/// A human-readable reason for every durable-launch failure mode.
+fn launch_failure_reason(error: &DurableLaunchError) -> String {
+    match error {
+        DurableLaunchError::MaintenanceGate { code, message, .. } => {
+            format!("maintenance gate rejected the launch ({code}): {message}")
+        }
+        DurableLaunchError::Rejected(_) => {
+            "launch rejected by parent-correlation validation".to_string()
+        }
+        DurableLaunchError::Store(error) => {
+            format!("durable launch persistence failed: {error:#}")
+        }
+        DurableLaunchError::LaunchRejected { message, .. } => message.clone(),
+    }
+}
+
+/// The session id a durable-launch failure already named, when one exists.
+fn launch_error_session_id(error: &DurableLaunchError) -> Option<String> {
+    match error {
+        DurableLaunchError::MaintenanceGate { session_id, .. } => Some(session_id.clone()),
+        DurableLaunchError::LaunchRejected { session_id, .. } => Some(session_id.clone()),
+        _ => None,
+    }
+}
+
+/// Terminally settles a launch failure: the occurrence and the ledger row
+/// both record the failure with its reason. A failed spawn must never leave
+/// claimed work or a running ledger row behind (coven#816 finding 1).
+fn settle_launch_failure(
+    conn: &Connection,
+    run_id: &str,
+    occurrence_id: &str,
+    reason: &str,
+    now: DateTime<Utc>,
+) {
+    if let Err(error) = settle_occurrence(conn, occurrence_id, "failed", Some(reason), now) {
+        eprintln!("coven automations: failed to settle occurrence {occurrence_id}: {error}");
+    }
+    if let Err(error) = record_run_finish(
+        conn,
+        run_id,
+        RunFinish {
+            status: "failed",
+            exit_code: None,
+            session_id: None,
+            log_json: None,
+            output_commit: None,
+        },
+        now,
+    ) {
+        eprintln!("coven automations: failed to settle run {run_id}: {error:#}");
+    }
+}
+
 /// Runs a routine once, now: fences and claims an immediate occurrence,
-/// records a ledger row, dispatches through the shared session-launch path,
-/// and leaves the run in flight with a bounded lease. Settlement — terminal
-/// status, exit code, bounded log, output delivery — happens through the
-/// reconciliation pass once the session finishes. A missing cwd fails the
-/// run with a recorded reason instead of guessing a project; a live
-/// previous occurrence fails the run (overlap: forbid).
+/// records a ledger row, persists the bounded lease and the durable session
+/// row before spawn, and dispatches through the shared session-launch
+/// primitive. Settlement — terminal status, exit code, bounded log, output
+/// delivery — happens through the reconciliation pass once the session
+/// finishes. A missing cwd or an unadmitted familiar fails the run with a
+/// recorded reason instead of guessing; a live previous occurrence fails
+/// the run (overlap: forbid); every launch failure is terminally settled
+/// in the ledger (coven#816 finding 1).
 pub fn run_routine_now(
+    coven_home: &Path,
     conn: &Connection,
     runtime: &dyn SessionRuntime,
     definition: &RoutineDefinition,
@@ -80,6 +174,17 @@ pub fn run_routine_now(
             session_id: None,
             error: Some("routine has no cwd; add a cwd before running".to_string()),
         });
+    };
+    let familiar = match resolve_familiar_for_run(coven_home, definition.familiar_id.as_deref()) {
+        Ok(familiar) => familiar,
+        Err(reason) => {
+            return Ok(RunOutcome {
+                run_id: String::new(),
+                status: "failed".to_string(),
+                session_id: None,
+                error: Some(reason),
+            });
+        }
     };
 
     let occurrence_id = fresh_id("occ");
@@ -120,43 +225,43 @@ pub fn run_routine_now(
     )
     .map_err(|error| format!("failed to record run start: {error:#}"))?;
 
-    let launch = build_session_launch(definition, cwd)?;
+    let mut launch = build_session_launch(definition, cwd)?;
+    launch.familiar_id = familiar.as_ref().map(|familiar| familiar.id.clone());
 
-    match runtime.launch_session(&launch) {
-        Ok(()) => {
-            // The run is in flight: keep the occurrence under a bounded
-            // lease, attach the session id, and let settlement happen from
-            // the Coven session store. Launch success is never reported as
-            // run success.
-            let lease = run_lease_minutes(definition);
-            let _ = mark_occurrence_running(conn, &occurrence_id, "manual", lease, now);
-            let _ = record_run_session(conn, &run_id, &launch.id);
+    // Persist the bounded lease before spawn: a crash after this point
+    // leaves recoverable work, never a stuck claim (coven#816 finding 1).
+    let lease = run_lease_minutes(definition);
+    if let Err(error) = mark_occurrence_running(conn, &occurrence_id, "manual", lease, now) {
+        let reason = format!("failed to persist the run lease: {error}");
+        settle_launch_failure(conn, &run_id, &occurrence_id, &reason, now);
+        return Ok(RunOutcome {
+            run_id,
+            status: "failed".to_string(),
+            session_id: None,
+            error: Some(reason),
+        });
+    }
+
+    match launch_durable(coven_home, &launch, runtime) {
+        Ok(record) => {
+            // The run is in flight under the persisted lease; settlement
+            // happens from the Coven session store. Launch success is never
+            // reported as run success.
+            let _ = record_run_session(conn, &run_id, &record.id);
             Ok(RunOutcome {
                 run_id,
                 status: "dispatched".to_string(),
-                session_id: Some(launch.id),
+                session_id: Some(record.id),
                 error: None,
             })
         }
         Err(error) => {
-            let reason = format!("{error:#}");
-            let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
-            let _ = record_run_finish(
-                conn,
-                &run_id,
-                RunFinish {
-                    status: "failed",
-                    exit_code: None,
-                    session_id: None,
-                    log_json: None,
-                    output_commit: None,
-                },
-                now,
-            );
+            let reason = launch_failure_reason(&error);
+            settle_launch_failure(conn, &run_id, &occurrence_id, &reason, now);
             Ok(RunOutcome {
                 run_id,
                 status: "failed".to_string(),
-                session_id: None,
+                session_id: launch_error_session_id(&error),
                 error: Some(reason),
             })
         }
@@ -192,14 +297,17 @@ pub struct DispatchReport {
     pub failed: Vec<String>,
 }
 
-/// Dispatches every claimed occurrence that the scheduler has fenced: builds
-/// the launch, records the ledger row, and launches through the shared
-/// runtime path. A dispatched run stays in flight under a bounded lease —
-/// the reconciliation pass (`delivery::settle_finished_runs`) settles the
-/// occurrence and the ledger once the session finishes. Claimed occurrences
-/// whose routine has no cwd fail with a recorded reason instead of guessing
-/// a project.
+/// Dispatches every valid claimed occurrence the scheduler has fenced:
+/// admits the familiar, records the ledger row, persists the bounded lease
+/// and the durable session row before spawn, and launches through the
+/// shared session-launch primitive. A dispatched run stays in flight under
+/// its lease — the reconciliation pass (`delivery::settle_finished_runs`)
+/// settles the occurrence and the ledger once the session finishes. Every
+/// launch failure is terminally settled in the ledger (coven#816 finding
+/// 1); claimed occurrences whose routine has no cwd fail with a recorded
+/// reason instead of guessing a project.
 pub fn dispatch_claimed_occurrences(
+    coven_home: &Path,
     conn: &Connection,
     runtime: &dyn SessionRuntime,
     now: DateTime<Utc>,
@@ -243,6 +351,17 @@ pub fn dispatch_claimed_occurrences(
             continue;
         };
 
+        let familiar = match resolve_familiar_for_run(coven_home, definition.familiar_id.as_deref())
+        {
+            Ok(familiar) => familiar,
+            Err(reason) => {
+                let reason = format!("{automation_id}: {reason}");
+                let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
+                report.failed.push(reason);
+                continue;
+            }
+        };
+
         let run_id = fresh_id("run");
         let started = record_run_start(
             conn,
@@ -258,36 +377,37 @@ pub fn dispatch_claimed_occurrences(
             continue;
         }
 
-        match build_session_launch(&definition, cwd).and_then(|launch| {
-            runtime
-                .launch_session(&launch)
-                .map(|()| launch)
-                .map_err(|error| format!("{error:#}"))
-        }) {
-            Ok(launch) => {
-                // The run is in flight: keep the occurrence under a bounded
-                // lease, attach the session id, and let settlement happen
-                // from the Coven session store. Launch success is never
-                // reported as run success (coven#816).
-                let lease = run_lease_minutes(&definition);
-                let _ = mark_occurrence_running(conn, &occurrence_id, "daemon", lease, now);
-                let _ = record_run_session(conn, &run_id, &launch.id);
+        let mut launch = match build_session_launch(&definition, cwd) {
+            Ok(launch) => launch,
+            Err(reason) => {
+                settle_launch_failure(conn, &run_id, &occurrence_id, &reason, now);
+                report.failed.push(format!("{automation_id}: {reason}"));
+                continue;
+            }
+        };
+        launch.familiar_id = familiar.as_ref().map(|familiar| familiar.id.clone());
+
+        // Persist the bounded lease before spawn: a crash after this point
+        // leaves recoverable work, never a stuck claim (coven#816 finding 1).
+        let lease = run_lease_minutes(&definition);
+        if let Err(error) = mark_occurrence_running(conn, &occurrence_id, "daemon", lease, now) {
+            let reason = format!("failed to persist the run lease: {error}");
+            settle_launch_failure(conn, &run_id, &occurrence_id, &reason, now);
+            report.failed.push(format!("{automation_id}: {reason}"));
+            continue;
+        }
+
+        match launch_durable(coven_home, &launch, runtime) {
+            Ok(record) => {
+                // The run is in flight under the persisted lease; settlement
+                // happens from the Coven session store. Launch success is
+                // never reported as run success (coven#816).
+                let _ = record_run_session(conn, &run_id, &record.id);
                 report.dispatched.push(run_id);
             }
-            Err(reason) => {
-                let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
-                let _ = record_run_finish(
-                    conn,
-                    &run_id,
-                    RunFinish {
-                        status: "failed",
-                        exit_code: None,
-                        session_id: None,
-                        log_json: None,
-                        output_commit: None,
-                    },
-                    now,
-                );
+            Err(error) => {
+                let reason = launch_failure_reason(&error);
+                settle_launch_failure(conn, &run_id, &occurrence_id, &reason, now);
                 report.failed.push(format!("{automation_id}: {reason}"));
             }
         }
@@ -358,20 +478,30 @@ mod tests {
         .unwrap()
     }
 
+    /// A temp COVEN_HOME with the real store layout (`coven.sqlite3`) and a
+    /// seeded familiar roster, because dispatch now resolves the familiar
+    /// through the shared admission path.
     fn temp_store() -> (tempfile::TempDir, Connection) {
         let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("store.sqlite");
-        initialize_store(&path).unwrap();
-        let conn = crate::store::open_store(&path).unwrap();
+        let home = temp.path();
+        std::fs::write(
+            home.join("familiars.toml"),
+            "[[familiar]]\nid = \"charm\"\ndisplay_name = \"Charm\"\nrole = \"Code\"\ndescription = \"Does the thing.\"\n",
+        )
+        .unwrap();
+        initialize_store(&home.join("coven.sqlite3")).unwrap();
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
         (temp, conn)
     }
 
     #[test]
-    fn successful_dispatch_leaves_the_run_in_flight() {
-        let (_temp, conn) = temp_store();
-        insert_definition(&conn, &definition("daily")).unwrap();
+    fn successful_dispatch_leaves_the_run_in_flight_and_a_durable_session_row() {
+        let (_temp, home_conn) = temp_store();
+        let home = _temp.path();
+        insert_definition(&home_conn, &definition("daily")).unwrap();
         let outcome = run_routine_now(
-            &conn,
+            home,
+            &home_conn,
             &crate::api::NoopSessionRuntime,
             &definition("daily"),
             Utc::now(),
@@ -381,9 +511,9 @@ mod tests {
         // settlement pass reports the terminal status from the Coven session
         // store.
         assert_eq!(outcome.status, "dispatched");
-        assert!(outcome.session_id.is_some());
+        let session_id = outcome.session_id.clone().unwrap();
 
-        let state: String = conn
+        let state: String = home_conn
             .query_row(
                 "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
                 [],
@@ -392,15 +522,24 @@ mod tests {
             .unwrap();
         assert_eq!(state, "running");
 
-        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        let runs = super::super::runs::list_runs(&home_conn, "daily", 10).unwrap();
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].status, "running");
         assert_eq!(runs[0].session_id, outcome.session_id);
         assert_eq!(runs[0].familiar_id.as_deref(), Some("charm"));
 
+        // The durable launch primitive persisted the session row before
+        // spawn (coven#816 finding 1).
+        let session = crate::store::get_session(&home_conn, &session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "running");
+        assert_eq!(session.project_root, "/work/project");
+
         // A live run blocks a second one (overlap: forbid).
         let second = run_routine_now(
-            &conn,
+            home,
+            &home_conn,
             &crate::api::NoopSessionRuntime,
             &definition("daily"),
             Utc::now(),
@@ -409,7 +548,7 @@ mod tests {
         assert_eq!(second.status, "failed");
         let second_error = second.error.clone().unwrap_or_default();
         assert!(second_error.contains("overlap"), "{second_error}");
-        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        let runs = super::super::runs::list_runs(&home_conn, "daily", 10).unwrap();
         assert_eq!(runs.len(), 1, "the rejected run records no ledger row");
     }
 
@@ -423,18 +562,25 @@ mod tests {
     }
 
     #[test]
-    fn failed_launch_records_a_failed_run() {
-        let (_temp, conn) = temp_store();
-        insert_definition(&conn, &definition("daily")).unwrap();
-        let outcome =
-            run_routine_now(&conn, &RejectingRuntime, &definition("daily"), Utc::now()).unwrap();
+    fn failed_launch_records_a_failed_run_and_a_failed_session_row() {
+        let (_temp, home_conn) = temp_store();
+        let home = _temp.path();
+        insert_definition(&home_conn, &definition("daily")).unwrap();
+        let outcome = run_routine_now(
+            home,
+            &home_conn,
+            &RejectingRuntime,
+            &definition("daily"),
+            Utc::now(),
+        )
+        .unwrap();
         assert_eq!(outcome.status, "failed");
         assert!(outcome.error.as_deref().unwrap().contains("synthetic"));
 
-        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        let runs = super::super::runs::list_runs(&home_conn, "daily", 10).unwrap();
         assert_eq!(runs[0].status, "failed");
 
-        let state: String = conn
+        let state: String = home_conn
             .query_row(
                 "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
                 [],
@@ -442,17 +588,26 @@ mod tests {
             )
             .unwrap();
         assert_eq!(state, "failed");
+
+        // The durable row the primitive persisted before spawn is terminally
+        // settled to `failed` — the launch failure is visible everywhere.
+        let session = crate::store::get_session(&home_conn, &outcome.session_id.unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "failed");
     }
 
     #[test]
     fn missing_cwd_fails_without_launching() {
-        let (_temp, conn) = temp_store();
+        let (_temp, home_conn) = temp_store();
+        let home = _temp.path();
         let mut definition = definition("nocwd");
         definition.cwd = None;
-        insert_definition(&conn, &definition).unwrap();
+        insert_definition(&home_conn, &definition).unwrap();
 
         let outcome = run_routine_now(
-            &conn,
+            home,
+            &home_conn,
             &crate::api::NoopSessionRuntime,
             &definition,
             Utc::now(),
@@ -460,5 +615,30 @@ mod tests {
         .unwrap();
         assert_eq!(outcome.status, "failed");
         assert!(outcome.error.as_deref().unwrap().contains("no cwd"));
+    }
+
+    #[test]
+    fn an_unadmitted_familiar_fails_without_launching() {
+        let (_temp, home_conn) = temp_store();
+        let home = _temp.path();
+        let mut definition = definition("ghost");
+        definition.familiar_id = Some("ghost".to_string());
+        insert_definition(&home_conn, &definition).unwrap();
+
+        let outcome = run_routine_now(
+            home,
+            &home_conn,
+            &crate::api::NoopSessionRuntime,
+            &definition,
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "failed");
+        assert!(
+            outcome.error.as_deref().unwrap().contains("ghost"),
+            "{outcome:?}"
+        );
+        let runs = super::super::runs::list_runs(&home_conn, "ghost", 10).unwrap();
+        assert_eq!(runs.len(), 0, "admission failures never record ledger rows");
     }
 }

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -315,14 +315,22 @@ pub fn dispatch_claimed_occurrences(
     let mut report = DispatchReport::default();
 
     let claimed: Vec<(String, String)> = {
+        let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         let mut statement = conn
             .prepare(
+                // Every valid existing claim — not just ones this pass made —
+                // reaches dispatch here, so control-plane claims and
+                // crash-interrupted claims never stay stuck (coven#816
+                // finding 2). Expired leases are excluded: lease recovery
+                // owns them.
                 "SELECT id, automation_id FROM automation_occurrences
-                 WHERE state = 'claimed' ORDER BY scheduled_for ASC",
+                 WHERE state = 'claimed'
+                   AND (lease_expires_at IS NULL OR lease_expires_at >= ?1)
+                 ORDER BY scheduled_for ASC",
             )
             .map_err(|error| format!("failed to list claimed occurrences: {error}"))?;
         let rows = statement
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .query_map(params![now_iso], |row| Ok((row.get(0)?, row.get(1)?)))
             .map_err(|error| format!("failed to list claimed occurrences: {error}"))?;
         let mut out = Vec::new();
         for row in rows {

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -2,18 +2,19 @@
 //!
 //! A run is a claimed occurrence dispatched through the exact session-launch
 //! path every other launch uses: the definition is re-read, the familiar and
-//! runtime are re-validated per run, a SessionLaunch is built, and the
-//! occurrence plus the run ledger settle together. Coven (not a harness home)
-//! owns the record.
+//! runtime are re-validated per run, a SessionLaunch is built, and the run
+//! goes in flight under a bounded lease. Coven (not a harness home) owns the
+//! record; terminal status, bounded log, and output delivery land through
+//! the delivery reconciliation pass.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Utc};
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 
 use super::definition::RoutineDefinition;
-use super::occurrences::{settle_occurrence, PlanOutcome};
-use super::runs::{record_run_finish, record_run_start, RunFinish};
+use super::occurrences::{claim_occurrence_by_id, mark_occurrence_running, settle_occurrence};
+use super::runs::{record_run_finish, record_run_session, record_run_start, RunFinish};
 use crate::api::{SessionLaunch, SessionRuntime};
 use crate::harness::HarnessLaunchMode;
 
@@ -33,10 +34,34 @@ fn fresh_id(prefix: &str) -> String {
     format!("{prefix}-{millis}")
 }
 
+/// The dispatch lease for a routine run: the definition's own timeout,
+/// bounded to the same 1..=1440 minute window claims use. The lease must
+/// outlive a healthy run so lease recovery only ever catches genuinely
+/// wedged work (coven#816: "never let a stale running record block a
+/// routine forever").
+fn run_lease_minutes(definition: &RoutineDefinition) -> i64 {
+    i64::from(definition.timeout_minutes.clamp(1, 24 * 60))
+}
+
+fn overlap_outcome(definition: &RoutineDefinition) -> RunOutcome {
+    RunOutcome {
+        run_id: String::new(),
+        status: "failed".to_string(),
+        session_id: None,
+        error: Some(format!(
+            "overlap: another occurrence of `{}` is still running",
+            definition.id
+        )),
+    }
+}
+
 /// Runs a routine once, now: fences and claims an immediate occurrence,
 /// records a ledger row, dispatches through the shared session-launch path,
-/// and settles occurrence + ledger together. A missing cwd fails the run
-/// with a recorded reason instead of guessing a project.
+/// and leaves the run in flight with a bounded lease. Settlement — terminal
+/// status, exit code, bounded log, output delivery — happens through the
+/// reconciliation pass once the session finishes. A missing cwd fails the
+/// run with a recorded reason instead of guessing a project; a live
+/// previous occurrence fails the run (overlap: forbid).
 pub fn run_routine_now(
     conn: &Connection,
     runtime: &dyn SessionRuntime,
@@ -64,17 +89,24 @@ pub fn run_routine_now(
             "INSERT OR IGNORE INTO automation_occurrences
                 (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
              VALUES (?1, ?2, ?3, 'planned', 0, ?3, ?3)",
-            rusqlite::params![occurrence_id, definition.id, now_iso],
+            params![occurrence_id, definition.id, now_iso],
         )
         .map_err(|error| format!("failed to fence immediate occurrence: {error}"))?;
     if inserted == 0 {
         return Err("immediate occurrence fence collided; retry".to_string());
     }
-    let _ = PlanOutcome::Planned; // keep the import meaningful if API changes
 
-    let claimed =
-        super::occurrences::claim_due_occurrence(conn, &definition.id, "manual", 60, now)?;
-    let occurrence_id = claimed.unwrap_or(occurrence_id);
+    let claimed = claim_occurrence_by_id(conn, &occurrence_id, "manual", 60, now)?;
+    if claimed.is_none() {
+        // The claim was refused — in practice a live sibling run appeared
+        // first (overlap: forbid). Release our fence so the daemon can never
+        // dispatch it later, then fail visibly.
+        let _ = conn.execute(
+            "DELETE FROM automation_occurrences WHERE id = ?1 AND state = 'planned'",
+            params![occurrence_id],
+        );
+        return Ok(overlap_outcome(definition));
+    }
 
     let run_id = fresh_id("run");
     record_run_start(
@@ -92,22 +124,16 @@ pub fn run_routine_now(
 
     match runtime.launch_session(&launch) {
         Ok(()) => {
-            let _ = settle_occurrence(conn, &occurrence_id, "succeeded", None, now);
-            let _ = record_run_finish(
-                conn,
-                &run_id,
-                RunFinish {
-                    status: "succeeded",
-                    exit_code: Some(0),
-                    session_id: Some(launch.id.clone()),
-                    log_json: None,
-                    output_commit: None,
-                },
-                now,
-            );
+            // The run is in flight: keep the occurrence under a bounded
+            // lease, attach the session id, and let settlement happen from
+            // the Coven session store. Launch success is never reported as
+            // run success.
+            let lease = run_lease_minutes(definition);
+            let _ = mark_occurrence_running(conn, &occurrence_id, "manual", lease, now);
+            let _ = record_run_session(conn, &run_id, &launch.id);
             Ok(RunOutcome {
                 run_id,
-                status: "succeeded".to_string(),
+                status: "dispatched".to_string(),
                 session_id: Some(launch.id),
                 error: None,
             })
@@ -167,10 +193,12 @@ pub struct DispatchReport {
 }
 
 /// Dispatches every claimed occurrence that the scheduler has fenced: builds
-/// the launch, records the ledger row, launches through the shared runtime
-/// path, and settles occurrence + ledger together. Claimed occurrences whose
-/// routine has no cwd fail with a recorded reason instead of guessing a
-/// project.
+/// the launch, records the ledger row, and launches through the shared
+/// runtime path. A dispatched run stays in flight under a bounded lease —
+/// the reconciliation pass (`delivery::settle_finished_runs`) settles the
+/// occurrence and the ledger once the session finishes. Claimed occurrences
+/// whose routine has no cwd fail with a recorded reason instead of guessing
+/// a project.
 pub fn dispatch_claimed_occurrences(
     conn: &Connection,
     runtime: &dyn SessionRuntime,
@@ -237,19 +265,13 @@ pub fn dispatch_claimed_occurrences(
                 .map_err(|error| format!("{error:#}"))
         }) {
             Ok(launch) => {
-                let _ = settle_occurrence(conn, &occurrence_id, "succeeded", None, now);
-                let _ = record_run_finish(
-                    conn,
-                    &run_id,
-                    RunFinish {
-                        status: "succeeded",
-                        exit_code: Some(0),
-                        session_id: Some(launch.id),
-                        log_json: None,
-                        output_commit: None,
-                    },
-                    now,
-                );
+                // The run is in flight: keep the occurrence under a bounded
+                // lease, attach the session id, and let settlement happen
+                // from the Coven session store. Launch success is never
+                // reported as run success (coven#816).
+                let lease = run_lease_minutes(&definition);
+                let _ = mark_occurrence_running(conn, &occurrence_id, "daemon", lease, now);
+                let _ = record_run_session(conn, &run_id, &launch.id);
                 report.dispatched.push(run_id);
             }
             Err(reason) => {
@@ -345,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn successful_run_settles_occurrence_and_ledger() {
+    fn successful_dispatch_leaves_the_run_in_flight() {
         let (_temp, conn) = temp_store();
         insert_definition(&conn, &definition("daily")).unwrap();
         let outcome = run_routine_now(
@@ -355,13 +377,11 @@ mod tests {
             Utc::now(),
         )
         .unwrap();
-        assert_eq!(outcome.status, "succeeded");
+        // Launch success is not run success: the run is dispatched and the
+        // settlement pass reports the terminal status from the Coven session
+        // store.
+        assert_eq!(outcome.status, "dispatched");
         assert!(outcome.session_id.is_some());
-
-        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
-        assert_eq!(runs.len(), 1);
-        assert_eq!(runs[0].status, "succeeded");
-        assert_eq!(runs[0].familiar_id.as_deref(), Some("charm"));
 
         let state: String = conn
             .query_row(
@@ -370,7 +390,36 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(state, "succeeded");
+        assert_eq!(state, "running");
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "running");
+        assert_eq!(runs[0].session_id, outcome.session_id);
+        assert_eq!(runs[0].familiar_id.as_deref(), Some("charm"));
+
+        // A live run blocks a second one (overlap: forbid).
+        let second = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(second.status, "failed");
+        let second_error = second.error.clone().unwrap_or_default();
+        assert!(second_error.contains("overlap"), "{second_error}");
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs.len(), 1, "the rejected run records no ledger row");
+    }
+
+    #[test]
+    fn build_session_launch_carries_familiar_and_runtime() {
+        let launch = build_session_launch(&definition("daily"), "/work/project").unwrap();
+        assert_eq!(launch.familiar_id.as_deref(), Some("charm"));
+        assert_eq!(launch.harness, "coven-code");
+        assert_eq!(launch.launch_mode, HarnessLaunchMode::NonInteractive);
+        assert_eq!(launch.project_root, "/work/project");
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/runs.rs
+++ b/crates/coven-cli/src/automations/runs.rs
@@ -30,10 +30,11 @@ pub const AUTOMATION_RUNS_SCHEMA_SQL: &str = "
         ON automation_runs(automation_id, started_at DESC);
 ";
 
-#[allow(dead_code)]
-const LOG_ENTRY_MAX_CHARS: usize = 64 * 1024;
+/// Per-run bounded log budget: a stored ledger log never exceeds this many
+/// characters. The delivery capture keeps the tail (latest events) when a
+/// session's normalized stream exceeds it.
+pub const LOG_ENTRY_MAX_CHARS: usize = 64 * 1024;
 
-#[allow(dead_code)]
 fn iso(instant: DateTime<Utc>) -> String {
     instant.to_rfc3339_opts(SecondsFormat::Millis, true)
 }
@@ -54,7 +55,6 @@ pub struct RunRecord {
     pub finished_at: Option<String>,
 }
 
-#[allow(dead_code)] // consumed by the part-4 dispatch path; tests cover it today
 pub fn record_run_start(
     conn: &Connection,
     run_id: &str,
@@ -81,7 +81,18 @@ pub fn record_run_start(
     Ok(())
 }
 
-#[allow(dead_code)] // consumed by the part-4 dispatch path; tests cover it today
+/// Attaches the launched session id to a still-running ledger row. The run
+/// has been dispatched but not settled: its terminal status, exit code, and
+/// bounded log arrive later via the reconciliation pass.
+pub fn record_run_session(conn: &Connection, run_id: &str, session_id: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE automation_runs SET session_id = ?2 WHERE id = ?1 AND status = 'running'",
+        params![run_id, session_id],
+    )
+    .context("failed to attach session id to run")?;
+    Ok(())
+}
+
 pub struct RunFinish {
     pub status: &'static str,
     pub exit_code: Option<i64>,
@@ -90,7 +101,6 @@ pub struct RunFinish {
     pub output_commit: Option<String>,
 }
 
-#[allow(dead_code)] // consumed by the part-4 dispatch path; tests cover it today
 pub fn record_run_finish(
     conn: &Connection,
     run_id: &str,

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -132,6 +132,7 @@ pub fn capabilities() -> CapabilityCatalog {
 
 pub fn route_action(
     payload: Value,
+    coven_home: &std::path::Path,
     conn: &rusqlite::Connection,
     runtime: &dyn crate::api::SessionRuntime,
 ) -> (u16, ControlActionResponse) {
@@ -294,7 +295,7 @@ pub fn route_action(
                     action,
                     origin,
                     intent_id,
-                    automation_run_payload(conn, runtime, &id, now),
+                    automation_run_payload(conn, coven_home, runtime, &id, now),
                 ),
                 Err(error) => return (400, rejected_action(action, error)),
             };
@@ -411,13 +412,20 @@ fn automation_import_payload(conn: &rusqlite::Connection) -> Value {
 
 fn automation_run_payload(
     conn: &rusqlite::Connection,
+    coven_home: &std::path::Path,
     runtime: &dyn crate::api::SessionRuntime,
     id: &str,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Value {
     match crate::automations::runner::load_definition_for_run(conn, id) {
         Ok(Some(definition)) => {
-            match crate::automations::runner::run_routine_now(conn, runtime, &definition, now) {
+            match crate::automations::runner::run_routine_now(
+                coven_home,
+                conn,
+                runtime,
+                &definition,
+                now,
+            ) {
                 Ok(outcome) => json!({
                     "runId": outcome.run_id,
                     "status": outcome.status,

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -354,17 +354,25 @@ fn automation_tick_payload(
     conn: &rusqlite::Connection,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Value {
-    match crate::automations::occurrences::tick(conn, now) {
-        Ok(report) => json!({
-            "planned": report.planned,
-            "alreadyFenced": report.already_fenced,
-            "pausedSkipped": report.paused_skipped,
-            "recovered": report.recovered,
-            "claimed": report.claimed,
-            "failed": report.failed,
-        }),
-        Err(error) => json!({ "error": format!("{error:#}") }),
-    }
+    let report = match crate::automations::occurrences::tick(conn, now) {
+        Ok(report) => report,
+        Err(error) => return json!({ "error": format!("{error:#}") }),
+    };
+    let settled = match crate::automations::delivery::settle_finished_runs(conn, now) {
+        Ok(settled) => settled,
+        Err(error) => return json!({ "error": error }),
+    };
+    json!({
+        "planned": report.planned,
+        "alreadyFenced": report.already_fenced,
+        "pausedSkipped": report.paused_skipped,
+        "recovered": report.recovered,
+        "claimed": report.claimed,
+        "settledSucceeded": settled.settled_succeeded,
+        "settledFailed": settled.settled_failed,
+        "failures": settled.failures,
+        "failed": report.failed,
+    })
 }
 
 fn automation_health_payload(

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -250,7 +250,7 @@ pub fn route_action(
                 action,
                 origin,
                 intent_id,
-                automation_tick_payload(conn, now),
+                automation_tick_payload(coven_home, conn, runtime, now),
             );
             (200, event)
         }
@@ -352,27 +352,31 @@ fn required_definition_field(
 }
 
 fn automation_tick_payload(
+    coven_home: &std::path::Path,
     conn: &rusqlite::Connection,
+    runtime: &dyn crate::api::SessionRuntime,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Value {
-    let report = match crate::automations::occurrences::tick(conn, now) {
+    // The action shares the daemon's full tick: plan, recover, claim,
+    // dispatch every valid existing claim, and settle finished runs. A
+    // control-plane claim is dispatched by this same pass — never left
+    // stuck for a later tick (coven#816 finding 2).
+    let report = match crate::automations::full_tick(coven_home, conn, runtime, now) {
         Ok(report) => report,
-        Err(error) => return json!({ "error": format!("{error:#}") }),
-    };
-    let settled = match crate::automations::delivery::settle_finished_runs(conn, now) {
-        Ok(settled) => settled,
         Err(error) => return json!({ "error": error }),
     };
     json!({
-        "planned": report.planned,
-        "alreadyFenced": report.already_fenced,
-        "pausedSkipped": report.paused_skipped,
-        "recovered": report.recovered,
-        "claimed": report.claimed,
-        "settledSucceeded": settled.settled_succeeded,
-        "settledFailed": settled.settled_failed,
-        "failures": settled.failures,
-        "failed": report.failed,
+        "planned": report.tick.planned,
+        "alreadyFenced": report.tick.already_fenced,
+        "pausedSkipped": report.tick.paused_skipped,
+        "recovered": report.tick.recovered,
+        "claimed": report.tick.claimed,
+        "dispatched": report.dispatch.dispatched,
+        "dispatchFailed": report.dispatch.failed,
+        "settledSucceeded": report.settlement.settled_succeeded,
+        "settledFailed": report.settlement.settled_failed,
+        "failures": report.settlement.failures,
+        "failed": report.tick.failed,
     })
 }
 

--- a/docs/start/automation.md
+++ b/docs/start/automation.md
@@ -12,6 +12,18 @@ Coven is the canonical shared local runtime for reusable automation. The chat/in
 user -> chat/intake client -> Coven -> adapters -> desktop/apps
 ```
 
+## Coven-native routine automations
+
+Recurring routine work (`coven.automations`) is **owned by Coven, end to
+end**: Coven stores the canonical routine definitions in its own store (never
+a harness home), its scheduler plans and fences every occurrence in durable
+state, dispatches runs with a fresh familiar + authority resolution, records
+the run ledger, and delivers outputs itself. An external runtime may execute
+an already-claimed occurrence, but it never owns the schedule and never owns
+the record — runtimes are replaceable workers. The `coven.scheduler`
+capability stays reserved for multi-host routing decisions and is not the
+recurring-work surface.
+
 Use the canonical [CLI reference](https://docs.opencoven.ai/docs/cli) for
 scriptable commands and the [local API guide](https://docs.opencoven.ai/docs/reference/api)
 for programmatic clients.


### PR DESCRIPTION
## Summary

Implements the next slice of Coven-native routine automations: **truthful run settlement, output delivery, and overlap enforcement** — the delivery/observability half of #816 (the "part 4" behaviors; parts 1, 5, 6, 7, 8 are already merged).

Before this change, a routine run was recorded `succeeded` with exit code `0` the moment `launch_session` returned — the ledger lied about runs that were still in flight or had failed. With this slice, Coven owns the whole lifecycle end to end:

- **Truthful settlement.** Dispatch leaves the run in flight: the occurrence moves to `running` under a bounded lease derived from the definition timeout, and the ledger row keeps `running` with the launched session id. A new reconciliation pass (`automations::delivery::settle_finished_runs`) settles both from the Coven session store — terminal status, exit code, and a bounded log of the normalized stream — and runs on every daemon tick and `coven.automations.tick`.
- **Atomic output delivery.** When a definition configures `outputTarget`, Coven (not the model) commits the final assistant payload with a tmp-file + rename atomic write. A failed output commit fails the run visibly; it is never reported as success. Nothing is delivered for failed runs.
- **Overlap enforcement.** `overlap: forbid` is now enforced at claim time: a routine with a live claimed/running occurrence rejects new claims (scheduled and manual alike). Run-now rejections fail visibly with an `overlap:` reason and record no ledger row, and never leave a stray planned occurrence behind.
- **Fail-closed wire defaults.** Definitions now default to `PAUSED`, runtime `coven-code`, misfire `latest`, overlap `forbid`, timezone `local` when fields are omitted on create.
- **Stale runs can never wedge a routine.** `running` rows carry bounded recoverable leases; lease recovery fails them with a recorded reason and the reconciliation pass settles their ledger rows.

`coven.scheduler` remains reserved for multi-host routing; recurring work stays advertised separately as `coven.automations`.

## Issue

Refs OpenCoven/coven#816

Refs OpenCoven/coven#816 (re-target upstream to close it)

## Test plan

Checked = ran locally on this host (no Rust toolchain available — cargo checks are deferred to CI):

- [x] `python scripts/check-secrets.py` — clean
- [x] `python3 scripts/check-coven-privacy.py --staged` — clean
- [x] Line-width audit (`<= 100 cols`) across all changed Rust files (rustfmt conformance)

Deferred to CI (no cargo/rustc on this host):

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace --locked`

New/updated focused tests: wire defaults; overlap-forbid claim rejection; bounded recoverable leases on `running` rows; dispatch leaves runs in flight (never instantly "successful"); overlap rejection records no second ledger row; bounded log keeps the tail within the 64 KiB budget; final-output selection; atomic output commit + temp-file cleanup; failed output commit fails the run visibly; failed session fails the run without delivery; recovered occurrence settles its ledger row; still-running rows untouched; daemon tick plans → claims → dispatches → settles; control-plane run-now/tick/runs end-to-end.

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#816.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/13], preserving source head `16d7b7f29df7125aa6434ddecab1313b66cf578a` and branch `agent/issue-816-native-familiar-automations-replace-harness-owned`.