### PR TITLE
feat(agents): add invocation identity and canonical invocation events

### DIFF
--- a/crates/coven-agents/README.md
+++ b/crates/coven-agents/README.md
@@ -27,6 +27,22 @@ from session history. Results correlate to calls by id, so the runner rejects a
 response that reuses one before running any tool in that response, with
 `RunError::DuplicateToolCallId`.
 
+Every run carries one stable `InvocationId` from its `InvocationStarted` event
+through its terminal event. Callers pin the identity through
+`RunOptions::invocation_id`; when they do not, the runner generates a
+process-scoped one that is not durable across restarts. Nested work correlates
+to its parent through `RunOptions::parent_invocation`, so observers can
+reconstruct parent/child relationships without parsing model prose. The
+canonical `InvocationEvent` stream, delivered to an `InvocationObserver`,
+reports the validated `AgentRef` target (with an optional revision pin) at
+start, the agent that completed or failed at the terminal event, and the
+invocation's `RunFailureKind` on failure. The legacy pointer-swap handoff is
+reported as `ControlTransferred`: it moves control inside one invocation and is
+not durable A2A delegation — an explicit delegation contract replaces it in a
+later slice. The `RunObserver` stream remains unchanged during migration and
+will be folded into the canonical events; `Runner::run` remains the
+compatibility facade while that migration is incomplete.
+
 `GoalLoopRunner` composes the single-run `Runner` into a bounded
 `loop-until-done` primitive. An injected `LoopEvaluator` decides whether each
 result satisfies the goal or supplies the next input, while an injected
@@ -43,8 +59,13 @@ does not own SQLite, daemon scheduling, GitHub labels, or UI state.
 
 The crate deliberately does not include an OpenAI client, a daemon command,
 MCP, sandbox execution, voice, or realtime transport. Those are adapters and
-application concerns. Keeping this crate as a workspace leaf also allows it to
-move into its own repository if the API stabilizes.
+application concerns. This crate is Coven's agent behavior/execution component:
+it owns the one-agent model/tool/policy loop. Invocation and delegation
+ownership belongs to the Psyche orchestration contracts, process and harness
+execution to the Coven daemon, and remote placement to the existing Coven hub.
+It must not grow into a second distributed A2A runtime. Keeping this crate as a
+workspace leaf also allows it to move into its own repository if the API
+stabilizes.
 
 The implementation was derived from public behavioral documentation and
 OpenCoven's existing runtime requirements, not from another SDK's source code.

--- a/crates/coven-agents/src/error.rs
+++ b/crates/coven-agents/src/error.rs
@@ -112,12 +112,16 @@ pub enum RunError {
 /// The runner never writes `new_items` to the session store on failure, so a
 /// failed run cannot silently become durable history. Persisting a partial
 /// transcript is a deliberate caller decision.
+///
+/// The wrapped error is boxed to keep `RunFailure` small: the runner returns
+/// it by value on every failure path, and the workspace clippy policy rejects
+/// `Err` variants larger than 128 bytes.
 #[derive(Debug)]
 pub struct RunFailure {
     /// The stable invocation identity of the failed run, matching the identity
     /// carried by its invocation events.
     pub invocation: InvocationId,
-    pub error: RunError,
+    pub error: Box<RunError>,
     /// Items produced during this run before it failed, in order. Always begins
     /// with the user message that started the run.
     pub new_items: Vec<RunItem>,
@@ -131,19 +135,19 @@ pub struct RunFailure {
 impl RunFailure {
     /// Discards the partial transcript and keeps only the error.
     pub fn into_error(self) -> RunError {
-        self.error
+        *self.error
     }
 }
 
 impl std::fmt::Display for RunFailure {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.error, formatter)
+        std::fmt::Display::fmt(self.error.as_ref(), formatter)
     }
 }
 
 impl std::error::Error for RunFailure {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.error)
+        Some(self.error.as_ref())
     }
 }
 
@@ -155,7 +159,7 @@ mod tests {
     fn run_failure_exposes_the_wrapped_error_as_its_source() {
         let failure = RunFailure {
             invocation: InvocationId::try_new("inv-test").unwrap(),
-            error: RunError::SessionUnavailable,
+            error: Box::new(RunError::SessionUnavailable),
             new_items: Vec::new(),
             turns: 0,
             handoffs: 0,

--- a/crates/coven-agents/src/error.rs
+++ b/crates/coven-agents/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{AgentId, RunItem};
+use crate::{AgentId, InvocationId, RunItem};
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -34,6 +34,13 @@ pub enum ConfigError {
         agent: AgentId,
         handoff: String,
         target: AgentId,
+    },
+    #[error("invocation id {reason}")]
+    InvalidInvocationId { reason: &'static str },
+    #[error("agent reference {component} {reason}")]
+    InvalidAgentRef {
+        component: &'static str,
+        reason: &'static str,
     },
 }
 
@@ -107,6 +114,9 @@ pub enum RunError {
 /// transcript is a deliberate caller decision.
 #[derive(Debug)]
 pub struct RunFailure {
+    /// The stable invocation identity of the failed run, matching the identity
+    /// carried by its invocation events.
+    pub invocation: InvocationId,
     pub error: RunError,
     /// Items produced during this run before it failed, in order. Always begins
     /// with the user message that started the run.
@@ -144,6 +154,7 @@ mod tests {
     #[test]
     fn run_failure_exposes_the_wrapped_error_as_its_source() {
         let failure = RunFailure {
+            invocation: InvocationId::try_new("inv-test").unwrap(),
             error: RunError::SessionUnavailable,
             new_items: Vec::new(),
             turns: 0,

--- a/crates/coven-agents/src/invocation.rs
+++ b/crates/coven-agents/src/invocation.rs
@@ -1,0 +1,297 @@
+use std::{
+    fmt,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{AgentId, ConfigError, RunFailureKind};
+
+const MAX_IDENTITY_BYTES: usize = 127;
+
+/// Validates one identity component of an invocation reference.
+///
+/// Invocation identity is correlation data that survives logging, queues, and
+/// transport, so unrestricted strings are not sufficient: an empty component
+/// correlates nothing, an oversized one truncates, and unbounded whitespace or
+/// control characters make ids ambiguous across systems that trim or escape.
+pub(crate) fn validate_identity_component(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("must not be empty");
+    }
+    if value.len() > MAX_IDENTITY_BYTES {
+        return Err("must not exceed 127 bytes");
+    }
+    if value.trim() != value {
+        return Err("must not start or end with whitespace");
+    }
+    if value.chars().any(char::is_control) {
+        return Err("must not contain control characters");
+    }
+    Ok(())
+}
+
+/// Stable identity for one invocation, from start through its terminal event.
+///
+/// A `Runner` run emits exactly one `InvocationStarted` event and exactly one
+/// terminal `InvocationCompleted` or `InvocationFailed` event, and every
+/// event in between carries the same [`InvocationId`]. Nested work correlates
+/// to its parent through the optional parent identity on
+/// [`RunOptions::parent_invocation`](crate::RunOptions::parent_invocation),
+/// so observers can reconstruct parent/child relationships without parsing
+/// model prose.
+///
+/// Construction is validated: ids must not be empty, must not exceed 127
+/// bytes, must not start or end with whitespace, and must not contain control
+/// characters. [`InvocationId::generate`] exists for callers that do not have
+/// a durable identity; it is unique within one process lifetime only, so
+/// durable callers must supply their own stable id until durable invocation
+/// persistence lands.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct InvocationId(String);
+
+impl InvocationId {
+    /// Validates and creates an invocation id.
+    pub fn try_new(value: impl Into<String>) -> Result<Self, ConfigError> {
+        let value = value.into();
+        if let Err(reason) = validate_identity_component(&value) {
+            return Err(ConfigError::InvalidInvocationId { reason });
+        }
+        Ok(Self(value))
+    }
+
+    /// Generates a process-scoped invocation id.
+    ///
+    /// The id is unique within one process lifetime and stable for the
+    /// duration of the run, but it is not durable across processes. Callers
+    /// that need an identity to survive a restart must pass their own id
+    /// through run options instead of relying on this generator.
+    pub fn generate() -> Self {
+        static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+        let counter = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos() as u64)
+            .unwrap_or_default();
+        Self(format!("inv_{nanos:016x}_{counter:04x}"))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for InvocationId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// A validated reference to an agent target with an optional revision pin.
+///
+/// Agent identity for routing and delegation is more than an unrestricted
+/// logical string: [`AgentRef`] validates its target and can pin a revision,
+/// so a future delegation contract can bind a child invocation to the exact
+/// agent definition its parent intended. The revision is optional while
+/// agents carry no revision metadata; it must be present once routing depends
+/// on it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AgentRef {
+    agent: AgentId,
+    revision: Option<String>,
+}
+
+impl AgentRef {
+    /// Validates and creates a reference without a revision pin.
+    pub fn try_new(agent: AgentId) -> Result<Self, ConfigError> {
+        Self::validate_component("agent", agent.as_str())?;
+        Ok(Self {
+            agent,
+            revision: None,
+        })
+    }
+
+    /// Validates and pins a revision on the reference.
+    pub fn with_revision(self, revision: impl Into<String>) -> Result<Self, ConfigError> {
+        let revision = revision.into();
+        Self::validate_component("revision", &revision)?;
+        Ok(Self {
+            revision: Some(revision),
+            ..self
+        })
+    }
+
+    fn validate_component(component: &'static str, value: &str) -> Result<(), ConfigError> {
+        if let Err(reason) = validate_identity_component(value) {
+            return Err(ConfigError::InvalidAgentRef { component, reason });
+        }
+        Ok(())
+    }
+
+    /// The referenced agent id.
+    pub fn agent(&self) -> &AgentId {
+        &self.agent
+    }
+
+    /// The pinned revision, when the reference carries one.
+    pub fn revision(&self) -> Option<&str> {
+        self.revision.as_deref()
+    }
+
+    /// Builds a reference for an agent id the runner already resolved.
+    ///
+    /// Registered agent ids were accepted by `Runner::new`, and a requested
+    /// but unregistered starting agent is reported verbatim in terminal
+    /// failure events, so this path deliberately skips re-validation.
+    pub(crate) fn from_agent(agent: AgentId) -> Self {
+        Self {
+            agent,
+            revision: None,
+        }
+    }
+}
+
+impl fmt::Display for AgentRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.revision {
+            Some(revision) => write!(formatter, "{revision}@{}", self.agent),
+            None => self.agent.fmt(formatter),
+        }
+    }
+}
+
+/// Canonical invocation telemetry.
+///
+/// Every invocation opens with exactly one [`InvocationEvent::InvocationStarted`]
+/// and closes with exactly one terminal
+/// [`InvocationEvent::InvocationCompleted`] or
+/// [`InvocationEvent::InvocationFailed`] event, so an observer can pair
+/// per-invocation state without leaking or orphaning it. Each event carries
+/// the invocation id that correlates it to the run; the started event carries
+/// the optional parent identity for nested work.
+///
+/// Attempt and executor binding is deliberately absent: the behavior loop has
+/// no executor concept yet, and the loop journal already records
+/// process-scoped attempt ids for journaled loops. The binding arrives with
+/// the executor seam, not before.
+///
+/// `RunObserver` remains the legacy per-run telemetry stream during
+/// migration; these canonical events are the contract later slices fold it
+/// into.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvocationEvent {
+    /// The invocation started. The first event of every invocation.
+    InvocationStarted {
+        invocation: InvocationId,
+        /// The parent invocation, when this is nested work.
+        parent: Option<InvocationId>,
+        /// The requested target agent.
+        target: AgentRef,
+    },
+    /// The legacy pointer-swap handoff transferred control to another agent.
+    ///
+    /// This is control transfer inside one invocation, not durable A2A
+    /// delegation: no child invocation exists, the transcript continues
+    /// in place, and no authority boundary is crossed. The explicit
+    /// delegation contract replaces it in a later slice.
+    ControlTransferred {
+        invocation: InvocationId,
+        from: AgentRef,
+        to: AgentRef,
+    },
+    /// The invocation completed. A terminal event.
+    InvocationCompleted {
+        invocation: InvocationId,
+        /// The agent that produced the final output.
+        final_target: AgentRef,
+        turns: usize,
+        control_transfers: usize,
+    },
+    /// The invocation failed. A terminal event.
+    InvocationFailed {
+        invocation: InvocationId,
+        /// The requested target, reported verbatim even when the failure
+        /// happened before the runner resolved it.
+        target: AgentRef,
+        kind: RunFailureKind,
+    },
+}
+
+/// Receives canonical [`InvocationEvent`] telemetry.
+pub trait InvocationObserver: Send + Sync {
+    fn on_invocation_event(&self, event: &InvocationEvent);
+}
+
+/// An [`InvocationObserver`] that discards every event.
+#[derive(Debug, Default)]
+pub struct NoopInvocationObserver;
+
+impl InvocationObserver for NoopInvocationObserver {
+    fn on_invocation_event(&self, _event: &InvocationEvent) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invocation_id_rejects_invalid_values() {
+        let oversized = "a".repeat(MAX_IDENTITY_BYTES + 1);
+        assert_eq!(
+            InvocationId::try_new("").unwrap_err().to_string(),
+            "invocation id must not be empty"
+        );
+        assert_eq!(
+            InvocationId::try_new(oversized).unwrap_err().to_string(),
+            "invocation id must not exceed 127 bytes"
+        );
+        assert_eq!(
+            InvocationId::try_new(" inv").unwrap_err().to_string(),
+            "invocation id must not start or end with whitespace"
+        );
+        assert_eq!(
+            InvocationId::try_new("inv\nx").unwrap_err().to_string(),
+            "invocation id must not contain control characters"
+        );
+    }
+
+    #[test]
+    fn generated_invocation_ids_are_unique_and_valid() {
+        let first = InvocationId::generate();
+        let second = InvocationId::generate();
+        assert_ne!(first, second);
+        assert_eq!(InvocationId::try_new(first.as_str()), Ok(first));
+    }
+
+    #[test]
+    fn agent_ref_requires_a_valid_agent_and_revision() {
+        assert_eq!(
+            AgentRef::try_new(AgentId::from("")).unwrap_err().to_string(),
+            "agent reference agent must not be empty"
+        );
+        let reference = AgentRef::try_new(AgentId::from("triage")).unwrap();
+        assert_eq!(reference.agent(), &AgentId::from("triage"));
+        assert_eq!(reference.revision(), None);
+        let rejection = reference.clone().with_revision("   ").unwrap_err();
+        assert_eq!(
+            rejection.to_string(),
+            "agent reference revision must not start or end with whitespace"
+        );
+    }
+
+    #[test]
+    fn agent_ref_displays_the_revision_pin() {
+        let reference = AgentRef::try_new(AgentId::from("triage"))
+            .unwrap()
+            .with_revision("v7")
+            .unwrap();
+        assert_eq!(reference.revision(), Some("v7"));
+        assert_eq!(reference.to_string(), "triage@v7");
+        assert_eq!(
+            AgentRef::try_new(AgentId::from("triage")).unwrap().to_string(),
+            "triage"
+        );
+    }
+}

--- a/crates/coven-agents/src/invocation.rs
+++ b/crates/coven-agents/src/invocation.rs
@@ -156,7 +156,7 @@ impl AgentRef {
 impl fmt::Display for AgentRef {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.revision {
-            Some(revision) => write!(formatter, "{revision}@{}", self.agent),
+            Some(revision) => write!(formatter, "{}@{revision}", self.agent),
             None => self.agent.fmt(formatter),
         }
     }
@@ -268,7 +268,9 @@ mod tests {
     #[test]
     fn agent_ref_requires_a_valid_agent_and_revision() {
         assert_eq!(
-            AgentRef::try_new(AgentId::from("")).unwrap_err().to_string(),
+            AgentRef::try_new(AgentId::from(""))
+                .unwrap_err()
+                .to_string(),
             "agent reference agent must not be empty"
         );
         let reference = AgentRef::try_new(AgentId::from("triage")).unwrap();
@@ -290,7 +292,9 @@ mod tests {
         assert_eq!(reference.revision(), Some("v7"));
         assert_eq!(reference.to_string(), "triage@v7");
         assert_eq!(
-            AgentRef::try_new(AgentId::from("triage")).unwrap().to_string(),
+            AgentRef::try_new(AgentId::from("triage"))
+                .unwrap()
+                .to_string(),
             "triage"
         );
     }

--- a/crates/coven-agents/src/lib.rs
+++ b/crates/coven-agents/src/lib.rs
@@ -6,6 +6,7 @@
 mod agent;
 mod error;
 mod guardrail;
+mod invocation;
 mod loop_journal;
 mod loop_runner;
 mod model;
@@ -17,6 +18,9 @@ mod tool;
 pub use agent::{Agent, AgentId, Handoff};
 pub use error::{BoxError, ConfigError, GuardrailStage, RunError, RunFailure};
 pub use guardrail::{GuardrailVerdict, InputGuardrail, OutputGuardrail};
+pub use invocation::{
+    AgentRef, InvocationEvent, InvocationId, InvocationObserver, NoopInvocationObserver,
+};
 pub use loop_journal::FileLoopJournal;
 pub use loop_runner::{
     GoalLoopRunner, InMemoryLoopJournal, LoopAttempt, LoopCheckpoint, LoopCheckpointStatus,

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -272,7 +272,7 @@ where
         .await
         .map_err(|error| RunFailure {
             invocation,
-            error,
+            error: Box::new(error),
             new_items: progress.items,
             turns: progress.turns,
             handoffs: progress.handoffs,

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -4,16 +4,24 @@ use std::{
 };
 
 use crate::{
-    Agent, AgentId, ConfigError, GuardrailStage, GuardrailVerdict, HandoffDefinition, ModelAction,
-    ModelRequest, NoopObserver, RunError, RunEvent, RunFailure, RunFailureKind, RunItem,
+    Agent, AgentId, AgentRef, ConfigError, GuardrailStage, GuardrailVerdict, HandoffDefinition,
+    InvocationEvent, InvocationId, InvocationObserver, ModelAction, ModelRequest,
+    NoopInvocationObserver, NoopObserver, RunError, RunEvent, RunFailure, RunFailureKind, RunItem,
     RunObserver, SessionStore,
 };
 
+/// Options for one [`Runner::run`] invocation.
+///
+/// `invocation_id` pins the run's stable invocation identity; when it is
+/// absent the runner generates a process-scoped one. `parent_invocation`
+/// correlates nested work to the invocation that requested it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunOptions {
     pub max_turns: usize,
     pub max_handoffs: usize,
     pub session_id: Option<String>,
+    pub invocation_id: Option<InvocationId>,
+    pub parent_invocation: Option<InvocationId>,
 }
 
 impl Default for RunOptions {
@@ -22,6 +30,8 @@ impl Default for RunOptions {
             max_turns: 16,
             max_handoffs: 8,
             session_id: None,
+            invocation_id: None,
+            parent_invocation: None,
         }
     }
 }
@@ -30,6 +40,9 @@ impl Default for RunOptions {
 pub struct RunResult {
     pub final_output: String,
     pub final_agent: AgentId,
+    /// The stable invocation identity that correlated this run from its
+    /// started event through its terminal event.
+    pub invocation: InvocationId,
     pub new_items: Vec<RunItem>,
     pub turns: usize,
     pub handoffs: usize,
@@ -53,6 +66,7 @@ where
     agents: BTreeMap<AgentId, Arc<Agent<C>>>,
     session: Option<Arc<dyn SessionStore>>,
     observer: Arc<dyn RunObserver>,
+    invocation_observer: Arc<dyn InvocationObserver>,
 }
 
 impl<C> Runner<C>
@@ -107,6 +121,7 @@ where
             agents: registered,
             session: None,
             observer: Arc::new(NoopObserver),
+            invocation_observer: Arc::new(NoopInvocationObserver),
         })
     }
 
@@ -120,11 +135,28 @@ where
         self
     }
 
-    fn fail(&self, agent: &AgentId, kind: RunFailureKind, error: RunError) -> RunError {
+    pub fn with_invocation_observer(mut self, observer: Arc<dyn InvocationObserver>) -> Self {
+        self.invocation_observer = observer;
+        self
+    }
+
+    fn fail(
+        &self,
+        invocation: &InvocationId,
+        agent: &AgentId,
+        kind: RunFailureKind,
+        error: RunError,
+    ) -> RunError {
         self.observer.on_event(&RunEvent::RunFailed {
             agent: agent.clone(),
             kind,
         });
+        self.invocation_observer
+            .on_invocation_event(&InvocationEvent::InvocationFailed {
+                invocation: invocation.clone(),
+                target: AgentRef::from_agent(agent.clone()),
+                kind,
+            });
         error
     }
 
@@ -141,6 +173,7 @@ where
     /// or tool execution.
     async fn check_input_guardrails(
         &self,
+        invocation: &InvocationId,
         agent: &Agent<C>,
         input: &str,
         context: &C,
@@ -148,6 +181,7 @@ where
         for guardrail in &agent.input_guardrails {
             let verdict = guardrail.check(input, context).await.map_err(|source| {
                 self.fail(
+                    invocation,
                     &agent.id,
                     RunFailureKind::InputGuardrail,
                     RunError::GuardrailFailed {
@@ -167,6 +201,7 @@ where
             });
             if let GuardrailVerdict::Reject { reason } = verdict {
                 return Err(self.fail(
+                    invocation,
                     &agent.id,
                     RunFailureKind::InputGuardrail,
                     RunError::GuardrailRejected {
@@ -184,9 +219,23 @@ where
 
     /// Runs `starting_agent` to a final output.
     ///
-    /// Every run emits exactly one `RunStarted` event followed by exactly one
-    /// terminal `RunCompleted` or `RunFailed` event, including when the
-    /// starting agent is unregistered, so observers can pair per-run state.
+    /// This signature is the compatibility facade while the invocation and
+    /// delegation contracts migrate: orchestration, durability, and remote
+    /// execution concerns will move out of it in later slices, and callers
+    /// keep working unchanged until then.
+    ///
+    /// Every run carries exactly one stable [`InvocationId`], resolved from
+    /// `options.invocation_id` or generated for the process, from its
+    /// `InvocationStarted` event through its terminal event. The identity is
+    /// returned on [`RunResult`] and carried on [`RunFailure`], so a caller
+    /// can correlate partial-failure evidence with the same id the observer
+    /// saw. Nested work passes the parent identity through
+    /// `options.parent_invocation`.
+    ///
+    /// On the legacy [`RunObserver`] stream, every run emits exactly one
+    /// `RunStarted` event followed by exactly one terminal `RunCompleted` or
+    /// `RunFailed` event, including when the starting agent is unregistered,
+    /// so observers can pair per-run state.
     ///
     /// A failure returns [`RunFailure`], which carries the transcript the run
     /// produced before it failed. A tool that fails mid-turn does not erase the
@@ -206,9 +255,14 @@ where
         context: &C,
         options: RunOptions,
     ) -> Result<RunResult, RunFailure> {
+        let invocation = options
+            .invocation_id
+            .clone()
+            .unwrap_or_else(InvocationId::generate);
         let mut progress = RunProgress::default();
 
         self.run_loop(
+            invocation.clone(),
             starting_agent.into(),
             input.into(),
             context,
@@ -217,6 +271,7 @@ where
         )
         .await
         .map_err(|error| RunFailure {
+            invocation,
             error,
             new_items: progress.items,
             turns: progress.turns,
@@ -226,12 +281,19 @@ where
 
     async fn run_loop(
         &self,
+        invocation: InvocationId,
         starting_agent: AgentId,
         input: String,
         context: &C,
         options: RunOptions,
         progress: &mut RunProgress,
     ) -> Result<RunResult, RunError> {
+        self.invocation_observer
+            .on_invocation_event(&InvocationEvent::InvocationStarted {
+                invocation: invocation.clone(),
+                parent: options.parent_invocation.clone(),
+                target: AgentRef::from_agent(starting_agent.clone()),
+            });
         self.observer.on_event(&RunEvent::RunStarted {
             starting_agent: starting_agent.clone(),
         });
@@ -242,19 +304,21 @@ where
 
         let mut current = self.agents.get(&starting_agent).cloned().ok_or_else(|| {
             self.fail(
+                &invocation,
                 &starting_agent,
                 RunFailureKind::Configuration,
                 RunError::UnknownStartingAgent(starting_agent.clone()),
             )
         })?;
 
-        self.check_input_guardrails(&current, &input, context)
+        self.check_input_guardrails(&invocation, &current, &input, context)
             .await?;
 
         let mut model_items = match (&options.session_id, &self.session) {
             (Some(session_id), Some(session)) => {
                 let mut items = session.load(session_id).await.map_err(|source| {
                     self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::Session,
                         RunError::SessionFailed {
@@ -268,6 +332,7 @@ where
             }
             (Some(_), None) => {
                 return Err(self.fail(
+                    &invocation,
                     &current.id,
                     RunFailureKind::Session,
                     RunError::SessionUnavailable,
@@ -318,6 +383,7 @@ where
                 .await
                 .map_err(|source| {
                     self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::Model,
                         RunError::ModelFailed {
@@ -339,6 +405,7 @@ where
             if response.actions.is_empty() {
                 let output = response.assistant_message.ok_or_else(|| {
                     self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -352,6 +419,7 @@ where
                 for guardrail in &current.output_guardrails {
                     let verdict = guardrail.check(&output, context).await.map_err(|source| {
                         self.fail(
+                            &invocation,
                             &current.id,
                             RunFailureKind::OutputGuardrail,
                             RunError::GuardrailFailed {
@@ -371,6 +439,7 @@ where
                     });
                     if let GuardrailVerdict::Reject { reason } = verdict {
                         return Err(self.fail(
+                            &invocation,
                             &current.id,
                             RunFailureKind::OutputGuardrail,
                             RunError::GuardrailRejected {
@@ -389,6 +458,7 @@ where
                         .await
                         .map_err(|source| {
                             self.fail(
+                                &invocation,
                                 &current.id,
                                 RunFailureKind::Session,
                                 RunError::SessionFailed {
@@ -404,9 +474,17 @@ where
                     turns: turn,
                     handoffs: progress.handoffs,
                 });
+                self.invocation_observer
+                    .on_invocation_event(&InvocationEvent::InvocationCompleted {
+                        invocation: invocation.clone(),
+                        final_target: AgentRef::from_agent(current.id.clone()),
+                        turns: turn,
+                        control_transfers: progress.handoffs,
+                    });
                 return Ok(RunResult {
                     final_output: output,
                     final_agent: current.id.clone(),
+                    invocation,
                     new_items: std::mem::take(&mut progress.items),
                     turns: turn,
                     handoffs: progress.handoffs,
@@ -421,6 +499,7 @@ where
             if handoff_actions > 0 {
                 if response.actions.len() != 1 {
                     return Err(self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -432,6 +511,7 @@ where
                 progress.handoffs += 1;
                 if progress.handoffs > options.max_handoffs {
                     return Err(self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::Limit,
                         RunError::MaxHandoffsExceeded {
@@ -442,6 +522,7 @@ where
 
                 let [ModelAction::Handoff(call)] = response.actions.as_slice() else {
                     return Err(self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -456,6 +537,7 @@ where
                     .find(|handoff| handoff.name == call.name)
                     .ok_or_else(|| {
                         self.fail(
+                            &invocation,
                             &current.id,
                             RunFailureKind::Handoff,
                             RunError::UnknownHandoff {
@@ -466,6 +548,7 @@ where
                     })?;
                 let target = self.agents.get(&handoff.target).cloned().ok_or_else(|| {
                     self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::Configuration,
                         RunError::InvalidConfiguration {
@@ -488,12 +571,18 @@ where
                     to: target.id.clone(),
                     name: handoff.name.clone(),
                 });
+                self.invocation_observer
+                    .on_invocation_event(&InvocationEvent::ControlTransferred {
+                        invocation: invocation.clone(),
+                        from: AgentRef::from_agent(current.id.clone()),
+                        to: AgentRef::from_agent(target.id.clone()),
+                    });
                 current = target;
                 // Ingress parity: the handoff target enforces the same input
                 // policy it would enforce as the starting agent, checked
                 // against the original user input, before its first model turn
                 // or tool execution.
-                self.check_input_guardrails(&current, &input, context)
+                self.check_input_guardrails(&invocation, &current, &input, context)
                     .await?;
                 continue;
             }
@@ -507,6 +596,7 @@ where
                 };
                 if !seen_call_ids.insert(call.id.clone()) {
                     return Err(self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::DuplicateToolCallId {
@@ -520,6 +610,7 @@ where
             for action in response.actions {
                 let ModelAction::ToolCall(call) = action else {
                     return Err(self.fail(
+                        &invocation,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -534,6 +625,7 @@ where
                     .find(|tool| tool.definition.name == call.name)
                     .ok_or_else(|| {
                         self.fail(
+                            &invocation,
                             &current.id,
                             RunFailureKind::Tool,
                             RunError::UnknownTool {
@@ -559,6 +651,7 @@ where
                         .await
                         .map_err(|source| {
                             self.fail(
+                                &invocation,
                                 &current.id,
                                 RunFailureKind::Tool,
                                 RunError::ToolFailed {
@@ -585,6 +678,7 @@ where
         }
 
         Err(self.fail(
+            &invocation,
             &current.id,
             RunFailureKind::Limit,
             RunError::MaxTurnsExceeded {

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -474,13 +474,14 @@ where
                     turns: turn,
                     handoffs: progress.handoffs,
                 });
-                self.invocation_observer
-                    .on_invocation_event(&InvocationEvent::InvocationCompleted {
+                self.invocation_observer.on_invocation_event(
+                    &InvocationEvent::InvocationCompleted {
                         invocation: invocation.clone(),
                         final_target: AgentRef::from_agent(current.id.clone()),
                         turns: turn,
                         control_transfers: progress.handoffs,
-                    });
+                    },
+                );
                 return Ok(RunResult {
                     final_output: output,
                     final_agent: current.id.clone(),
@@ -571,12 +572,13 @@ where
                     to: target.id.clone(),
                     name: handoff.name.clone(),
                 });
-                self.invocation_observer
-                    .on_invocation_event(&InvocationEvent::ControlTransferred {
+                self.invocation_observer.on_invocation_event(
+                    &InvocationEvent::ControlTransferred {
                         invocation: invocation.clone(),
                         from: AgentRef::from_agent(current.id.clone()),
                         to: AgentRef::from_agent(target.id.clone()),
-                    });
+                    },
+                );
                 current = target;
                 // Ingress parity: the handoff target enforces the same input
                 // policy it would enforce as the starting agent, checked

--- a/crates/coven-agents/tests/invocation.rs
+++ b/crates/coven-agents/tests/invocation.rs
@@ -1,0 +1,340 @@
+use std::{
+    collections::VecDeque,
+    io,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use coven_agents::{
+    Agent, AgentId, AgentRef, BoxError, Handoff, HandoffCall, InvocationEvent, InvocationId,
+    InvocationObserver, Model, ModelAction, ModelRequest, ModelResponse, RunEvent, RunFailureKind,
+    RunObserver, RunOptions, Runner,
+};
+
+struct QueueModel {
+    responses: Mutex<VecDeque<ModelResponse>>,
+}
+
+impl QueueModel {
+    fn new(responses: impl IntoIterator<Item = ModelResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses.into_iter().collect()),
+        }
+    }
+}
+
+#[async_trait]
+impl Model<()> for QueueModel {
+    async fn generate(
+        &self,
+        _request: ModelRequest,
+        _context: &(),
+    ) -> Result<ModelResponse, BoxError> {
+        self.responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| Box::new(io::Error::other("no queued response")) as BoxError)
+    }
+}
+
+#[derive(Default)]
+struct RecordingInvocationObserver {
+    events: Mutex<Vec<InvocationEvent>>,
+}
+
+impl RecordingInvocationObserver {
+    fn events(&self) -> Vec<InvocationEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl InvocationObserver for RecordingInvocationObserver {
+    fn on_invocation_event(&self, event: &InvocationEvent) {
+        self.events.lock().unwrap().push(event.clone());
+    }
+}
+
+#[derive(Default)]
+struct RecordingRunObserver {
+    events: Mutex<Vec<RunEvent>>,
+}
+
+impl RecordingRunObserver {
+    fn events(&self) -> Vec<RunEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl RunObserver for RecordingRunObserver {
+    fn on_event(&self, event: &RunEvent) {
+        self.events.lock().unwrap().push(event.clone());
+    }
+}
+
+fn event_invocation(event: &InvocationEvent) -> &InvocationId {
+    match event {
+        InvocationEvent::InvocationStarted { invocation, .. }
+        | InvocationEvent::ControlTransferred { invocation, .. }
+        | InvocationEvent::InvocationCompleted { invocation, .. }
+        | InvocationEvent::InvocationFailed { invocation, .. } => invocation,
+    }
+}
+
+/// Asserts the invocation identity contract: the canonical stream opens with
+/// exactly one `InvocationStarted`, closes with exactly one terminal event,
+/// and every event in between carries the same invocation identity.
+fn assert_single_invocation_identity(events: &[InvocationEvent]) -> InvocationId {
+    assert!(!events.is_empty(), "an invocation must emit at least one event");
+    assert!(
+        matches!(events.first(), Some(InvocationEvent::InvocationStarted { .. })),
+        "InvocationStarted must be the first event, got {events:?}"
+    );
+    let terminal = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                InvocationEvent::InvocationCompleted { .. }
+                    | InvocationEvent::InvocationFailed { .. }
+            )
+        })
+        .count();
+    assert_eq!(terminal, 1, "expected one terminal event, got {events:?}");
+
+    let identity = event_invocation(events.first().expect("non-empty stream")).clone();
+    for event in events {
+        assert_eq!(
+            event_invocation(event),
+            &identity,
+            "every event must carry the same invocation identity, got {events:?}"
+        );
+    }
+    identity
+}
+
+#[tokio::test]
+async fn one_identity_carries_from_started_to_terminal_event() {
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output("done")]));
+    let runner = Runner::new([Agent::new("a", "A", "Answer.", model)])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+
+    let result = runner
+        .run("a", "Hello", &(), RunOptions::default())
+        .await
+        .unwrap();
+    let events = observer.events();
+    let identity = assert_single_invocation_identity(&events);
+
+    assert_eq!(result.invocation, identity);
+    match &events[0] {
+        InvocationEvent::InvocationStarted { parent, target, .. } => {
+            assert_eq!(*parent, None);
+            assert_eq!(target.agent(), &AgentId::from("a"));
+            assert_eq!(target.revision(), None);
+        }
+        other => panic!("the first event must be InvocationStarted, got {other:?}"),
+    }
+    match events.last().expect("non-empty stream") {
+        InvocationEvent::InvocationCompleted { final_target, turns, control_transfers, .. } => {
+            assert_eq!(final_target.agent(), &AgentId::from("a"));
+            assert_eq!(*turns, 1);
+            assert_eq!(*control_transfers, 0);
+        }
+        other => panic!("the last event must be InvocationCompleted, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn caller_supplied_identity_is_used_verbatim() {
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output("done")]));
+    let runner = Runner::new([Agent::new("a", "A", "Answer.", model)])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+
+    let options = RunOptions {
+        invocation_id: Some(InvocationId::try_new("inv-fixed").unwrap()),
+        ..RunOptions::default()
+    };
+    let result = runner.run("a", "Hello", &(), options).await.unwrap();
+    let identity = assert_single_invocation_identity(&observer.events());
+
+    assert_eq!(identity.as_str(), "inv-fixed");
+    assert_eq!(result.invocation, identity);
+}
+
+#[tokio::test]
+async fn generated_identities_differ_across_runs() {
+    let model = Arc::new(QueueModel::new([
+        ModelResponse::final_output("first"),
+        ModelResponse::final_output("second"),
+    ]));
+    let runner = Runner::new([Agent::new("a", "A", "Answer.", model)]).unwrap();
+
+    let first = runner
+        .run("a", "One", &(), RunOptions::default())
+        .await
+        .unwrap();
+    let second = runner
+        .run("a", "Two", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    assert_ne!(first.invocation, second.invocation);
+}
+
+#[tokio::test]
+async fn parent_identity_correlates_nested_work() {
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output("done")]));
+    let runner = Runner::new([Agent::new("child", "Child", "Answer.", model)])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+
+    let parent = InvocationId::try_new("inv-parent").unwrap();
+    let options = RunOptions {
+        parent_invocation: Some(parent.clone()),
+        ..RunOptions::default()
+    };
+    let result = runner.run("child", "Hello", &(), options).await.unwrap();
+
+    let events = observer.events();
+    assert_single_invocation_identity(&events);
+    match &events[0] {
+        InvocationEvent::InvocationStarted { invocation, parent: observed, .. } => {
+            assert_eq!(*observed, Some(parent.clone()));
+            assert_ne!(*invocation, parent);
+        }
+        other => panic!("the first event must be InvocationStarted, got {other:?}"),
+    }
+    assert_ne!(result.invocation, parent);
+}
+
+#[tokio::test]
+async fn legacy_handoff_is_reported_as_a_control_transfer() {
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let model = Arc::new(QueueModel::new([
+        ModelResponse::actions(vec![ModelAction::Handoff(HandoffCall::new("to_b"))]),
+        ModelResponse::final_output("done from b"),
+    ]));
+    let agents = [
+        Agent::new("a", "A", "Delegate.", model.clone())
+            .with_handoff(Handoff::new("to_b", "Hand off to b", "b")),
+        Agent::new("b", "B", "Answer.", model),
+    ];
+    let runner = Runner::new(agents).unwrap().with_invocation_observer(observer.clone());
+
+    let result = runner
+        .run("a", "Hello", &(), RunOptions::default())
+        .await
+        .unwrap();
+    let events = observer.events();
+    let identity = assert_single_invocation_identity(&events);
+
+    assert_eq!(result.final_agent, AgentId::from("b"));
+    assert_eq!(result.invocation, identity);
+    let transfers: Vec<&InvocationEvent> = events
+        .iter()
+        .filter(|event| matches!(event, InvocationEvent::ControlTransferred { .. }))
+        .collect();
+    assert_eq!(transfers.len(), 1, "expected one control transfer, got {events:?}");
+    match transfers[0] {
+        InvocationEvent::ControlTransferred { from, to, .. } => {
+            assert_eq!(from.agent(), &AgentId::from("a"));
+            assert_eq!(to.agent(), &AgentId::from("b"));
+        }
+        other => panic!("expected a control transfer, got {other:?}"),
+    }
+    match events.last().expect("non-empty stream") {
+        InvocationEvent::InvocationCompleted { final_target, control_transfers, .. } => {
+            assert_eq!(final_target.agent(), &AgentId::from("b"));
+            assert_eq!(*control_transfers, 1);
+        }
+        other => panic!("the last event must be InvocationCompleted, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn failed_run_carries_the_identity_to_the_terminal_event() {
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let model = Arc::new(QueueModel::new([]));
+    let runner = Runner::new([Agent::new("a", "A", "Answer.", model)])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+
+    let options = RunOptions {
+        invocation_id: Some(InvocationId::try_new("inv-doomed").unwrap()),
+        ..RunOptions::default()
+    };
+    let failure = runner.run("a", "Hello", &(), options).await.unwrap_err();
+    let events = observer.events();
+    let identity = assert_single_invocation_identity(&events);
+
+    assert_eq!(failure.invocation, identity);
+    assert_eq!(identity.as_str(), "inv-doomed");
+    match events.last().expect("non-empty stream") {
+        InvocationEvent::InvocationFailed { target, kind: RunFailureKind::Model, .. } => {
+            assert_eq!(target.agent(), &AgentId::from("a"));
+        }
+        other => panic!("the last event must be InvocationFailed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn both_observer_streams_stay_paired_for_one_run() {
+    let invocation_observer = Arc::new(RecordingInvocationObserver::default());
+    let run_observer = Arc::new(RecordingRunObserver::default());
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output("done")]));
+    let runner = Runner::new([Agent::new("a", "A", "Answer.", model)])
+        .unwrap()
+        .with_observer(run_observer.clone())
+        .with_invocation_observer(invocation_observer.clone());
+
+    let result = runner
+        .run("a", "Hello", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    let invocation_events = invocation_observer.events();
+    let run_events = run_observer.events();
+    let identity = assert_single_invocation_identity(&invocation_events);
+    assert_eq!(result.invocation, identity);
+    assert!(
+        matches!(run_events.first(), Some(RunEvent::RunStarted { .. })),
+        "the legacy stream must still open with RunStarted, got {run_events:?}"
+    );
+    assert_eq!(
+        run_events
+            .iter()
+            .filter(|event| matches!(event, RunEvent::RunStarted { .. }))
+            .count(),
+        1
+    );
+    assert!(
+        matches!(run_events.last(), Some(RunEvent::RunCompleted { .. })),
+        "the legacy stream must still close with RunCompleted, got {run_events:?}"
+    );
+}
+
+#[test]
+fn invocation_contract_types_roundtrip_through_serde() {
+    let id = InvocationId::try_new("inv-42").unwrap();
+    assert_eq!(serde_json::to_string(&id).unwrap(), "\"inv-42\"");
+    assert_eq!(serde_json::from_str::<InvocationId>("\"inv-42\"").unwrap(), id);
+
+    let reference = AgentRef::try_new(AgentId::from("triage"))
+        .unwrap()
+        .with_revision("v7")
+        .unwrap();
+    let json = serde_json::to_string(&reference).unwrap();
+    assert_eq!(json, r#"{"agent":"triage","revision":"v7"}"#);
+    assert_eq!(serde_json::from_str::<AgentRef>(&json).unwrap(), reference);
+
+    let bare = AgentRef::try_new(AgentId::from("triage")).unwrap();
+    let bare_json = serde_json::to_string(&bare).unwrap();
+    assert_eq!(bare_json, r#"{"agent":"triage","revision":null}"#);
+    assert_eq!(serde_json::from_str::<AgentRef>(&bare_json).unwrap(), bare);
+}

--- a/crates/coven-agents/tests/invocation.rs
+++ b/crates/coven-agents/tests/invocation.rs
@@ -85,9 +85,15 @@ fn event_invocation(event: &InvocationEvent) -> &InvocationId {
 /// exactly one `InvocationStarted`, closes with exactly one terminal event,
 /// and every event in between carries the same invocation identity.
 fn assert_single_invocation_identity(events: &[InvocationEvent]) -> InvocationId {
-    assert!(!events.is_empty(), "an invocation must emit at least one event");
     assert!(
-        matches!(events.first(), Some(InvocationEvent::InvocationStarted { .. })),
+        !events.is_empty(),
+        "an invocation must emit at least one event"
+    );
+    assert!(
+        matches!(
+            events.first(),
+            Some(InvocationEvent::InvocationStarted { .. })
+        ),
         "InvocationStarted must be the first event, got {events:?}"
     );
     let terminal = events
@@ -138,7 +144,12 @@ async fn one_identity_carries_from_started_to_terminal_event() {
         other => panic!("the first event must be InvocationStarted, got {other:?}"),
     }
     match events.last().expect("non-empty stream") {
-        InvocationEvent::InvocationCompleted { final_target, turns, control_transfers, .. } => {
+        InvocationEvent::InvocationCompleted {
+            final_target,
+            turns,
+            control_transfers,
+            ..
+        } => {
             assert_eq!(final_target.agent(), &AgentId::from("a"));
             assert_eq!(*turns, 1);
             assert_eq!(*control_transfers, 0);
@@ -204,7 +215,11 @@ async fn parent_identity_correlates_nested_work() {
     let events = observer.events();
     assert_single_invocation_identity(&events);
     match &events[0] {
-        InvocationEvent::InvocationStarted { invocation, parent: observed, .. } => {
+        InvocationEvent::InvocationStarted {
+            invocation,
+            parent: observed,
+            ..
+        } => {
             assert_eq!(*observed, Some(parent.clone()));
             assert_ne!(*invocation, parent);
         }
@@ -221,11 +236,16 @@ async fn legacy_handoff_is_reported_as_a_control_transfer() {
         ModelResponse::final_output("done from b"),
     ]));
     let agents = [
-        Agent::new("a", "A", "Delegate.", model.clone())
-            .with_handoff(Handoff::new("to_b", "Hand off to b", "b")),
+        Agent::new("a", "A", "Delegate.", model.clone()).with_handoff(Handoff::new(
+            "to_b",
+            "Hand off to b",
+            "b",
+        )),
         Agent::new("b", "B", "Answer.", model),
     ];
-    let runner = Runner::new(agents).unwrap().with_invocation_observer(observer.clone());
+    let runner = Runner::new(agents)
+        .unwrap()
+        .with_invocation_observer(observer.clone());
 
     let result = runner
         .run("a", "Hello", &(), RunOptions::default())
@@ -240,7 +260,11 @@ async fn legacy_handoff_is_reported_as_a_control_transfer() {
         .iter()
         .filter(|event| matches!(event, InvocationEvent::ControlTransferred { .. }))
         .collect();
-    assert_eq!(transfers.len(), 1, "expected one control transfer, got {events:?}");
+    assert_eq!(
+        transfers.len(),
+        1,
+        "expected one control transfer, got {events:?}"
+    );
     match transfers[0] {
         InvocationEvent::ControlTransferred { from, to, .. } => {
             assert_eq!(from.agent(), &AgentId::from("a"));
@@ -249,7 +273,11 @@ async fn legacy_handoff_is_reported_as_a_control_transfer() {
         other => panic!("expected a control transfer, got {other:?}"),
     }
     match events.last().expect("non-empty stream") {
-        InvocationEvent::InvocationCompleted { final_target, control_transfers, .. } => {
+        InvocationEvent::InvocationCompleted {
+            final_target,
+            control_transfers,
+            ..
+        } => {
             assert_eq!(final_target.agent(), &AgentId::from("b"));
             assert_eq!(*control_transfers, 1);
         }
@@ -276,7 +304,11 @@ async fn failed_run_carries_the_identity_to_the_terminal_event() {
     assert_eq!(failure.invocation, identity);
     assert_eq!(identity.as_str(), "inv-doomed");
     match events.last().expect("non-empty stream") {
-        InvocationEvent::InvocationFailed { target, kind: RunFailureKind::Model, .. } => {
+        InvocationEvent::InvocationFailed {
+            target,
+            kind: RunFailureKind::Model,
+            ..
+        } => {
             assert_eq!(target.agent(), &AgentId::from("a"));
         }
         other => panic!("the last event must be InvocationFailed, got {other:?}"),
@@ -323,7 +355,10 @@ async fn both_observer_streams_stay_paired_for_one_run() {
 fn invocation_contract_types_roundtrip_through_serde() {
     let id = InvocationId::try_new("inv-42").unwrap();
     assert_eq!(serde_json::to_string(&id).unwrap(), "\"inv-42\"");
-    assert_eq!(serde_json::from_str::<InvocationId>("\"inv-42\"").unwrap(), id);
+    assert_eq!(
+        serde_json::from_str::<InvocationId>("\"inv-42\"").unwrap(),
+        id
+    );
 
     let reference = AgentRef::try_new(AgentId::from("triage"))
         .unwrap()

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -1034,7 +1034,7 @@ async fn handoff_target_enforces_the_same_input_policy_as_direct_entry() {
         .unwrap_err();
 
     assert!(matches!(
-        direct_failure.error,
+        *direct_failure.error,
         RunError::GuardrailRejected {
             ref agent,
             stage: GuardrailStage::Input,
@@ -1075,7 +1075,7 @@ async fn handoff_target_enforces_the_same_input_policy_as_direct_entry() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::GuardrailRejected {
             ref agent,
             stage: GuardrailStage::Input,
@@ -1277,7 +1277,7 @@ async fn multi_hop_handoff_target_rejection_prevents_the_target_model_turn() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::GuardrailRejected {
             ref agent,
             stage: GuardrailStage::Input,
@@ -1328,7 +1328,7 @@ async fn handoff_target_guardrail_error_is_distinguishable_from_a_rejection() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::GuardrailFailed {
             ref agent,
             ref guardrail,
@@ -1412,7 +1412,7 @@ async fn handoff_cannot_be_combined_with_tool_calls() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::InvalidModelResponse { ref reason, .. } if reason == "a handoff cannot be combined with other actions"
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 0);

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -378,7 +378,7 @@ async fn blocking_input_guardrail_prevents_model_execution() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::GuardrailRejected {
             stage: GuardrailStage::Input,
             ..
@@ -460,7 +460,7 @@ async fn rejected_output_is_not_appended_to_the_session() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::GuardrailRejected {
             stage: GuardrailStage::Output,
             ..
@@ -498,7 +498,7 @@ async fn bounded_runner_stops_repeated_tool_turns() {
     let failure = runner.run("loop", "Loop.", &(), options).await.unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::MaxTurnsExceeded { limit: 2 }
     ));
     assert_eq!(failure.turns, 2);
@@ -540,7 +540,7 @@ async fn bounded_runner_stops_repeated_handoffs() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::MaxHandoffsExceeded { limit: 1 }
     ));
     assert_eq!(failure.handoffs, 2);
@@ -561,7 +561,7 @@ async fn rejects_empty_model_responses() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::InvalidModelResponse { .. }
     ));
 }
@@ -602,7 +602,7 @@ async fn unknown_starting_agent_reports_a_paired_run_lifecycle() {
         .unwrap_err();
 
     assert!(
-        matches!(failure.error, RunError::UnknownStartingAgent(ref id) if id.as_str() == "missing")
+        matches!(*failure.error, RunError::UnknownStartingAgent(ref id) if id.as_str() == "missing")
     );
     assert_eq!(model.calls.load(Ordering::SeqCst), 0);
     assert_paired_lifecycle(&observer.events());
@@ -626,7 +626,7 @@ async fn missing_session_store_reports_a_paired_run_lifecycle() {
         .await
         .unwrap_err();
 
-    assert!(matches!(failure.error, RunError::SessionUnavailable));
+    assert!(matches!(*failure.error, RunError::SessionUnavailable));
     assert_eq!(model.calls.load(Ordering::SeqCst), 0);
     assert_paired_lifecycle(&observer.events());
 }
@@ -648,7 +648,7 @@ async fn tool_failure_reports_a_paired_run_lifecycle() {
         .await
         .unwrap_err();
 
-    assert!(matches!(failure.error, RunError::ToolFailed { ref tool, .. } if tool == "explode"));
+    assert!(matches!(*failure.error, RunError::ToolFailed { ref tool, .. } if tool == "explode"));
     let events = observer.events();
     assert_paired_lifecycle(&events);
     assert!(events.iter().any(|event| matches!(
@@ -706,7 +706,7 @@ async fn tool_failure_returns_the_partial_transcript() {
         .await
         .unwrap_err();
 
-    assert!(matches!(failure.error, RunError::ToolFailed { ref tool, .. } if tool == "explode"));
+    assert!(matches!(*failure.error, RunError::ToolFailed { ref tool, .. } if tool == "explode"));
     assert_eq!(
         failure.to_string(),
         "tool `explode` for agent `worker` failed"
@@ -769,7 +769,7 @@ async fn tool_failure_after_a_handoff_returns_the_whole_run_transcript() {
         .await
         .unwrap_err();
 
-    assert!(matches!(failure.error, RunError::ToolFailed { .. }));
+    assert!(matches!(*failure.error, RunError::ToolFailed { .. }));
     assert_eq!(failure.turns, 2);
     assert_eq!(failure.handoffs, 1);
 
@@ -815,7 +815,7 @@ async fn duplicate_tool_call_ids_in_one_response_execute_no_tools() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 0);
@@ -866,7 +866,7 @@ async fn tool_call_id_reused_across_turns_executes_only_once() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
     ));
     assert_eq!(failure.turns, 2);
@@ -932,7 +932,7 @@ async fn resumed_history_rejects_reused_tool_call_id() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 0);
@@ -978,7 +978,7 @@ async fn resumed_result_only_history_rejects_reused_tool_call_id() {
         .unwrap_err();
 
     assert!(matches!(
-        failure.error,
+        *failure.error,
         RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 0);


### PR DESCRIPTION
## Summary

Slice 1 of N of the `coven-agents` refactor onto invocation/delegation contracts — ordered-migration **stage 2** of issue #804 ("Introduce stable invocation identity and telemetry"). Stage 1 (ingress-policy parity + characterization) is owned by #803 and intentionally untouched here.

What this slice adds to `crates/coven-agents`:

- **`InvocationId`** — a validated stable identity (non-empty, ≤127 bytes, no boundary whitespace or control characters). One run carries exactly one identity from its started event through its terminal event. When `RunOptions::invocation_id` is absent the runner generates a process-scoped one; this is documented as **not durable across restarts** — durable callers must supply their own stable id until the durable invocation store lands (stage 7).
- **Parent correlation** — `RunOptions::parent_invocation` carries the optional parent identity on the started event, so nested work correlates without parsing model prose.
- **`AgentRef`** — a validated target reference with an optional revision pin, so canonical events stop treating an unrestricted logical string as sufficient future routing/identity semantics.
- **Canonical `InvocationEvent` stream + `InvocationObserver`** — every invocation emits exactly one `InvocationStarted` and exactly one terminal `InvocationCompleted`/`InvocationFailed`, with correlation, target/source, and terminal outcome (`RunFailureKind` on failure). The legacy pointer-swap handoff is reported as **`ControlTransferred`** — control transfer inside one invocation, explicitly *not* durable A2A delegation (the stage-11 rename; the real `DelegationSpec` contract is stage 3). Attempt/executor binding is deliberately deferred to the executor seam (stage 8).
- **Compatibility facades preserved** — `Runner::run` keeps its signature; the `RunObserver` stream is unchanged for existing observers (proven by the existing test suite); the invocation identity is additionally exposed on `RunResult` and `RunFailure` so partial-failure evidence carries the same id the observer saw.

Files changed: `crates/coven-agents/src/invocation.rs` (new contract module), `src/runner.rs` (identity resolution + canonical event emission), `src/error.rs` (`ConfigError::InvalidInvocationId`/`InvalidAgentRef`, `RunFailure.invocation`), `src/lib.rs` (exports), `tests/invocation.rs` (new focused tests), crate `README.md` (contract + behavior-component framing). No new dependencies; `Cargo.lock` untouched.

**What remains for later slices (the issue stays open):** stage 1 characterization (owned by #803), stage 3 `DelegationSpec` + handoff deprecation, stage 4 context/authority boundary, stage 5 `AgentLoop` extraction, stage 6 lifecycle semantics, stage 7 durable invocation/adoption/recovery aligned with Psyche's attempt vocabulary, stage 8 executor seam, stage 9 hub placement, stage 10 observability unification, stage 11 legacy removal.

## Issue

Refs OpenCoven/coven#804 (slice 1 of N — the issue intentionally stays open until the remaining stages land).

## Test plan

Local environment has **no Rust toolchain and no Python** (per task constraints: no cargo/rustc, no make/g++), so compile proof is deferred to CI:

- [x] Manual line-by-line review of the full diff against the repo's rustfmt/clippy conventions (chain widths, struct-literal widths, import shapes matched against existing formatted sources)
- [x] Brace/paren balance and line-length smoke checks on all changed files
- [ ] `cargo fmt --check` — deferred to CI
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — deferred to CI
- [ ] `cargo test --workspace --locked` — deferred to CI. New `tests/invocation.rs` covers: identity stability start→terminal, verbatim caller-supplied ids, generated-id uniqueness, parent correlation, legacy handoff reported as `ControlTransferred`, failure identity threading on `RunFailure` + terminal event, both observer streams staying paired, and serde roundtrip of the contract types; in-module unit tests cover validation rules and `Display`.
- [ ] `python scripts/check-secrets.py` + privacy guard — deferred to CI policy-guard (no secrets, tokens, or absolute home paths introduced)

## Risk and Rollback

- Risk level: low — additive contract surface in a workspace-leaf crate (`coven-agents` is not imported by any other crate); existing public behavior (`Runner::run` signature, `RunObserver` stream) is preserved; the only breaking change is the new required fields on `RunResult`/`RunFailure` constructions, which exist only inside this crate and its tests.
- Rollback plan: revert the single commit; no data or protocol migration involved.

## Agent Handoff

- Current state: one signed commit on `agent/issue-804-p1-refactor-coven-agents-onto-invocation`, draft until CI is green.
- Follow-ups: stage 3 `DelegationSpec` (child invocation contract with non-widening authority), then `AgentLoop` extraction (stage 5); fold the legacy `RunObserver` stream into the canonical invocation events once callers are migrated.
- Known gaps: generated invocation ids are process-scoped, not durable (documented on `InvocationId::generate`); `AgentRef` revision is carried but agents have no revision metadata yet (documented on the type).

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#804.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/14], preserving source head `6a0372d977702038bc7833d92d7771717e3dc486` and branch `agent/issue-804-p1-refactor-coven-agents-onto-invocation`.