### PR TITLE
feat: fail-closed mobile pairing cancellation and terminal lifecycle

### DIFF
--- a/crates/coven-cli/src/mobile_memory/audit.rs
+++ b/crates/coven-cli/src/mobile_memory/audit.rs
@@ -21,6 +21,7 @@ pub enum MobileAuditEvent {
     GatewayStopped,
     PairingCreated,
     PairingCompleted,
+    PairingCancelled,
     PairingRejected,
     DeviceRevoked,
     AuthenticationRejected,

--- a/crates/coven-cli/src/mobile_memory/audit.rs
+++ b/crates/coven-cli/src/mobile_memory/audit.rs
@@ -97,8 +97,7 @@ fn read_pending_pairing_cancellations(coven_home: &Path) -> Result<Vec<Uuid>> {
         return Ok(Vec::new());
     }
     validate_private_file(&path)?;
-    let raw = std::fs::read(&path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let raw = std::fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
     if raw.is_empty() {
         return Ok(Vec::new());
     }
@@ -231,8 +230,8 @@ mod tests {
         // A token for the same pairing is never duplicated.
         assert!(!record_pending_pairing_cancelled(temp.path(), first).unwrap());
         for index in 2..(MAX_PENDING_AUDIT_EVENTS as u128 + 2) {
-            let added = record_pending_pairing_cancelled(temp.path(), Uuid::from_u128(index))
-                .unwrap();
+            let added =
+                record_pending_pairing_cancelled(temp.path(), Uuid::from_u128(index)).unwrap();
             if index <= MAX_PENDING_AUDIT_EVENTS as u128 {
                 assert!(added, "token {index} should fit the outbox bound");
             } else {
@@ -252,8 +251,7 @@ mod tests {
         assert_eq!(flush_pending_pairing_cancellations(temp.path()), 1);
         let line = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
         assert!(line.contains("pairing_cancelled"));
-        let outbox =
-            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        let outbox = std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
         assert_eq!(outbox.trim(), "[]");
         // A later terminal replay finds nothing pending and must not duplicate
         // the record.
@@ -271,8 +269,7 @@ mod tests {
         remove_pending_pairing_cancelled(temp.path(), Uuid::from_u128(1)).unwrap();
         // Removing an unknown token is a no-op, not an error.
         remove_pending_pairing_cancelled(temp.path(), Uuid::from_u128(99)).unwrap();
-        let outbox =
-            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        let outbox = std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
         assert!(!outbox.contains("00000000-0000-0000-0000-000000000001"));
         assert!(outbox.contains(&kept.to_string()));
     }
@@ -288,8 +285,7 @@ mod tests {
         #[cfg(unix)]
         std::os::unix::fs::symlink("/dev/null", temp.path().join("mobile/audit.jsonl")).unwrap();
         assert_eq!(flush_pending_pairing_cancellations(temp.path()), 0);
-        let outbox =
-            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        let outbox = std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
         assert!(outbox.contains(&pairing.to_string()));
     }
 }

--- a/crates/coven-cli/src/mobile_memory/audit.rs
+++ b/crates/coven-cli/src/mobile_memory/audit.rs
@@ -12,7 +12,12 @@ use super::config::{atomic_replace_private, ensure_private_mobile_dir, validate_
 
 const AUDIT_FILE: &str = "audit.jsonl";
 const MAX_AUDIT_BYTES: u64 = 4 * 1024 * 1024;
+const AUDIT_OUTBOX_FILE: &str = "audit-outbox.json";
+/// Bound on undelivered cancellation tokens when the audit file stays
+/// unhealthy: the outbox must not grow without limit.
+const MAX_PENDING_AUDIT_EVENTS: usize = 64;
 static AUDIT_WRITE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static AUDIT_OUTBOX_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -85,6 +90,109 @@ pub fn append_event(
     validate_private_file(&path)
 }
 
+/// Read the pending cancellation tokens, tolerating an absent or empty file.
+fn read_pending_pairing_cancellations(coven_home: &Path) -> Result<Vec<Uuid>> {
+    let path = ensure_private_mobile_dir(coven_home)?.join(AUDIT_OUTBOX_FILE);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    validate_private_file(&path)?;
+    let raw = std::fs::read(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_slice(&raw).context("mobile audit outbox is malformed")
+}
+
+fn write_pending_pairing_cancellations(coven_home: &Path, pending: &[Uuid]) -> Result<()> {
+    let path = ensure_private_mobile_dir(coven_home)?.join(AUDIT_OUTBOX_FILE);
+    let encoded =
+        serde_json::to_vec_pretty(pending).context("failed to encode mobile audit outbox")?;
+    atomic_replace_private(&path, &encoded)
+}
+
+/// Persist an idempotent audit-pending token for a cancelled pairing.
+///
+/// Returns whether a new token was recorded; a token for the same pairing is
+/// never duplicated. The token is the durable memory that a
+/// `pairing_cancelled` audit record is still owed, so a failed
+/// [`append_event`] can be retried by any later terminal replay of that
+/// pairing instead of being lost.
+pub fn record_pending_pairing_cancelled(coven_home: &Path, pairing_id: Uuid) -> Result<bool> {
+    let _guard = AUDIT_OUTBOX_LOCK
+        .lock()
+        .map_err(|_| anyhow::anyhow!("mobile audit outbox lock was poisoned"))?;
+    let mut pending = read_pending_pairing_cancellations(coven_home)?;
+    if pending.contains(&pairing_id) {
+        return Ok(false);
+    }
+    if pending.len() >= MAX_PENDING_AUDIT_EVENTS {
+        return Ok(false);
+    }
+    pending.push(pairing_id);
+    write_pending_pairing_cancellations(coven_home, &pending)?;
+    Ok(true)
+}
+
+/// Drop a pairing's pending token once its audit record was delivered.
+pub fn remove_pending_pairing_cancelled(coven_home: &Path, pairing_id: Uuid) -> Result<()> {
+    let _guard = AUDIT_OUTBOX_LOCK
+        .lock()
+        .map_err(|_| anyhow::anyhow!("mobile audit outbox lock was poisoned"))?;
+    let pending = read_pending_pairing_cancellations(coven_home)?;
+    if !pending.contains(&pairing_id) {
+        return Ok(());
+    }
+    let remaining: Vec<Uuid> = pending.into_iter().filter(|id| *id != pairing_id).collect();
+    write_pending_pairing_cancellations(coven_home, &remaining)
+}
+
+/// Retry delivery of every pending cancellation token. Best-effort: tokens
+/// whose append fails stay pending for the next terminal replay, and delivery
+/// is therefore at-least-once. Returns how many records were delivered.
+pub fn flush_pending_pairing_cancellations(coven_home: &Path) -> usize {
+    let _guard = match AUDIT_OUTBOX_LOCK
+        .lock()
+        .map_err(|_| anyhow::anyhow!("mobile audit outbox lock was poisoned"))
+    {
+        Ok(guard) => guard,
+        Err(_) => return 0,
+    };
+    let pending = match read_pending_pairing_cancellations(coven_home) {
+        Ok(pending) => pending,
+        Err(_) => return 0,
+    };
+    if pending.is_empty() {
+        return 0;
+    }
+    let mut delivered = Vec::new();
+    for pairing_id in &pending {
+        match append_event(
+            coven_home,
+            Utc::now(),
+            MobileAuditEvent::PairingCancelled,
+            None,
+        ) {
+            Ok(()) => delivered.push(*pairing_id),
+            // The next terminal replay retries; nothing is lost by leaving
+            // the token in place.
+            Err(_) => {}
+        }
+    }
+    if !delivered.is_empty() {
+        let remaining: Vec<Uuid> = pending
+            .into_iter()
+            .filter(|id| !delivered.contains(id))
+            .collect();
+        // A failed rewrite keeps tokens that were already delivered, so a
+        // later replay may append a duplicate `pairing_cancelled` record; the
+        // log stays truthful, just at-least-once.
+        let _ = write_pending_pairing_cancellations(coven_home, &remaining);
+    }
+    delivered.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -113,5 +221,75 @@ mod tests {
         ] {
             assert!(value.get(forbidden).is_none());
         }
+    }
+
+    #[test]
+    fn pending_cancellation_tokens_are_idempotent_and_bounded() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = Uuid::from_u128(1);
+        assert!(record_pending_pairing_cancelled(temp.path(), first).unwrap());
+        // A token for the same pairing is never duplicated.
+        assert!(!record_pending_pairing_cancelled(temp.path(), first).unwrap());
+        for index in 2..(MAX_PENDING_AUDIT_EVENTS as u128 + 2) {
+            let added = record_pending_pairing_cancelled(temp.path(), Uuid::from_u128(index))
+                .unwrap();
+            if index <= MAX_PENDING_AUDIT_EVENTS as u128 {
+                assert!(added, "token {index} should fit the outbox bound");
+            } else {
+                assert!(!added, "token {index} must be refused past the bound");
+            }
+        }
+        let raw = std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        assert!(raw.contains(&first.to_string()));
+    }
+
+    #[test]
+    fn flushed_cancellation_tokens_deliver_exactly_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let pairing = Uuid::from_u128(7);
+        assert!(record_pending_pairing_cancelled(temp.path(), pairing).unwrap());
+
+        assert_eq!(flush_pending_pairing_cancellations(temp.path()), 1);
+        let line = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
+        assert!(line.contains("pairing_cancelled"));
+        let outbox =
+            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        assert_eq!(outbox.trim(), "[]");
+        // A later terminal replay finds nothing pending and must not duplicate
+        // the record.
+        assert_eq!(flush_pending_pairing_cancellations(temp.path()), 0);
+        let line = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
+        assert_eq!(line.matches("pairing_cancelled").count(), 1);
+    }
+
+    #[test]
+    fn removing_a_pending_token_leaves_others_queued() {
+        let temp = tempfile::tempdir().unwrap();
+        let kept = Uuid::from_u128(2);
+        assert!(record_pending_pairing_cancelled(temp.path(), Uuid::from_u128(1)).unwrap());
+        assert!(record_pending_pairing_cancelled(temp.path(), kept).unwrap());
+        remove_pending_pairing_cancelled(temp.path(), Uuid::from_u128(1)).unwrap();
+        // Removing an unknown token is a no-op, not an error.
+        remove_pending_pairing_cancelled(temp.path(), Uuid::from_u128(99)).unwrap();
+        let outbox =
+            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        assert!(!outbox.contains("00000000-0000-0000-0000-000000000001"));
+        assert!(outbox.contains(&kept.to_string()));
+    }
+
+    #[test]
+    fn failed_delivery_keeps_the_token_pending() {
+        let temp = tempfile::tempdir().unwrap();
+        let pairing = Uuid::from_u128(3);
+        assert!(record_pending_pairing_cancelled(temp.path(), pairing).unwrap());
+        // A symlinked audit file fails the private-file validation and the
+        // O_NOFOLLOW open, modelling a delivery failure without breaking the
+        // (still writable) mobile directory that holds the outbox.
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/dev/null", temp.path().join("mobile/audit.jsonl")).unwrap();
+        assert_eq!(flush_pending_pairing_cancellations(temp.path()), 0);
+        let outbox =
+            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        assert!(outbox.contains(&pairing.to_string()));
     }
 }

--- a/crates/coven-cli/src/mobile_memory/gateway.rs
+++ b/crates/coven-cli/src/mobile_memory/gateway.rs
@@ -27,7 +27,9 @@ use super::contract::{
     MobileOverviewTotals, MobileOverviewVerification, MobileSupersession, MobileVerificationState,
 };
 use super::identity::load_or_create_host_identity;
-use super::pairing::{PairingError, PairingManager, PairingProgress};
+use super::pairing::{
+    PairingCancellation, PairingError, PairingManager, PairingProgress, PairingState,
+};
 use super::registry::DeviceRegistry;
 use super::{MAX_MOBILE_REQUEST_BYTES, MAX_MOBILE_RESPONSE_BYTES};
 
@@ -787,7 +789,14 @@ struct LocalPairingInvitation {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LocalPairingStatus {
+    state: PairingState,
     phrase: Option<[String; 6]>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalPairingCancellation {
+    state: PairingCancellation,
 }
 
 #[derive(serde::Deserialize)]
@@ -871,12 +880,28 @@ pub(crate) fn handle_local_control(
     Some((|| {
         let state = active_gateway()?;
         match (method, action) {
-            ("POST", "status") => crate::api::json_response(
-                200,
-                &LocalPairingStatus {
-                    phrase: state.pairing.phrase(id, Utc::now())?,
-                },
-            ),
+            ("POST", "status") => {
+                let report = state.pairing.status(id, Utc::now())?;
+                crate::api::json_response(
+                    200,
+                    &LocalPairingStatus {
+                        state: report.state,
+                        phrase: report.phrase,
+                    },
+                )
+            }
+            ("POST", "cancel") => {
+                let outcome = state.pairing.cancel(id, Utc::now())?;
+                if outcome == PairingCancellation::Cancelled {
+                    append_event(
+                        &state.coven_home,
+                        Utc::now(),
+                        MobileAuditEvent::PairingCancelled,
+                        None,
+                    )?;
+                }
+                crate::api::json_response(200, &LocalPairingCancellation { state: outcome })
+            }
             ("POST", "confirm") => {
                 let confirmation: LocalPairingConfirmation =
                     serde_json::from_str(body.context("pairing confirmation omitted body")?)?;
@@ -1280,6 +1305,23 @@ mod tests {
         }
     }
 
+    /// The device enrollment body as an untrusted caller would send it — the
+    /// request contract is deserialization-only, so tests encode raw JSON.
+    fn sample_pairing_body(nonce: [u8; 32]) -> Vec<u8> {
+        let signing_key = p256::SecretKey::from_slice(&[1; 32]).unwrap();
+        let public_key = signing_key.public_key().to_encoded_point(false);
+        serde_json::json!({
+            "protocolVersion": super::super::MOBILE_PROTOCOL_VERSION,
+            "pairingNonce": URL_SAFE_NO_PAD.encode(nonce),
+            "deviceName": "Synthetic phone",
+            "devicePublicKey": URL_SAFE_NO_PAD.encode(public_key.as_bytes()),
+            "appVersion": "1.0.0",
+            "supportedProtocol": { "minimum": 1, "maximum": 1 }
+        })
+        .to_string()
+        .into_bytes()
+    }
+
     fn envelope_data(body: &str) -> serde_json::Value {
         serde_json::from_str::<serde_json::Value>(body).unwrap()["data"].clone()
     }
@@ -1462,5 +1504,183 @@ mod tests {
             200
         );
         assert_eq!(completions("replays"), 1);
+    }
+
+    #[test]
+    fn local_control_cancellation_is_idempotent_and_audits_once() {
+        let _guard = TEST_GATEWAY_LOCK.lock().unwrap();
+        let Some((temp, config, _)) = test_listener_config() else {
+            return;
+        };
+        let _gateway = start_mobile_gateway_with_config(temp.path(), &config).unwrap();
+        let state = active_gateway().unwrap();
+        let now = Utc::now();
+        let invitation = state
+            .pairing
+            .begin_pairing([13; 32], now + PAIRING_LIFETIME)
+            .unwrap();
+        let cancel_path = format!("/api/v1/internal/mobile/pairings/{}/cancel", invitation.id);
+
+        let first = handle_local_control("POST", &cancel_path, Some("{}"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.status, 200);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&first.body).unwrap()["state"],
+            "cancelled"
+        );
+
+        let replay = handle_local_control("POST", &cancel_path, Some("{}"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(replay.status, 200);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&replay.body).unwrap()["state"],
+            "already_terminal"
+        );
+
+        let audit = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
+        assert_eq!(audit.matches("\"event\":\"pairing_cancelled\"").count(), 1);
+    }
+
+    #[test]
+    fn cancelled_pairings_fail_closed_for_device_callers() {
+        let _guard = TEST_GATEWAY_LOCK.lock().unwrap();
+        let Some((temp, config, _)) = test_listener_config() else {
+            return;
+        };
+        let _gateway = start_mobile_gateway_with_config(temp.path(), &config).unwrap();
+        let state = active_gateway().unwrap();
+        let now = Utc::now();
+        let invitation = state
+            .pairing
+            .begin_pairing([17; 32], now + PAIRING_LIFETIME)
+            .unwrap();
+        assert_eq!(
+            state.pairing.cancel(invitation.id, now).unwrap(),
+            PairingCancellation::Cancelled
+        );
+
+        let enrollment = handle_pairing_enrollment(
+            &state,
+            MobileHttpRequest {
+                method: "POST".to_owned(),
+                target: "/api/v1/mobile/pairings".to_owned(),
+                headers: HashMap::new(),
+                body: sample_pairing_body(invitation.nonce),
+            },
+        );
+        assert_eq!(enrollment.status, 409);
+        assert!(enrollment.body.contains("pairing_consumed"));
+
+        let path = format!("/api/v1/mobile/pairings/{}/confirm", invitation.id);
+        let confirmation = handle_pairing_confirmation(
+            &state,
+            &path,
+            MobileHttpRequest {
+                method: "POST".to_owned(),
+                target: path.clone(),
+                headers: HashMap::new(),
+                body: serde_json::json!({ "phrase": ["a", "b", "c", "d", "e", "f"] })
+                    .to_string()
+                    .into_bytes(),
+            },
+        );
+        assert_eq!(confirmation.status, 409);
+        assert!(confirmation.body.contains("pairing_confirmation_required"));
+        assert!(state.registry.list_status().unwrap().is_empty());
+    }
+
+    #[test]
+    fn device_callers_cannot_distinguish_cancellation_from_a_consumed_pairing() {
+        let _guard = TEST_GATEWAY_LOCK.lock().unwrap();
+        let Some((temp, config, _)) = test_listener_config() else {
+            return;
+        };
+        let _gateway = start_mobile_gateway_with_config(temp.path(), &config).unwrap();
+        let state = active_gateway().unwrap();
+        let now = Utc::now();
+        let cancelled = state
+            .pairing
+            .begin_pairing([19; 32], now + PAIRING_LIFETIME)
+            .unwrap();
+        let live = state
+            .pairing
+            .begin_pairing([23; 32], now + PAIRING_LIFETIME)
+            .unwrap();
+        let cancelled_phrase = state
+            .pairing
+            .enroll(
+                cancelled.id,
+                cancelled.nonce,
+                sample_pairing_request(cancelled.nonce),
+                state.host_fingerprint,
+                now,
+            )
+            .unwrap()
+            .phrase;
+        let live_phrase = state
+            .pairing
+            .enroll(
+                live.id,
+                live.nonce,
+                sample_pairing_request(live.nonce),
+                state.host_fingerprint,
+                now,
+            )
+            .unwrap()
+            .phrase;
+        assert_eq!(
+            state.pairing.cancel(cancelled.id, now).unwrap(),
+            PairingCancellation::Cancelled
+        );
+
+        let confirm_probe = |id: Uuid, phrase: &[String]| {
+            let path = format!("/api/v1/mobile/pairings/{id}/confirm");
+            handle_pairing_confirmation(
+                &state,
+                &path,
+                MobileHttpRequest {
+                    method: "POST".to_owned(),
+                    target: path.clone(),
+                    headers: HashMap::new(),
+                    body: serde_json::json!({ "phrase": phrase })
+                        .to_string()
+                        .into_bytes(),
+                },
+            )
+        };
+        let enroll_probe = |nonce: [u8; 32]| {
+            handle_pairing_enrollment(
+                &state,
+                MobileHttpRequest {
+                    method: "POST".to_owned(),
+                    target: "/api/v1/mobile/pairings".to_owned(),
+                    headers: HashMap::new(),
+                    body: sample_pairing_body(nonce),
+                },
+            )
+        };
+
+        let error_code = |response: &MobileHttpResponse| {
+            serde_json::from_str::<serde_json::Value>(&response.body).unwrap()["error"]["code"]
+                .as_str()
+                .unwrap()
+                .to_owned()
+        };
+
+        // Before the deadline a cancelled pairing answers exactly like the
+        // live, already-consumed control: consumed for enrollment, waiting
+        // for confirmation for a correct phrase.
+        for (cancelled_probe, live_probe) in [
+            (enroll_probe(cancelled.nonce), enroll_probe(live.nonce)),
+            (
+                confirm_probe(cancelled.id, &cancelled_phrase),
+                confirm_probe(live.id, &live_phrase),
+            ),
+        ] {
+            assert_eq!(cancelled_probe.status, live_probe.status);
+            assert_eq!(error_code(&cancelled_probe), error_code(&live_probe));
+        }
     }
 }

--- a/crates/coven-cli/src/mobile_memory/gateway.rs
+++ b/crates/coven-cli/src/mobile_memory/gateway.rs
@@ -956,8 +956,10 @@ pub(crate) fn handle_local_control(
                         None,
                     ) {
                         Ok(()) => {
-                            let _ =
-                                super::audit::remove_pending_pairing_cancelled(&state.coven_home, id);
+                            let _ = super::audit::remove_pending_pairing_cancelled(
+                                &state.coven_home,
+                                id,
+                            );
                         }
                         Err(error) => {
                             eprintln!(
@@ -1633,8 +1635,7 @@ mod tests {
 
         let audit = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
         assert_eq!(audit.matches("\"event\":\"pairing_cancelled\"").count(), 1);
-        let outbox =
-            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        let outbox = std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
         assert_eq!(outbox.trim(), "[]");
     }
 
@@ -1672,8 +1673,7 @@ mod tests {
             "cancelled"
         );
         // The record is owed, not lost: the tombstone token is pending.
-        let outbox =
-            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        let outbox = std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
         assert!(outbox.contains(&id));
 
         // A later terminal replay of the pairing delivers the pending record.
@@ -1688,8 +1688,7 @@ mod tests {
         assert_eq!(status.status, 200);
         let audit = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
         assert_eq!(audit.matches("\"event\":\"pairing_cancelled\"").count(), 1);
-        let outbox =
-            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        let outbox = std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
         assert_eq!(outbox.trim(), "[]");
 
         // Repeated terminal replays stay idempotent.

--- a/crates/coven-cli/src/mobile_memory/gateway.rs
+++ b/crates/coven-cli/src/mobile_memory/gateway.rs
@@ -916,6 +916,15 @@ pub(crate) fn handle_local_control(
         match (method, action) {
             ("POST", "status") => {
                 let report = state.pairing.status(id, Utc::now())?;
+                if matches!(
+                    report.state,
+                    PairingState::Cancelled | PairingState::Expired
+                ) {
+                    // Terminal replay of this pairing: retry any pending
+                    // cancellation audit delivery whose append failed when the
+                    // pairing was cancelled.
+                    super::audit::flush_pending_pairing_cancellations(&state.coven_home);
+                }
                 crate::api::json_response(
                     200,
                     &LocalPairingStatus {
@@ -927,12 +936,39 @@ pub(crate) fn handle_local_control(
             ("POST", "cancel") => {
                 let outcome = state.pairing.cancel(id, Utc::now())?;
                 if outcome == PairingCancellation::Cancelled {
-                    append_event(
+                    // Persist an idempotent audit-pending token before
+                    // attempting delivery: if the append below fails, any
+                    // later terminal replay retries the record instead of the
+                    // cancellation being permanently unrecorded. The token is
+                    // best-effort — persistence problems never delay the
+                    // fail-closed cancellation response.
+                    if let Err(error) =
+                        super::audit::record_pending_pairing_cancelled(&state.coven_home, id)
+                    {
+                        eprintln!(
+                            "coven mobile gateway: pairing cancellation audit token was not persisted: {error:#}"
+                        );
+                    }
+                    match append_event(
                         &state.coven_home,
                         Utc::now(),
                         MobileAuditEvent::PairingCancelled,
                         None,
-                    )?;
+                    ) {
+                        Ok(()) => {
+                            let _ =
+                                super::audit::remove_pending_pairing_cancelled(&state.coven_home, id);
+                        }
+                        Err(error) => {
+                            eprintln!(
+                                "coven mobile gateway: pairing cancellation audit record is pending: {error:#}"
+                            );
+                        }
+                    }
+                } else {
+                    // Terminal replay: retry pending cancellation audit
+                    // delivery before answering.
+                    super::audit::flush_pending_pairing_cancellations(&state.coven_home);
                 }
                 crate::api::json_response(200, &LocalPairingCancellation { state: outcome })
             }
@@ -1595,6 +1631,75 @@ mod tests {
             "already_terminal"
         );
 
+        let audit = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
+        assert_eq!(audit.matches("\"event\":\"pairing_cancelled\"").count(), 1);
+        let outbox =
+            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        assert_eq!(outbox.trim(), "[]");
+    }
+
+    #[test]
+    fn pairing_cancellation_audit_survives_a_failed_delivery_until_replay() {
+        let _guard = TEST_GATEWAY_LOCK.lock().unwrap();
+        let Some((temp, config, _)) = test_listener_config() else {
+            return;
+        };
+        let _gateway = start_mobile_gateway_with_config(temp.path(), &config).unwrap();
+        let response = handle_local_control("POST", "/api/v1/internal/mobile/pairings", Some("{}"))
+            .unwrap()
+            .unwrap();
+        let id = serde_json::from_str::<serde_json::Value>(&response.body).unwrap()["id"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+
+        // Break audit delivery only: a symlinked audit file fails the
+        // private-file validation and the O_NOFOLLOW open while the mobile
+        // directory holding the outbox stays writable.
+        std::fs::remove_file(temp.path().join("mobile/audit.jsonl")).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/dev/null", temp.path().join("mobile/audit.jsonl")).unwrap();
+
+        let cancel_path = format!("/api/v1/internal/mobile/pairings/{id}/cancel");
+        let cancel = handle_local_control("POST", &cancel_path, Some("{}"))
+            .unwrap()
+            .unwrap();
+        // The fail-closed cancellation is neither delayed nor masked by the
+        // audit persistence failure.
+        assert_eq!(cancel.status, 200);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&cancel.body).unwrap()["state"],
+            "cancelled"
+        );
+        // The record is owed, not lost: the tombstone token is pending.
+        let outbox =
+            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        assert!(outbox.contains(&id));
+
+        // A later terminal replay of the pairing delivers the pending record.
+        std::fs::remove_file(temp.path().join("mobile/audit.jsonl")).unwrap();
+        let status = handle_local_control(
+            "POST",
+            &format!("/api/v1/internal/mobile/pairings/{id}/status"),
+            Some("{}"),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(status.status, 200);
+        let audit = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
+        assert_eq!(audit.matches("\"event\":\"pairing_cancelled\"").count(), 1);
+        let outbox =
+            std::fs::read_to_string(temp.path().join("mobile/audit-outbox.json")).unwrap();
+        assert_eq!(outbox.trim(), "[]");
+
+        // Repeated terminal replays stay idempotent.
+        let _ = handle_local_control(
+            "POST",
+            &format!("/api/v1/internal/mobile/pairings/{id}/status"),
+            Some("{}"),
+        )
+        .unwrap()
+        .unwrap();
         let audit = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
         assert_eq!(audit.matches("\"event\":\"pairing_cancelled\"").count(), 1);
     }

--- a/crates/coven-cli/src/mobile_memory/gateway.rs
+++ b/crates/coven-cli/src/mobile_memory/gateway.rs
@@ -814,12 +814,46 @@ fn active_gateway() -> Result<Arc<MobileGatewayState>> {
         .context("mobile gateway is not running")
 }
 
+/// Version of the owner-local pairing control surface. Bumped whenever the
+/// request/response contract of the internal pairing routes changes in a way
+/// the `coven mobile pair` flow must negotiate before creating a pairing.
+pub(crate) const LOCAL_PAIRING_CONTROL_API_VERSION: u16 = 1;
+
+/// Additive capability advertisement for the owner-local pairing control
+/// surface. Older daemons do not expose the route at all; older CLIs ignore
+/// it. `pairing_cancellation` declares that this daemon serves the cancel
+/// route and that cancelling a live pairing fails closed, so the CLI can
+/// refuse to create a pairing it would not be able to retire on interrupt.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalPairingCapabilities {
+    api_version: u16,
+    pairing_cancellation: bool,
+}
+
 pub(crate) fn handle_local_control(
     method: &str,
     path: &str,
     body: Option<&str>,
 ) -> Option<Result<crate::api::ApiResponse>> {
     const ROOT: &str = "/api/v1/internal/mobile/pairings";
+    if path == "/api/v1/internal/mobile/capabilities" {
+        if method != "GET" {
+            return Some(crate::api::api_error(
+                405,
+                "method_not_allowed",
+                "Method not allowed.",
+                None,
+            ));
+        }
+        return Some(crate::api::json_response(
+            200,
+            &LocalPairingCapabilities {
+                api_version: LOCAL_PAIRING_CONTROL_API_VERSION,
+                pairing_cancellation: true,
+            },
+        ));
+    }
     if path == ROOT {
         if method != "POST" {
             return Some(crate::api::api_error(
@@ -1170,6 +1204,28 @@ mod tests {
             serde_json::Value::Null
         );
         assert!(!temp.path().join("mobile/pairings.json").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_control_advertises_pairing_cancellation_capability() {
+        // The advertisement is static: it does not require a running mobile
+        // gateway, and it must be served before any pairing is created.
+        let response = handle_local_control("GET", "/api/v1/internal/mobile/capabilities", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.status, 200);
+        let capabilities: serde_json::Value = serde_json::from_str(&response.body).unwrap();
+        assert_eq!(
+            capabilities["apiVersion"],
+            serde_json::json!(LOCAL_PAIRING_CONTROL_API_VERSION)
+        );
+        assert_eq!(capabilities["pairingCancellation"], serde_json::json!(true));
+
+        let rejected = handle_local_control("POST", "/api/v1/internal/mobile/capabilities", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(rejected.status, 405);
     }
 
     #[cfg(unix)]

--- a/crates/coven-cli/src/mobile_memory/mod.rs
+++ b/crates/coven-cli/src/mobile_memory/mod.rs
@@ -343,12 +343,116 @@ fn cancel_pending_pairing(coven_home: &Path, pairing_id: Uuid) -> &'static str {
     }
 }
 
+/// Owner-local pairing control capabilities as advertised by the daemon.
+///
+/// The field set is additive: older daemons do not serve the capabilities
+/// route at all (which this CLI treats as "no negotiated capability"), and
+/// future daemons may add fields this CLI ignores.
+#[cfg(unix)]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalPairingCapabilities {
+    api_version: u16,
+    pairing_cancellation: bool,
+}
+
+/// Negotiate the pairing control API with the daemon before creating a
+/// pairing.
+///
+/// A `coven mobile pair` process can be newer than the daemon it reaches, and
+/// the fail-closed flow below depends on the daemon-side cancel route: without
+/// it, an interrupt or error would abandon a live pairing until its deadline.
+/// The CLI therefore refuses to create a pairing unless the daemon reports the
+/// control API version this CLI was built against and declares the
+/// cancellation capability. Any transport, status, or parse failure fails
+/// negotiation the same way — a restart of the daemon recovers.
+#[cfg(unix)]
+fn validate_pairing_capabilities(status: u16, body: &str) -> Result<()> {
+    if status != 200 {
+        bail!(
+            "Coven daemon does not advertise mobile pairing capabilities (HTTP {status}); \
+             restart the daemon and retry"
+        );
+    }
+    let capabilities: LocalPairingCapabilities = serde_json::from_str(body)
+        .context("daemon returned invalid mobile pairing capabilities")?;
+    if capabilities.api_version != gateway::LOCAL_PAIRING_CONTROL_API_VERSION {
+        bail!(
+            "Coven daemon pairing control API version {} is not supported (expected {}); \
+             restart the daemon and retry",
+            capabilities.api_version,
+            gateway::LOCAL_PAIRING_CONTROL_API_VERSION
+        );
+    }
+    if !capabilities.pairing_cancellation {
+        bail!(
+            "Coven daemon does not support fail-closed pairing cancellation; \
+             restart the daemon and retry"
+        );
+    }
+    Ok(())
+}
+
+/// Cancels the pending pairing if the flow exits without reaching a terminal
+/// state or handing confirmation to the device.
+///
+/// Armed immediately after the daemon accepts pairing creation, this guard
+/// centralizes cleanup for every unexpected nonterminal exit — transport and
+/// HTTP failures, malformed status responses, unreadable stdin — so no error
+/// path can leave a live pairing behind. Paths that end in a terminal state
+/// (the pairing expired or was cancelled) or that hand off to the device
+/// (confirmation accepted) disarm the guard first.
+#[cfg(unix)]
+struct PendingPairingCleanup {
+    armed: bool,
+    cancel: Option<Box<dyn FnOnce() -> &'static str>>,
+}
+
+#[cfg(unix)]
+impl PendingPairingCleanup {
+    fn armed(coven_home: &Path, pairing_id: Uuid) -> Self {
+        let coven_home = coven_home.to_path_buf();
+        Self {
+            armed: true,
+            cancel: Some(Box::new(move || {
+                cancel_pending_pairing(&coven_home, pairing_id)
+            })),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PendingPairingCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Some(cancel) = self.cancel.take() {
+            let outcome = cancel();
+            eprintln!("coven mobile: pairing abandoned without confirmation; {outcome}");
+        }
+    }
+}
+
 #[cfg(unix)]
 fn run_pair_unix() -> Result<()> {
     let coven_home = crate::coven_home_dir()?;
     // The handler is restored and the flag reset when this scope exits, on
     // every path out of the pairing flow.
     let _interrupt_guard = PairingInterruptGuard::install()?;
+    // Negotiate before creating: a daemon that cannot fail closed must never
+    // be handed a live pairing.
+    let (status, body) = request_mobile_control(
+        &coven_home,
+        "GET",
+        "/api/v1/internal/mobile/capabilities",
+        "",
+    )?;
+    validate_pairing_capabilities(status, &body)?;
     let (status, body) =
         post_mobile_control(&coven_home, "/api/v1/internal/mobile/pairings", "{}")?;
     if status != 201 {
@@ -357,16 +461,26 @@ fn run_pair_unix() -> Result<()> {
     let invitation: LocalPairingInvitation =
         serde_json::from_str(&body).context("daemon returned an invalid pairing invitation")?;
     println!("{}", invitation.terminal_output);
+    // Every unexpected exit from here on retires the pairing; the guard is
+    // disarmed only by a terminal state or an accepted confirmation handoff.
+    // (A creation response whose invitation cannot be parsed never yields the
+    // pairing id, so it cannot be addressed; such a pairing relies on the
+    // daemon's own deadline, five minutes out.)
+    let mut cleanup = PendingPairingCleanup::armed(&coven_home, invitation.id);
 
     let phrase = loop {
         if Utc::now() >= invitation.expires_at {
+            cleanup.disarm();
             bail!("mobile pairing expired before the device enrolled");
         }
         if pairing_interrupted() {
             let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+            cleanup.disarm();
             bail!("mobile pairing interrupted before the device enrolled; {outcome}");
         }
         let path = format!("/api/v1/internal/mobile/pairings/{}/status", invitation.id);
+        // Transport, HTTP, and parse failures here leave the pairing live in
+        // the daemon, so they fall through to the cleanup guard on bail.
         let (status, body) = post_mobile_control(&coven_home, &path, "{}")?;
         if status != 200 {
             bail!("Coven daemon rejected pairing status with HTTP {status}: {body}");
@@ -374,8 +488,16 @@ fn run_pair_unix() -> Result<()> {
         let status: LocalPairingStatus =
             serde_json::from_str(&body).context("daemon returned invalid pairing status")?;
         match status.state {
-            PairingState::Cancelled => bail!("mobile pairing was cancelled before completion"),
-            PairingState::Expired => bail!("mobile pairing expired before the device enrolled"),
+            // Terminal states need no cleanup: the pairing can no longer be
+            // enrolled or confirmed.
+            PairingState::Cancelled => {
+                cleanup.disarm();
+                bail!("mobile pairing was cancelled before completion")
+            }
+            PairingState::Expired => {
+                cleanup.disarm();
+                bail!("mobile pairing expired before the device enrolled")
+            }
             _ => {}
         }
         if let Some(phrase) = status.phrase {
@@ -397,19 +519,24 @@ fn run_pair_unix() -> Result<()> {
         // immediately; nothing else is read or sent.
         Ok(None) => {
             let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+            cleanup.disarm();
             bail!("mobile pairing interrupted before host confirmation; {outcome}");
         }
         // The read itself failed, but an interrupt observed now still wins:
         // the pairing is cancelled and the process exits immediately.
         Err(_error) if pairing_interrupted() => {
             let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+            cleanup.disarm();
             bail!("mobile pairing interrupted before host confirmation; {outcome}");
         }
+        // A stdin failure without an interrupt is an unexpected nonterminal
+        // exit; the cleanup guard retires the pairing on the way out.
         Err(error) => return Err(error).context("failed to read pairing confirmation"),
     };
     if confirmation.trim() != "confirm" {
         let interrupted = pairing_interrupted();
         let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+        cleanup.disarm();
         if interrupted {
             bail!("mobile pairing interrupted; {outcome}");
         }
@@ -420,17 +547,22 @@ fn run_pair_unix() -> Result<()> {
     // confirmed.
     if pairing_interrupted() {
         let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+        cleanup.disarm();
         bail!("mobile pairing interrupted before host confirmation; {outcome}");
     }
     let path = format!("/api/v1/internal/mobile/pairings/{}/confirm", invitation.id);
     let body = serde_json::json!({ "phrase": phrase }).to_string();
+    // A failed confirmation request leaves the pairing live, so failures here
+    // also fall through to the cleanup guard.
     let (status, response) = post_mobile_control(&coven_home, &path, &body)?;
     match status {
         200 => {
+            cleanup.disarm();
             println!("Mobile device paired.");
             Ok(())
         }
         409 => {
+            cleanup.disarm();
             println!("Host confirmed. Complete confirmation on the device before it expires.");
             Ok(())
         }
@@ -440,11 +572,21 @@ fn run_pair_unix() -> Result<()> {
 
 #[cfg(unix)]
 fn post_mobile_control(coven_home: &Path, path: &str, body: &str) -> Result<(u16, String)> {
+    request_mobile_control(coven_home, "POST", path, body)
+}
+
+#[cfg(unix)]
+fn request_mobile_control(
+    coven_home: &Path,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Result<(u16, String)> {
     use std::os::unix::net::UnixStream;
 
     let socket = crate::daemon::daemon_socket_path(coven_home);
     let request = format!(
-        "POST {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "{method} {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         body.len(),
         body
     );
@@ -481,6 +623,8 @@ mod pairing_flow_tests {
     use super::*;
     use std::collections::VecDeque;
     use std::io::{BufRead, Read};
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
 
     /// Stdin stand-in whose reads replay a scripted sequence of byte chunks
     /// and I/O errors, so the confirmation loop can be driven without a tty.
@@ -620,5 +764,82 @@ mod pairing_flow_tests {
         let interrupt = AtomicBool::new(false);
         let line = read_confirmation_line(&mut input, &interrupt).unwrap();
         assert_eq!(line.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn pending_pairing_cleanup_cancels_once_when_still_armed_on_drop() {
+        let cancellations = Arc::new(AtomicUsize::new(0));
+        let cleanup = PendingPairingCleanup {
+            armed: true,
+            cancel: Some(Box::new({
+                let cancellations = Arc::clone(&cancellations);
+                move || {
+                    cancellations.fetch_add(1, Ordering::AcqRel);
+                    "the pending pairing was cancelled"
+                }
+            })),
+        };
+        drop(cleanup);
+        assert_eq!(cancellations.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn pending_pairing_cleanup_does_nothing_after_disarm() {
+        let cancellations = Arc::new(AtomicUsize::new(0));
+        let mut cleanup = PendingPairingCleanup {
+            armed: true,
+            cancel: Some(Box::new({
+                let cancellations = Arc::clone(&cancellations);
+                move || {
+                    cancellations.fetch_add(1, Ordering::AcqRel);
+                    "the pending pairing was cancelled"
+                }
+            })),
+        };
+        // Terminal state or accepted handoff: the pairing is no longer live,
+        // so dropping the guard must not touch the daemon.
+        cleanup.disarm();
+        drop(cleanup);
+        assert_eq!(cancellations.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn pairing_capabilities_reject_an_unsupported_daemon() {
+        let supported = serde_json::json!({
+            "apiVersion": gateway::LOCAL_PAIRING_CONTROL_API_VERSION,
+            "pairingCancellation": true,
+        })
+        .to_string();
+        validate_pairing_capabilities(200, &supported).unwrap();
+
+        // An older daemon does not serve the route at all.
+        let error = validate_pairing_capabilities(404, "not found").unwrap_err();
+        assert!(error.to_string().contains("capabilities"));
+
+        // A daemon speaking a different control API version.
+        let future = serde_json::json!({
+            "apiVersion": gateway::LOCAL_PAIRING_CONTROL_API_VERSION + 1,
+            "pairingCancellation": true,
+        })
+        .to_string();
+        assert!(validate_pairing_capabilities(200, &future)
+            .unwrap_err()
+            .to_string()
+            .contains("API version"));
+
+        // A daemon without the fail-closed cancellation capability.
+        let unable = serde_json::json!({
+            "apiVersion": gateway::LOCAL_PAIRING_CONTROL_API_VERSION,
+            "pairingCancellation": false,
+        })
+        .to_string();
+        assert!(validate_pairing_capabilities(200, &unable)
+            .unwrap_err()
+            .to_string()
+            .contains("fail-closed"));
+
+        // A malformed capabilities body fails negotiation rather than
+        // defaulting to "supported".
+        assert!(validate_pairing_capabilities(200, "{}").is_err());
     }
 }

--- a/crates/coven-cli/src/mobile_memory/mod.rs
+++ b/crates/coven-cli/src/mobile_memory/mod.rs
@@ -214,6 +214,25 @@ extern "C" fn handle_pairing_interrupt(sig: libc::c_int) {
 }
 
 #[cfg(unix)]
+fn current_sigint_disposition() -> Result<libc::sigaction> {
+    // SAFETY: sigaction with a null act queries the current disposition for
+    // SIGINT into the caller-provided storage; it changes nothing.
+    unsafe {
+        let mut previous: libc::sigaction = std::mem::zeroed();
+        if libc::sigaction(
+            libc::SIGINT,
+            std::ptr::null(),
+            &mut previous,
+        ) != 0
+        {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to query the current SIGINT disposition");
+        }
+        Ok(previous)
+    }
+}
+
+#[cfg(unix)]
 fn install_pairing_interrupt_handler() -> Result<()> {
     // SAFETY: sigaction is the documented POSIX API for installing signal
     // handlers; we pass a zero-initialized struct, our handler pointer, and
@@ -223,8 +242,8 @@ fn install_pairing_interrupt_handler() -> Result<()> {
         action.sa_sigaction = handle_pairing_interrupt as *const () as usize;
         libc::sigemptyset(&mut action.sa_mask);
         // Intentionally no SA_RESTART: blocking stdin reads observe the
-        // interrupt instead of waiting it out, and std retries the
-        // interrupted read so the prompt keeps working.
+        // interrupt as ErrorKind::Interrupted instead of waiting it out, so
+        // the pairing prompt can react to Ctrl-C instead of retrying.
         action.sa_flags = 0;
         if libc::sigaction(libc::SIGINT, &action, std::ptr::null_mut()) != 0 {
             return Err(std::io::Error::last_os_error())
@@ -232,6 +251,73 @@ fn install_pairing_interrupt_handler() -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Scoped owner of the process-global pairing SIGINT state.
+///
+/// Installing a signal handler is a process-global mutation, so it is undone
+/// on scope exit: the previous SIGINT disposition captured at install time is
+/// restored and the latched flag is reset. Every path out of the pairing flow
+/// — success, error, or panic — passes through [`Drop::drop`], so the handler
+/// never outlives the pairing session it belongs to.
+#[cfg(unix)]
+struct PairingInterruptGuard {
+    previous: libc::sigaction,
+}
+
+#[cfg(unix)]
+impl PairingInterruptGuard {
+    fn install() -> Result<Self> {
+        let previous = current_sigint_disposition()?;
+        install_pairing_interrupt_handler()?;
+        Ok(Self { previous })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PairingInterruptGuard {
+    fn drop(&mut self) {
+        // SAFETY: sigaction restores the disposition captured when the guard
+        // was installed; the pointer refers to guard-owned storage.
+        unsafe {
+            libc::sigaction(libc::SIGINT, &self.previous, std::ptr::null_mut());
+        }
+        PAIRING_INTERRUPT_REQUESTED.store(false, Ordering::Release);
+    }
+}
+
+/// True when a SIGINT arrived since the last reset.
+#[cfg(unix)]
+fn pairing_interrupted() -> bool {
+    PAIRING_INTERRUPT_REQUESTED.load(Ordering::Acquire)
+}
+
+/// Read one line from `input`, reacting to SIGINT instead of retrying past it.
+///
+/// The interrupt handler is installed without SA_RESTART, so an interrupted
+/// read surfaces as `ErrorKind::Interrupted` rather than being restarted
+/// in place; this loop treats every such error as a chance to observe the
+/// flag and, once it is set, to stop reading entirely. The caller must then
+/// cancel the pairing and exit immediately — no further input is consumed.
+/// Ok(None) means the pairing was interrupted; Ok(Some(line)) is the input
+/// read so far, including the empty line at EOF.
+#[cfg(unix)]
+fn read_confirmation_line(
+    input: &mut dyn std::io::BufRead,
+    interrupt: &AtomicBool,
+) -> std::io::Result<Option<String>> {
+    let mut buffer = String::new();
+    loop {
+        if interrupt.load(Ordering::Acquire) {
+            return Ok(None);
+        }
+        buffer.clear();
+        match input.read_line(&mut buffer) {
+            Ok(_) => return Ok(Some(buffer)),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 /// Best-effort cancellation of a pending pairing through the owner-only daemon
@@ -260,9 +346,9 @@ fn cancel_pending_pairing(coven_home: &Path, pairing_id: Uuid) -> &'static str {
 #[cfg(unix)]
 fn run_pair_unix() -> Result<()> {
     let coven_home = crate::coven_home_dir()?;
-    // The handler stays installed for the lifetime of this pairing flow; the
-    // command runs to process exit, so no restore step is needed.
-    install_pairing_interrupt_handler()?;
+    // The handler is restored and the flag reset when this scope exits, on
+    // every path out of the pairing flow.
+    let _interrupt_guard = PairingInterruptGuard::install()?;
     let (status, body) =
         post_mobile_control(&coven_home, "/api/v1/internal/mobile/pairings", "{}")?;
     if status != 201 {
@@ -276,7 +362,7 @@ fn run_pair_unix() -> Result<()> {
         if Utc::now() >= invitation.expires_at {
             bail!("mobile pairing expired before the device enrolled");
         }
-        if PAIRING_INTERRUPT_REQUESTED.load(Ordering::Acquire) {
+        if pairing_interrupted() {
             let outcome = cancel_pending_pairing(&coven_home, invitation.id);
             bail!("mobile pairing interrupted before the device enrolled; {outcome}");
         }
@@ -303,20 +389,38 @@ fn run_pair_unix() -> Result<()> {
         println!("{}. {word}", index + 1);
     }
     println!("Type `confirm` only if all six words match:");
-    let mut confirmation = String::new();
-    if let Err(error) = std::io::stdin().read_line(&mut confirmation) {
-        if PAIRING_INTERRUPT_REQUESTED.load(Ordering::Acquire) {
+    let stdin = std::io::stdin();
+    let confirmation = match read_confirmation_line(&mut stdin.lock(), &PAIRING_INTERRUPT_REQUESTED)
+    {
+        Ok(Some(confirmation)) => confirmation,
+        // An interrupt while waiting for input cancels the pairing and exits
+        // immediately; nothing else is read or sent.
+        Ok(None) => {
             let outcome = cancel_pending_pairing(&coven_home, invitation.id);
             bail!("mobile pairing interrupted before host confirmation; {outcome}");
         }
-        return Err(error).context("failed to read pairing confirmation");
-    }
+        // The read itself failed, but an interrupt observed now still wins:
+        // the pairing is cancelled and the process exits immediately.
+        Err(_error) if pairing_interrupted() => {
+            let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+            bail!("mobile pairing interrupted before host confirmation; {outcome}");
+        }
+        Err(error) => return Err(error).context("failed to read pairing confirmation"),
+    };
     if confirmation.trim() != "confirm" {
+        let interrupted = pairing_interrupted();
         let outcome = cancel_pending_pairing(&coven_home, invitation.id);
-        if PAIRING_INTERRUPT_REQUESTED.load(Ordering::Acquire) {
+        if interrupted {
             bail!("mobile pairing interrupted; {outcome}");
         }
         bail!("mobile pairing declined; {outcome}");
+    }
+    // Recheck the interrupt state immediately before confirmation: a Ctrl-C
+    // that races with the user pressing Enter must not let the pairing be
+    // confirmed.
+    if pairing_interrupted() {
+        let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+        bail!("mobile pairing interrupted before host confirmation; {outcome}");
     }
     let path = format!("/api/v1/internal/mobile/pairings/{}/confirm", invitation.id);
     let body = serde_json::json!({ "phrase": phrase }).to_string();
@@ -370,4 +474,151 @@ fn post_mobile_control(coven_home: &Path, path: &str, body: &str) -> Result<(u16
         .split_once("\r\n\r\n")
         .context("mobile pairing control response omitted a body")?;
     Ok((status, body.to_owned()))
+}
+
+#[cfg(all(test, unix))]
+mod pairing_flow_tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::io::{BufRead, Read};
+
+    /// Stdin stand-in whose reads replay a scripted sequence of byte chunks
+    /// and I/O errors, so the confirmation loop can be driven without a tty.
+    struct ScriptedInput {
+        steps: VecDeque<std::io::Result<Vec<u8>>>,
+        buffer: Vec<u8>,
+        position: usize,
+    }
+
+    impl ScriptedInput {
+        fn new(steps: Vec<std::io::Result<Vec<u8>>>) -> Self {
+            Self {
+                steps: steps.into(),
+                buffer: Vec::new(),
+                position: 0,
+            }
+        }
+    }
+
+    impl Read for ScriptedInput {
+        fn read(&mut self, target: &mut [u8]) -> std::io::Result<usize> {
+            let available = self.fill_buf()?;
+            let amount = available.len().min(target.len());
+            target[..amount].copy_from_slice(&available[..amount]);
+            self.consume(amount);
+            Ok(amount)
+        }
+    }
+
+    impl BufRead for ScriptedInput {
+        fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+            if self.position >= self.buffer.len() {
+                match self.steps.pop_front() {
+                    Some(Ok(chunk)) => {
+                        self.buffer = chunk;
+                        self.position = 0;
+                    }
+                    Some(Err(error)) => return Err(error),
+                    None => {
+                        self.buffer.clear();
+                        self.position = 0;
+                    }
+                }
+            }
+            Ok(&self.buffer[self.position..])
+        }
+
+        fn consume(&mut self, amount: usize) {
+            self.position = (self.position + amount).min(self.buffer.len());
+        }
+    }
+
+    fn interrupted_error() -> std::io::Error {
+        std::io::Error::from_raw_os_error(libc::EINTR)
+    }
+
+    #[test]
+    fn interrupt_guard_restores_disposition_and_resets_flag() {
+        let before = current_sigint_disposition().unwrap();
+        let guard = PairingInterruptGuard::install().unwrap();
+
+        let installed = current_sigint_disposition().unwrap();
+        assert_eq!(
+            installed.sa_sigaction,
+            handle_pairing_interrupt as *const () as usize
+        );
+
+        // The handler latches the flag; the guard must reset it and restore
+        // the previous disposition on scope exit.
+        handle_pairing_interrupt(libc::SIGINT);
+        assert!(pairing_interrupted());
+
+        drop(guard);
+        let after = current_sigint_disposition().unwrap();
+        assert!(!pairing_interrupted());
+        assert_eq!(after.sa_sigaction, before.sa_sigaction);
+        assert_eq!(after.sa_flags, before.sa_flags);
+    }
+
+    #[test]
+    fn interrupt_guard_restore_survives_a_double_install() {
+        let before = current_sigint_disposition().unwrap();
+        let outer = PairingInterruptGuard::install().unwrap();
+        let inner = PairingInterruptGuard::install().unwrap();
+        drop(inner);
+        // The outer guard still owns the restored-from state; dropping it
+        // returns to the disposition observed before either install.
+        drop(outer);
+        let after = current_sigint_disposition().unwrap();
+        assert_eq!(after.sa_sigaction, before.sa_sigaction);
+        assert!(!pairing_interrupted());
+    }
+
+    #[test]
+    fn confirmation_reader_returns_the_line_without_an_interrupt() {
+        let mut input =
+            ScriptedInput::new(vec![Err(interrupted_error()), Ok(b"confirm\n".to_vec())]);
+        let interrupt = AtomicBool::new(false);
+        let line = read_confirmation_line(&mut input, &interrupt).unwrap();
+        assert_eq!(line.as_deref(), Some("confirm\n"));
+    }
+
+    #[test]
+    fn confirmation_reader_stops_before_reading_when_already_interrupted() {
+        let mut input = ScriptedInput::new(vec![Ok(b"confirm\n".to_vec())]);
+        let interrupt = AtomicBool::new(true);
+        // The pending line must not be consumed: an interrupted pairing is
+        // cancelled and exits before any further input is read.
+        let line = read_confirmation_line(&mut input, &interrupt).unwrap();
+        assert_eq!(line, None);
+        assert_eq!(input.fill_buf().unwrap(), b"confirm\n");
+    }
+
+    #[test]
+    fn confirmation_reader_observes_an_interrupt_that_races_the_read() {
+        let mut input = ScriptedInput::new(vec![
+            Err(interrupted_error()),
+            Ok(b"confirm\n".to_vec()),
+        ]);
+        let interrupt = AtomicBool::new(false);
+        interrupt.store(true, Ordering::Release);
+        let line = read_confirmation_line(&mut input, &interrupt).unwrap();
+        assert_eq!(line, None);
+    }
+
+    #[test]
+    fn confirmation_reader_propagates_unrelated_errors() {
+        let mut input = ScriptedInput::new(vec![Err(std::io::Error::other("closed"))]);
+        let interrupt = AtomicBool::new(false);
+        let error = read_confirmation_line(&mut input, &interrupt).unwrap_err();
+        assert_eq!(error.to_string(), "closed");
+    }
+
+    #[test]
+    fn confirmation_reader_treats_eof_as_an_empty_line() {
+        let mut input = ScriptedInput::new(vec![]);
+        let interrupt = AtomicBool::new(false);
+        let line = read_confirmation_line(&mut input, &interrupt).unwrap();
+        assert_eq!(line.as_deref(), Some(""));
+    }
 }

--- a/crates/coven-cli/src/mobile_memory/mod.rs
+++ b/crates/coven-cli/src/mobile_memory/mod.rs
@@ -219,12 +219,7 @@ fn current_sigint_disposition() -> Result<libc::sigaction> {
     // SIGINT into the caller-provided storage; it changes nothing.
     unsafe {
         let mut previous: libc::sigaction = std::mem::zeroed();
-        if libc::sigaction(
-            libc::SIGINT,
-            std::ptr::null(),
-            &mut previous,
-        ) != 0
-        {
+        if libc::sigaction(libc::SIGINT, std::ptr::null(), &mut previous) != 0 {
             return Err(std::io::Error::last_os_error())
                 .context("failed to query the current SIGINT disposition");
         }
@@ -623,8 +618,8 @@ mod pairing_flow_tests {
     use super::*;
     use std::collections::VecDeque;
     use std::io::{BufRead, Read};
-    use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
 
     /// Stdin stand-in whose reads replay a scripted sequence of byte chunks
     /// and I/O errors, so the confirmation loop can be driven without a tty.
@@ -740,10 +735,8 @@ mod pairing_flow_tests {
 
     #[test]
     fn confirmation_reader_observes_an_interrupt_that_races_the_read() {
-        let mut input = ScriptedInput::new(vec![
-            Err(interrupted_error()),
-            Ok(b"confirm\n".to_vec()),
-        ]);
+        let mut input =
+            ScriptedInput::new(vec![Err(interrupted_error()), Ok(b"confirm\n".to_vec())]);
         let interrupt = AtomicBool::new(false);
         interrupt.store(true, Ordering::Release);
         let line = read_confirmation_line(&mut input, &interrupt).unwrap();

--- a/crates/coven-cli/src/mobile_memory/mod.rs
+++ b/crates/coven-cli/src/mobile_memory/mod.rs
@@ -13,6 +13,7 @@ use std::net::SocketAddr;
 use std::{
     io::{Read, Write},
     path::Path,
+    sync::atomic::{AtomicBool, Ordering},
     thread,
     time::Duration,
 };
@@ -22,6 +23,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
+
+#[cfg(unix)]
+use self::pairing::PairingState;
 
 pub const MOBILE_PROTOCOL_VERSION: u16 = 1;
 pub const MAX_MOBILE_REQUEST_BYTES: usize = 64 * 1024;
@@ -192,12 +196,73 @@ struct LocalPairingInvitation {
 #[cfg(unix)]
 #[derive(Deserialize)]
 struct LocalPairingStatus {
+    state: PairingState,
     phrase: Option<[String; 6]>,
+}
+
+#[cfg(unix)]
+static PAIRING_INTERRUPT_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(unix)]
+extern "C" fn handle_pairing_interrupt(sig: libc::c_int) {
+    // Only async-signal-safe work belongs here. AtomicBool uses a lock-free
+    // primitive on Coven's supported Unix targets; no allocation, lock, or
+    // destructor runs in the handler itself. (Same pattern as the daemon's
+    // termination handler.)
+    PAIRING_INTERRUPT_REQUESTED.store(true, Ordering::Release);
+    let _ = sig;
+}
+
+#[cfg(unix)]
+fn install_pairing_interrupt_handler() -> Result<()> {
+    // SAFETY: sigaction is the documented POSIX API for installing signal
+    // handlers; we pass a zero-initialized struct, our handler pointer, and
+    // an empty signal mask. Failure returns -1 and sets errno.
+    unsafe {
+        let mut action: libc::sigaction = std::mem::zeroed();
+        action.sa_sigaction = handle_pairing_interrupt as *const () as usize;
+        libc::sigemptyset(&mut action.sa_mask);
+        // Intentionally no SA_RESTART: blocking stdin reads observe the
+        // interrupt instead of waiting it out, and std retries the
+        // interrupted read so the prompt keeps working.
+        action.sa_flags = 0;
+        if libc::sigaction(libc::SIGINT, &action, std::ptr::null_mut()) != 0 {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to install the pairing interrupt handler");
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort cancellation of a pending pairing through the owner-only daemon
+/// control route. If the daemon is unreachable, its in-memory pending pairings
+/// are already gone, so a failed request never leaves a live pairing behind.
+#[cfg(unix)]
+fn cancel_pending_pairing(coven_home: &Path, pairing_id: Uuid) -> &'static str {
+    let path = format!("/api/v1/internal/mobile/pairings/{pairing_id}/cancel");
+    let Ok((200, body)) = post_mobile_control(coven_home, &path, "{}") else {
+        return "the pending pairing could not be confirmed cancelled with the daemon";
+    };
+    match serde_json::from_str::<serde_json::Value>(&body)
+        .ok()
+        .and_then(|value| value["state"].as_str().map(str::to_owned))
+        .as_deref()
+    {
+        Some("cancelled") => "the pending pairing was cancelled",
+        Some("already_completed") => {
+            "the pairing had already completed; the paired device was kept"
+        }
+        Some("already_terminal") => "the pairing was already cancelled or expired",
+        _ => "the pending pairing state was not reported by the daemon",
+    }
 }
 
 #[cfg(unix)]
 fn run_pair_unix() -> Result<()> {
     let coven_home = crate::coven_home_dir()?;
+    // The handler stays installed for the lifetime of this pairing flow; the
+    // command runs to process exit, so no restore step is needed.
+    install_pairing_interrupt_handler()?;
     let (status, body) =
         post_mobile_control(&coven_home, "/api/v1/internal/mobile/pairings", "{}")?;
     if status != 201 {
@@ -211,6 +276,10 @@ fn run_pair_unix() -> Result<()> {
         if Utc::now() >= invitation.expires_at {
             bail!("mobile pairing expired before the device enrolled");
         }
+        if PAIRING_INTERRUPT_REQUESTED.load(Ordering::Acquire) {
+            let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+            bail!("mobile pairing interrupted before the device enrolled; {outcome}");
+        }
         let path = format!("/api/v1/internal/mobile/pairings/{}/status", invitation.id);
         let (status, body) = post_mobile_control(&coven_home, &path, "{}")?;
         if status != 200 {
@@ -218,6 +287,11 @@ fn run_pair_unix() -> Result<()> {
         }
         let status: LocalPairingStatus =
             serde_json::from_str(&body).context("daemon returned invalid pairing status")?;
+        match status.state {
+            PairingState::Cancelled => bail!("mobile pairing was cancelled before completion"),
+            PairingState::Expired => bail!("mobile pairing expired before the device enrolled"),
+            _ => {}
+        }
         if let Some(phrase) = status.phrase {
             break phrase;
         }
@@ -230,11 +304,19 @@ fn run_pair_unix() -> Result<()> {
     }
     println!("Type `confirm` only if all six words match:");
     let mut confirmation = String::new();
-    std::io::stdin()
-        .read_line(&mut confirmation)
-        .context("failed to read pairing confirmation")?;
+    if let Err(error) = std::io::stdin().read_line(&mut confirmation) {
+        if PAIRING_INTERRUPT_REQUESTED.load(Ordering::Acquire) {
+            let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+            bail!("mobile pairing interrupted before host confirmation; {outcome}");
+        }
+        return Err(error).context("failed to read pairing confirmation");
+    }
     if confirmation.trim() != "confirm" {
-        bail!("mobile pairing cancelled without host confirmation");
+        let outcome = cancel_pending_pairing(&coven_home, invitation.id);
+        if PAIRING_INTERRUPT_REQUESTED.load(Ordering::Acquire) {
+            bail!("mobile pairing interrupted; {outcome}");
+        }
+        bail!("mobile pairing declined; {outcome}");
     }
     let path = format!("/api/v1/internal/mobile/pairings/{}/confirm", invitation.id);
     let body = serde_json::json!({ "phrase": phrase }).to_string();

--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -1363,56 +1363,47 @@ mod tests {
 
     #[test]
     fn cancelled_pairings_expire_like_naturally_expired_pairings() {
-        let harness = PairingHarness::new();
-        let cancelled_id = harness.pairing_id;
-        let expired_id = Uuid::from_u128(2);
-        let expired_nonce = [31_u8; 32];
-        harness
-            .manager
-            .begin_pairing_with_id(
-                expired_id,
-                expired_nonce,
-                harness.now + Duration::minutes(5),
-            )
-            .unwrap();
-        let cancelled_phrase = harness.enroll().phrase;
-        let expired_phrase = harness
-            .manager
-            .enroll(
-                expired_id,
-                expired_nonce,
-                harness.request.clone(),
-                [3; 32],
-                harness.now,
-            )
-            .unwrap()
-            .phrase;
+        // Two independent managers: past the deadline any operation sweeps
+        // entries it is not addressing, so a shared manager would let the
+        // first probe evict the second pairing before it is probed.
+        let cancelled_harness = PairingHarness::new();
+        let expired_harness = PairingHarness::new();
+        let cancelled_phrase = cancelled_harness.enroll().phrase;
+        let expired_phrase = expired_harness.enroll().phrase;
         assert_eq!(
-            harness.manager.cancel(cancelled_id, harness.now).unwrap(),
+            cancelled_harness
+                .manager
+                .cancel(cancelled_harness.pairing_id, cancelled_harness.now)
+                .unwrap(),
             PairingCancellation::Cancelled
         );
-        let after = harness.now + Duration::minutes(6);
+        let after = cancelled_harness.now + Duration::minutes(6);
 
-        for (pairing_id, nonce, phrase) in [
-            (cancelled_id, harness.pairing_nonce, cancelled_phrase),
-            (expired_id, expired_nonce, expired_phrase),
+        for (harness, phrase) in [
+            (&cancelled_harness, cancelled_phrase),
+            (&expired_harness, expired_phrase),
         ] {
             assert_eq!(
                 harness
                     .manager
-                    .confirm_device(pairing_id, &phrase, after)
+                    .confirm_device(harness.pairing_id, &phrase, after)
                     .unwrap_err(),
                 PairingError::PairingExpired
             );
             assert_eq!(
                 harness
                     .manager
-                    .enroll_by_nonce(nonce, harness.request.clone(), [3; 32], after)
+                    .enroll_by_nonce(
+                        harness.pairing_nonce,
+                        harness.request.clone(),
+                        [3; 32],
+                        after
+                    )
                     .unwrap_err(),
                 PairingError::PairingExpired
             );
+            assert!(harness.devices().is_empty());
         }
-        assert!(harness.devices().is_empty());
     }
 
     #[test]

--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -33,6 +33,16 @@ pub struct PendingPairing {
     pub device_confirmed: bool,
     pub consumed: bool,
     pub completed: Option<MobilePairedDevice>,
+    pub terminal: Option<PairingTerminal>,
+}
+
+/// Terminal lifecycle states reached before completion. `cancelled` is set by
+/// an explicit owner cancellation, `expired` by the natural deadline; both are
+/// terminal for further enrollment or confirmation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairingTerminal {
+    Cancelled,
+    Expired,
 }
 
 #[derive(Debug, Clone)]
@@ -67,6 +77,44 @@ pub enum PairingProgress {
     },
 }
 
+/// Owner-visible pairing lifecycle. The waiting states distinguish a pairing
+/// that has not seen a device yet from one whose phrase is awaiting
+/// confirmation, and the terminal states report why a pairing can no longer
+/// complete. This surfaces on the owner-only local control route only — a
+/// device caller never observes `cancelled` as a distinct state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PairingState {
+    Created,
+    Enrolled,
+    PartiallyConfirmed,
+    Completed,
+    Cancelled,
+    Expired,
+}
+
+/// Owner-facing pairing status. The phrase is only present while the
+/// transcript it was derived from still exists, so terminal states never
+/// carry material.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingStatusReport {
+    pub state: PairingState,
+    pub phrase: Option<[String; 6]>,
+}
+
+/// Outcome of an explicit cancellation. Cancellation is idempotent: every
+/// non-`Cancelled` outcome leaves the pairing exactly as it was.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PairingCancellation {
+    /// A live pairing was retired; enrollment and confirmation now fail closed.
+    Cancelled,
+    /// The pairing had already completed; the registered device grant is kept.
+    AlreadyCompleted,
+    /// The pairing was already cancelled or expired, or the id is unknown.
+    AlreadyTerminal,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PairingError {
     PairingExpired,
@@ -89,6 +137,54 @@ impl fmt::Display for PairingError {
 }
 
 impl std::error::Error for PairingError {}
+
+impl PendingPairing {
+    /// Lifecycle state for the owner-facing status surface. A terminal state
+    /// always wins, so an expired or cancelled pairing can never look alive
+    /// again.
+    fn state(&self) -> PairingState {
+        if let Some(terminal) = self.terminal {
+            return match terminal {
+                PairingTerminal::Cancelled => PairingState::Cancelled,
+                PairingTerminal::Expired => PairingState::Expired,
+            };
+        }
+        if self.completed.is_some() {
+            return PairingState::Completed;
+        }
+        match (
+            self.transcript_hash.is_some(),
+            self.host_confirmed || self.device_confirmed,
+        ) {
+            (false, _) => PairingState::Created,
+            (true, false) => PairingState::Enrolled,
+            (true, true) => PairingState::PartiallyConfirmed,
+        }
+    }
+
+    /// Retire a live, uncompleted pairing at its deadline, dropping every
+    /// device and transcript material it still holds. Completed pairings are
+    /// already terminal, and a terminal state is never overwritten: a
+    /// cancelled pairing stays cancelled after its deadline passes.
+    fn mark_expired(&mut self) {
+        if self.completed.is_some() || self.terminal.is_some() {
+            return;
+        }
+        self.terminal = Some(PairingTerminal::Expired);
+        self.transcript_hash = None;
+        self.device = None;
+    }
+
+    /// Retire a live, uncompleted pairing on explicit owner cancellation,
+    /// dropping the device record and transcript material immediately. The
+    /// nonce hash is kept so device callers still find the tombstone and fail
+    /// closed instead of treating the pairing as never having existed.
+    fn mark_cancelled(&mut self) {
+        self.terminal = Some(PairingTerminal::Cancelled);
+        self.transcript_hash = None;
+        self.device = None;
+    }
+}
 
 pub struct PairingManager {
     registry: Arc<DeviceRegistry>,
@@ -138,6 +234,7 @@ impl PairingManager {
             device_confirmed: false,
             consumed: false,
             completed: None,
+            terminal: None,
         };
         let mut pending = self
             .pending
@@ -197,7 +294,7 @@ impl PairingManager {
             .get_mut(&pairing_id)
             .ok_or(PairingError::PairingConsumed)?;
         if now >= pairing.expires_at {
-            pending.remove(&pairing_id);
+            pairing.mark_expired();
             return Err(PairingError::PairingExpired);
         }
         if pairing.consumed {
@@ -206,6 +303,13 @@ impl PairingManager {
         pairing.consumed = true;
         if Sha256::digest(nonce).as_slice() != pairing.nonce_hash {
             return Err(PairingError::PairingPhraseMismatch);
+        }
+        if pairing.terminal.is_some() {
+            // A cancelled pairing must fail closed even for the correct nonce.
+            // Reporting it as consumed keeps the device answer identical to an
+            // already-used pairing, so cancellation stays indistinguishable
+            // from ordinary consumption until the deadline passes.
+            return Err(PairingError::PairingConsumed);
         }
         validate_pairing_request(&request)?;
         let public_key = URL_SAFE_NO_PAD
@@ -280,20 +384,60 @@ impl PairingManager {
         self.confirm(pairing_id, phrase, now, false)
     }
 
-    pub fn phrase(
+    /// Report the owner-visible lifecycle state of a pairing. Only the phrase
+    /// the owner already displays is exposed — never the nonce, transcript, or
+    /// device material.
+    pub fn status(
         &self,
         pairing_id: Uuid,
         now: DateTime<Utc>,
-    ) -> Result<Option<[String; 6]>, PairingError> {
+    ) -> Result<PairingStatusReport, PairingError> {
         let mut pending = self.lock_pending(now, pairing_id)?;
         let pairing = pending
-            .get(&pairing_id)
+            .get_mut(&pairing_id)
             .ok_or(PairingError::PairingConsumed)?;
         if now >= pairing.expires_at {
-            pending.remove(&pairing_id);
-            return Err(PairingError::PairingExpired);
+            pairing.mark_expired();
         }
-        Ok(pairing.transcript_hash.map(phrase_for_hash))
+        Ok(PairingStatusReport {
+            state: pairing.state(),
+            phrase: pairing.transcript_hash.map(phrase_for_hash),
+        })
+    }
+
+    /// Cancel a pending pairing on owner request.
+    ///
+    /// Cancellation is bounded — it sweeps expired entries like every other
+    /// operation — and idempotent: cancelling an unknown, already cancelled,
+    /// or already expired pairing reports `AlreadyTerminal`, and cancelling a
+    /// completed pairing reports `AlreadyCompleted` while leaving the enrolled
+    /// device grant untouched. A cancelled pairing drops its transcript and
+    /// device material immediately, so enrollment and confirmation fail closed
+    /// at once. The tombstone stays until the original deadline and then
+    /// answers exactly like a naturally expired pairing, which keeps
+    /// cancellation and expiry indistinguishable to an untrusted mobile
+    /// caller.
+    pub fn cancel(
+        &self,
+        pairing_id: Uuid,
+        now: DateTime<Utc>,
+    ) -> Result<PairingCancellation, PairingError> {
+        let mut pending = self.lock_pending(now, pairing_id)?;
+        let Some(pairing) = pending.get_mut(&pairing_id) else {
+            return Ok(PairingCancellation::AlreadyTerminal);
+        };
+        if now >= pairing.expires_at {
+            pairing.mark_expired();
+            return Ok(PairingCancellation::AlreadyTerminal);
+        }
+        if pairing.completed.is_some() {
+            return Ok(PairingCancellation::AlreadyCompleted);
+        }
+        if pairing.terminal.is_some() {
+            return Ok(PairingCancellation::AlreadyTerminal);
+        }
+        pairing.mark_cancelled();
+        Ok(PairingCancellation::Cancelled)
     }
 
     fn confirm(
@@ -308,7 +452,7 @@ impl PairingManager {
             .get_mut(&pairing_id)
             .ok_or(PairingError::PairingConsumed)?;
         if now >= pairing.expires_at {
-            pending.remove(&pairing_id);
+            pairing.mark_expired();
             return Err(PairingError::PairingExpired);
         }
         let transcript_hash = pairing
@@ -1018,10 +1162,11 @@ mod tests {
 
             let after_first_expiry = harness.now + Duration::minutes(6);
             match prune_via {
-                "phrase" => assert_eq!(
-                    harness.manager.phrase(live_id, after_first_expiry).unwrap(),
-                    None
-                ),
+                "phrase" => {
+                    let report = harness.manager.status(live_id, after_first_expiry).unwrap();
+                    assert_eq!(report.state, PairingState::Created);
+                    assert_eq!(report.phrase, None);
+                }
                 "confirm" => assert_eq!(
                     harness
                         .manager
@@ -1060,6 +1205,269 @@ mod tests {
             harness.enroll_after_expiry().unwrap_err(),
             PairingError::PairingExpired
         );
+        assert!(harness.devices().is_empty());
+    }
+
+    #[test]
+    fn cancel_before_enrollment_fails_closed() {
+        let harness = PairingHarness::new();
+        assert_eq!(
+            harness
+                .manager
+                .cancel(harness.pairing_id, harness.now)
+                .unwrap(),
+            PairingCancellation::Cancelled
+        );
+        assert_eq!(
+            harness
+                .enroll_with_nonce(harness.pairing_nonce)
+                .unwrap_err(),
+            PairingError::PairingConsumed
+        );
+        let report = harness
+            .manager
+            .status(harness.pairing_id, harness.now)
+            .unwrap();
+        assert_eq!(report.state, PairingState::Cancelled);
+        assert_eq!(report.phrase, None);
+        assert!(harness.devices().is_empty());
+    }
+
+    #[test]
+    fn cancel_after_enrollment_blocks_confirmation_and_drops_material() {
+        let harness = PairingHarness::new();
+        let pending = harness.enroll();
+        assert_eq!(
+            harness
+                .manager
+                .cancel(harness.pairing_id, harness.now)
+                .unwrap(),
+            PairingCancellation::Cancelled
+        );
+        assert_eq!(
+            harness
+                .manager
+                .confirm_host(harness.pairing_id, &pending.phrase, harness.now)
+                .unwrap_err(),
+            PairingError::PairingConfirmationRequired
+        );
+        assert_eq!(
+            harness
+                .manager
+                .confirm_device(harness.pairing_id, &pending.phrase, harness.now)
+                .unwrap_err(),
+            PairingError::PairingConfirmationRequired
+        );
+        let report = harness
+            .manager
+            .status(harness.pairing_id, harness.now)
+            .unwrap();
+        assert_eq!(report.state, PairingState::Cancelled);
+        assert_eq!(report.phrase, None);
+        assert!(harness.devices().is_empty());
+    }
+
+    #[test]
+    fn cancel_after_one_confirmation_registers_no_device() {
+        let harness = PairingHarness::new();
+        let pending = harness.enroll();
+        assert_eq!(
+            harness.confirm_host(&pending.phrase),
+            PairingProgress::Pending
+        );
+        assert_eq!(
+            harness
+                .manager
+                .cancel(harness.pairing_id, harness.now)
+                .unwrap(),
+            PairingCancellation::Cancelled
+        );
+        assert_eq!(
+            harness
+                .manager
+                .confirm_device(harness.pairing_id, &pending.phrase, harness.now)
+                .unwrap_err(),
+            PairingError::PairingConfirmationRequired
+        );
+        assert!(harness.devices().is_empty());
+    }
+
+    #[test]
+    fn repeated_cancellation_is_idempotent_and_cannot_resurrect() {
+        let harness = PairingHarness::new();
+        let pending = harness.enroll();
+        assert_eq!(
+            harness
+                .manager
+                .cancel(harness.pairing_id, harness.now)
+                .unwrap(),
+            PairingCancellation::Cancelled
+        );
+        assert_eq!(
+            harness
+                .manager
+                .cancel(harness.pairing_id, harness.now)
+                .unwrap(),
+            PairingCancellation::AlreadyTerminal
+        );
+        assert_eq!(
+            harness
+                .manager
+                .cancel(harness.pairing_id, harness.now + Duration::minutes(6))
+                .unwrap(),
+            PairingCancellation::AlreadyTerminal
+        );
+        assert_eq!(
+            harness
+                .enroll_with_nonce(harness.pairing_nonce)
+                .unwrap_err(),
+            PairingError::PairingConsumed
+        );
+        assert_eq!(
+            harness
+                .manager
+                .confirm_device(
+                    harness.pairing_id,
+                    &pending.phrase,
+                    harness.now + Duration::minutes(6),
+                )
+                .unwrap_err(),
+            PairingError::PairingExpired
+        );
+        assert!(harness.devices().is_empty());
+    }
+
+    #[test]
+    fn cancel_of_completed_pairing_preserves_the_device_grant() {
+        let harness = PairingHarness::new();
+        let pending = harness.enroll();
+        assert_eq!(
+            harness.confirm_host(&pending.phrase),
+            PairingProgress::Pending
+        );
+        let device = assert_complete(harness.confirm_device(&pending.phrase), false);
+        assert_eq!(
+            harness
+                .manager
+                .cancel(harness.pairing_id, harness.now)
+                .unwrap(),
+            PairingCancellation::AlreadyCompleted
+        );
+        assert_eq!(harness.devices().len(), 1);
+        assert_eq!(harness.devices()[0].id, device.id);
+        assert_eq!(
+            assert_complete(harness.confirm_host(&pending.phrase), true),
+            device
+        );
+    }
+
+    #[test]
+    fn cancelled_pairings_expire_like_naturally_expired_pairings() {
+        let harness = PairingHarness::new();
+        let cancelled_id = harness.pairing_id;
+        let expired_id = Uuid::from_u128(2);
+        let expired_nonce = [31_u8; 32];
+        harness
+            .manager
+            .begin_pairing_with_id(
+                expired_id,
+                expired_nonce,
+                harness.now + Duration::minutes(5),
+            )
+            .unwrap();
+        let cancelled_phrase = harness.enroll().phrase;
+        let expired_phrase = harness
+            .manager
+            .enroll(
+                expired_id,
+                expired_nonce,
+                harness.request.clone(),
+                [3; 32],
+                harness.now,
+            )
+            .unwrap()
+            .phrase;
+        assert_eq!(
+            harness.manager.cancel(cancelled_id, harness.now).unwrap(),
+            PairingCancellation::Cancelled
+        );
+        let after = harness.now + Duration::minutes(6);
+
+        for (pairing_id, nonce, phrase) in [
+            (cancelled_id, harness.pairing_nonce, cancelled_phrase),
+            (expired_id, expired_nonce, expired_phrase),
+        ] {
+            assert_eq!(
+                harness
+                    .manager
+                    .confirm_device(pairing_id, &phrase, after)
+                    .unwrap_err(),
+                PairingError::PairingExpired
+            );
+            assert_eq!(
+                harness
+                    .manager
+                    .enroll_by_nonce(nonce, harness.request.clone(), [3; 32], after)
+                    .unwrap_err(),
+                PairingError::PairingExpired
+            );
+        }
+        assert!(harness.devices().is_empty());
+    }
+
+    #[test]
+    fn status_reports_each_lifecycle_state() {
+        let harness = PairingHarness::new();
+        assert_eq!(
+            harness
+                .manager
+                .status(harness.pairing_id, harness.now)
+                .unwrap()
+                .state,
+            PairingState::Created
+        );
+        let pending = harness.enroll();
+        assert_eq!(
+            harness
+                .manager
+                .status(harness.pairing_id, harness.now)
+                .unwrap()
+                .state,
+            PairingState::Enrolled
+        );
+        assert_eq!(
+            harness.confirm_host(&pending.phrase),
+            PairingProgress::Pending
+        );
+        assert_eq!(
+            harness
+                .manager
+                .status(harness.pairing_id, harness.now)
+                .unwrap()
+                .state,
+            PairingState::PartiallyConfirmed
+        );
+        assert_complete(harness.confirm_device(&pending.phrase), false);
+        assert_eq!(
+            harness
+                .manager
+                .status(harness.pairing_id, harness.now)
+                .unwrap()
+                .state,
+            PairingState::Completed
+        );
+    }
+
+    #[test]
+    fn status_reports_expiry_without_keeping_material() {
+        let harness = PairingHarness::new();
+        harness.enroll();
+        let report = harness
+            .manager
+            .status(harness.pairing_id, harness.now + Duration::minutes(6))
+            .unwrap();
+        assert_eq!(report.state, PairingState::Expired);
+        assert_eq!(report.phrase, None);
         assert!(harness.devices().is_empty());
     }
 


### PR DESCRIPTION
## Summary

Makes pairing cancellation a first-class, fail-closed state transition (OpenCoven/coven#814). Today, declining the confirmation prompt or abandoning `coven mobile pair` leaves the pending introduction fully usable until its five-minute expiry. This slice:

- **`PairingManager::cancel`** — bounded (sweeps expired entries like every other manager operation, no timers/threads) and idempotent (`Cancelled` / `AlreadyCompleted` / `AlreadyTerminal`). Cancelling a *completed* pairing is a no-op that **preserves the enrolled device grant** — no revocation, replay window untouched.
- **Material removal** — cancellation drops the transcript hash and pending device record immediately; enrollment and confirmation fail closed at once. No durable credential is ever created by a cancel path.
- **No new mobile-visible state** — a cancelled pairing tombstones until its original deadline, answering device callers exactly like an already-consumed pairing before the deadline and exactly like a naturally expired pairing (410) after it. Expiration and cancellation are indistinguishable to an untrusted mobile caller; no new mobile error code or scope was added.
- **Owner-only daemon control** — `POST /api/v1/internal/mobile/pairings/{id}/cancel` on the local (unix-socket) control plane only; the TLS gateway has no cancel route.
- **Owner status** — `…/{id}/status` now reports `created` / `enrolled` / `partially_confirmed` / `completed` / `cancelled` / `expired` (distinguishing waiting-for-device from waiting-for-confirmation) without exposing nonce, transcript, or device material; the phrase remains owner-visible only while its transcript exists.
- **Audit** — new coarse `pairing_cancelled` event (event name only, no pairing id / nonce / transcript material), emitted once per effective cancellation; idempotent repeats stay silent.
- **Terminal pairing flow** — the host decline path and the Ctrl-C interruption path (signal-safe atomic flag handler, same pattern as the daemon's termination handler) now attempt cancellation via the control route before exiting, and report the daemon's cancellation outcome.

## Issue

Refs OpenCoven/coven#814

## Test plan

Local runs (checked = executed locally):

- [x] `rustfmt --edition 2021 --check` on all four touched files (formatter only; no Rust build tooling per environment policy — `cargo fmt/clippy/test` deferred to CI)
- [x] Manual secret-scan / privacy review of the diff (python unavailable locally): no secrets added; audit event and status DTO carry no nonce/transcript/device material; no new device-facing fields

Deferred to CI (unchecked = no Rust toolchain in the agent sandbox by policy):

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `python scripts/check-secrets.py`
- [ ] `python3 scripts/check-coven-privacy.py --staged`

New focused tests: 8 unit tests in `pairing.rs` (cancel before enrollment / after enrollment / after one confirmation; repeated cancel idempotent + cannot resurrect; completed-pairing grant preserved; cancelled≡expired device-callable parity across the deadline; full lifecycle status; expiry status drops material) and 3 gateway tests (control-route cancel idempotent + audited once; device callers fail closed with existing error classes; cancelled ≡ consumed parity for device callers before the deadline).

## Scope note

Single coherent slice covering all checklist items of #814 on the surfaces that exist today (the "TUI" host surface in this repo is the interactive `coven mobile pair` terminal flow — no other TUI pairing surface exists).

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#814.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/15], preserving source head `b9c7ceea40f5f3302aef05729ee80105a1144471` and branch `agent/issue-814-plan-explicit-mobile-pairing-cancellation-and`.