### PR TITLE
docs(automations): bind automation runs to principal authority and receipts

### DIFF
--- a/specs/coven-automation-authority/PRODUCT.md
+++ b/specs/coven-automation-authority/PRODUCT.md
@@ -139,7 +139,7 @@ fails closed when the referenced binding cannot be resolved.
 
 ## Side-effect classes and safe defaults
 
-Ratified risk vocabulary, aligned with organization-wide agent risk classes:
+Proposed risk vocabulary — to be ratified against the organization-wide agent risk classes before the authority module lands (slice 2):
 
 | Class | Meaning | Unattended default |
 |---|---|---|

--- a/specs/coven-automation-authority/PRODUCT.md
+++ b/specs/coven-automation-authority/PRODUCT.md
@@ -1,0 +1,276 @@
+# Coven Automation Authority — PRODUCT
+
+**Status:** Draft v1 · 2026-08-30
+**Owner:** Coven runtime
+**Acceptance target:** "Every Coven automation occurrence is dispatched only as an authenticated, explicitly authorized embodiment of the intended familiar, with fresh runtime capability checks, approval handling, replay resistance, and a verifiable receipt describing exactly what authority was exercised."
+**Source issue:** coven#857 · Parent program coven#854 · Protocol dependency coven#855 · Foundation coven#816
+
+## Problem
+
+Coven now owns recurring automation end to end: routine definitions persist in
+the Coven store, the daemon fences occurrences with a lease, and every run
+dispatches through the shared session-launch path into the Coven-owned run
+ledger (`crates/coven-cli/src/automations/`). That foundation propagates a
+familiar identifier into the launch path — but the identifier is the only thing
+it propagates.
+
+A routine carrying `familiarId = "charm"` is not sufficient proof that Charm
+ran, that the current principal authorized the run, or that the runtime had
+permission to perform its effects. Today:
+
+1. **The familiar string is not an identity.** `familiar_identity.rs` resolves a
+   display name from `familiars.toml`; nothing pins a familiar root, an
+   identity revision, or a declaration digest to a run.
+2. **There is no authenticated principal at dispatch.** The scheduler is trusted
+   implicitly; no per-run authentication, authorization decision, or revocation
+   check exists between occurrence claim and runtime launch.
+3. **The run ledger records outcomes, not authority.** `automation_runs` stores
+   status, exit code, and a bounded log — it cannot answer "what authority was
+   exercised, under which approval, decided against which policy revision?"
+4. **Approvals do not exist for automations.** Nothing binds an approval to an
+   operation, consumes it, expires it, or prevents its replay against a
+   changed definition.
+5. **The Psyche execution binding (`psyche.execution_binding.v1`) covers
+   Psyche-orchestrated sessions only.** Coven-owned automation dispatch — the
+   direct scheduler path — has no equivalent binding of its own.
+
+Until this contract is enforced, recurring familiar work must be treated as a
+local execution convenience — not proof of authorized familiar continuity — and
+unattended external side effects must remain disabled or approval-gated. This
+spec makes the guarantees normative so implementation slices can land against a
+single reviewable surface.
+
+## Canonical boundaries
+
+This contract consumes, and must not duplicate, canonical semantics owned
+elsewhere:
+
+- **Familiar Contract / continuity profile** (`specs/coven-familiar-spec/`)
+  defines the familiar root, identity revisions, same-familiar rules, and
+  principal binding. Coven resolves those inputs at dispatch time; it does not
+  re-derive familiar identity from `familiars.toml` display data.
+- **Coven Threads / authority profile** defines protected actions, capability
+  decisions, approval semantics, degrade-to-proposal behavior, and authority
+  evidence. The daemon's authority weave (`threads_gate.rs`) is the local
+  enforcement point for protected surfaces.
+- **Coven** resolves those inputs, authorizes dispatch, owns
+  occurrence/run/attempt state, and commits the resulting receipt.
+- **Psyche** may execute a multi-step authorized action but does not create
+  identity or schedule authority. Its `psyche.execution_binding.v1` wire
+  contract (`execution_binding.rs`) stays opaque to Coven and is unchanged by
+  this spec.
+- **Cave/SDK** propose, approve, inspect, and verify; they do not infer
+  permission or author lifecycle truth.
+
+## The AutomationExecutionBinding
+
+Before any runtime launch, Coven atomically constructs or references an
+immutable **`AutomationExecutionBinding`** (wire contract
+`coven.automation_execution_binding.v1`). The binding is the only dispatch
+credential: a run without one does not launch, and a runtime that receives an
+unbound launch has hit an implementation bug, not a fast path.
+
+The binding contains at least:
+
+| # | Field | Shape | Producer | Notes |
+|---|---|---|---|---|
+| 1 | `automationId` | stable id | definition store | key of the routine |
+| 2 | `definitionRevision` + `definitionDigest` | monotonic revision, `sha256:` digest of canonical `definition_json` | definition store | pins the exact definition; in-place edits mint a new revision |
+| 3 | `occurrenceId`, `occurrenceKey`, `fenceGeneration` | ids + counter | occurrence ledger | `occurrenceId` + `UNIQUE(automation_id, scheduled_for)` fence; `attempt` count is the fence generation |
+| 4 | `runId`, `attemptId`, `adoptedRequestKey` | ids + adoption key | run ledger / `psyche.request_adoption.v1` | the adopted request/idempotency key |
+| 5 | `principalId` | stable opaque id | principal resolution | never a display name or email |
+| 6 | `credentialRef` | credential/key id or authorization proof reference | principal resolution | an identifier, never secret material |
+| 7 | `authorization` | operation, nonce, issued/valid times, replay state | AutomationAuthorizer | per-run, single-use |
+| 8 | `familiarRootId` | stable root id | Familiar Binding Resolver | aliases must resolve to exactly one root |
+| 9 | `familiarIdentityRevision` + `declarationDigest` | exact revision + `sha256:` digest | Familiar Binding Resolver | pins the identity/declaration the run embodies |
+| 10 | `identityStatus` | valid / revoked / retired / paused at decision time | Familiar Binding Resolver | decision-time state, not creation-time state |
+| 11 | `memoryProjectionIds` | allowed projection ids only | authorization decision | present only where authorized |
+| 12 | `threadsDecision` + `protectedSurfaceManifestDigest` | permit / degrade / reject + manifest digest | Threads authority profile | decision digest pins what the gate saw |
+| 13 | `capabilities` | requested, granted, denied, degraded sets | Runtime Capability Resolver | exact operation-specific grants |
+| 14 | `approval` | requirement, approval id/evidence, scope, expiry, consumption state | approval ledger | `not_required` is an explicit value |
+| 15 | `riskClass` | R0–R4 (below) | definition review | never self-declared by prompt text |
+| 16 | `runtime` | exact descriptor/version/capabilities + selection rationale | Runtime Capability Resolver | pinned in the run, not discovered at launch |
+| 17 | `policyVersions` | policy/profile revisions used for the decision | decision producer | every input version that affected the outcome |
+| 18 | `decidedAt` + `producedBy` | timestamp + authoritative producer | Coven | who constructed the binding |
+
+The binding is constructed atomically with the authorization decision — one
+snapshot, one commit — and is immutable once committed.
+
+### The bounded runtime projection
+
+The runtime receives only the projection it needs to execute: the prompt, the
+working directory, the familiar embodiment context, its exact capability set,
+and the session correlation ids. It must **not** receive:
+
+- principal credentials, key material, or authorization proofs;
+- unrelated familiar identity history;
+- private audit material or other familiars' data;
+- broad ambient authority merely because the scheduler is trusted.
+
+The existing `SessionLaunch` shape stays the transport; the binding adds a
+reference (id + digest), not a copy of authority material, and the launch path
+fails closed when the referenced binding cannot be resolved.
+
+## Per-run authorization rules
+
+1. Identity and authority are resolved **after** occurrence claim and
+   immediately before dispatch. Creation-time revisions, credentials, approvals,
+   runtime availability, and authorizations are never reused.
+2. A paused, retired, or revoked familiar or principal **fails closed** with a
+   typed, durable reason recorded on the occurrence.
+3. A definition revision naming a familiar alias must resolve to exactly one
+   stable root or the dispatch is refused as ambiguous.
+4. Runtime capability descriptors must satisfy the action's declared
+   requirements and be pinned in the run. Descriptor mismatch or downgrade
+   refuses dispatch.
+5. Unknown, stale, malformed, incompatible, or unavailable policy inputs refuse
+   dispatch. There is no best-effort path.
+6. Authorization and the binding commit operate on the same immutable
+   snapshot/transaction boundary where the store allows it, and on a
+   verifiable digest pair everywhere else (time-of-check/time-of-use is
+   narrowed, never assumed away).
+7. Approval evidence is operation-specific, bounded, expiring,
+   non-transferable, and consumed or otherwise replay-safe. An approval for
+   one occurrence/run cannot authorize another occurrence, a changed
+   definition, or expanded capabilities.
+8. Policy changes while a run is active do not rewrite history. Revocation and
+   cancellation during queued, awaiting-approval, dispatching, and running
+   states are explicit, auditable transitions.
+
+## Side-effect classes and safe defaults
+
+Ratified risk vocabulary, aligned with organization-wide agent risk classes:
+
+| Class | Meaning | Unattended default |
+|---|---|---|
+| **R0** | read-only/local analysis, no protected mutation | allowed only under an explicit narrow grant |
+| **R1** | bounded local artifact creation in an approved scope | allowed only under an explicit narrow grant |
+| **R2** | mutable local state or migrations | requires a reviewed policy and a deterministic fixture/rollback contract |
+| **R3** | network, credentials, user data, remote APIs, publication, external effects | per-run or tightly scoped recurring approval + protected-owner policy |
+| **R4** | identity, authorization, persistence control, release, deletion, security-critical mutation | per-run or tightly scoped recurring approval + protected-owner policy |
+
+Default policy:
+
+- New and imported routines start **paused** (this matches the landed
+  definition default and stays normative).
+- Unsupported or ambiguous actions degrade to proposal where safe — staged
+  like the authority gate's pending proposals, never written — and otherwise
+  reject.
+- Prompt text, tags, runtime names, and client payloads cannot self-declare a
+  risk class or grant capabilities. The class comes from the reviewed
+  definition and policy, not from content under the runtime's control.
+
+## Approval lifecycle
+
+Authoritative states and transitions:
+
+```text
+not_required
+required -> requested -> approved | rejected | expired | revoked
+approved -> consumed | revoked | expired
+```
+
+Requirements:
+
+- Approval requests record the exact definition revision, occurrence, action
+  digest, capabilities, familiar revision, and intended runtime.
+- Any relevant change after approval — definition revision, action digest,
+  capability set, familiar revision, intended runtime — invalidates the
+  approval.
+- Cave/SDK approval calls run under authenticated principal context with
+  stable adoption keys; no client can directly write `approved` into run
+  state.
+- Approval refusal or expiry leaves the occurrence explainable and recoverable
+  without launching.
+- The scheduler may wait within a bounded policy window or skip/fail according
+  to a declared approval-misfire policy; both are recorded.
+- Approvals are consumed at use, or carry a nonce that makes replay
+  detectable. Replay fails closed.
+
+## Receipt and audit evidence
+
+On every terminal run, Coven commits a versioned **`AutomationReceipt`**
+(`coven.automation_receipt.v1`) that an independent verifier can check without
+trusting the producer. It includes:
+
+- all definition/occurrence/run/attempt correlation;
+- the exact familiar and principal binding (root, revision, digests);
+- authorization, approval, and capability decision digests;
+- runtime descriptor and session correlation;
+- exercised capabilities and the declared side-effect class;
+- start/finish timestamps and terminal disposition;
+- normalized result, artifact, and delivery digests;
+- retry/cancellation/recovery history;
+- failure and partial-delivery details;
+- producer identity, integrity/authentication, and the event cursor;
+- privacy/retention class and redaction status.
+
+A receipt proves what Coven observed and authorized. It must **not** overclaim
+model intent, legal agency, personhood, ownership, correctness of generated
+content, or completion of effects Coven could not verify. "Dispatched" and
+"completed external effect" are different claims; receipts record the first
+and, where verifiable, the second — never an inference between them.
+
+## Privacy and erasure
+
+- Public/operational receipt fields are stored separately from sensitive
+  identity, prompt, memory, and authority payloads.
+- Sensitive payloads are encrypted at rest where the deployment profile
+  requires it, reusing the at-rest encryption primitives Coven already owns.
+- Stable opaque ids and digests are preferred over copying declarations or
+  personal data into every row or event.
+- Retention, redaction, tombstone, and erasure semantics are defined without
+  breaking minimum security/audit evidence; erasure applies to redactable
+  payloads, never to the structural audit spine.
+- A changefeed/subscriber receives only fields authorized for that principal
+  and client profile.
+- Logs and errors never print credentials, raw approval secrets, unrestricted
+  prompts, private memories, or unrelated filesystem paths. Error paths carry
+  static field paths, matching the existing validation-error style.
+
+## Threat model and required refusals
+
+The implementation must prove, with tests, refusal or safe handling of:
+
+- forged `familiarId` or principal strings;
+- stale/revoked identity revision;
+- replayed approval or command nonce;
+- approval reused after definition/action change;
+- capability escalation through prompt text, tags, runtime name, or client payload;
+- confused deputy across two familiars, projects, or principals;
+- runtime capability descriptor mismatch/downgrade;
+- stale policy snapshot and time-of-check/time-of-use races;
+- duplicate scheduler/worker acting under an old fence;
+- forged client-authored run/approval/receipt state;
+- tampered receipt/event/history;
+- unauthorized read of sensitive run evidence;
+- revocation during queued, awaiting-approval, dispatching, and running states.
+
+Every refusal is fail-closed: an unknown, stale, malformed, or ambiguous input
+refuses dispatch with a typed reason. A missing adapter must fail closed; it
+must not fall back to unbound launch.
+
+## Acceptance criteria
+
+- [ ] Every dispatched run pins an exact principal, familiar root/revision,
+      authority decision, runtime descriptor, definition revision, occurrence
+      fence, and adopted request.
+- [ ] Revoked, stale, ambiguous, or unauthorized bindings cannot dispatch.
+- [ ] Approval is operation-specific, replay-safe, and invalidated by
+      relevant changes.
+- [ ] External effects remain safely gated by explicit risk/capability policy.
+- [ ] Terminal runs produce independently verifiable, privacy-classified
+      receipts.
+- [ ] No client or runtime can forge authoritative lifecycle, approval, or
+      receipt state.
+- [ ] Cross-repository vectors prove compatibility at immutable revisions.
+- [ ] Direct and Psyche-orchestrated runs use the same binding and receipt
+      semantics.
+
+## Non-goals
+
+- Reimplementing the Familiar Contract, SPAR continuity, Threads, or runtime
+  registries in the scheduler.
+- Treating familiarity or a human-readable name as authentication.
+- Claiming exactly-once external effects Coven cannot verify.
+- Granting broad unattended R3/R4 authority in v1.

--- a/specs/coven-automation-authority/TECH.md
+++ b/specs/coven-automation-authority/TECH.md
@@ -1,0 +1,233 @@
+# Coven Automation Authority — TECH
+
+**Status:** Draft v1 · 2026-08-30
+**Companion to:** [PRODUCT.md](./PRODUCT.md)
+
+This document maps the PRODUCT contract onto the current code and lists the
+deltas needed to enforce it end to end.
+
+## Current code mapped to PRODUCT
+
+| PRODUCT element | Code location | State |
+|---|---|---|
+| Routine definitions, default PAUSED | `crates/coven-cli/src/automations/definition.rs` | Implemented (`AUTOMATION_SCHEMA_VERSION = 1`, `RoutineStatus::Paused` default) |
+| Definition revision + digest pinning | (none — `automation_definitions` rows mutate in place) | **Missing** |
+| Occurrence fence + lease | `crates/coven-cli/src/automations/occurrences.rs` | Implemented — `UNIQUE(automation_id, scheduled_for)` fence, compare-and-set claim, lease owner/expiry, `attempt` counter |
+| Canonical occurrence key + fence generation | `attempt` column only | **Partial** — needs explicit fence-generation semantics on top of `attempt` |
+| Shared dispatch path | `crates/coven-cli/src/automations/runner.rs` (`run_routine_now`, `dispatch_claimed_occurrences`) | Implemented — every run builds a `SessionLaunch` and dispatches through `SessionRuntime` |
+| Per-run authorization between claim and launch | (none — the scheduler is trusted implicitly) | **Missing** |
+| Principal identity + authentication | (none — local trust; no principal resolution at dispatch) | **Missing** |
+| Familiar root / identity revision / declaration digest | `crates/coven-cli/src/familiar_identity.rs` | **Partial** — resolves an id to a display context from `familiars.toml`; no root, revision, digest, or revocation state |
+| Adopted request / idempotency key | `crates/coven-cli/src/request_adoption.rs`, `adoption_gate.rs` | Implemented for the Psyche request path (`psyche.request_adoption.v1`, file-lock mutual exclusion); not consumed by automation dispatch |
+| Psyche execution binding | `crates/coven-cli/src/execution_binding.rs` | Implemented — opaque `psyche.execution_binding.v1` validation for Psyche-orchestrated sessions; unchanged by this spec |
+| Threads protected-surface decision | `crates/coven-cli/src/threads_gate.rs` | Implemented for the daemon edit path — authority weave, fail-closed verdicts, degrade-to-proposal staging, append-only `ward_audit`; not wired into automation dispatch |
+| Runtime capability descriptors | `crates/coven-cli/src/capabilities.rs` | **Partial** — harness capability discovery manifests; no per-action requirement matching or dispatch-time pinning |
+| Approval lifecycle | (none for automations) | **Missing** |
+| Run ledger | `crates/coven-cli/src/automations/runs.rs` | Implemented — `automation_runs` records status/exit/session/log/output-commit; no binding correlation or receipt |
+| Automation receipt | (none) | **Missing** |
+| Nonce / replay protection | (none) | **Missing** |
+| Redaction, at-rest encryption, retention | `crates/coven-cli/src/privacy.rs`, `encrypted_artifacts.rs`, trust-layer retention pruning | Implemented — reusable for receipt payload classes |
+| Scheduler cadence | `crates/coven-cli/src/automations/daemon_tick.rs` | Implemented — 60s tick: plan, recover, claim, dispatch |
+
+## Integration seams
+
+The implementation introduces four narrow traits (consumed by
+`runner.rs`; production adapters wrap canonical versioned artifacts; tests use
+deterministic fakes and golden vectors). A missing adapter fails closed —
+it must not fall back to unbound launch:
+
+```rust
+trait FamiliarBindingResolver {
+    fn resolve_for_automation(&self, request: BindingRequest) -> Result<FamiliarBinding, BindingError>;
+}
+
+trait AutomationAuthorizer {
+    fn authorize(&self, request: AuthorizationRequest) -> Result<AuthorizationDecision, AuthorizationError>;
+}
+
+trait RuntimeCapabilityResolver {
+    fn select(&self, request: RuntimeRequirement) -> Result<RuntimeBinding, RuntimeError>;
+}
+
+trait ReceiptSigner {
+    fn commit(&self, receipt: ReceiptBody) -> Result<CommittedReceipt, ReceiptError>;
+}
+```
+
+Seam placement:
+
+- A new `crates/coven-cli/src/automations/authority/` module owns the trait
+  definitions, the `AutomationExecutionBinding` type (wire contract
+  `coven.automation_execution_binding.v1`), typed refusal errors, and the
+  deterministic fakes. The binding type follows the closed-wire style of
+  `execution_binding.rs`: exact member-set check, `deny_unknown_fields`,
+  opaque-value syntax validation, static field paths in errors, no offending
+  values echoed.
+- `runner.rs` changes shape, not direction: claim → resolve → authorize →
+  bind → dispatch → settle → receipt. Dispatch of a claimed occurrence
+  without a committed binding is a bug, not a fallback.
+- `threads_gate.rs` verdicts feed `AuthorizationDecision` as the
+  protected-surface decision; degrade outcomes stage proposals exactly like
+  the gate does today, so automation writes never bypass the authority weave.
+- `request_adoption.rs` keys become the `adoptedRequestKey` input; the
+  adoption gate's lock discipline is the model for approval consumption.
+- The Psyche path is unaffected: when a run arrives with a
+  `psyche.execution_binding.v1`, Coven validates it exactly as today. The two
+  contracts share semantics (root/revision/digest pinning, decisions, receipts)
+  but stay separate artifacts — Coven does not reinterpret Psyche fields, and
+  Psyche does not author Coven authority state.
+
+## Schema changes
+
+All additions live in the single Coven store and follow its
+`*_SCHEMA_SQL` constant pattern:
+
+```sql
+-- Definitions become revisable: in-place edits mint a new revision row.
+CREATE TABLE IF NOT EXISTS automation_definition_revisions (
+    automation_id TEXT NOT NULL,
+    revision INTEGER NOT NULL,
+    definition_digest TEXT NOT NULL,   -- sha256 of canonical definition_json
+    definition_json TEXT NOT NULL,
+    risk_class TEXT NOT NULL,          -- R0..R4, set by reviewed policy
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (automation_id, revision)
+);
+
+-- One immutable binding per run, committed with its authorization decision.
+CREATE TABLE IF NOT EXISTS automation_execution_bindings (
+    run_id TEXT PRIMARY KEY NOT NULL,
+    binding_json TEXT NOT NULL,
+    binding_digest TEXT NOT NULL,
+    principal_id TEXT NOT NULL,
+    familiar_root_id TEXT NOT NULL,
+    familiar_identity_revision TEXT NOT NULL,
+    definition_revision INTEGER NOT NULL,
+    decided_at TEXT NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES automation_runs(id)
+);
+
+-- Approval ledger; clients may request, never grant.
+CREATE TABLE IF NOT EXISTS automation_approvals (
+    id TEXT PRIMARY KEY NOT NULL,
+    automation_id TEXT NOT NULL,
+    definition_revision INTEGER NOT NULL,
+    occurrence_id TEXT,
+    action_digest TEXT NOT NULL,
+    capabilities_digest TEXT NOT NULL,
+    familiar_identity_revision TEXT NOT NULL,
+    intended_runtime TEXT NOT NULL,
+    risk_class TEXT NOT NULL,
+    principal_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    state TEXT NOT NULL,               -- required/requested/approved/rejected/expired/revoked/consumed
+    nonce TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    consumed_by_run_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+-- Single-use authorization nonces (replay protection).
+CREATE TABLE IF NOT EXISTS automation_nonces (
+    nonce TEXT PRIMARY KEY NOT NULL,
+    purpose TEXT NOT NULL,
+    run_id TEXT,
+    consumed_at TEXT
+);
+
+-- Append-only receipt spine; sensitive payload classes route through
+-- encrypted_artifacts per the trust-layer rules.
+CREATE TABLE IF NOT EXISTS automation_receipts (
+    run_id TEXT PRIMARY KEY NOT NULL,
+    receipt_version INTEGER NOT NULL,
+    receipt_digest TEXT NOT NULL,
+    receipt_json TEXT NOT NULL,        -- public/operational fields only
+    privacy_class TEXT NOT NULL,
+    redaction_status TEXT NOT NULL,
+    committed_at TEXT NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES automation_runs(id)
+);
+
+ALTER TABLE automation_runs ADD COLUMN binding_id TEXT;
+ALTER TABLE automation_runs ADD COLUMN receipt_id TEXT;
+ALTER TABLE automation_runs ADD COLUMN principal_id TEXT;
+```
+
+Append-only enforcement (receipts, bindings, nonces) uses the same
+trigger-in-schema technique the `ward_audit` table uses, so tamper resistance
+does not depend on call-site discipline.
+
+## Dispatch sequence
+
+```text
+daemon tick
+  -> claim occurrence (existing compare-and-set, lease, attempt++)
+  -> FamiliarBindingResolver.resolve_for_automation
+       root + identity revision + declaration digest + decision-time status
+       ambiguous alias | paused | revoked | retired -> typed refusal, fail closed
+  -> AutomationAuthorizer.authorize
+       principal authentication, nonce issue, Threads verdict,
+       capability decision, approval requirement + consumption, risk class
+       -> AuthorizationDecision + AutomationExecutionBinding, one snapshot
+  -> binding commit (same transaction where possible; digest pair otherwise)
+  -> RuntimeCapabilityResolver.select
+       exact descriptor/version/capabilities pinned to the run
+  -> SessionLaunch (existing shared path) carrying binding reference
+  -> settle occurrence + run ledger (existing)
+  -> ReceiptSigner.commit (every terminal disposition, including refusals
+       that consumed an occurrence)
+```
+
+Refusals between claim and dispatch settle the occurrence with a typed,
+durable reason and still commit a receipt recording the refusal — an
+authorization refusal is audit evidence, not silence.
+
+## Verification plan
+
+| PRODUCT requirement | Test surface |
+|---|---|
+| Principal authentication, nonce, rotation, revocation, replay | `automations::authority` unit tests: nonce single-use, replay refusal, revocation between claim and dispatch |
+| Familiar alias → root resolution and ambiguity | fake resolver vectors: unique root, ambiguous alias, unknown alias — all deterministic |
+| Exact revision/digest pinning; stale-revision refusal | definition edit between approval and dispatch invalidates the approval and refuses dispatch |
+| Threads permit / degrade / reject vectors | fake `AutomationAuthorizer` seeded with gate verdicts; degrade stages a proposal, nothing launches |
+| Approval creation, race, expiry, revocation, consumption, replay | approval-ledger tests: two consumers race one approval, expired approval refuses, changed definition invalidates |
+| Runtime capability match / downgrade | fake `RuntimeCapabilityResolver`: requirement satisfied / descriptor downgrade / unavailable runtime |
+| TOCTOU around claim → authorize → commit → dispatch | digest-pair assertions on the binding snapshot; policy change mid-sequence refuses or records, never silently proceeds |
+| Receipt canonicalization, tamper, authentication, redaction | golden receipt vectors; digest mismatch detection; sensitive-field redaction before `receipt_json` |
+| Privacy authorization for history/changefeed readers | reader-profile tests: public fields only; encrypted payload refs never resolve over client profiles |
+| Duplicate worker under an old fence | lease-expiry double-claim test (extends the existing occurrence CAS tests) |
+| Cross-repository canaries | golden vectors exchanged with Familiar Contract, Threads, Runtimes, SDK, and Cave at pinned artifact revisions |
+
+Golden vectors live beside the fake adapters and are checked into the repo so
+every consumer verifies the same bytes.
+
+## Delivery plan (slices)
+
+This spec is **slice 1 of N**. The landed foundation (coven#816) keeps running
+unchanged until each slice lands; the PRODUCT standing rule applies throughout:
+recurring familiar work is a local execution convenience, and unattended
+external side effects stay disabled or approval-gated.
+
+1. **This spec** — the normative contract and the code map.
+2. **Binding + resolver seams** — `authority/` module, binding type, fail-closed
+   gate in `runner.rs`, definition revisions table, deterministic fakes.
+3. **Authorization + nonces** — principal resolution, Threads verdict feed,
+   nonce table, replay tests.
+4. **Approvals** — ledger, lifecycle transitions, consumption, Cave/SDK surface.
+5. **Receipts + privacy classes** — receipt spine, canonicalization, redaction,
+   retention, changefeed field authorization.
+6. **Cross-repository canaries** — exchanged golden vectors at pinned revisions.
+
+## Local checks for docs-only changes
+
+This slice is documentation only; the routed CI surface is docs. Run locally:
+
+```sh
+python scripts/check-secrets.py
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Rust gates (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
+warnings`, `cargo test --workspace --locked`) apply from slice 2 onward, when
+code changes join the spec.


### PR DESCRIPTION
## Summary

Slice 1 of the coven#857 P0: the normative spec that binds every Coven automation run to principal authority, familiar revisions, capabilities, approvals, and receipts.

- `specs/coven-automation-authority/PRODUCT.md` — the normative contract: an immutable `AutomationExecutionBinding` (`coven.automation_execution_binding.v1`) pinned per dispatched run (principal, familiar root/identity revision/declaration digest, Threads decision, capability grants, approval evidence, risk class R0–R4, runtime descriptor, policy versions), per-run authorization rules that fail closed, the approval lifecycle, the versioned `AutomationReceipt`, privacy/erasure rules, and the required threat-model refusals.
- `specs/coven-automation-authority/TECH.md` — maps the contract onto the landed coven#816 automations foundation (`automations/*`, run ledger), the Psyche execution-binding and request-adoption seams, the threads authority gate, and the privacy/encryption primitives; defines the four trait seams (`FamiliarBindingResolver`, `AutomationAuthorizer`, `RuntimeCapabilityResolver`, `ReceiptSigner`), schema deltas, the threat-vector test matrix, and the delivery slices.

Until the enforcement slices land, the standing rule from the issue holds: recurring familiar work is a local execution convenience — not proof of authorized familiar continuity — and unattended external side effects remain disabled or approval-gated.

**Slice 1 of N**: this PR ships the spec only (slice 1); slices 2–6 (binding/resolver seams, authorization + nonces, approvals, receipts + privacy classes, cross-repo canaries) are listed in TECH.md's delivery plan.

## Issue

Refs OpenCoven/coven#857

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#857.

## Implementation

- Approach: spec-first, matching the repo's `specs/<name>/PRODUCT.md` + `TECH.md` convention (see `specs/coven-trust-layer/`, `specs/coven-familiar-spec/`). The contract consumes canonical semantics from the Familiar Contract and Threads authority profiles rather than duplicating them; Coven-owned state (occurrence/run/attempt, binding, receipt) is specified as new seams beside the landed `automations/` modules, and the Psyche `psyche.execution_binding.v1` contract stays opaque and untouched.
- User-visible behavior: none yet — this slice changes no runtime behavior.
- Compatibility notes: no code changes; schema deltas in TECH.md are additive and gated behind later slices.

## Verification

- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [ ] `cargo fmt --check` (deferred — docs-only slice; no Rust toolchain in the authoring environment; CI covers it)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` (deferred — docs-only slice)
- [ ] `cargo test --workspace --locked` (deferred — docs-only slice)
- [ ] Additional manual checks: no code paths touched; diff is two new spec documents under `specs/`.

## Risk and Rollback

- Risk level: low — documentation only, no runtime surface.
- Rollback plan: revert the single commit; no schema, API, or behavior change.

## Agent Handoff

- Current state: spec committed on `agent/issue-857-p0-bind-automation-runs-to-principal`, pushed to the fork.
- Follow-ups: implementation slices 2–6 per TECH.md ("Delivery plan"), starting with the `authority/` module and the fail-closed dispatch gate in `runner.rs`.
- Known gaps: everything under "Current code mapped to PRODUCT → Missing/Partial" in TECH.md; the bead packet for this issue is tracked externally (this PR does not edit bead state).

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/17], preserving source head `3e7561c19642cdc4fa4e3530f71026df82331465` and branch `agent/issue-857-p0-bind-automation-runs-to-principal`.