### PR TITLE
docs: plan passkey recovery, trusted-device introductions, and attestation (coven#788)

### DIFF
--- a/docs/design/mobile-device-trust.md
+++ b/docs/design/mobile-device-trust.md
@@ -323,7 +323,7 @@ The migration is additive and staged:
 - `#785` — versioned pairing offer, transcript hardening, portable test vectors, and E2EE rendezvous handshake.
 - `#786` — generalized grants, assurance policy, exact-action authorization, device management, and registry migration.
 - `#787` — relay-first reconnect, local discovery fast path, session resumption, and push-as-wakeup semantics.
-- `#788` — trusted-device introduction, passkey/recovery contracts, threshold policy, and optional attestation.
+- `#788` — trusted-device introduction, passkey/recovery contracts, threshold policy, and optional attestation; planned in [`mobile-recovery-and-introduction-plan.md`](mobile-recovery-and-introduction-plan.md).
 
 ## Merge gates for implementation PRs
 

--- a/docs/design/mobile-recovery-and-introduction-plan.md
+++ b/docs/design/mobile-recovery-and-introduction-plan.md
@@ -1,0 +1,752 @@
+# Mobile Recovery, Trusted-Device Introduction, and Optional Attestation Plan
+
+**Status:** proposed plan and implementation contract for the `#788` scope of the `#784`–`#788` mobile connection track
+**Parent architecture:** [`mobile-device-trust.md`](mobile-device-trust.md) (accepted, `#784`)
+**Builds on:** `#786` (device-bound credentials, grants, assurance), `#787` (reconnection, discovery, relay)
+**Delivery slot:** PR 7 — "Recovery and trusted-device introduction" in [`../architecture/mobile-device-pairing-delivery-plan.md`](../architecture/mobile-device-pairing-delivery-plan.md)
+**Threat model base:** [`../security/mobile-device-pairing-threat-model.md`](../security/mobile-device-pairing-threat-model.md)
+**Authority owner:** Coven daemon / Rust authority layer
+
+## 1. Purpose and scope
+
+This plan defines the concrete contracts for the `#788` issue:
+
+1. **Trusted-device introduction** — an already trusted device authorizes a new installation with a fresh step-up verification and a signed enrollment transcript.
+2. **Passkey recovery** — optional, account-backed recovery and remote-enrollment paths that never make a cloud account, synced passkey, Apple/Google ecosystem, or platform attestation the canonical OpenCoven/familiar identity.
+3. **Optional attestation** — app/hardware assurance represented as policy attributes (`verified_official_app`, `verified_hardware_key`, `unattested_device`) that increase assurance without breaking the open/self-hosted trust model.
+4. **Recovery as a protocol** — explicit, auditable ceremonies that keep *recovering access* strictly separate from *replacing or rotating a familiar's identity*.
+
+Non-goals: implementing WebAuthn servers, Apple App Attest, or Android attestation verification in this repository; hosting an account service; changing the pairing v1/v2 QR enrollment path; widening any v1 grant.
+
+## 2. Current implementation baseline
+
+Claims about the present system cite the code:
+
+| Fact | Path |
+| --- | --- |
+| Authority layer (pairing, auth, registry, gateway, audit) | `crates/coven-cli/src/mobile_memory/` (`pairing.rs`, `auth.rs`, `registry.rs`, `gateway.rs`, `audit.rs`) |
+| Grant model: `DeviceScope` (12 capabilities), `AssuranceLevel` (`possession`, `recent_user_verification`, `fresh_user_verification`, `fresh_biometric`, `step_up`), `DeviceGrant` with `subject_key_id`, audience, restrictions, `revocation_epoch` | `crates/coven-cli/src/mobile_memory/grant.rs` |
+| Exact-action authorization: `DeviceActionIntent` canonicalizes scope, operation, target, effect digest, nonce, and a ≤300 s window over `COVEN-ACTION/1` | `crates/coven-cli/src/mobile_memory/grant.rs` (`canonical_bytes`) |
+| Device records: `DeviceRecord` + per-device `DeviceGrant`, atomic replacement, bounded at 128 records, legacy v1 migration | `crates/coven-cli/src/mobile_memory/registry.rs` |
+| Request authentication: `COVEN-MEMORY/1` canonical string (method, path+query, timestamp, nonce, body digest), P-256 ECDSA, ±300 s window, replay cache (10 000 entries), 120 requests/window rate limit | `crates/coven-cli/src/mobile_memory/auth.rs` |
+| Pairing: single-use nonce, `COVEN-PAIR/2` transcript domain, transcript-derived six-word phrase, idempotent completion | `crates/coven-cli/src/mobile_memory/pairing.rs` |
+| Audit: append-only JSONL `audit.jsonl` with `MobileAuditEvent` (`PairingCreated`, `PairingCompleted`, `PairingRejected`, `DeviceRevoked`, `AuthenticationRejected`, `RateLimited`, …) | `crates/coven-cli/src/mobile_memory/audit.rs` |
+| CLI surface: `coven memory mobile enable|disable|status|pair|devices [revoke <id>]` | `crates/coven-cli/src/main.rs`, `crates/coven-cli/src/mobile_memory/mod.rs` |
+| Gateway routes under `/api/v1/mobile/*`, private-network HTTPS-only bind | `crates/coven-cli/src/mobile_memory/gateway.rs`, `config.rs` |
+| Diagnostic JSON schemas for offer/grant/enrollment/transaction/revocation objects | `spec/device-pairing/v1/*.schema.json` |
+| Capability and assurance vocabularies | `spec/device-pairing/v1/capabilities.json` |
+| Domain-separation label registry | `spec/device-pairing/v1/domain-separation.md` |
+| Rendezvous relay (bounded, opaque) | `crates/coven-relay/src/ws.rs` |
+| Familiar identity (manifest, resolver, effective familiar) | `crates/coven-cli/src/familiar_identity.rs`, `docs/familiars/identity.md` |
+
+What does **not** exist yet, and what this plan adds: trusted-device introduction objects, a passkey/account factor contract, recovery ceremonies and events, identity-rotation semantics, and attestation assurance attributes. The accepted architecture already sketches these in [`mobile-device-trust.md`](mobile-device-trust.md) §"Passkeys, trusted-device introduction, and recovery", §"Optional attestation", and migration Stage D; this document turns those paragraphs into normative objects, state machines, policies, and examples.
+
+## 3. Protocol objects
+
+New objects are added to the pairing protocol family at object version 1. Their canonical encoding is deterministic CBOR in a COSE envelope, exactly like the v1 objects (`spec/device-pairing/v1/conformance-manifest.json`); the JSON below is the diagnostic form, in the style of `spec/device-pairing/v1/device-grant.schema.json`. The implementation PR lands these schemas as files under `spec/device-pairing/v2/` and registers the new objects in a v2 conformance manifest.
+
+New domain-separation labels (to be appended to `spec/device-pairing/v1/domain-separation.md`; code-level short forms follow the `COVEN-PAIR/2` convention in `pairing.rs`):
+
+```text
+OpenCoven/IntroductionRequest/v1     (short form: COVEN-INTRO-REQ/1)
+OpenCoven/IntroductionApproval/v1    (short form: COVEN-INTRO-APPR/1)
+OpenCoven/IntroductionTranscript/v1  (short form: COVEN-INTRO-TX/1)
+OpenCoven/RecoveryPolicy/v1          (short form: COVEN-RECOVERY-POLICY/1)
+OpenCoven/RecoveryEvent/v1           (short form: COVEN-RECOVERY-EVENT/1)
+OpenCoven/AttestationClaim/v1        (short form: COVEN-ATTEST-CLAIM/1)
+```
+
+Shared `$defs` reused from the v1 schemas: `keyReference` (algorithm `Ed25519 | P-256`, `keyId`, `publicKey`), `identityReference` (type `owner | installation | device | trust-domain`), integer timestamps.
+
+### 3.1 IntroductionRequest
+
+Created by the **new endpoint**, delivered over the authenticated E2EE channel (#787) or shown as a follow-on request to an existing trusted device. It commits to everything the approval will be about.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/device-pairing/v2/introduction-request.schema.json",
+  "title": "OpenCoven IntroductionRequest v1 diagnostic JSON representation",
+  "description": "Request from a new endpoint asking an existing trusted device or the owner to introduce it into one trust domain. Canonical signed form is deterministic CBOR in COSE_Sign1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version", "trustDomain", "installationFingerprint", "endpointKey",
+    "pairwiseDeviceId", "requestedScopes", "requestedAssurance",
+    "deviceContext", "nonce", "expiresAt", "signature"
+  ],
+  "properties": {
+    "version": { "const": 1 },
+    "trustDomain": { "type": "string", "minLength": 8, "maxLength": 256 },
+    "installationFingerprint": {
+      "description": "SHA-256 over the target installation's canonical host key, base64url; binds the request to one installation.",
+      "type": "string", "minLength": 43, "maxLength": 43,
+      "pattern": "^[A-Za-z0-9_-]{43}$"
+    },
+    "endpointKey": { "$ref": "#/$defs/keyReference" },
+    "pairwiseDeviceId": {
+      "description": "Domain-separated identifier derived per (endpoint key, trust domain); never a global device ID.",
+      "type": "string", "minLength": 8, "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._:-]+$"
+    },
+    "requestedScopes": {
+      "type": "array", "uniqueItems": true, "minItems": 1,
+      "items": { "enum": [
+        "sessions.metadata.read", "conversations.read", "messages.send",
+        "tools.request", "tools.approve", "secrets.read",
+        "memory.familiar.read", "memory.familiar.write",
+        "identity.admin", "devices.enroll", "devices.revoke",
+        "identity.export", "memory.export"
+      ] }
+    },
+    "requestedAssurance": {
+      "enum": ["possession", "recent_user_verification", "fresh_user_verification", "fresh_biometric", "step_up"]
+    },
+    "deviceContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "humanReadableName"],
+      "properties": {
+        "platform": { "enum": ["ios", "android", "macos", "linux", "windows", "other"] },
+        "humanReadableName": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "appVariant": {
+          "description": "Free-text build context such as 'official build' or 'self-built'; never an authority input by itself.",
+          "type": "string", "maxLength": 80
+        }
+      }
+    },
+    "nonce": {
+      "description": "Fresh 32-byte random value, base64url; single-use.",
+      "type": "string", "pattern": "^[A-Za-z0-9_-]{43}$"
+    },
+    "expiresAt": { "type": "integer", "minimum": 0 },
+    "signature": {
+      "description": "endpointKey signature over OpenCoven/IntroductionRequest/v1 canonical bytes.",
+      "type": "string", "pattern": "^[A-Za-z0-9_-]+$"
+    }
+  },
+  "$defs": {
+    "keyReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "keyId", "publicKey"],
+      "properties": {
+        "algorithm": { "enum": ["Ed25519", "P-256"] },
+        "keyId": { "type": "string", "minLength": 8, "maxLength": 128, "pattern": "^[A-Za-z0-9._:-]+$" },
+        "publicKey": { "type": "string", "minLength": 43, "maxLength": 128, "pattern": "^[A-Za-z0-9_-]+$" }
+      }
+    }
+  }
+}
+```
+
+Privacy constraints (extend `spec/device-pairing/v1/privacy.md` rule 8): `deviceContext` must not carry hardware serials, advertising IDs, account-provider identifiers, phone numbers, or biometric metadata. `humanReadableName` is display-only and capped at 80 characters, matching `MAX_DEVICE_NAME_CHARS` in `registry.rs`.
+
+### 3.2 IntroductionApproval
+
+Created by each **approving device** (or the owner root credential) after a fresh step-up verification. Each approval is independently verifiable; the installation authority counts them against policy.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/device-pairing/v2/introduction-approval.schema.json",
+  "title": "OpenCoven IntroductionApproval v1 diagnostic JSON representation",
+  "description": "One approval of an IntroductionRequest, signed by an existing trusted device key or the owner root credential after fresh local user verification.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version", "introductionTranscriptHash", "approver", "approverRole",
+    "assurance", "assuranceNonce", "issuedAt", "expiresAt", "signature"
+  ],
+  "properties": {
+    "version": { "const": 1 },
+    "introductionTranscriptHash": {
+      "description": "SHA-256 over OpenCoven/IntroductionTranscript/v1 canonical bytes; commits to the full request and grant template.",
+      "type": "string", "pattern": "^[A-Za-z0-9_-]{43}$"
+    },
+    "approver": { "$ref": "#/$defs/keyReference" },
+    "approverRole": { "enum": ["trusted-device", "owner-root", "recovery-provider"] },
+    "assurance": {
+      "description": "Locally verified step-up level at signing time; MUST be fresh_user_verification or fresh_biometric for trusted-device approvers.",
+      "enum": ["fresh_user_verification", "fresh_biometric", "step_up"]
+    },
+    "assuranceNonce": {
+      "description": "32-byte value displayed/echoed by the step-up UI and bound into the signature; prevents evidence replay.",
+      "type": "string", "pattern": "^[A-Za-z0-9_-]{43}$"
+    },
+    "attestation": {
+      "description": "Optional assurance attributes held by the approver, minimally included when policy requires them.",
+      "type": "array", "uniqueItems": true,
+      "items": { "enum": ["verified_official_app", "verified_hardware_key"] }
+    },
+    "issuedAt": { "type": "integer", "minimum": 0 },
+    "expiresAt": { "type": "integer", "minimum": 0 },
+    "signature": {
+      "description": "approver signature over OpenCoven/IntroductionApproval/v1 canonical bytes.",
+      "type": "string", "pattern": "^[A-Za-z0-9_-]+$"
+    }
+  },
+  "$defs": {
+    "keyReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "keyId", "publicKey"],
+      "properties": {
+        "algorithm": { "enum": ["Ed25519", "P-256"] },
+        "keyId": { "type": "string", "minLength": 8, "maxLength": 128, "pattern": "^[A-Za-z0-9._:-]+$" },
+        "publicKey": { "type": "string", "minLength": 43, "maxLength": 128, "pattern": "^[A-Za-z0-9_-]+$" }
+      }
+    }
+  }
+}
+```
+
+The **introduction transcript** is canonical and covers at minimum: protocol version, `trustDomain`, `installationFingerprint`, the new endpoint public key and `pairwiseDeviceId`, the full `requestedScopes` set, `requestedAssurance`, the `deviceContext` digest, `nonce`, `expiresAt`, the *grant template* (audience, restrictions, `minimum_assurance`, planned `expires_at` policy), and the identity-reference of the expected issuer. This is the same transcript principle as `docs/design/mobile-device-trust.md` §"Transcript binding" and the `COVEN-PAIR/2` transcript in `pairing.rs` (`PairingTranscript::hash`).
+
+### 3.3 RecoveryPolicy
+
+Owner-controlled policy document, stored and interpreted by the authority layer (never by clients or the account service).
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/device-pairing/v2/recovery-policy.schema.json",
+  "title": "OpenCoven RecoveryPolicy v1 diagnostic JSON representation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "trustDomain", "introductionPolicy", "recoveryFactors", "attestationPolicy", "updatedAt"],
+  "properties": {
+    "version": { "const": 1 },
+    "trustDomain": { "type": "string", "minLength": 8, "maxLength": 256 },
+    "introductionPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["standardMinApprovals", "rootMinApprovals", "requireDistinctApprovers"],
+      "properties": {
+        "standardMinApprovals": { "type": "integer", "minimum": 1, "maximum": 9 },
+        "rootMinApprovals": { "type": "integer", "minimum": 1, "maximum": 9 },
+        "requireDistinctApprovers": { "type": "boolean" }
+      }
+    },
+    "recoveryFactors": {
+      "description": "Factor combination that is sufficient to restore owner access. At least two distinct factor kinds are REQUIRED by this plan.",
+      "type": "array", "minItems": 2, "uniqueItems": true,
+      "items": { "enum": [
+        "passkey_account", "recovery_key", "trusted_device",
+        "owner_root_credential", "attested_device", "n_of_m_devices"
+      ] }
+    },
+    "recoveryThreshold": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["of", "minimum"],
+      "properties": {
+        "of": { "type": "integer", "minimum": 1, "maximum": 9 },
+        "minimum": { "type": "integer", "minimum": 1, "maximum": 9 }
+      }
+    },
+    "attestationPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default", "requireFor"],
+      "properties": {
+        "default": { "enum": ["ignore", "prefer"] },
+        "requireFor": {
+          "type": "array", "uniqueItems": true,
+          "items": { "enum": ["secrets_read", "identity_admin", "devices_enroll", "devices_revoke", "identity_export", "memory_export"] }
+        }
+      }
+    },
+    "updatedAt": { "type": "integer", "minimum": 0 }
+  }
+}
+```
+
+### 3.4 RecoveryEvent
+
+Append-only audit record, same storage discipline as `audit.jsonl` in `audit.rs` (private directory, atomic append, no secret material).
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/device-pairing/v2/recovery-event.schema.json",
+  "title": "OpenCoven RecoveryEvent v1 diagnostic JSON representation",
+  "description": "Explicit, auditable record of a recovery or rotation ceremony. Never contains private keys, passkey identifiers, or account-provider identifiers.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "eventId", "kind", "subject", "actors", "epoch", "occurredAt"],
+  "properties": {
+    "version": { "const": 1 },
+    "eventId": { "type": "string", "pattern": "^[A-Za-z0-9_-]{22}$" },
+    "kind": {
+      "enum": [
+        "recovery_started", "recovery_denied", "access_restored",
+        "device_key_rotated", "identity_rotated", "root_rotated",
+        "familiar_identity_adopted", "recovery_policy_changed"
+      ]
+    },
+    "subject": { "$ref": "#/$defs/identityReference" },
+    "actors": {
+      "description": "Abstract factor kinds only (see privacy.md rule 8): no credential IDs, no key material.",
+      "type": "array", "uniqueItems": true, "minItems": 1,
+      "items": { "enum": ["passkey_account", "recovery_key", "trusted_device", "owner_root_credential", "attested_device", "n_of_m_devices"] }
+    },
+    "epoch": {
+      "description": "revocation_epoch value after this event; rotations increment it.",
+      "type": "integer", "minimum": 0
+    },
+    "rotatesIdentity": { "type": "boolean" },
+    "outOfBandContext": {
+      "description": "Human-readable ceremony description safe for audit; no secrets.",
+      "type": "string", "maxLength": 200
+    },
+    "occurredAt": { "type": "integer", "minimum": 0 }
+  },
+  "$defs": {
+    "identityReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id"],
+      "properties": {
+        "type": { "enum": ["owner", "installation", "device", "trust-domain", "familiar"] },
+        "id": { "type": "string", "minLength": 8, "maxLength": 256, "pattern": "^[A-Za-z0-9._:-]+$" }
+      }
+    }
+  }
+}
+```
+
+### 3.5 AttestationClaim
+
+An **assurance attribute** bound to a device key inside one trust domain. It is evidence about the app/key environment, never an identity, and never sufficient by itself for anything.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/device-pairing/v2/attestation-claim.schema.json",
+  "title": "OpenCoven AttestationClaim v1 diagnostic JSON representation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "attribute", "evidence", "subject", "audience", "nonce", "issuedAt", "expiresAt", "verifierSignature"],
+  "properties": {
+    "version": { "const": 1 },
+    "attribute": { "enum": ["verified_official_app", "verified_hardware_key", "unattested_device"] },
+    "evidence": {
+      "enum": ["apple_app_attest", "android_key_attestation", "android_play_integrity", "self_declared", "none"]
+    },
+    "subject": { "$ref": "#/$defs/keyReference" },
+    "audience": { "$ref": "#/$defs/identityReference" },
+    "nonce": { "type": "string", "pattern": "^[A-Za-z0-9_-]{43}$" },
+    "issuedAt": { "type": "integer", "minimum": 0 },
+    "expiresAt": { "type": "integer", "minimum": 0 },
+    "verifierSignature": {
+      "description": "Signature of the attestation verifier over OpenCoven/AttestationClaim/v1 canonical bytes.",
+      "type": "string", "pattern": "^[A-Za-z0-9_-]+$"
+    }
+  },
+  "$defs": {
+    "keyReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "keyId", "publicKey"],
+      "properties": {
+        "algorithm": { "enum": ["Ed25519", "P-256"] },
+        "keyId": { "type": "string", "minLength": 8, "maxLength": 128, "pattern": "^[A-Za-z0-9._:-]+$" },
+        "publicKey": { "type": "string", "minLength": 43, "maxLength": 128, "pattern": "^[A-Za-z0-9_-]+$" }
+      }
+    },
+    "identityReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id"],
+      "properties": {
+        "type": { "enum": ["trust-domain", "installation"] },
+        "id": { "type": "string", "minLength": 8, "maxLength": 256, "pattern": "^[A-Za-z0-9._:-]+$" }
+      }
+    }
+  }
+}
+```
+
+### 3.6 TypeScript reference types
+
+Reference shapes for the TypeScript integration packages (`packages/`). They are documentation of the diagnostic JSON, not a second authority; the Rust authority layer remains the only decision point (see `docs/design/mobile-device-trust.md` §"Authority boundary").
+
+```typescript
+export type Capability =
+  | 'sessions.metadata.read' | 'conversations.read' | 'messages.send'
+  | 'tools.request' | 'tools.approve' | 'secrets.read'
+  | 'memory.familiar.read' | 'memory.familiar.write'
+  | 'identity.admin' | 'devices.enroll' | 'devices.revoke'
+  | 'identity.export' | 'memory.export';
+
+export type Assurance =
+  | 'possession' | 'recent_user_verification' | 'fresh_user_verification'
+  | 'fresh_biometric' | 'step_up';
+
+export type AttestationAttribute =
+  | 'verified_official_app' | 'verified_hardware_key' | 'unattested_device';
+
+export interface KeyReference {
+  algorithm: 'Ed25519' | 'P-256';
+  keyId: string;
+  publicKey: string; // unpadded base64url
+}
+
+export interface IntroductionRequest {
+  version: 1;
+  trustDomain: string;
+  installationFingerprint: string; // base64url SHA-256 of host key
+  endpointKey: KeyReference;
+  pairwiseDeviceId: string;
+  requestedScopes: Capability[];
+  requestedAssurance: Assurance;
+  deviceContext: {
+    platform: 'ios' | 'android' | 'macos' | 'linux' | 'windows' | 'other';
+    humanReadableName: string;
+    appVariant?: string;
+  };
+  nonce: string;
+  expiresAt: number; // unix seconds
+  signature: string;
+}
+
+export interface IntroductionApproval {
+  version: 1;
+  introductionTranscriptHash: string;
+  approver: KeyReference;
+  approverRole: 'trusted-device' | 'owner-root' | 'recovery-provider';
+  assurance: 'fresh_user_verification' | 'fresh_biometric' | 'step_up';
+  assuranceNonce: string;
+  attestation?: Exclude<AttestationAttribute, 'unattested_device'>[];
+  issuedAt: number;
+  expiresAt: number;
+  signature: string;
+}
+
+export type RecoveryFactor =
+  | 'passkey_account' | 'recovery_key' | 'trusted_device'
+  | 'owner_root_credential' | 'attested_device' | 'n_of_m_devices';
+
+export interface RecoveryPolicy {
+  version: 1;
+  trustDomain: string;
+  introductionPolicy: {
+    standardMinApprovals: number;
+    rootMinApprovals: number;
+    requireDistinctApprovers: boolean;
+  };
+  recoveryFactors: RecoveryFactor[];
+  recoveryThreshold?: { of: number; minimum: number };
+  attestationPolicy: { default: 'ignore' | 'prefer'; requireFor: Capability[] };
+  updatedAt: number;
+}
+
+export type RecoveryEventKind =
+  | 'recovery_started' | 'recovery_denied' | 'access_restored'
+  | 'device_key_rotated' | 'identity_rotated' | 'root_rotated'
+  | 'familiar_identity_adopted' | 'recovery_policy_changed';
+
+export interface RecoveryEvent {
+  version: 1;
+  eventId: string;
+  kind: RecoveryEventKind;
+  subject: { type: 'owner' | 'installation' | 'device' | 'trust-domain' | 'familiar'; id: string };
+  actors: RecoveryFactor[];
+  epoch: number;
+  rotatesIdentity?: boolean;
+  outOfBandContext?: string;
+  occurredAt: number;
+}
+
+export interface AttestationClaim {
+  version: 1;
+  attribute: AttestationAttribute;
+  evidence: 'apple_app_attest' | 'android_key_attestation' | 'android_play_integrity' | 'self_declared' | 'none';
+  subject: KeyReference;
+  audience: { type: 'trust-domain' | 'installation'; id: string };
+  nonce: string;
+  issuedAt: number;
+  expiresAt: number;
+  verifierSignature: string;
+}
+```
+
+## 4. Trusted-device introduction
+
+### 4.1 Flow
+
+```text
+New Psyche/TUI node                       Existing trusted phone
+      │                                           │
+      │ 1. IntroductionRequest                     │
+      │─────────── over authenticated E2EE ───────▶│
+      │                                           │ 2. render material fields
+      │                                           │    fresh step-up (biometric / user verification)
+      │                                           │    IntroductionApproval signed by device key
+      │ 3. approvals collected                     │
+      │◀───────────────────────────────────────────┘
+      ▼
+Installation authority (Rust)
+      │ 4. verify signatures, count approvals vs RecoveryPolicy,
+      │    re-check transcript, bind grant to endpointKey
+      ▼
+scoped grant → new installation (DeviceGrant, registry.rs)
+```
+
+Delivery reuses the #787 channels: the authenticated relayed session (`crates/coven-relay/`) or the direct mobile gateway (`gateway.rs`). The push notification, when used, is a wake-up that names an opaque pending request — it carries no authorization (privacy rule 6, `spec/device-pairing/v1/privacy.md`).
+
+### 4.2 Transcript binding (issue checkbox 1)
+
+The approval MUST bind, in the signed `introductionTranscriptHash`:
+
+- the new endpoint public key (`endpointKey`) and its `pairwiseDeviceId`;
+- the exact `requestedScopes` set and `requestedAssurance`;
+- the single-use `nonce` and `expiresAt`;
+- the human-readable `deviceContext` (digest of the rendered text the approver saw);
+- the target `installationFingerprint` and trust domain;
+- the grant template the authority will issue.
+
+Any change to any of these changes the transcript hash and invalidates every collected approval. This is the same fail-closed principle as capability substitution defense in the threat model, and it reuses the canonical-bytes discipline of `DeviceActionIntent::canonical_bytes` (`grant.rs`).
+
+### 4.3 Fresh step-up authentication (issue checkbox 2)
+
+An introduction approval is a step-up operation by definition. The approving device MUST verify the local user immediately before signing:
+
+- `assurance: fresh_biometric` where the platform enforces biometric policy (iOS LocalAuthentication / Android BiometricPrompt strong biometrics), otherwise `fresh_user_verification`;
+- the step-up result gates use of the device private key exactly as in `docs/design/mobile-device-trust.md` §"Biometrics and step-up authorization" — the biometric itself never enters the protocol;
+- `assuranceNonce` binds the approval to this specific step-up event, so captured approvals cannot be replayed for a different request;
+- passcode fallback is representable only as `fresh_user_verification`, never as `fresh_biometric` (threat model: "Biometric exfiltration or false representation").
+
+### 4.4 Introduction state machine
+
+```text
+drafted
+  │ endpoint signs request
+  ▼
+requested ── expiresAt / cancel / malformed ──▶ terminal (erased)
+  │ approvals collected (one or more, per policy)
+  ▼
+approved ── authority verifies + counts ──▶ denied → terminal (RecoveryEvent: recovery_denied)
+  │ transcript re-verified at authority
+  ▼
+enrolling
+  │ grant written (registry.register_with_grant)
+  ▼
+completed ── later revoke/expire/rotate ──▶ revoked-or-expired (existing registry semantics)
+```
+
+Rules:
+
+- Nonces are single-use and bounded; expired requests are pruned like pairing invitations (`PairingManager::prune_expired`, `pairing.rs`).
+- Approval counting happens only in the authority layer; a relay, the account service, or the requesting endpoint can never count its own approvals.
+- The completed introduction is auditable: the authority appends a `RecoveryEvent` with `kind: access_restored` (for recovery paths) or extends the device lifecycle events in `audit.rs` with the introduction outcome.
+
+### 4.5 One device or N-of-M? (issue checkbox 3)
+
+**Recommendation:** one fresh-step-up trusted device is sufficient by default; root-level policy can require N-of-M.
+
+| Enrollment class | Default policy | Rationale |
+| --- | --- | --- |
+| Standard endpoint (conversation/message scopes) | `standardMinApprovals: 1` | Matches the QR bootstrap trust level; friction proportional to risk. |
+| Elevated endpoint (`tools.approve`, `secrets_read`) | `standardMinApprovals: 1` + `attestationPolicy.requireFor` or narrower grant | Scope narrowing substitutes for ceremony overhead. |
+| Root-level endpoint (`identity.admin`, `devices.enroll`, `devices.revoke`, `identity.export`, `memory.export`) | `rootMinApprovals: 2` with `requireDistinctApprovers: true` | A single compromised trusted device must not be able to mint root-level authority silently. |
+
+Alternatives considered: (a) always N-of-M — rejected as the default because a sole owner with one phone could never bootstrap; (b) always 1 — rejected for root-level classes because it concentrates trust in one device; (c) time-delayed approval (24 h cooling) — kept as an optional owner knob, not a default. The policy knob lives in `RecoveryPolicy.introductionPolicy`; the owner decides; the authority enforces.
+
+### 4.6 Compromised relay / account service (issue checkbox 4)
+
+The property to hold: **a compromised relay or account service alone cannot enroll an endpoint.**
+
+- Enrollment authority is derived only from signatures over the introduction transcript made by trusted-device keys or the owner root credential. Neither the relay (`crates/coven-relay/`) nor any account service holds those keys or a role in the signature chain.
+- The account service can, at most, deliver requests and echo opaque state. Its artifacts are consumed only as *assurance attributes* (`AttestationClaim`), which never mint authority (threat-model invariant 8: "A cloud account, passkey, push provider, or attestation provider alone cannot mint root authority").
+- An offline/self-hosted Coven completes introductions with no account service at all: the account path is optional and additive.
+- The authority re-derives and re-verifies the transcript server-side before issuing the grant, so a malicious intermediary cannot present an approval for a different request (transcript substitution fails the hash check).
+
+## 5. Passkeys
+
+### 5.1 Where passkeys are used
+
+| Use | Mechanism | Authority effect |
+| --- | --- | --- |
+| Optional OpenCoven account sign-in | WebAuthn/passkey ceremony against the (optional) account provider | Account-session only; no Coven authority |
+| Account/recovery authentication | Passkey ceremony as one `passkey_account` factor | Counts toward `RecoveryPolicy.recoveryFactors` |
+| Remote enrollment authorization | Account-authenticated session *initiates* an introduction request delivery | Still requires trusted-device/owner approvals (§4.6) |
+| Approving a new installation from an already trusted device | Passkey as an additional factor on the approving device, never a substitute for its device key | Assurance attribute at most |
+| Cross-platform browser/native login | Standard WebAuthn; platform-neutral | Account-session only |
+
+### 5.2 Hard prohibitions (issue checkboxes)
+
+A passkey — in particular a synced passkey — MUST NOT be treated as:
+
+1. **the sole root key of a familiar** — familiar identity keys are managed by the authority layer and the identity resolver (`familiar_identity.rs`, `docs/familiars/identity.md`); a synced passkey exists in a platform sync fabric outside OpenCoven's control;
+2. **proof of one particular physical device** — a synced passkey may be available on every device in a platform account; it proves account possession, not device possession. Device identity remains the pairwise, non-exportable device key (`grant.rs` `subject_key_id`);
+3. **a globally reused familiar/device identifier** — passkey credential IDs are scoped to the account RP and MUST NOT appear in Coven protocol surfaces (privacy rule 8);
+4. **the only recovery mechanism** — `RecoveryPolicy.recoveryFactors` must always offer at least one account-independent path (recovery key, owner root credential, or trusted-device quorum).
+
+Mechanistically: a successful passkey ceremony yields an account-layer session that may *request* ceremonies and may contribute the `passkey_account` factor to recovery counting. It never signs `DeviceGrant`s, never appears in `DeviceGrant.subject_key_id`, and never substitutes for `fresh_user_verification`/`fresh_biometric` in an `IntroductionApproval`.
+
+## 6. Recovery
+
+### 6.1 Recovery is a first-class protocol
+
+Recovery ceremonies are explicit objects and events (`RecoveryPolicy`, `RecoveryEvent`), not a password-reset fallback. Evaluated combinations:
+
+| Combination | Use | Notes |
+| --- | --- | --- |
+| passkey/account + trusted device | Owner regains account, then approves re-enrollment from the trusted phone | Common "new laptop" path |
+| recovery key/seed | Offline, account-independent restoration | Generated at first enrollment, displayed once, stored by the owner outside OpenCoven; the seed never transits the account service |
+| another trusted device | Surviving-device approval of a new endpoint | §4 |
+| N-of-M trusted-device approval | Owner policy for high-assurance households/teams | `recoveryThreshold` |
+| owner root credential | Last-resort local ceremony on the installation itself | Works with all network paths down |
+
+Minimum viable default (recommended): **recovery key + passkey account**, with the trusted-device path always available while any enrolled device survives. All combinations are owner-selectable via `RecoveryPolicy`.
+
+### 6.2 Recovering access ≠ rotating identity (issue requirement)
+
+Two distinct ceremonies with distinct event kinds:
+
+```text
+Recovery (restore access)                    Rotation (replace identity)
+recovery_started                             identity_rotated proposed
+  │ factors collected per RecoveryPolicy       │ quorum per introductionPolicy.rootMinApprovals
+  ▼                                            ▼
+access_restored                              rotation quorum met
+  │ same familiar/installation identity         │ revocation_epoch += 1 (DeviceGrant.revocation_epoch)
+  │ new DeviceGrant(s) for the new endpoint     │ old keys revoked; new keys enrolled
+  │ familiar identity untouched                 │ familiar identity key replaced deliberately
+  ▼                                            ▼
+RecoveryEvent(kind: access_restored,         RecoveryEvent(kind: identity_rotated,
+              rotatesIdentity: false)                       rotatesIdentity: true)
+```
+
+Invariants:
+
+- Recovery NEVER rotates, deletes, or rewrites familiar identity or memory (threat-model invariant: "Revoking a device does not rotate or destroy familiar identity").
+- Rotation is always explicit: it requires the root-level threshold (§4.5), produces `RecoveryEvent` records with `rotatesIdentity: true`, bumps `revocation_epoch` (the same epoch semantics `DeviceGrant` and `registry.rs` already use to invalidate pre-rotation state), and is refused while any recovery ceremony is mid-flight.
+- Every step of both ceremonies appends `RecoveryEvent` records to the same private append-only audit stream as `audit.rs` — recovery events and key rotations are explicit and auditable.
+
+### 6.3 Golden example — recovery event after a lost laptop
+
+Example literals in this section are intentionally synthetic placeholders (repeated low-entropy tokens), not real key material.
+
+```json
+{
+  "version": 1,
+  "eventId": "evt-evt-evt-evt-evt-ev",
+  "kind": "access_restored",
+  "subject": { "type": "device", "id": "trust-alpha:pairwise-7f3a91" },
+  "actors": ["passkey_account", "trusted_device"],
+  "epoch": 4,
+  "rotatesIdentity": false,
+  "outOfBandContext": "Lost laptop re-enrolled as replacement endpoint after passkey account auth and phone approval",
+  "occurredAt": 1790000000
+}
+```
+
+## 7. Optional attestation
+
+### 7.1 Attribute registry
+
+Canonical snake_case values match `restrictions.attestation` in `spec/device-pairing/v1/device-grant.schema.json` (display labels from the issue: *verified-official-app*, *verified-hardware-key*, *unattested-device*):
+
+| Attribute | Meaning | Typical evidence |
+| --- | --- | --- |
+| `unattested_device` | Default for every device; self-built clients, dev builds, self-hosted runtimes | `none` or `self_declared` |
+| `verified_official_app` | App binary provenance verified (e.g. Apple App Attest; Android Play integrity signals) | `apple_app_attest`, `android_play_integrity` |
+| `verified_hardware_key` | Key is hardware-protected (e.g. Secure Enclave; Android hardware-backed Keystore attestation) | `apple_app_attest` key assurance, `android_key_attestation` |
+
+Mapping notes: Apple App Attest and Android key attestation are evaluated by an optional verifier component; OpenCoven protocol surfaces see only the resulting `AttestationClaim` — opaque receipts, no attestation payloads, per privacy rule 7 ("attestation values are minimized to policy-relevant assurance claims").
+
+### 7.2 Policy integration and the open trust model
+
+- Absence of attestation is **not** a protocol failure: `unattested_device` is a full participant subject to owner policy (threat model: "Attestation lock-in" controls).
+- `attestationPolicy.default` is `prefer` or `ignore`; `requireFor` may name only high-risk capabilities (`secrets_read`, `identity_admin`, device enrollment/revocation, exports) and only the owner can set it.
+- Attestation never replaces proof of possession, owner delegation, or local user verification; it can only *add* assurance to an operation that already passed those checks.
+- Attestation claims are audience-bound to one trust domain and expire; they cannot correlate a device across Covens (privacy rules 1 and 8).
+- Self-hosted deployments can run their own verifier or none at all; nothing in the protocol requires a proprietary service.
+
+### 7.3 Golden example — policy-gated secrets approval
+
+```json
+{
+  "version": 1,
+  "attribute": "verified_hardware_key",
+  "evidence": "android_key_attestation",
+  "subject": {
+    "algorithm": "P-256",
+    "keyId": "trust-alpha:device-key-placeholder",
+    "publicKey": "pk-pk-pk-pk-pk-pk-pk-pk-pk-pk-pk-pk-pk-pk-p"
+  },
+  "audience": { "type": "trust-domain", "id": "trust-alpha" },
+  "nonce": "nonce-nonce-nonce-nonce-nonce-nonce-nonce-n",
+  "issuedAt": 1790000000,
+  "expiresAt": 1790086400,
+  "verifierSignature": "sig-sig-sig-sig-sig-sig-sig-sig-sig-sig-sig-s"
+}
+```
+
+With `attestationPolicy.requireFor: ["secrets_read"]`, a `tools.approve` transaction on `secrets_read` (see `DeviceActionIntent`, `grant.rs`) succeeds only when the approving device key carries a valid `verified_hardware_key` or `verified_official_app` claim. The same transaction from an `unattested_device` key fails with a policy error that names the missing attribute — never a generic denial.
+
+## 8. Policy examples (issue table, mapped)
+
+| Scenario | Required policy |
+| --- | --- |
+| Normal conversation | Valid enrolled device: device key + live `DeviceGrant` (`possession`) — `auth.rs` request verification path |
+| Tool approval | Enrolled device + fresh local user verification — `DeviceActionIntent` with `require_fresh_user_verification_for` restriction (`grant.rs`) |
+| Secrets/root administration | Hardware-backed or attested device and/or second factor when `attestationPolicy.requireFor` / `rootMinApprovals` say so (§4.5, §7.2) |
+| New-device enrollment | Fresh step-up on an existing trusted device; threshold approval per `introductionPolicy`; optionally attested approvers (§4) |
+
+## 9. Threat-model deltas
+
+Extends `docs/security/mobile-device-pairing-threat-model.md` without weakening any existing control:
+
+- **Compromised trusted device**: can introduce one scoped endpoint within `expiresAt`; root-level classes require `rootMinApprovals ≥ 2` distinct approvers; the epoch bump and audit trail bound and expose the damage; owner revokes via the existing `registry.revoke` path.
+- **Passkey/account provider compromise**: cannot enroll endpoints (§4.6); cannot read or forge E2EE sessions; can at most request attention.
+- **Attestation forgery**: verifier compromise yields only assurance attributes, which cannot mint authority; owner policy that never sets `requireFor` is unaffected.
+- **Recovery-ceremony phishing**: `assuranceNonce` and transcript hashing make collected approvals useless for any other request; recovery events are user-visible in `coven memory mobile status` output (which already surfaces device/grant state, `registry.list_status`).
+
+## 10. Acceptance criteria mapping
+
+| Issue acceptance criterion | Where satisfied |
+| --- | --- |
+| Recover/enroll remotely without exposing familiar/root private material to OpenCoven infrastructure | §4.1 (transcript-bound approvals), §5.1, §6.1 (recovery key stays owner-held); grants issued locally by the authority |
+| Synced passkeys do not masquerade as physical-device identity | §5.2 prohibitions; `subject_key_id` remains the pairwise device key |
+| Attestation increases assurance without breaking the open/self-hosted model | §7.2; `unattested_device` full participation; no mandatory proprietary dependency |
+| A compromised account service alone cannot mint arbitrary device authority | §4.6; threat-model invariant 8 |
+| Recovery events and identity/key rotations are explicit and auditable | §3.4 `RecoveryEvent`, §6.2 ceremonies, §6.3 example; same audit stream as `audit.rs` |
+| Owner can choose stricter policies without imposing proprietary platforms on every Coven | §3.3 `RecoveryPolicy`, §4.5 defaults, §7.2 policy knobs |
+
+## 11. Implementation staging
+
+Aligned with delivery-plan PR 7; each sub-stage is independently mergeable and preserves v1/v2 behavior:
+
+1. **7a — objects and policy engine (Rust, authority layer):** new module (suggested: `crates/coven-cli/src/mobile_memory/recovery.rs`) with the five objects, canonical encoding, domain labels, `RecoveryPolicy` storage and evaluation; registry extension for introduction state; JSON schemas under `spec/device-pairing/v2/` plus a v2 conformance manifest and test-vector files; adversarial tests (substitution, replay, threshold bypass, expired approvals).
+2. **7b — introduction flow:** CLI (`coven memory mobile introduce`), approval UI surface on the trusted device, delivery over #787 transports, gateway/internal routes mirroring the existing `/api/v1/internal/mobile/pairings` pattern (`gateway.rs`), audit integration.
+3. **7c — recovery ceremonies and events:** `RecoveryPolicy` ceremony runner, `RecoveryEvent` append-only log, epoch-bump rotation path, `coven memory mobile recovery` command group, export/redaction rules.
+4. **7d — optional attestation adapter contract:** verifier adapter interface (no proprietary SDK in core), claim cache with expiry, policy gating in the authority, `attestationPolicy` enforcement tests for both `prefer` and `requireFor` modes and for the no-verifier/self-hosted configuration.
+
+Merge gates: the repository gates (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `python scripts/check-secrets.py`, `python3 scripts/check-coven-privacy.py --staged`) plus the delivery-plan merge policy: positive, negative, replay, downgrade, and malformed-input tests appropriate to the layer; migration/compatibility notes for stored registry state.
+
+## 12. Decisions and alternatives considered
+
+| Decision | Choice | Alternatives rejected/deferred |
+| --- | --- | --- |
+| Who may approve an introduction | Trusted-device keys and the owner root credential, after fresh step-up | Account service as approver — rejected (invariant 8); relay as approver — rejected |
+| 1 vs N-of-M | 1 by default, N-of-M for root classes via owner policy (§4.5) | Always-N — locks out single-device owners; always-1 — concentrates root trust |
+| Passkey → familiar root | Never; account-layer factor only (§5.2) | Synced-passkey-as-root — rejected by issue and architecture |
+| Recovery default factors | recovery key + passkey account + surviving trusted device (§6.1) | Hosted Shamir/social recovery — deferred (privacy tradeoff, needs its own threat model); security questions — rejected |
+| WebAuthn prf-derived owner keys | Deferred | Ties the owner root to account-provider availability; revisit only with an explicit owner opt-in |
+| Attestation requirement | Optional, policy-gated, per-operation (§7.2) | Global mandatory attestation — rejected (breaks self-built/self-hosted clients) |
+| Attestation value space | Reuse the v1 grant restriction enum (§7.1) | New vocabulary — rejected (fragmentation, migration cost) |
+| Where the account factor lives | Optional external provider; protocol sees only abstract factor kinds (§5) | First-party required account — rejected; protocol-embedded account — out of scope for this repo |
+
+## 13. Verification plan
+
+Implementation PRs must add, at minimum:
+
+- deterministic CBOR/COSE vectors for each new object (canonical-encoding suite, `conformance-manifest.json` suites);
+- negative tests: transcript substitution, scope substitution, expired/single-use nonce replay, threshold bypass, approval-for-another-request, unknown attribute/evidence values (fail closed), attestation claim expiry;
+- integration tests with a malicious relay/account shim: no enrollment without valid approvals; account service compromise reduces to a no-op on the authority path;
+- privacy tests: no passkey credential IDs, attestation receipts, hardware IDs, or biometric metadata in any protocol object, audit record, or log line (extends `scripts/check-coven-privacy.py` coverage);
+- revocation/rotation tests: epoch bump invalidates pre-rotation grants and resumption material while leaving familiar identity untouched.


### PR DESCRIPTION
## Summary

- Adds `docs/design/mobile-recovery-and-introduction-plan.md` — the `#788` plan and implementation contract for **trusted-device introductions, passkey recovery, and optional attestation**, sitting under the accepted `#784` mobile trust architecture and slotted to delivery-plan PR 7 ("Recovery and trusted-device introduction" in `docs/architecture/mobile-device-pairing-delivery-plan.md`).
- Defines five new protocol objects at object version 1 with diagnostic JSON Schemas and TypeScript reference types: `IntroductionRequest`, `IntroductionApproval`, `RecoveryPolicy`, `RecoveryEvent`, `AttestationClaim` — plus their domain-separation labels for the registry in `spec/device-pairing/v1/domain-separation.md` (the implementation PR lands the schemas as files under `spec/device-pairing/v2/` and registers the objects in a v2 conformance manifest).
- Specifies the introduction transcript binding (endpoint public key, requested scopes, nonce, expiry, human-readable device context, grant template), the mandatory fresh step-up on every approving device, the introduction state machine, and the anti-substitution/replay properties.
- Recommends the 1-vs-N-of-M policy: one fresh-step-up trusted device suffices for standard enrollment; `RecoveryPolicy.introductionPolicy.rootMinApprovals` (default 2, distinct approvers) gates root-level classes (`identity.admin`, `devices.enroll|revoke`, exports).
- Defines passkey usage boundaries: allowed uses (optional account sign-in, recovery authentication, remote-enrollment authorization, installation approval as an extra factor, cross-platform browser/native login) and hard prohibitions (never the sole familiar/root key, never proof of one physical device, never a globally reused identifier, never the only recovery path).
- Defines recovery as a first-class protocol: factor-combination matrix (passkey/account, recovery key, another trusted device, N-of-M, owner root credential), explicit ceremonies that keep *recovering access* (`access_restored`, `rotatesIdentity: false`) separate from *replacing/rotating identity* (`identity_rotated`, `rotatesIdentity: true`, `revocation_epoch` bump), and append-only `RecoveryEvent` audit records matching the `audit.rs` stream discipline.
- Specifies optional platform attestation as assurance attributes (`unattested_device`, `verified_official_app`, `verified_hardware_key` — reusing the v1 grant-restriction enum from `spec/device-pairing/v1/device-grant.schema.json`) mapped from Apple App Attest / Android hardware key attestation / Play integrity signals, with owner-policy gating and full protocol participation for self-built, self-hosted, and dev builds.
- Documents why a compromised relay or account service alone cannot mint device authority; threat-model deltas; acceptance-criteria mapping; implementation staging (7a–7d) with merge gates.
- Cross-links the plan from `docs/design/mobile-device-trust.md` (`#788` row of the issue-to-delivery mapping).
- Every current-state claim cites existing code paths (`crates/coven-cli/src/mobile_memory/*.rs`, `crates/coven-relay/src/ws.rs`, `crates/coven-cli/src/familiar_identity.rs`, `spec/device-pairing/v1/*`).

No product code changes — specification artifacts only; nothing in the diff can weaken v1 privacy, replay, revocation, canonicalization, or audit guarantees.

## Issue

Refs OpenCoven/coven#788 (parent #784; builds on #786, #787).

`Closes #788` is intentionally not used even though this is an upstream PR: the delivery plan's merge policy states plan issues close only when their acceptance criteria are demonstrated, not merely scaffolded, and #788 remains the umbrella for the implementation stages sequenced in the plan (§11).

## Test plan

- [x] `python3 scripts/check-secrets.py` — clean locally
- [x] `python3 scripts/check-coven-privacy.py --staged` — clean locally (2 files)
- [x] All 7 embedded JSON blocks parse as valid JSON; the two golden examples were validated against their schemas (required fields, enums, base64url patterns) with a local node script
- [x] Targeted structural review of schema/example consistency (required/`additionalProperties`/enum/pattern checks)
- [ ] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked` — deferred to CI; no Rust or TypeScript code is touched (docs-only diff)
- Docs-only diff, so CI's classifier (`scripts/classify-ci-changes.py`) should set `docs_only` and skip the Rust/npm jobs.

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#788.

---

> Recreated upstream from [https://github.com/CompleteDotTech/coven/pull/18], preserving source head `53894b95b5dec2c02dddfae87cc636fa8a14dd25` and branch `agent/issue-788-plan-passkey-recovery-trusted-device-introductions`.