### PR TITLE
test: add the end-to-end certification matrix and machine-readable receipt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
       - run: python3 scripts/check-ci-workflow-test.py
       - run: node --test scripts/package-github-release-test.mjs
       - run: node --test scripts/release-stress-test.mjs
+      - run: node --test scripts/certification-receipt-test.mjs
       - run: scripts/check-workflows.sh
 
   rust-lint-linux:

--- a/docs/reference/certification.md
+++ b/docs/reference/certification.md
@@ -53,7 +53,7 @@ node scripts/certification-receipt.mjs --strict   # fail closed on open blockers
 ```
 
 The receipt is deterministic and keyed by the candidate digests, carries the
-support-matrix version (`1.0.0`), one entry per row, the summary counts, the
+support-matrix version (`1.1.0`), one entry per row, the summary counts, the
 open blockers, and a `reviewerDecision` that stays `null` until release
 authorization ([#805](https://github.com/OpenCoven/coven/issues/805)) sets it
 after human review. The receipt never self-certifies.
@@ -289,7 +289,7 @@ Generate the live counts with
 `node scripts/certification-receipt.mjs`; the summary partitions every row into
 `requiredPassed` / `requiredFailed` / `requiredUnknown` / `notApplicable` /
 `experimentalDisabled` / `deferred`, and `releaseBlockers` lists exactly the
-rows that keep certification open. As of support-matrix version `1.0.0` the
+rows that keep certification open. As of support-matrix version `1.1.0` the
 open blockers are the recovery/API-boundary/docs gaps named in lanes A, D, H,
 and I — all owned by [#807](https://github.com/OpenCoven/coven/issues/807) and
 [#778](https://github.com/OpenCoven/coven/issues/778) rather than silently

--- a/docs/reference/certification.md
+++ b/docs/reference/certification.md
@@ -105,17 +105,27 @@ packages.
 | --- | --- | --- | --- |
 | B1 | Linux x64: packaged tarball onboarding plus source-equivalent checks pass in CI. | [`npm-onboarding-pr`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`rust-test-linux`](../../.github/workflows/ci.yml) | required / passed |
 | B2 | Windows x64: packaged tarball onboarding plus the Rust suite pass in CI. | [`npm-onboarding-pr`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`rust-test-windows`](../../.github/workflows/ci.yml) | required / passed |
-| B3 | macOS Apple Silicon: Rust suite, packaged onboarding, and AFS-mount legs run per push and at release tags. | [`rust-test-macos`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`afs-mount-macos`](../../.github/workflows/ci.yml) · [`release-npm.yml`](../../.github/workflows/release-npm.yml) | required / passed |
-| B4 | macOS Intel x64: a distinct public package path exists and its CI leg runs per push and at release tags. | [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`release-npm.yml`](../../.github/workflows/release-npm.yml) · [README](../../README.md) | required / passed |
+| B3 | macOS Apple Silicon: Rust suite, packaged onboarding, and AFS-mount legs run per push to main; tag-built macOS packages are never exercised on a macOS runner. | [`rust-test-macos`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`afs-mount-macos`](../../.github/workflows/ci.yml) · [`release-npm.yml`](../../.github/workflows/release-npm.yml) | required / unknown (open blocker) |
+| B4 | macOS Intel x64: a distinct public package path exists and its CI leg runs per push to main; the tag-built Intel package is never exercised on a macOS runner. | [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`release-npm.yml`](../../.github/workflows/release-npm.yml) · [README](../../README.md) | required / unknown (open blocker) |
 | B5 | Real-hardware confirmation per platform: registry install, doctor, and a first session on end-user machines. | [`releasing.md`](../../docs/reference/releasing.md) · [#805](https://github.com/OpenCoven/coven/issues/805) | deferred |
 | B6 | Any additional architecture/platform beyond the declared support matrix. | [README](../../README.md) | not applicable |
 
-B1–B4 are proven by GitHub-hosted CI on the declared OS images. **B5 is the
-external real-hardware lane**: the release runbook's fresh-consumer install
-verification (`npm install -g @opencoven/cli@X.Y.Z`, `coven --version`,
-`coven doctor` on a machine that never had Coven) is an operator step attached
-to the release record, owned by #805. B6 is justified by the support contract:
-Alpine and arm64 Linux are explicitly not claims.
+B1/B2 are proven by GitHub-hosted CI on the declared OS images for every PR
+merge commit and every push to `main`. **B3/B4 are open on purpose**: their
+per-push macOS legs are real, but the release workflow
+([`release-npm.yml`](../../.github/workflows/release-npm.yml)) builds the
+tag-built macOS packages on macOS runners and only dry-runs them on
+`ubuntu-latest` — no macOS runner executes the packaged onboarding at tag time,
+so release coverage is recorded as unknown (owner:
+[#805](https://github.com/OpenCoven/coven/issues/805)) rather than claimed. The
+support inventory in
+[`scripts/certification-matrix.mjs`](../../scripts/certification-matrix.mjs)
+encodes this as `releaseOnboardingRunner: null` for both macOS platforms.
+**B5 is the external real-hardware lane**: the release runbook's
+fresh-consumer install verification (`npm install -g @opencoven/cli@X.Y.Z`,
+`coven --version`, `coven doctor` on a machine that never had Coven) is an
+operator step attached to the release record, owned by #805. B6 is justified by
+the support contract: Alpine and arm64 Linux are explicitly not claims.
 
 ## Lane C — real harness/provider certification
 
@@ -290,10 +300,12 @@ Generate the live counts with
 `requiredPassed` / `requiredFailed` / `requiredUnknown` / `notApplicable` /
 `experimentalDisabled` / `deferred`, and `releaseBlockers` lists exactly the
 rows that keep certification open. As of support-matrix version `1.1.0` the
-open blockers are the recovery/API-boundary/docs gaps named in lanes A, D, H,
-and I — all owned by [#807](https://github.com/OpenCoven/coven/issues/807) and
-[#778](https://github.com/OpenCoven/coven/issues/778) rather than silently
-skipped.
+open blockers are the macOS release-coverage rows in lane B (owned by
+[#805](https://github.com/OpenCoven/coven/issues/805)) and the
+recovery/API-boundary/docs gaps named in lanes A, D, H, and I — all owned by
+[#807](https://github.com/OpenCoven/coven/issues/807),
+[#778](https://github.com/OpenCoven/coven/issues/778), and #805 rather than
+silently skipped.
 
 Rules for changing the matrix:
 

--- a/docs/reference/certification.md
+++ b/docs/reference/certification.md
@@ -1,0 +1,309 @@
+---
+summary: "End-to-end certification matrix for Coven: lanes, rows, outcomes, and evidence."
+description: "The certification rule, lane-by-lane row tables with evidence links, candidate and receipt generation, and the external operator lanes for real hardware and real credentials."
+read_when:
+  - Certifying a release candidate
+  - Checking whether a support claim is proven
+  - Reporting release readiness
+title: "Coven end-to-end certification matrix"
+---
+
+This is the integration-certification authority for Coven
+([OpenCoven/coven#779](https://github.com/OpenCoven/coven/issues/779), child of
+[#670](https://github.com/OpenCoven/coven/issues/670)). It consumes focused
+implementation evidence from [#777](https://github.com/OpenCoven/coven/issues/777)
+and [#778](https://github.com/OpenCoven/coven/issues/778) and release-governance
+evidence from [#805](https://github.com/OpenCoven/coven/issues/805) instead of
+duplicating their work. Test totals, spec counts, and source-level unit coverage
+alone do not establish release readiness: every support claim below maps to a
+certification row with an explicit outcome and evidence, or it is recorded as an
+open blocker.
+
+The rows live once, in
+[`scripts/certification-matrix.mjs`](../../scripts/certification-matrix.mjs).
+This page renders them;
+[`scripts/certification-receipt-test.mjs`](../../scripts/certification-receipt-test.mjs)
+fails when the two drift apart.
+
+## Certification rule
+
+Every row has exactly one outcome:
+
+| Outcome | Meaning |
+| --- | --- |
+| `required / passed` | Supported and proven on the exact candidate/artifact. |
+| `required / failed` | A supported claim proven broken: a release/support blocker. |
+| `required / unknown (open blocker)` | A support claim without sufficient evidence yet. Recorded explicitly, never hidden; it blocks release certification until resolved. |
+| `not applicable` | Excluded by the support contract, with the justification stated. |
+| `experimental / disabled` | Visible as experimental and incapable of becoming supported through packaging drift. |
+| `deferred` | Named owner issue and absent from current support claims. |
+
+`Skipped`, `unknown`, and "unit tests passed" are **not** terminal outcomes for
+a required row: `scripts/certification-receipt.mjs --strict` fails closed on
+every `required / unknown (open blocker)` and `required / failed` row.
+
+## Candidate, receipts, and proof triggers
+
+A **candidate** is a source commit plus its tree digest (and, once one exists, a
+signed tag and published artifact digests). The receipt is generated with:
+
+```sh
+node scripts/certification-receipt.mjs            # print the receipt
+node scripts/certification-receipt.mjs --strict   # fail closed on open blockers
+```
+
+The receipt is deterministic and keyed by the candidate digests, carries the
+support-matrix version (`1.0.0`), one entry per row, the summary counts, the
+open blockers, and a `reviewerDecision` that stays `null` until release
+authorization ([#805](https://github.com/OpenCoven/coven/issues/805)) sets it
+after human review. The receipt never self-certifies.
+
+Rows are proven on different triggers, and the receipt records which:
+
+- **per pull request** — the lanes CI runs on every PR merge commit (policy
+  guard, Rust lint/tests on Linux and Windows, npm packaged-journey legs on
+  Linux x64 and Windows x64, AFS-mount where routed);
+- **per push to `main` and at release tags** — the legs that need dedicated
+  runners (macOS suites, full four-platform npm onboarding);
+- **at tag time** — the release gates in
+  [`release-npm.yml`](../../.github/workflows/release-npm.yml) and
+  [`release-github.yml`](../../.github/workflows/release-github.yml);
+- **operator lanes (external)** — real hardware, real provider credentials, and
+  the deployed docs site. These are documented below as external by design and
+  are deliberately not CI lanes; see the issue's non-goal about not blocking
+  every PR on real cloud/provider/device tests.
+
+## Lane A — hermetic packaged first-session E2E
+
+Owner: [#777](https://github.com/OpenCoven/coven/issues/777) (closed — the
+journey exists and runs in CI). Fresh `COVEN_HOME`, isolated environment, fake
+deterministic harness, no developer-checkout reliance.
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| A1 | The packaged artifact is built and packed from the exact candidate source, not an arbitrary developer checkout. | [`npm-onboarding-pr`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`test-cli-prepublish.mjs`](../../scripts/test-cli-prepublish.mjs) · [`publish-npm.mjs`](../../scripts/publish-npm.mjs) | required / passed |
+| A2 | The produced tarball installs and runs in an isolated environment with a fresh COVEN_HOME. | [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) · [`test-cli-prepublish.mjs`](../../scripts/test-cli-prepublish.mjs) · [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) | required / passed |
+| A3 | Progressive command discovery holds on the installed artifact: curated default help, complete help contract, internals hidden. | [`help_disclosure.rs`](../../crates/coven-cli/tests/help_disclosure.rs) · [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) · [`export-cli-help-contract.mjs`](../../scripts/export-cli-help-contract.mjs) | required / passed |
+| A4 | Install/doctor/health, first project/session, deterministic fake harness, first output, inspect/events/log/status, input, kill/terminal disposition, and cleanup all work through the packaged CLI. | [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) · [`fake-codex.mjs`](../../scripts/fixtures/fake-codex.mjs) · [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) | required / passed |
+| A5 | The journey does not rely on repository-relative files, undeclared developer tools, global state, or preexisting user configuration. | [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) · [`config_paths.rs`](../../crates/coven-cli/tests/config_paths.rs) | required / passed |
+| A6 | Uninstall/cleanup removes test state without deleting unrelated user or workspace data. | [`uninstall.md`](../../docs/install/uninstall.md) · [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) | required / unknown (open blocker) |
+| A7 | Failure output names the failed operation and the safe next action without leaking sensitive payloads. | [`doctor_prose_contract.rs`](../../crates/coven-cli/tests/doctor_prose_contract.rs) · [`doctor_json_contract.rs`](../../crates/coven-cli/tests/doctor_json_contract.rs) · [`privacy.rs`](../../crates/coven-cli/src/privacy.rs) · [`check-coven-privacy.py`](../../scripts/check-coven-privacy.py) | required / passed |
+
+A6 is open: the journey asserts its own daemon cleanup and the uninstall
+contract is documented, but no automated check exercises uninstall on a
+populated `COVEN_HOME` or asserts unrelated sibling data survives. Owner:
+[#807](https://github.com/OpenCoven/coven/issues/807).
+
+## Lane B — supported platform/package matrix
+
+The support contract
+([README](../../README.md), npm platform packages) claims macOS arm64/x64,
+glibc Linux x64, and Windows x64 via `@opencoven/cli` plus its four native
+packages.
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| B1 | Linux x64: packaged tarball onboarding plus source-equivalent checks pass in CI. | [`npm-onboarding-pr`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`rust-test-linux`](../../.github/workflows/ci.yml) | required / passed |
+| B2 | Windows x64: packaged tarball onboarding plus the Rust suite pass in CI. | [`npm-onboarding-pr`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`rust-test-windows`](../../.github/workflows/ci.yml) | required / passed |
+| B3 | macOS Apple Silicon: Rust suite, packaged onboarding, and AFS-mount legs run per push and at release tags. | [`rust-test-macos`](../../.github/workflows/ci.yml) · [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`afs-mount-macos`](../../.github/workflows/ci.yml) · [`release-npm.yml`](../../.github/workflows/release-npm.yml) | required / passed |
+| B4 | macOS Intel x64: a distinct public package path exists and its CI leg runs per push and at release tags. | [`npm-onboarding-main`](../../.github/workflows/ci.yml) · [`release-npm.yml`](../../.github/workflows/release-npm.yml) · [README](../../README.md) | required / passed |
+| B5 | Real-hardware confirmation per platform: registry install, doctor, and a first session on end-user machines. | [`releasing.md`](../../docs/reference/releasing.md) · [#805](https://github.com/OpenCoven/coven/issues/805) | deferred |
+| B6 | Any additional architecture/platform beyond the declared support matrix. | [README](../../README.md) | not applicable |
+
+B1–B4 are proven by GitHub-hosted CI on the declared OS images. **B5 is the
+external real-hardware lane**: the release runbook's fresh-consumer install
+verification (`npm install -g @opencoven/cli@X.Y.Z`, `coven --version`,
+`coven doctor` on a machine that never had Coven) is an operator step attached
+to the release record, owned by #805. B6 is justified by the support contract:
+Alpine and arm64 Linux are explicitly not claims.
+
+## Lane C — real harness/provider certification
+
+Supported harness set: Codex, Claude Code, GitHub Copilot CLI. The hermetic PR
+lane stays credential-free; real credentials are the external operator lane.
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| C1 | A clean authentication/setup path is documented and exercised for every supported provider. | [`setup_cli.rs`](../../crates/coven-cli/tests/setup_cli.rs) · [`cli-setup.md`](../../docs/reference/cli-setup.md) · [`doctor_auth_boundary.rs`](../../crates/coven-cli/tests/doctor_auth_boundary.rs) | required / passed |
+| C2 | Launch, first output, input/continuation, termination, and final status work through the public interface. | [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) · [`fake-codex.mjs`](../../scripts/fixtures/fake-codex.mjs) · [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) · [`harness_parity.rs`](../../crates/coven-cli/tests/harness_parity.rs) | required / passed |
+| C3 | Missing/expired/refused credentials fail closed with actionable normalized errors. | [`doctor_auth_boundary.rs`](../../crates/coven-cli/tests/doctor_auth_boundary.rs) · [`setup_cli.rs`](../../crates/coven-cli/tests/setup_cli.rs) · [`doctor_prose_contract.rs`](../../crates/coven-cli/tests/doctor_prose_contract.rs) | required / passed |
+| C4 | Credentials never appear in event, log, or evidence output. | [`privacy.rs`](../../crates/coven-cli/src/privacy.rs) · [`check-coven-privacy.py`](../../scripts/check-coven-privacy.py) · [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) · [`setup_cli.rs`](../../crates/coven-cli/tests/setup_cli.rs) | required / passed |
+| C5 | Provider disappearance/timeout produces bounded state rather than indefinite ambiguity. | [`process_supervisor.rs`](../../crates/coven-cli/tests/process_supervisor.rs) · [`release-stress.mjs`](../../scripts/release-stress.mjs) · [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) | required / passed |
+| C6 | Unsupported providers never become implicitly supported because an executable happens to exist on PATH. | [`harness.rs`](../../crates/coven-cli/src/harness.rs) · [`harness_parity.rs`](../../crates/coven-cli/tests/harness_parity.rs) | required / passed |
+| C7 | Real-credential certification per supported provider (verify-only packet with real turns). | [`certify-release.sh`](../../scripts/certify-release.sh) · [`releasing.md`](../../docs/reference/releasing.md) · [#805](https://github.com/OpenCoven/coven/issues/805) | deferred |
+
+C1–C6 are proven hermetically (the fake deterministic harness, the auth-boundary
+and report-redaction contracts). **C7 is the external real-credential lane**:
+`coven setup <provider> --verify-only` requires an interactive TTY, explicit
+network/cost consent, and real provider usage, so it runs as the operator
+certification packet ([`scripts/certify-release.sh`](../../scripts/certify-release.sh))
+attached to the release record. Provider-specific model latency is not conflated
+with Coven control-plane latency: C2/C5 assert bounded control-plane behavior
+against deterministic fixtures.
+
+## Lane D — lifecycle, restart, and recovery
+
+Fault-oriented cases, not only normal shutdown. This lane has the most open
+blockers, which is exactly the point of the matrix: recovery gaps are surfaced,
+not averaged away. Owner for the open rows:
+[#807](https://github.com/OpenCoven/coven/issues/807).
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| D1 | Daemon restart preserves durable sessions and state, including the managed identity contract. | [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) · [`windows_daemon_lifecycle.rs`](../../crates/coven-cli/tests/windows_daemon_lifecycle.rs) | required / passed |
+| D2 | Harness/process crash before and after first output reaches bounded terminal-or-unknown state. | [`process_supervisor.rs`](../../crates/coven-cli/tests/process_supervisor.rs) | required / unknown (open blocker) |
+| D3 | Client disconnect/reconnect and event-cursor continuation work. | [`health.rs`](../../crates/coven-client/tests/health.rs) · [`api.rs`](../../crates/coven-cli/src/api.rs) · [`lifecycle.rs`](../../crates/coven-client/src/lifecycle.rs) | required / passed |
+| D4 | Endpoint/peer replacement honors the typed client safety contract and never auto-replays a consequential mutation merely because transport changed. | [`error.rs`](../../crates/coven-client/src/error.rs) · [`lifecycle.rs`](../../crates/coven-client/src/lifecycle.rs) | required / unknown (open blocker) |
+| D5 | Kill/cancel during active work reaches an authoritative terminal or explicit unknown/recovery state. | [`process_supervisor.rs`](../../crates/coven-cli/tests/process_supervisor.rs) · [`user-journey-e2e.mjs`](../../scripts/user-journey-e2e.mjs) · [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) | required / passed |
+| D6 | Duplicate/retried requests use the operation idempotency/adoption semantics or are refused where the outcome is ambiguous. | [`parallel_protocol.rs`](../../crates/coven-cli/tests/parallel_protocol.rs) | required / unknown (open blocker) |
+| D7 | Interrupted cleanup/orphan reconciliation is visible and deterministic. | [`release-stress.mjs`](../../scripts/release-stress.mjs) · [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) | required / unknown (open blocker) |
+| D8 | Corrupted state fails visibly and deterministically instead of silently succeeding. | [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) | required / passed |
+| D9 | Unwritable state fails visibly and preserves recoverable evidence. | [#807](https://github.com/OpenCoven/coven/issues/807) · [`smoke.rs`](../../crates/coven-cli/tests/smoke.rs) | required / unknown (open blocker) |
+
+Explicit uncertainty is acceptable; false success is not. D2/D4/D6/D7/D9 are
+open because supervisor-level termination, typed-client errors, concurrent
+request safety, and cleanup stress are proven while the specific
+crash-window/replay/idempotency/orphan/unwritable contracts are not yet pinned
+by tests.
+
+## Lane E — events, backpressure, and evidence integrity
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| E1 | Event cursor continuation and paging semantics are exercised against the daemon contract. | [`health.rs`](../../crates/coven-client/tests/health.rs) · [`api.rs`](../../crates/coven-cli/src/api.rs) | required / passed |
+| E2 | Event-writer pressure preserves lifecycle/tool/error/exit capacity according to contract. | [`event_writer.rs`](../../crates/coven-cli/src/event_writer.rs) · [`release-stress.mjs`](../../scripts/release-stress.mjs) | required / passed |
+| E3 | Raw output loss/truncation is explicit, bounded, and observable rather than silent. | [`api.rs`](../../crates/coven-cli/src/api.rs) | required / passed |
+| E4 | Oversized/malformed event/request bodies fail through structured errors. | [`api.rs`](../../crates/coven-cli/src/api.rs) · [`API-CONTRACT.md`](../../docs/API-CONTRACT.md) | required / passed |
+| E5 | Redaction remains applied to default persisted/returned evidence. | [`privacy.rs`](../../crates/coven-cli/src/privacy.rs) · [`setup_cli.rs`](../../crates/coven-cli/tests/setup_cli.rs) · [`check-coven-privacy.py`](../../scripts/check-coven-privacy.py) | required / passed |
+| E6 | Raw sensitive artifact opt-in remains separately protected/encrypted/retained according to current security policy. | [`encrypted_artifacts.rs`](../../crates/coven-cli/src/encrypted_artifacts.rs) · [#808](https://github.com/OpenCoven/coven/issues/808) | deferred |
+| E7 | Evidence receipts contain digests/references and sanitized outcomes rather than prompts, credentials, or unrestricted terminal output. | [`certify-release.sh`](../../scripts/certify-release.sh) · [`releasing.md`](../../docs/reference/releasing.md) · [`check-coven-privacy.py`](../../scripts/check-coven-privacy.py) | required / passed |
+
+E6 waits on [#808](https://github.com/OpenCoven/coven/issues/808): encrypted
+artifact storage exists in code, but the retention/encryption contract it must
+certify against is being consolidated there.
+
+## Lane F — AgentFS security and installed-artifact gate
+
+A storage benchmark or a generic workspace green run never promotes a
+mount/security surface automatically.
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| F1 | AFS mount stays experimental/disabled until its dedicated gate passes; it cannot become supported through packaging drift. | [AgentFS design](../../specs/coven-agent-fs/DESIGN.md) · [mount spike](../../specs/coven-agent-fs/MOUNT-SPIKE.md) · [`afs-mount-linux`](../../.github/workflows/ci.yml) · [`afs-mount-macos`](../../.github/workflows/ci.yml) | experimental / disabled |
+| F2 | Installed-artifact mount gate exercised per platform before any mount support claim. | [`afs-mount-e2e.sh`](../../scripts/afs-mount-e2e.sh) · [`afs-mount-smoke.sh`](../../scripts/afs-mount-smoke.sh) | deferred |
+| F3 | Pre-enablement gate (helper availability, credential observation, case-insensitive .git, handle reuse/gate-root enforcement, access-control boundaries, crash/restart/unmount recovery, concurrency, platform behavior, safe-disabled behavior) stays closed while the surface is experimental. | [AgentFS design](../../specs/coven-agent-fs/DESIGN.md) · [`afs-mount-e2e.sh`](../../scripts/afs-mount-e2e.sh) | experimental / disabled |
+
+F1/F3: mount is a cargo feature outside default builds and the spec scopes
+productionizing the mount spike out, so no mount capability is a support claim.
+**F2 is the external artifact-level gate**:
+[`scripts/afs-mount-e2e.sh --installed`](../../scripts/afs-mount-e2e.sh) is a
+manual post-release verification — the v0.3.0 incident (published package
+omitted the mount helper) is why it must stay artifact-level.
+
+## Lane G — coven-agents/A2A boundary
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| G1 | Direct/handoff target ingress-policy parity is proven before stronger cross-agent safety claims. | [#803](https://github.com/OpenCoven/coven/issues/803) | deferred |
+| G2 | Local coven-agents behavior is certified as local/in-process semantics under the invocation/delegation contracts. | [`runner.rs`](../../crates/coven-agents/tests/runner.rs) · [`loop_runner.rs`](../../crates/coven-agents/tests/loop_runner.rs) · [#804](https://github.com/OpenCoven/coven/issues/804) | deferred |
+| G3 | No certification row describes the legacy handoff pointer-swap as durable distributed A2A request/response. | [handoff spec](../../specs/coven-handoff-packet/TECH.md) | not applicable |
+| G4 | Local and Coven-backed executors share one conformance suite (authorization, stable invocation ID, events, timeout/cancel, ambiguous adoption, duplicate submission, interruption, cleanup, secret-free evidence). | [#804](https://github.com/OpenCoven/coven/issues/804) | deferred |
+| G5 | Remote/multi-host placement reuses the existing hub and stays below agent-visible APIs. | [multi-host spec](../../specs/coven-multi-host-daemon/TECH.md) | not applicable |
+
+G1 is blocked behind [#803](https://github.com/OpenCoven/coven/issues/803);
+G2/G4 follow the [#804](https://github.com/OpenCoven/coven/issues/804)
+architecture migration so the suite does not certify a moving contract. G3/G5
+record the boundaries that keep A2A claims from outrunning the architecture.
+
+## Lane H — public client/API compatibility
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| H1 | Named version/capability negotiation works on the exact candidate. | [`API-CONTRACT.md`](../../docs/API-CONTRACT.md) · [`http.rs`](../../crates/coven-client/src/http.rs) · [`api.rs`](../../crates/coven-cli/src/api.rs) | required / passed |
+| H2 | Published client/package fixtures match the actual daemon contract. | [`health.rs`](../../crates/coven-client/tests/health.rs) · [`test-cli-prepublish.mjs`](../../scripts/test-cli-prepublish.mjs) · [`publish-npm-test.mjs`](../../scripts/publish-npm-test.mjs) | required / passed |
+| H3 | Unsupported version/capability denial is structured and deterministic. | [`API-CONTRACT.md`](../../docs/API-CONTRACT.md) · [`error.rs`](../../crates/coven-client/src/error.rs) | required / passed |
+| H4 | Authentication/peer binding remains separate from capability advertisement. | [`AUTH.md`](../../docs/AUTH.md) · [`remote-listener-auth.md`](../../docs/design/remote-listener-auth.md) | required / unknown (open blocker) |
+| H5 | Malformed/oversized/unauthorized mutation paths fail before effects. | [`api.rs`](../../crates/coven-cli/src/api.rs) · [`API-CONTRACT.md`](../../docs/API-CONTRACT.md) | required / passed |
+| H6 | Package consumers never rely on unpublished repository internals. | [npm/coven/package.json](../../npm/coven/package.json) · [`test-cli-prepublish.mjs`](../../scripts/test-cli-prepublish.mjs) · [`publish-npm-test.mjs`](../../scripts/publish-npm-test.mjs) | required / passed |
+
+H4 is open: the separation is documented policy, but no hermetic test pins it on
+the running daemon. Owner: [#807](https://github.com/OpenCoven/coven/issues/807).
+
+## Lane I — docs and first-response correctness
+
+Owners: [#775](https://github.com/OpenCoven/coven/issues/775),
+[#776](https://github.com/OpenCoven/coven/issues/776),
+[#778](https://github.com/OpenCoven/coven/issues/778).
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| I1 | Canonical docs build and link checks pass in repository and deployed-site contexts. | [#778](https://github.com/OpenCoven/coven/issues/778) · [`DOCS-MAINTENANCE.md`](../../docs/DOCS-MAINTENANCE.md) | deferred |
+| I2 | Browser journey from install/discovery through first session/recovery uses the shipped commands/contracts. | [#778](https://github.com/OpenCoven/coven/issues/778) | deferred |
+| I3 | Duplicate local public docs are removed or explicitly source-adjacent. | [`DOCS-MAINTENANCE.md`](../../docs/DOCS-MAINTENANCE.md) | required / unknown (open blocker) |
+| I4 | Help contract remains complete while default help is progressively disclosed. | [`help_disclosure.rs`](../../crates/coven-cli/tests/help_disclosure.rs) · [`export-cli-help-contract.mjs`](../../scripts/export-cli-help-contract.mjs) · [`cli-docs-test.mjs`](../../scripts/cli-docs-test.mjs) | required / passed |
+| I5 | Security/support text matches the security-policy truth and current capability state. | [#808](https://github.com/OpenCoven/coven/issues/808) · [`SAFETY-MODEL.md`](../../docs/SAFETY-MODEL.md) | deferred |
+| I6 | No stale product/version/support claim survives after a certification state changes. | [`DOCS-MAINTENANCE.md`](../../docs/DOCS-MAINTENANCE.md) | required / unknown (open blocker) |
+
+I1/I2 belong to the deployed-site program in
+[#778](https://github.com/OpenCoven/coven/issues/778) — external to this
+repository's CI by design. I3/I6 are open because the docs rules are normative
+but not yet machine-checked.
+
+## Lane J — release authorization and exact artifact evidence
+
+Owned by [#805](https://github.com/OpenCoven/coven/issues/805), consumed here.
+No release tag is in flight for the current candidate, so tag-time rows are
+recorded as not applicable for this candidate with their standing gates cited.
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| J1 | Exact release/tag target has every required check success. | [`release-npm.yml`](../../.github/workflows/release-npm.yml) · [`release-github.yml`](../../.github/workflows/release-github.yml) | not applicable |
+| J2 | Branch/ruleset/review protection evidence includes administrators. | [#805](https://github.com/OpenCoven/coven/issues/805) | deferred |
+| J3 | Signed tag/trusted signer/provenance/SBOM or declared dependency receipt passes. | [`release-npm.yml`](../../.github/workflows/release-npm.yml) · [`release-github.yml`](../../.github/workflows/release-github.yml) · [`releasing.md`](../../docs/reference/releasing.md) | not applicable |
+| J4 | Generated/version state is coherent and clean. | [`publish-npm.mjs`](../../scripts/publish-npm.mjs) · [`publish-npm-test.mjs`](../../scripts/publish-npm-test.mjs) · [`package-github-release-test.mjs`](../../scripts/package-github-release-test.mjs) | required / passed |
+| J5 | Release channels agree on public version/support state. | [#805](https://github.com/OpenCoven/coven/issues/805) · [`releasing.md`](../../docs/reference/releasing.md) | deferred |
+| J6 | Artifact/package digests used by E2E match the published artifacts. | [`releasing.md`](../../docs/reference/releasing.md) · [`release-github.yml`](../../.github/workflows/release-github.yml) | not applicable |
+| J7 | Mutation tests prove failed/missing checks, tag mismatch, signer failure, or security-disabled surfaces fail closed. | [`release-github.yml`](../../.github/workflows/release-github.yml) · [`release-stress.mjs`](../../scripts/release-stress.mjs) | deferred |
+
+## Lane K — device/mobile trust expansion
+
+Issues [#785](https://github.com/OpenCoven/coven/issues/785)–[#788](https://github.com/OpenCoven/coven/issues/788)
+define the device-bound/QR/reconnection/recovery program. Those capabilities
+remain outside the current shipped certification until they are support claims.
+
+| ID | Certification row | Evidence | Outcome |
+| --- | --- | --- | --- |
+| K1 | Device-bound/QR/reconnection/recovery capabilities stay outside shipped certification until they become support claims. | [#785](https://github.com/OpenCoven/coven/issues/785) · [pairing spec](../../spec/device-pairing/v1/README.md) · [`mobile-pairing-protocol-v2.md`](../../docs/design/mobile-pairing-protocol-v2.md) | not applicable |
+
+When the program is promoted, certification must require: cryptographic
+peer/device identity and scoped grants; QR/bootstrap replay/expiry/refusal
+coverage; biometric/passkey authorization semantics where claimed; local
+discovery and relay fallback without widening authority; device
+revocation/recovery/rotation; and cross-device continuity evidence that
+preserves familiar/session authority rather than introducing a client-side
+source of truth.
+
+## Current state and how to update this matrix
+
+Generate the live counts with
+`node scripts/certification-receipt.mjs`; the summary partitions every row into
+`requiredPassed` / `requiredFailed` / `requiredUnknown` / `notApplicable` /
+`experimentalDisabled` / `deferred`, and `releaseBlockers` lists exactly the
+rows that keep certification open. As of support-matrix version `1.0.0` the
+open blockers are the recovery/API-boundary/docs gaps named in lanes A, D, H,
+and I — all owned by [#807](https://github.com/OpenCoven/coven/issues/807) and
+[#778](https://github.com/OpenCoven/coven/issues/778) rather than silently
+skipped.
+
+Rules for changing the matrix:
+
+1. Edit [`scripts/certification-matrix.mjs`](../../scripts/certification-matrix.mjs)
+   and the tables on this page in the same commit — the test suite fails on
+   drift.
+2. A required row never moves to `required / unknown` silently: the
+   justification and owner issue must land with the change.
+3. Evidence references must resolve: repo paths must exist, CI jobs must be
+   declared in [`ci.yml`](../../.github/workflows/ci.yml), and deferred rows
+   must name their owner issue.
+4. Bump `SUPPORT_MATRIX_VERSION` when the row set or the support contract it
+   reflects changes, and state the change in the PR description.

--- a/scripts/certification-matrix.mjs
+++ b/scripts/certification-matrix.mjs
@@ -22,8 +22,63 @@
 // `Skipped` is not in the vocabulary on purpose: it is not a terminal outcome
 // for a required certification row.
 
-export const SUPPORT_MATRIX_VERSION = '1.0.0';
+export const SUPPORT_MATRIX_VERSION = '1.1.0';
 export const RECEIPT_VERSION = 1;
+
+// Canonical support inventory: the machine-readable support contract that row
+// applicability is derived from. A row may never claim coverage for a platform
+// that is not declared here, and every platform declared here must be covered
+// by at least one certification row (both enforced by the test suite).
+//
+// `releaseBuildRunner` is the runner that compiles the tag-built package for
+// the platform in `.github/workflows/release-npm.yml`. `releaseOnboardingRunner`
+// is the runner that *executes* the packaged onboarding verification of that
+// tag-built package at tag time; `null` means no such leg exists in the release
+// workflow, so release-time coverage for the platform cannot be claimed — rows
+// covering it must stay `required-unknown` at the release channel instead of
+// asserting coverage that does not run.
+export const SUPPORT_INVENTORY = {
+  version: 1,
+  wrapperPackage: '@opencoven/cli',
+  channels: ['source-checkout', 'release-tag'],
+  platforms: [
+    {
+      id: 'linux-x64-gnu',
+      package: '@opencoven/cli-linux-x64',
+      ciRunner: 'ubuntu-latest',
+      releaseBuildRunner: 'ubuntu-latest',
+      releaseOnboardingRunner: 'ubuntu-latest'
+    },
+    {
+      id: 'windows-x64',
+      package: '@opencoven/cli-windows',
+      ciRunner: 'windows-latest',
+      releaseBuildRunner: 'windows-latest',
+      // The release workflow's npm-dry-run leg executes on ubuntu-latest only;
+      // no Windows runner exercises the tag-built Windows package.
+      releaseOnboardingRunner: null
+    },
+    {
+      id: 'macos-arm64',
+      package: '@opencoven/cli-macos',
+      ciRunner: 'macos-26',
+      releaseBuildRunner: 'macos-26',
+      // The release workflow builds macOS packages on macOS runners but the
+      // onboarding/dry-run verification leg runs on ubuntu-latest only.
+      releaseOnboardingRunner: null
+    },
+    {
+      id: 'macos-x64',
+      package: '@opencoven/cli-macos-x64',
+      ciRunner: 'macos-15-intel',
+      releaseBuildRunner: 'macos-15-intel',
+      releaseOnboardingRunner: null
+    }
+  ]
+};
+
+export const SOURCE_CHECKOUT_CHANNEL = 'source-checkout';
+export const RELEASE_TAG_CHANNEL = 'release-tag';
 
 export const OUTCOMES = {
   REQUIRED_PASSED: 'required-passed',
@@ -225,6 +280,7 @@ export const CERTIFICATION_MATRIX = [
     id: 'B1',
     lane: 'B',
     claim: 'Linux x64: packaged tarball onboarding plus source-equivalent checks pass in CI.',
+    platforms: ['linux-x64-gnu'],
     outcome: OUTCOMES.REQUIRED_PASSED,
     evidence: [
       { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-pr' },
@@ -236,6 +292,7 @@ export const CERTIFICATION_MATRIX = [
     id: 'B2',
     lane: 'B',
     claim: 'Windows x64: packaged tarball onboarding plus the Rust suite pass in CI.',
+    platforms: ['windows-x64'],
     outcome: OUTCOMES.REQUIRED_PASSED,
     evidence: [
       { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-pr' },
@@ -247,6 +304,7 @@ export const CERTIFICATION_MATRIX = [
     id: 'B3',
     lane: 'B',
     claim: 'macOS Apple Silicon: Rust suite, packaged onboarding, and AFS-mount legs run per push and at release tags.',
+    platforms: ['macos-arm64'],
     outcome: OUTCOMES.REQUIRED_PASSED,
     evidence: [
       { kind: 'ci-job', ref: 'ci.yml#rust-test-macos' },
@@ -259,6 +317,7 @@ export const CERTIFICATION_MATRIX = [
     id: 'B4',
     lane: 'B',
     claim: 'macOS Intel x64: a distinct public package path exists and its CI leg runs per push and at release tags.',
+    platforms: ['macos-x64'],
     outcome: OUTCOMES.REQUIRED_PASSED,
     evidence: [
       { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
@@ -270,6 +329,7 @@ export const CERTIFICATION_MATRIX = [
     id: 'B5',
     lane: 'B',
     claim: 'Real-hardware confirmation per platform: registry install, doctor, and a first session on end-user machines.',
+    platforms: ['linux-x64-gnu', 'windows-x64', 'macos-arm64', 'macos-x64'],
     outcome: OUTCOMES.DEFERRED,
     evidence: [
       { kind: 'runbook', ref: 'docs/reference/releasing.md' },
@@ -784,6 +844,9 @@ export const CERTIFICATION_MATRIX = [
     id: 'J1',
     lane: 'J',
     claim: 'Exact release/tag target has every required check success.',
+    // Release-only requirement: applicable as soon as the candidate carries a
+    // release tag, regardless of the statically declared outcome below.
+    applicableWhen: { channels: [RELEASE_TAG_CHANNEL] },
     outcome: OUTCOMES.NOT_APPLICABLE,
     evidence: [
       { kind: 'workflow', ref: '.github/workflows/release-npm.yml' },
@@ -804,6 +867,7 @@ export const CERTIFICATION_MATRIX = [
     id: 'J3',
     lane: 'J',
     claim: 'Signed tag/trusted signer/provenance/SBOM or declared dependency receipt passes.',
+    applicableWhen: { channels: [RELEASE_TAG_CHANNEL] },
     outcome: OUTCOMES.NOT_APPLICABLE,
     evidence: [
       { kind: 'workflow', ref: '.github/workflows/release-npm.yml' },
@@ -839,6 +903,7 @@ export const CERTIFICATION_MATRIX = [
     id: 'J6',
     lane: 'J',
     claim: 'Artifact/package digests used by E2E match the published artifacts.',
+    applicableWhen: { channels: [RELEASE_TAG_CHANNEL] },
     outcome: OUTCOMES.NOT_APPLICABLE,
     evidence: [
       { kind: 'runbook', ref: 'docs/reference/releasing.md' },
@@ -907,6 +972,7 @@ export function validateMatrix(rows = CERTIFICATION_MATRIX) {
   const errors = [];
   const seen = new Set();
   const laneIds = new Set(LANES.map((lane) => lane.id));
+  const platformIds = new Set(SUPPORT_INVENTORY.platforms.map((platform) => platform.id));
 
   for (const row of rows) {
     const where = `row ${row.id ?? '<missing id>'}`;
@@ -942,6 +1008,29 @@ export function validateMatrix(rows = CERTIFICATION_MATRIX) {
     ) {
       errors.push(`${where}: outcome '${row.outcome}' requires a justification`);
     }
+    if (row.applicableWhen !== undefined) {
+      const channels = row.applicableWhen?.channels;
+      if (
+        !Array.isArray(channels) ||
+        channels.length === 0 ||
+        !channels.every((channel) => SUPPORT_INVENTORY.channels.includes(channel))
+      ) {
+        errors.push(
+          `${where}: applicableWhen.channels must be a non-empty subset of ${SUPPORT_INVENTORY.channels.join(', ')}`
+        );
+      }
+    }
+    if (row.platforms !== undefined) {
+      if (
+        !Array.isArray(row.platforms) ||
+        row.platforms.length === 0 ||
+        !row.platforms.every((platform) => platformIds.has(platform))
+      ) {
+        errors.push(
+          `${where}: platforms must be a non-empty subset of the support inventory (${[...platformIds].join(', ')})`
+        );
+      }
+    }
     for (const ref of row.evidence ?? []) {
       if (!EVIDENCE_KINDS[ref.kind]) {
         errors.push(`${where}: evidence kind '${ref.kind}' is not defined`);
@@ -954,25 +1043,141 @@ export function validateMatrix(rows = CERTIFICATION_MATRIX) {
   return errors;
 }
 
+// The candidate context drives row applicability: the channel comes from how
+// the candidate is being certified (source checkout vs. release tag) and the
+// tag exists exactly when the channel is the release channel. This replaces
+// the old model where release-only rows were statically not-applicable and
+// could silently vanish from go/no-go even when a tag was in flight.
+export function resolveCandidateContext({ channel, tag = null } = {}) {
+  if (!SUPPORT_INVENTORY.channels.includes(channel)) {
+    throw new Error(
+      `unknown certification channel '${channel}'; expected one of ${SUPPORT_INVENTORY.channels.join(', ')}`
+    );
+  }
+  const releaseChannel = channel === RELEASE_TAG_CHANNEL;
+  if (releaseChannel) {
+    if (typeof tag !== 'string' || !/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(tag)) {
+      throw new Error(`release-tag candidates require a tag named vX.Y.Z[-suffix]; got '${tag ?? ''}'`);
+    }
+  } else if (tag != null) {
+    throw new Error(`channel '${channel}' must not carry a release tag; got '${tag}'`);
+  }
+  return Object.freeze({ channel, tag: releaseChannel ? tag : null });
+}
+
+// Whether a row applies to the candidate context, and why. Rows marked
+// `applicableWhen` apply whenever the candidate channel matches, which
+// overrides a statically declared not-applicable outcome (the release rows in
+// lane J). Everything else applies per its declared outcome.
+export function resolveApplicability(row, context) {
+  const declaredChannels = row.applicableWhen?.channels;
+  if (Array.isArray(declaredChannels)) {
+    if (declaredChannels.includes(context.channel)) {
+      return { applicable: true, basis: 'channel-matches-applicableWhen' };
+    }
+    return { applicable: false, basis: 'channel-not-in-applicableWhen' };
+  }
+  if (row.outcome === OUTCOMES.NOT_APPLICABLE) {
+    return { applicable: false, basis: 'declared-not-applicable' };
+  }
+  return { applicable: true, basis: 'declared-applicable' };
+}
+
 // The certification rule from the issue, executable: skipped/unknown are not
-// terminal outcomes for a required row, and a proven-failed required row is a
-// release blocker. Returns the open blockers for the current matrix.
-export function certificationBlockers(rows = CERTIFICATION_MATRIX) {
+// terminal outcomes for a required row, a proven-failed required row is a
+// release blocker, deferred rows are pending at the source channel and become
+// blockers at the release channel, and release-only rows apply as soon as the
+// candidate carries a tag. Returns the open blockers for the given context.
+export function certificationBlockers(rows = CERTIFICATION_MATRIX, context = null) {
+  const candidateContext = context ?? resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL });
+  const releaseChannel = candidateContext.channel === RELEASE_TAG_CHANNEL;
+  const blockers = [];
+  for (const row of rows) {
+    const applicability = resolveApplicability(row, candidateContext);
+    if (!applicability.applicable) {
+      continue;
+    }
+    if (row.outcome === OUTCOMES.NOT_APPLICABLE) {
+      // A release-only row whose channel arrived while the row is still
+      // statically not-applicable is exactly the drift this function exists to
+      // catch: the requirement is live but no evidence obligation is recorded.
+      if (applicability.basis === 'channel-matches-applicableWhen') {
+        blockers.push({
+          id: row.id,
+          lane: row.lane,
+          reason: `release-only row became applicable for channel '${candidateContext.channel}' but is still statically not-applicable with no evidence binding`,
+          ownerIssue: row.ownerIssue ?? null
+        });
+      }
+      continue;
+    }
+    if (row.outcome === OUTCOMES.REQUIRED_FAILED) {
+      blockers.push({
+        id: row.id,
+        lane: row.lane,
+        reason: `required row proven failed: ${row.justification ?? row.claim}`,
+        ownerIssue: row.ownerIssue ?? null
+      });
+    } else if (row.outcome === OUTCOMES.REQUIRED_UNKNOWN) {
+      blockers.push({
+        id: row.id,
+        lane: row.lane,
+        reason: `required row has an explicit unknown disposition: ${
+          row.justification ?? 'no justification recorded'
+        }`,
+        ownerIssue: row.ownerIssue ?? null
+      });
+    } else if (row.outcome === OUTCOMES.DEFERRED && releaseChannel) {
+      // Deferred rows must never disappear from a release go/no-go: at tag
+      // time each of them is an open requirement owned by its issue.
+      blockers.push({
+        id: row.id,
+        lane: row.lane,
+        reason: `release candidate still carries a deferred requirement owned by #${row.ownerIssue}: ${
+          row.justification ?? 'no justification recorded'
+        }`,
+        ownerIssue: row.ownerIssue ?? null
+      });
+    }
+  }
+  return blockers;
+}
+
+// Deferred rows stay visible in every go/no-go: at the source channel they are
+// pending (owned, not blocking), at the release channel they are blockers.
+export function pendingRows(rows = CERTIFICATION_MATRIX, context = null) {
+  const candidateContext = context ?? resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL });
+  if (candidateContext.channel === RELEASE_TAG_CHANNEL) {
+    return [];
+  }
   return rows
-    .filter(
-      (row) => row.outcome === OUTCOMES.REQUIRED_FAILED || row.outcome === OUTCOMES.REQUIRED_UNKNOWN
-    )
-    .map((row) => ({
-      id: row.id,
-      lane: row.lane,
-      reason:
-        row.outcome === OUTCOMES.REQUIRED_FAILED
-          ? `required row proven failed: ${row.justification ?? row.claim}`
-          : `required row has an explicit unknown disposition: ${
-              row.justification ?? 'no justification recorded'
-            }`,
-      ownerIssue: row.ownerIssue ?? null
-    }));
+    .filter((row) => row.outcome === OUTCOMES.DEFERRED)
+    .map((row) => ({ id: row.id, lane: row.lane, ownerIssue: row.ownerIssue ?? null }));
+}
+
+// The go/no-go verdict for a candidate context. `go` requires zero blockers,
+// zero pending rows at the release channel, and — at the release channel — an
+// approved reviewer decision recorded by release authorization (#805). The
+// receipt never self-certifies: without an approved decision record the
+// release channel cannot be `go`.
+export function goNoGo(rows = CERTIFICATION_MATRIX, context = null, { reviewerDecision = null } = {}) {
+  const candidateContext = context ?? resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL });
+  const releaseChannel = candidateContext.channel === RELEASE_TAG_CHANNEL;
+  const blockers = certificationBlockers(rows, candidateContext);
+  const pending = pendingRows(rows, candidateContext);
+  const verdict =
+    blockers.length === 0 && (!releaseChannel || (pending.length === 0 && reviewerDecision === 'approved'))
+      ? 'go'
+      : 'no-go';
+  return {
+    channel: candidateContext.channel,
+    tag: candidateContext.tag,
+    verdict,
+    blockers,
+    pending,
+    reviewerDecision: releaseChannel ? reviewerDecision : null,
+    summary: matrixSummary(rows)
+  };
 }
 
 export function matrixSummary(rows = CERTIFICATION_MATRIX) {

--- a/scripts/certification-matrix.mjs
+++ b/scripts/certification-matrix.mjs
@@ -1,0 +1,1008 @@
+// Single source of truth for the Coven end-to-end certification matrix.
+//
+// Issue OpenCoven/coven#779 is the integration-certification authority: it
+// consumes focused implementation evidence from #777/#778 and release
+// governance evidence from #805 rather than duplicating them. This module is
+// that matrix in machine-readable form. docs/reference/certification.md
+// renders it; scripts/certification-receipt.mjs turns it into the structured
+// certification receipt; scripts/certification-receipt-test.mjs keeps the
+// doc, the matrix, and the CI wiring from drifting apart.
+//
+// Every row carries exactly one outcome:
+//
+//   required-passed        supported and proven on the exact candidate
+//   required-failed        supported claim proven broken (release blocker)
+//   required-unknown       support claim without sufficient evidence (open
+//                          blocker — explicit, never hidden)
+//   not-applicable         excluded by the support contract
+//   experimental-disabled  visible as experimental and incapable of becoming
+//                          supported through packaging drift
+//   deferred               named owner issue, absent from current claims
+//
+// `Skipped` is not in the vocabulary on purpose: it is not a terminal outcome
+// for a required certification row.
+
+export const SUPPORT_MATRIX_VERSION = '1.0.0';
+export const RECEIPT_VERSION = 1;
+
+export const OUTCOMES = {
+  REQUIRED_PASSED: 'required-passed',
+  REQUIRED_FAILED: 'required-failed',
+  REQUIRED_UNKNOWN: 'required-unknown',
+  NOT_APPLICABLE: 'not-applicable',
+  EXPERIMENTAL_DISABLED: 'experimental-disabled',
+  DEFERRED: 'deferred'
+};
+
+export const ALL_OUTCOMES = new Set(Object.values(OUTCOMES));
+
+// Outcomes that close a certification row. `required-unknown` is deliberately
+// absent: it is an explicit, open blocker — never a terminal state.
+export const TERMINAL_OUTCOMES = new Set([
+  OUTCOMES.REQUIRED_PASSED,
+  OUTCOMES.REQUIRED_FAILED,
+  OUTCOMES.NOT_APPLICABLE,
+  OUTCOMES.EXPERIMENTAL_DISABLED,
+  OUTCOMES.DEFERRED
+]);
+
+// Evidence kinds and what they point at. Every kind is resolved by the test
+// suite: repo paths must exist, CI jobs must be declared in ci.yml, and issue
+// refs must name an upstream issue.
+export const EVIDENCE_KINDS = {
+  'ci-job': { description: 'GitHub Actions job declared in ci.yml' },
+  workflow: { repoPath: true },
+  test: { repoPath: true },
+  script: { repoPath: true },
+  docs: { repoPath: true },
+  spec: { repoPath: true },
+  package: { repoPath: true },
+  runbook: { repoPath: true },
+  issue: { repoPath: false }
+};
+
+export const LANES = [
+  {
+    id: 'A',
+    title: 'Hermetic packaged first-session E2E',
+    ownerIssue: 777,
+    description:
+      'Packaged-artifact first-session journey with a fresh COVEN_HOME and no developer-checkout reliance.'
+  },
+  {
+    id: 'B',
+    title: 'Supported platform/package matrix',
+    ownerIssue: null,
+    description:
+      'Required packaged/source-equivalent checks on the declared support matrix; real-hardware confirmation is an external operator lane.'
+  },
+  {
+    id: 'C',
+    title: 'Real harness/provider certification',
+    ownerIssue: 805,
+    description:
+      'Codex, Claude Code, and GitHub Copilot CLI support; real credentials stay in the operator lane, hermetic subsets in CI.'
+  },
+  {
+    id: 'D',
+    title: 'Lifecycle, restart, and recovery',
+    ownerIssue: 807,
+    description: 'Fault-oriented cases, not only normal shutdown.'
+  },
+  {
+    id: 'E',
+    title: 'Events, backpressure, and evidence integrity',
+    ownerIssue: null,
+    description: 'Event cursors, bounded writers, truncation, redaction, and evidence receipts.'
+  },
+  {
+    id: 'F',
+    title: 'AgentFS security and installed-artifact gate',
+    ownerIssue: null,
+    description: 'Mount surfaces stay experimental/disabled until their dedicated gate passes.'
+  },
+  {
+    id: 'G',
+    title: 'coven-agents/A2A boundary',
+    ownerIssue: 804,
+    description: 'Ingress parity and executor conformance gated by #803/#804.'
+  },
+  {
+    id: 'H',
+    title: 'Public client/API compatibility',
+    ownerIssue: null,
+    description: 'Version negotiation, contract fixtures, structured denial, fail-before-effects mutations.'
+  },
+  {
+    id: 'I',
+    title: 'Docs and first-response correctness',
+    ownerIssue: 778,
+    description: 'Canonical docs, browser journey, help contract, security/support text truth.'
+  },
+  {
+    id: 'J',
+    title: 'Release authorization and exact artifact evidence',
+    ownerIssue: 805,
+    description: 'Consumed from #805: tag-time gates, protection evidence, digests, fail-closed mutations.'
+  },
+  {
+    id: 'K',
+    title: 'Device/mobile trust expansion',
+    ownerIssue: null,
+    description: 'Issues #785–#788 program; outside shipped certification until support claims exist.'
+  }
+];
+
+export const CERTIFICATION_MATRIX = [
+  // ---------------------------------------------------------------- Lane A
+  {
+    id: 'A1',
+    lane: 'A',
+    claim:
+      'The packaged artifact is built and packed from the exact candidate source, not an arbitrary developer checkout.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-pr' },
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
+      { kind: 'script', ref: 'scripts/test-cli-prepublish.mjs' },
+      { kind: 'script', ref: 'scripts/publish-npm.mjs' }
+    ]
+  },
+  {
+    id: 'A2',
+    lane: 'A',
+    claim: 'The produced tarball installs and runs in an isolated environment with a fresh COVEN_HOME.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' },
+      { kind: 'script', ref: 'scripts/test-cli-prepublish.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' }
+    ]
+  },
+  {
+    id: 'A3',
+    lane: 'A',
+    claim:
+      'Progressive command discovery holds on the installed artifact: curated default help, complete help contract, internals hidden.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/help_disclosure.rs' },
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' },
+      { kind: 'script', ref: 'scripts/export-cli-help-contract.mjs' }
+    ]
+  },
+  {
+    id: 'A4',
+    lane: 'A',
+    claim:
+      'Install/doctor/health, first project/session, deterministic fake harness, first output, inspect/events/log/status, input, kill/terminal disposition, and cleanup all work through the packaged CLI.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' },
+      { kind: 'script', ref: 'scripts/fixtures/fake-codex.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' }
+    ]
+  },
+  {
+    id: 'A5',
+    lane: 'A',
+    claim:
+      'The journey does not rely on repository-relative files, undeclared developer tools, global state, or preexisting user configuration.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/config_paths.rs' }
+    ]
+  },
+  {
+    id: 'A6',
+    lane: 'A',
+    claim: 'Uninstall/cleanup removes test state without deleting unrelated user or workspace data.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [
+      { kind: 'docs', ref: 'docs/install/uninstall.md' },
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' }
+    ],
+    ownerIssue: 807,
+    justification:
+      'The hermetic journey asserts its own daemon cleanup and the uninstall contract is documented, but no automated check exercises uninstall on a populated COVEN_HOME or asserts unrelated sibling data survives.'
+  },
+  {
+    id: 'A7',
+    lane: 'A',
+    claim: 'Failure output names the failed operation and the safe next action without leaking sensitive payloads.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/doctor_prose_contract.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/doctor_json_contract.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/src/privacy.rs' },
+      { kind: 'script', ref: 'scripts/check-coven-privacy.py' }
+    ]
+  },
+
+  // ---------------------------------------------------------------- Lane B
+  {
+    id: 'B1',
+    lane: 'B',
+    claim: 'Linux x64: packaged tarball onboarding plus source-equivalent checks pass in CI.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-pr' },
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
+      { kind: 'ci-job', ref: 'ci.yml#rust-test-linux' }
+    ]
+  },
+  {
+    id: 'B2',
+    lane: 'B',
+    claim: 'Windows x64: packaged tarball onboarding plus the Rust suite pass in CI.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-pr' },
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
+      { kind: 'ci-job', ref: 'ci.yml#rust-test-windows' }
+    ]
+  },
+  {
+    id: 'B3',
+    lane: 'B',
+    claim: 'macOS Apple Silicon: Rust suite, packaged onboarding, and AFS-mount legs run per push and at release tags.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'ci-job', ref: 'ci.yml#rust-test-macos' },
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
+      { kind: 'ci-job', ref: 'ci.yml#afs-mount-macos' },
+      { kind: 'workflow', ref: '.github/workflows/release-npm.yml' }
+    ]
+  },
+  {
+    id: 'B4',
+    lane: 'B',
+    claim: 'macOS Intel x64: a distinct public package path exists and its CI leg runs per push and at release tags.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
+      { kind: 'workflow', ref: '.github/workflows/release-npm.yml' },
+      { kind: 'docs', ref: 'README.md' }
+    ]
+  },
+  {
+    id: 'B5',
+    lane: 'B',
+    claim: 'Real-hardware confirmation per platform: registry install, doctor, and a first session on end-user machines.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'runbook', ref: 'docs/reference/releasing.md' },
+      { kind: 'issue', ref: 'OpenCoven/coven#805' }
+    ],
+    ownerIssue: 805,
+    justification:
+      'GitHub-hosted runners prove the declared OS images; end-user hardware variation (OEM images, real HOME profiles, sandboxing) is an operator release step in the runbook and stays external to the per-PR CI lane by design.'
+  },
+  {
+    id: 'B6',
+    lane: 'B',
+    claim: 'Any additional architecture/platform beyond the declared support matrix.',
+    outcome: OUTCOMES.NOT_APPLICABLE,
+    evidence: [{ kind: 'docs', ref: 'README.md' }],
+    justification:
+      'The support contract claims macOS arm64/x64, glibc Linux x64, and Windows x64 only; Alpine and arm64 Linux are explicitly not support claims.'
+  },
+
+  // ---------------------------------------------------------------- Lane C
+  {
+    id: 'C1',
+    lane: 'C',
+    claim: 'A clean authentication/setup path is documented and exercised for every supported provider.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/setup_cli.rs' },
+      { kind: 'docs', ref: 'docs/reference/cli-setup.md' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/doctor_auth_boundary.rs' }
+    ]
+  },
+  {
+    id: 'C2',
+    lane: 'C',
+    claim:
+      'Launch, first output, input/continuation, termination, and final status work through the public interface.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' },
+      { kind: 'script', ref: 'scripts/fixtures/fake-codex.mjs' },
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/harness_parity.rs' }
+    ]
+  },
+  {
+    id: 'C3',
+    lane: 'C',
+    claim: 'Missing/expired/refused credentials fail closed with actionable normalized errors.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/doctor_auth_boundary.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/setup_cli.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/doctor_prose_contract.rs' }
+    ]
+  },
+  {
+    id: 'C4',
+    lane: 'C',
+    claim: 'Credentials never appear in event, log, or evidence output.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/src/privacy.rs' },
+      { kind: 'script', ref: 'scripts/check-coven-privacy.py' },
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/setup_cli.rs' }
+    ]
+  },
+  {
+    id: 'C5',
+    lane: 'C',
+    claim: 'Provider disappearance/timeout produces bounded state rather than indefinite ambiguity.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/process_supervisor.rs' },
+      { kind: 'script', ref: 'scripts/release-stress.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' }
+    ]
+  },
+  {
+    id: 'C6',
+    lane: 'C',
+    claim: 'Unsupported providers never become implicitly supported because an executable happens to exist on PATH.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/src/harness.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/harness_parity.rs' }
+    ]
+  },
+  {
+    id: 'C7',
+    lane: 'C',
+    claim: 'Real-credential certification per supported provider (verify-only packet with real turns).',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'script', ref: 'scripts/certify-release.sh' },
+      { kind: 'runbook', ref: 'docs/reference/releasing.md' },
+      { kind: 'issue', ref: 'OpenCoven/coven#805' }
+    ],
+    ownerIssue: 805,
+    justification:
+      'Real provider credentials, an interactive TTY with explicit network/cost consent, and real usage spend keep this an operator certification-packet step; the hermetic PR lane stays credential-free.'
+  },
+
+  // ---------------------------------------------------------------- Lane D
+  {
+    id: 'D1',
+    lane: 'D',
+    claim: 'Daemon restart preserves durable sessions and state, including the managed identity contract.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/windows_daemon_lifecycle.rs' }
+    ]
+  },
+  {
+    id: 'D2',
+    lane: 'D',
+    claim: 'Harness/process crash before and after first output reaches bounded terminal-or-unknown state.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [{ kind: 'test', ref: 'crates/coven-cli/tests/process_supervisor.rs' }],
+    ownerIssue: 807,
+    justification:
+      'Supervisor-level termination and stress cleanup are proven, but no hermetic test injects a harness crash in both the before-first-output and after-first-output windows and asserts the recorded disposition.'
+  },
+  {
+    id: 'D3',
+    lane: 'D',
+    claim: 'Client disconnect/reconnect and event-cursor continuation work.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-client/tests/health.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/src/api.rs' },
+      { kind: 'test', ref: 'crates/coven-client/src/lifecycle.rs' }
+    ]
+  },
+  {
+    id: 'D4',
+    lane: 'D',
+    claim:
+      'Endpoint/peer replacement honors the typed client safety contract and never auto-replays a consequential mutation merely because transport changed.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-client/src/error.rs' },
+      { kind: 'test', ref: 'crates/coven-client/src/lifecycle.rs' }
+    ],
+    ownerIssue: 807,
+    justification:
+      'The typed client and its version-mismatch errors exist, but no test pins the no-auto-replay rule for consequential mutations across a transport replacement.'
+  },
+  {
+    id: 'D5',
+    lane: 'D',
+    claim: 'Kill/cancel during active work reaches an authoritative terminal or explicit unknown/recovery state.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/process_supervisor.rs' },
+      { kind: 'script', ref: 'scripts/user-journey-e2e.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' }
+    ]
+  },
+  {
+    id: 'D6',
+    lane: 'D',
+    claim:
+      'Duplicate/retried requests use the operation idempotency/adoption semantics or are refused where the outcome is ambiguous.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [{ kind: 'test', ref: 'crates/coven-cli/tests/parallel_protocol.rs' }],
+    ownerIssue: 807,
+    justification:
+      'Concurrent request safety is exercised, but no test submits a duplicate consequential mutation and asserts adoption-or-refusal semantics.'
+  },
+  {
+    id: 'D7',
+    lane: 'D',
+    claim: 'Interrupted cleanup/orphan reconciliation is visible and deterministic.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [
+      { kind: 'script', ref: 'scripts/release-stress.mjs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' }
+    ],
+    ownerIssue: 807,
+    justification:
+      'Process-cleanup stress and journey daemon cleanup are proven, but no focused test reconciles an orphan left by an interrupted cleanup.'
+  },
+  {
+    id: 'D8',
+    lane: 'D',
+    claim: 'Corrupted state fails visibly and deterministically instead of silently succeeding.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [{ kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' }]
+  },
+  {
+    id: 'D9',
+    lane: 'D',
+    claim: 'Unwritable state fails visibly and preserves recoverable evidence.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [
+      { kind: 'issue', ref: 'OpenCoven/coven#807' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/smoke.rs' }
+    ],
+    ownerIssue: 807,
+    justification:
+      'No automated unwritable-state test exists; the gap is surfaced for the reliability scorecard program (#807).'
+  },
+
+  // ---------------------------------------------------------------- Lane E
+  {
+    id: 'E1',
+    lane: 'E',
+    claim: 'Event cursor continuation and paging semantics are exercised against the daemon contract.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-client/tests/health.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/src/api.rs' }
+    ]
+  },
+  {
+    id: 'E2',
+    lane: 'E',
+    claim: 'Event-writer pressure preserves lifecycle/tool/error/exit capacity according to contract.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/src/event_writer.rs' },
+      { kind: 'script', ref: 'scripts/release-stress.mjs' }
+    ]
+  },
+  {
+    id: 'E3',
+    lane: 'E',
+    claim: 'Raw output loss/truncation is explicit, bounded, and observable rather than silent.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [{ kind: 'test', ref: 'crates/coven-cli/src/api.rs' }]
+  },
+  {
+    id: 'E4',
+    lane: 'E',
+    claim: 'Oversized/malformed event/request bodies fail through structured errors.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/src/api.rs' },
+      { kind: 'docs', ref: 'docs/API-CONTRACT.md' }
+    ]
+  },
+  {
+    id: 'E5',
+    lane: 'E',
+    claim: 'Redaction remains applied to default persisted/returned evidence.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/src/privacy.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/tests/setup_cli.rs' },
+      { kind: 'script', ref: 'scripts/check-coven-privacy.py' }
+    ]
+  },
+  {
+    id: 'E6',
+    lane: 'E',
+    claim: 'Raw sensitive artifact opt-in remains separately protected/encrypted/retained according to current security policy.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/src/encrypted_artifacts.rs' },
+      { kind: 'issue', ref: 'OpenCoven/coven#808' }
+    ],
+    ownerIssue: 808,
+    justification:
+      'Encrypted artifact storage exists in code, but the security-policy consolidation (#808) must first declare the retention/encryption contract this row certifies against.'
+  },
+  {
+    id: 'E7',
+    lane: 'E',
+    claim:
+      'Evidence receipts contain digests/references and sanitized outcomes rather than prompts, credentials, or unrestricted terminal output.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'script', ref: 'scripts/certify-release.sh' },
+      { kind: 'runbook', ref: 'docs/reference/releasing.md' },
+      { kind: 'script', ref: 'scripts/check-coven-privacy.py' }
+    ]
+  },
+
+  // ---------------------------------------------------------------- Lane F
+  {
+    id: 'F1',
+    lane: 'F',
+    claim:
+      'AFS mount stays experimental/disabled until its dedicated gate passes; it cannot become supported through packaging drift.',
+    outcome: OUTCOMES.EXPERIMENTAL_DISABLED,
+    evidence: [
+      { kind: 'spec', ref: 'specs/coven-agent-fs/DESIGN.md' },
+      { kind: 'spec', ref: 'specs/coven-agent-fs/MOUNT-SPIKE.md' },
+      { kind: 'ci-job', ref: 'ci.yml#afs-mount-linux' },
+      { kind: 'ci-job', ref: 'ci.yml#afs-mount-macos' }
+    ],
+    justification:
+      'Mount is a cargo feature outside default builds and the spec scopes productionizing the mount spike out, so no mount capability is a current support claim.'
+  },
+  {
+    id: 'F2',
+    lane: 'F',
+    claim: 'Installed-artifact mount gate exercised per platform before any mount support claim.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'script', ref: 'scripts/afs-mount-e2e.sh' },
+      { kind: 'script', ref: 'scripts/afs-mount-smoke.sh' }
+    ],
+    ownerIssue: 805,
+    justification:
+      'The `--installed` gate is a manual post-release verification that needs a platform with local mount support; the v0.3.0 incident (published package omitted the mount helper) is why it must stay artifact-level and external to CI.'
+  },
+  {
+    id: 'F3',
+    lane: 'F',
+    claim:
+      'Pre-enablement gate (helper availability, credential observation, case-insensitive .git, handle reuse/gate-root enforcement, access-control boundaries, crash/restart/unmount recovery, concurrency, platform behavior, safe-disabled behavior) stays closed while the surface is experimental.',
+    outcome: OUTCOMES.EXPERIMENTAL_DISABLED,
+    evidence: [
+      { kind: 'spec', ref: 'specs/coven-agent-fs/DESIGN.md' },
+      { kind: 'script', ref: 'scripts/afs-mount-e2e.sh' }
+    ],
+    justification:
+      'The gate checklist is defined but unclaimed; the mount capability stays experimental/disabled and cannot become supported through packaging drift because it is a feature-gated cargo feature outside default builds.'
+  },
+
+  // ---------------------------------------------------------------- Lane G
+  {
+    id: 'G1',
+    lane: 'G',
+    claim: 'Direct/handoff target ingress-policy parity is proven before stronger cross-agent safety claims.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [{ kind: 'issue', ref: 'OpenCoven/coven#803' }],
+    ownerIssue: 803,
+    justification: '#803 owns target-ingress-policy parity; stronger cross-agent claims stay blocked behind it.'
+  },
+  {
+    id: 'G2',
+    lane: 'G',
+    claim: 'Local coven-agents behavior is certified as local/in-process semantics under the invocation/delegation contracts.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-agents/tests/runner.rs' },
+      { kind: 'test', ref: 'crates/coven-agents/tests/loop_runner.rs' },
+      { kind: 'issue', ref: 'OpenCoven/coven#804' }
+    ],
+    ownerIssue: 804,
+    justification:
+      'Local runner behavior is tested today, but certifying it now would pin a contract that #804 is migrating; the row follows that migration.'
+  },
+  {
+    id: 'G3',
+    lane: 'G',
+    claim: 'No certification row describes the legacy handoff pointer-swap as durable distributed A2A request/response.',
+    outcome: OUTCOMES.NOT_APPLICABLE,
+    evidence: [{ kind: 'spec', ref: 'specs/coven-handoff-packet/TECH.md' }],
+    justification:
+      'The legacy handoff remains a local pointer swap; no distributed A2A request/response claim exists in docs or specs to certify.'
+  },
+  {
+    id: 'G4',
+    lane: 'G',
+    claim:
+      'Local and Coven-backed executors share one conformance suite (authorization, stable invocation ID, events, timeout/cancel, ambiguous adoption, duplicate submission, interruption, cleanup, secret-free evidence).',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [{ kind: 'issue', ref: 'OpenCoven/coven#804' }],
+    ownerIssue: 804,
+    justification: 'The shared conformance suite is part of the #804 architecture migration.'
+  },
+  {
+    id: 'G5',
+    lane: 'G',
+    claim: 'Remote/multi-host placement reuses the existing hub and stays below agent-visible APIs.',
+    outcome: OUTCOMES.NOT_APPLICABLE,
+    evidence: [{ kind: 'spec', ref: 'specs/coven-multi-host-daemon/TECH.md' }],
+    justification: 'No remote/multi-host placement support claim exists; the hub-based design remains below agent-visible APIs.'
+  },
+
+  // ---------------------------------------------------------------- Lane H
+  {
+    id: 'H1',
+    lane: 'H',
+    claim: 'Named version/capability negotiation works on the exact candidate.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'docs', ref: 'docs/API-CONTRACT.md' },
+      { kind: 'test', ref: 'crates/coven-client/src/http.rs' },
+      { kind: 'test', ref: 'crates/coven-cli/src/api.rs' }
+    ]
+  },
+  {
+    id: 'H2',
+    lane: 'H',
+    claim: 'Published client/package fixtures match the actual daemon contract.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-client/tests/health.rs' },
+      { kind: 'script', ref: 'scripts/test-cli-prepublish.mjs' },
+      { kind: 'script', ref: 'scripts/publish-npm-test.mjs' }
+    ]
+  },
+  {
+    id: 'H3',
+    lane: 'H',
+    claim: 'Unsupported version/capability denial is structured and deterministic.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'docs', ref: 'docs/API-CONTRACT.md' },
+      { kind: 'test', ref: 'crates/coven-client/src/error.rs' }
+    ]
+  },
+  {
+    id: 'H4',
+    lane: 'H',
+    claim: 'Authentication/peer binding remains separate from capability advertisement.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [
+      { kind: 'docs', ref: 'docs/AUTH.md' },
+      { kind: 'docs', ref: 'docs/design/remote-listener-auth.md' }
+    ],
+    ownerIssue: 807,
+    justification:
+      'The separation is documented policy, but no hermetic test pins it on the running daemon; gap surfaced for the reliability scorecard program (#807).'
+  },
+  {
+    id: 'H5',
+    lane: 'H',
+    claim: 'Malformed/oversized/unauthorized mutation paths fail before effects.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/src/api.rs' },
+      { kind: 'docs', ref: 'docs/API-CONTRACT.md' }
+    ]
+  },
+  {
+    id: 'H6',
+    lane: 'H',
+    claim: 'Package consumers never rely on unpublished repository internals.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'package', ref: 'npm/coven/package.json' },
+      { kind: 'script', ref: 'scripts/test-cli-prepublish.mjs' },
+      { kind: 'script', ref: 'scripts/publish-npm-test.mjs' }
+    ]
+  },
+
+  // ---------------------------------------------------------------- Lane I
+  {
+    id: 'I1',
+    lane: 'I',
+    claim: 'Canonical docs build and link checks pass in repository and deployed-site contexts.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'issue', ref: 'OpenCoven/coven#778' },
+      { kind: 'docs', ref: 'docs/DOCS-MAINTENANCE.md' }
+    ],
+    ownerIssue: 778,
+    justification: 'Docs build/link/browser-journey tooling is owned by #778, which is still open.'
+  },
+  {
+    id: 'I2',
+    lane: 'I',
+    claim: 'Browser journey from install/discovery through first session/recovery uses the shipped commands/contracts.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [{ kind: 'issue', ref: 'OpenCoven/coven#778' }],
+    ownerIssue: 778,
+    justification: 'The deployed-site browser journey is #778 scope.'
+  },
+  {
+    id: 'I3',
+    lane: 'I',
+    claim: 'Duplicate local public docs are removed or explicitly source-adjacent.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [{ kind: 'docs', ref: 'docs/DOCS-MAINTENANCE.md' }],
+    ownerIssue: 778,
+    justification:
+      'The ownership rules are normative, but no automated duplicate-docs check runs; #778 owns the docs tooling that would enforce it.'
+  },
+  {
+    id: 'I4',
+    lane: 'I',
+    claim: 'Help contract remains complete while default help is progressively disclosed.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'test', ref: 'crates/coven-cli/tests/help_disclosure.rs' },
+      { kind: 'script', ref: 'scripts/export-cli-help-contract.mjs' },
+      { kind: 'script', ref: 'scripts/cli-docs-test.mjs' }
+    ]
+  },
+  {
+    id: 'I5',
+    lane: 'I',
+    claim: 'Security/support text matches the security-policy truth and current capability state.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'issue', ref: 'OpenCoven/coven#808' },
+      { kind: 'docs', ref: 'docs/SAFETY-MODEL.md' }
+    ],
+    ownerIssue: 808,
+    justification: '#808 consolidates security-policy truth; this row certifies text against that outcome.'
+  },
+  {
+    id: 'I6',
+    lane: 'I',
+    claim: 'No stale product/version/support claim survives after a certification state changes.',
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
+    evidence: [{ kind: 'docs', ref: 'docs/DOCS-MAINTENANCE.md' }],
+    ownerIssue: 778,
+    justification:
+      'The stale-content rule is documented, but no check binds support-claim text to the certification state recorded here; #778 owns the docs tooling.'
+  },
+
+  // ---------------------------------------------------------------- Lane J
+  {
+    id: 'J1',
+    lane: 'J',
+    claim: 'Exact release/tag target has every required check success.',
+    outcome: OUTCOMES.NOT_APPLICABLE,
+    evidence: [
+      { kind: 'workflow', ref: '.github/workflows/release-npm.yml' },
+      { kind: 'workflow', ref: '.github/workflows/release-github.yml' }
+    ],
+    justification: 'No release tag is in flight for this candidate; the release gates run on the exact tag commit when a signed tag is pushed.'
+  },
+  {
+    id: 'J2',
+    lane: 'J',
+    claim: 'Branch/ruleset/review protection evidence includes administrators.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [{ kind: 'issue', ref: 'OpenCoven/coven#805' }],
+    ownerIssue: 805,
+    justification: 'Protection-scope evidence including administrators needs admin-surface attestation outside this token\'s measured permissions.'
+  },
+  {
+    id: 'J3',
+    lane: 'J',
+    claim: 'Signed tag/trusted signer/provenance/SBOM or declared dependency receipt passes.',
+    outcome: OUTCOMES.NOT_APPLICABLE,
+    evidence: [
+      { kind: 'workflow', ref: '.github/workflows/release-npm.yml' },
+      { kind: 'workflow', ref: '.github/workflows/release-github.yml' },
+      { kind: 'runbook', ref: 'docs/reference/releasing.md' }
+    ],
+    justification: 'Proven per release by the signed-tag verification, OIDC provenance, and signature-audit preflight; no tag is in flight for this candidate.'
+  },
+  {
+    id: 'J4',
+    lane: 'J',
+    claim: 'Generated/version state is coherent and clean.',
+    outcome: OUTCOMES.REQUIRED_PASSED,
+    evidence: [
+      { kind: 'script', ref: 'scripts/publish-npm.mjs' },
+      { kind: 'script', ref: 'scripts/publish-npm-test.mjs' },
+      { kind: 'script', ref: 'scripts/package-github-release-test.mjs' }
+    ]
+  },
+  {
+    id: 'J5',
+    lane: 'J',
+    claim: 'Release channels agree on public version/support state.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'issue', ref: 'OpenCoven/coven#805' },
+      { kind: 'runbook', ref: 'docs/reference/releasing.md' }
+    ],
+    ownerIssue: 805,
+    justification: 'Channel agreement is a release-time attestation owned by #805.'
+  },
+  {
+    id: 'J6',
+    lane: 'J',
+    claim: 'Artifact/package digests used by E2E match the published artifacts.',
+    outcome: OUTCOMES.NOT_APPLICABLE,
+    evidence: [
+      { kind: 'runbook', ref: 'docs/reference/releasing.md' },
+      { kind: 'workflow', ref: '.github/workflows/release-github.yml' }
+    ],
+    justification: 'No published artifact exists for this untagged candidate; the SHA256SUMS surface plus fresh-install verification binds digests at release.'
+  },
+  {
+    id: 'J7',
+    lane: 'J',
+    claim: 'Mutation tests prove failed/missing checks, tag mismatch, signer failure, or security-disabled surfaces fail closed.',
+    outcome: OUTCOMES.DEFERRED,
+    evidence: [
+      { kind: 'workflow', ref: '.github/workflows/release-github.yml' },
+      { kind: 'script', ref: 'scripts/release-stress.mjs' }
+    ],
+    ownerIssue: 805,
+    justification: 'The release workflows fail closed by design; adversarial mutation-test evidence is #805 scope.'
+  },
+
+  // ---------------------------------------------------------------- Lane K
+  {
+    id: 'K1',
+    lane: 'K',
+    claim:
+      'Device-bound/QR/reconnection/recovery capabilities stay outside shipped certification until they become support claims.',
+    outcome: OUTCOMES.NOT_APPLICABLE,
+    evidence: [
+      { kind: 'issue', ref: 'OpenCoven/coven#785' },
+      { kind: 'spec', ref: 'spec/device-pairing/v1/README.md' },
+      { kind: 'docs', ref: 'docs/design/mobile-pairing-protocol-v2.md' }
+    ],
+    justification:
+      'No device/QR/biometric capability is a current support claim. Promotion requires cryptographic peer/device identity with scoped grants, QR replay/expiry/refusal coverage, biometric/passkey semantics where claimed, discovery/relay fallback without widened authority, device revocation/recovery/rotation, and cross-device continuity that preserves familiar/session authority.'
+  }
+];
+
+// Human-readable labels used in docs/reference/certification.md tables. The
+// parity test in certification-receipt-test.mjs keeps these in lockstep.
+export const OUTCOME_LABELS = {
+  'required-passed': 'required / passed',
+  'required-failed': 'required / failed',
+  'required-unknown': 'required / unknown (open blocker)',
+  'not-applicable': 'not applicable',
+  'experimental-disabled': 'experimental / disabled',
+  deferred: 'deferred'
+};
+
+function laneTitle(laneId) {
+  const lane = LANES.find((entry) => entry.id === laneId);
+  if (!lane) {
+    throw new Error(`matrix row references unknown lane ${laneId}`);
+  }
+  return lane.title;
+}
+
+export function laneOf(laneId) {
+  return LANES.find((entry) => entry.id === laneId) ?? null;
+}
+
+// Structural validation of the matrix itself. Returns a list of problems; an
+// empty list means the matrix is internally consistent and every
+// non-terminal row is accountable (owner issue and/or justification where the
+// outcome demands one).
+export function validateMatrix(rows = CERTIFICATION_MATRIX) {
+  const errors = [];
+  const seen = new Set();
+  const laneIds = new Set(LANES.map((lane) => lane.id));
+
+  for (const row of rows) {
+    const where = `row ${row.id ?? '<missing id>'}`;
+    if (!/^[A-K]\d+$/.test(row.id ?? '')) {
+      errors.push(`${where}: id must look like <lane letter><digits>`);
+      continue;
+    }
+    if (seen.has(row.id)) {
+      errors.push(`${where}: duplicate id`);
+    }
+    seen.add(row.id);
+    if (!laneIds.has(row.lane)) {
+      errors.push(`${where}: lane '${row.lane}' is not declared`);
+    }
+    if (!ALL_OUTCOMES.has(row.outcome)) {
+      errors.push(`${where}: unknown outcome '${row.outcome}'`);
+    }
+    if (!row.claim || row.claim.length < 16) {
+      errors.push(`${where}: claim is missing or too short to be a certification row`);
+    }
+    if (!Array.isArray(row.evidence) || row.evidence.length === 0) {
+      errors.push(`${where}: every row needs at least one evidence reference`);
+    }
+    if (row.outcome === OUTCOMES.DEFERRED && !row.ownerIssue) {
+      errors.push(`${where}: deferred rows must name an owner issue`);
+    }
+    if (
+      (row.outcome === OUTCOMES.NOT_APPLICABLE ||
+        row.outcome === OUTCOMES.EXPERIMENTAL_DISABLED ||
+        row.outcome === OUTCOMES.REQUIRED_UNKNOWN ||
+        row.outcome === OUTCOMES.REQUIRED_FAILED) &&
+      !row.justification
+    ) {
+      errors.push(`${where}: outcome '${row.outcome}' requires a justification`);
+    }
+    for (const ref of row.evidence ?? []) {
+      if (!EVIDENCE_KINDS[ref.kind]) {
+        errors.push(`${where}: evidence kind '${ref.kind}' is not defined`);
+      }
+      if (!ref.ref) {
+        errors.push(`${where}: evidence entry is missing ref`);
+      }
+    }
+  }
+  return errors;
+}
+
+// The certification rule from the issue, executable: skipped/unknown are not
+// terminal outcomes for a required row, and a proven-failed required row is a
+// release blocker. Returns the open blockers for the current matrix.
+export function certificationBlockers(rows = CERTIFICATION_MATRIX) {
+  return rows
+    .filter(
+      (row) => row.outcome === OUTCOMES.REQUIRED_FAILED || row.outcome === OUTCOMES.REQUIRED_UNKNOWN
+    )
+    .map((row) => ({
+      id: row.id,
+      lane: row.lane,
+      reason:
+        row.outcome === OUTCOMES.REQUIRED_FAILED
+          ? `required row proven failed: ${row.justification ?? row.claim}`
+          : `required row has an explicit unknown disposition: ${
+              row.justification ?? 'no justification recorded'
+            }`,
+      ownerIssue: row.ownerIssue ?? null
+    }));
+}
+
+export function matrixSummary(rows = CERTIFICATION_MATRIX) {
+  const summary = {
+    requiredPassed: 0,
+    requiredFailed: 0,
+    requiredUnknown: 0,
+    notApplicable: 0,
+    experimentalDisabled: 0,
+    deferred: 0,
+    total: rows.length
+  };
+  for (const row of rows) {
+    if (row.outcome === OUTCOMES.REQUIRED_PASSED) summary.requiredPassed += 1;
+    else if (row.outcome === OUTCOMES.REQUIRED_FAILED) summary.requiredFailed += 1;
+    else if (row.outcome === OUTCOMES.REQUIRED_UNKNOWN) summary.requiredUnknown += 1;
+    else if (row.outcome === OUTCOMES.NOT_APPLICABLE) summary.notApplicable += 1;
+    else if (row.outcome === OUTCOMES.EXPERIMENTAL_DISABLED) summary.experimentalDisabled += 1;
+    else if (row.outcome === OUTCOMES.DEFERRED) summary.deferred += 1;
+  }
+  return summary;
+}
+
+export function receiptLanes(rows = CERTIFICATION_MATRIX) {
+  return LANES.map((lane) => ({
+    id: lane.id,
+    title: lane.title,
+    ownerIssue: lane.ownerIssue ?? null,
+    rows: rows
+      .filter((row) => row.lane === lane.id)
+      .map((row) => ({ ...row, laneTitle: laneTitle(row.lane) }))
+  }));
+}

--- a/scripts/certification-matrix.mjs
+++ b/scripts/certification-matrix.mjs
@@ -303,27 +303,35 @@ export const CERTIFICATION_MATRIX = [
   {
     id: 'B3',
     lane: 'B',
-    claim: 'macOS Apple Silicon: Rust suite, packaged onboarding, and AFS-mount legs run per push and at release tags.',
+    claim:
+      'macOS Apple Silicon: Rust suite, packaged onboarding, and AFS-mount legs run per push to main; tag-built macOS packages are never exercised on a macOS runner.',
     platforms: ['macos-arm64'],
-    outcome: OUTCOMES.REQUIRED_PASSED,
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
     evidence: [
       { kind: 'ci-job', ref: 'ci.yml#rust-test-macos' },
       { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
       { kind: 'ci-job', ref: 'ci.yml#afs-mount-macos' },
       { kind: 'workflow', ref: '.github/workflows/release-npm.yml' }
-    ]
+    ],
+    ownerIssue: 805,
+    justification:
+      'Per-push macOS coverage is real (rust-test-macos, npm-onboarding-main, and afs-mount-macos run on macos-26), but the release workflow builds the tag-built macOS packages on macOS runners and only dry-runs them on ubuntu-latest: no macOS runner executes the packaged onboarding at tag time. The support inventory records releaseOnboardingRunner: null for both macOS platforms, so this row claims per-push coverage only and stays unknown until a tag-built macOS onboarding leg exists.'
   },
   {
     id: 'B4',
     lane: 'B',
-    claim: 'macOS Intel x64: a distinct public package path exists and its CI leg runs per push and at release tags.',
+    claim:
+      'macOS Intel x64: a distinct public package path exists and its CI leg runs per push to main; the tag-built Intel package is never exercised on a macOS runner.',
     platforms: ['macos-x64'],
-    outcome: OUTCOMES.REQUIRED_PASSED,
+    outcome: OUTCOMES.REQUIRED_UNKNOWN,
     evidence: [
       { kind: 'ci-job', ref: 'ci.yml#npm-onboarding-main' },
       { kind: 'workflow', ref: '.github/workflows/release-npm.yml' },
       { kind: 'docs', ref: 'README.md' }
-    ]
+    ],
+    ownerIssue: 805,
+    justification:
+      'npm-onboarding-main runs the Intel package leg on macos-15-intel per push, but the release workflow only dry-runs the tag-built Intel package on ubuntu-latest; release-time coverage is unknown until a matching-runner release onboarding leg exists.'
   },
   {
     id: 'B5',

--- a/scripts/certification-receipt-test.mjs
+++ b/scripts/certification-receipt-test.mjs
@@ -12,10 +12,17 @@ import {
   LANES,
   OUTCOMES,
   OUTCOME_LABELS,
+  RELEASE_TAG_CHANNEL,
+  SOURCE_CHECKOUT_CHANNEL,
+  SUPPORT_INVENTORY,
   SUPPORT_MATRIX_VERSION,
   TERMINAL_OUTCOMES,
   certificationBlockers,
+  goNoGo,
   matrixSummary,
+  pendingRows,
+  resolveApplicability,
+  resolveCandidateContext,
   validateMatrix
 } from './certification-matrix.mjs';
 import { buildReceipt, parseArgs, resolveCandidate } from './certification-receipt.mjs';
@@ -284,5 +291,149 @@ test('strict cli exits nonzero while the matrix carries open blockers', () => {
     assert.match(result.stderr, /open blocker/);
   } else {
     assert.equal(result.status, 0);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Applicability, the support inventory, and the go/no-go verdict.
+
+test('candidate contexts are validated against the support inventory', () => {
+  assert.deepEqual(resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL }), {
+    channel: SOURCE_CHECKOUT_CHANNEL,
+    tag: null
+  });
+  const tagged = resolveCandidateContext({ channel: RELEASE_TAG_CHANNEL, tag: 'v1.2.3' });
+  assert.equal(tagged.channel, RELEASE_TAG_CHANNEL);
+  assert.equal(tagged.tag, 'v1.2.3');
+
+  assert.throws(() => resolveCandidateContext({ channel: 'vibes' }), /unknown certification channel/);
+  assert.throws(
+    () => resolveCandidateContext({ channel: RELEASE_TAG_CHANNEL, tag: 'not-a-version' }),
+    /release-tag candidates require a tag/
+  );
+  assert.throws(
+    () => resolveCandidateContext({ channel: RELEASE_TAG_CHANNEL }),
+    /release-tag candidates require a tag/
+  );
+  assert.throws(
+    () => resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL, tag: 'v1.2.3' }),
+    /must not carry a release tag/
+  );
+});
+
+test('release-only rows are derived applicable from the candidate channel/tag, not statically frozen', () => {
+  const sourceContext = resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL });
+  const releaseContext = resolveCandidateContext({ channel: RELEASE_TAG_CHANNEL, tag: 'v9.9.9' });
+
+  for (const rowId of ['J1', 'J3', 'J6']) {
+    const row = CERTIFICATION_MATRIX.find((candidate) => candidate.id === rowId);
+    assert.deepEqual(
+      resolveApplicability(row, sourceContext),
+      { applicable: false, basis: 'channel-not-in-applicableWhen' },
+      `${rowId} must not apply to a source checkout`
+    );
+    assert.equal(
+      resolveApplicability(row, releaseContext).applicable,
+      true,
+      `${rowId} must apply to a tagged release candidate`
+    );
+  }
+});
+
+test('deferred rows cannot vanish from the release go/no-go', () => {
+  const sourceContext = resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL });
+  const releaseContext = resolveCandidateContext({ channel: RELEASE_TAG_CHANNEL, tag: 'v9.9.9' });
+
+  const deferredIds = CERTIFICATION_MATRIX.filter((row) => row.outcome === OUTCOMES.DEFERRED).map(
+    (row) => row.id
+  );
+  assert.ok(deferredIds.length > 0, 'the matrix must carry deferred rows for this test to mean anything');
+
+  // Source channel: deferred rows are pending, owned, and not blockers.
+  const sourceBlockers = certificationBlockers(CERTIFICATION_MATRIX, sourceContext);
+  const sourcePending = pendingRows(CERTIFICATION_MATRIX, sourceContext);
+  for (const id of deferredIds) {
+    assert.ok(!sourceBlockers.some((blocker) => blocker.id === id), `${id} must not block a source checkout`);
+    assert.ok(sourcePending.some((row) => row.id === id), `${id} must stay visible as pending`);
+    assert.ok(sourcePending.find((row) => row.id === id).ownerIssue, `${id} must name its owner issue`);
+  }
+
+  // Release channel: every deferred row becomes an explicit blocker.
+  const releaseBlockers = certificationBlockers(CERTIFICATION_MATRIX, releaseContext);
+  for (const id of deferredIds) {
+    const blocker = releaseBlockers.find((entry) => entry.id === id);
+    assert.ok(blocker, `${id} must block a tagged release`);
+    assert.match(blocker.reason, /deferred requirement/);
+    assert.ok(blocker.ownerIssue, `${id} blocker must carry its owner issue`);
+  }
+  assert.equal(pendingRows(CERTIFICATION_MATRIX, releaseContext).length, 0);
+});
+
+test('statically not-applicable release rows become blockers once a tag is in flight', () => {
+  const releaseContext = resolveCandidateContext({ channel: RELEASE_TAG_CHANNEL, tag: 'v9.9.9' });
+  const blockers = certificationBlockers(CERTIFICATION_MATRIX, releaseContext);
+  for (const rowId of ['J1', 'J3', 'J6']) {
+    const blocker = blockers.find((entry) => entry.id === rowId);
+    assert.ok(blocker, `${rowId} must block a tagged release while it carries no evidence binding`);
+    assert.match(blocker.reason, /became applicable/);
+  }
+  const sourceBlockers = certificationBlockers(CERTIFICATION_MATRIX);
+  for (const rowId of ['J1', 'J3', 'J6']) {
+    assert.ok(!sourceBlockers.some((entry) => entry.id === rowId));
+  }
+});
+
+test('go/no-go verdict requires zero blockers, no pending release rows, and an approved reviewer decision', () => {
+  const sourceContext = resolveCandidateContext({ channel: SOURCE_CHECKOUT_CHANNEL });
+  assert.equal(goNoGo(CERTIFICATION_MATRIX, sourceContext).verdict, 'no-go');
+  assert.ok(goNoGo(CERTIFICATION_MATRIX, sourceContext).blockers.length > 0);
+
+  // A synthetic fully-passed matrix still cannot self-certify a release: the
+  // reviewer decision is missing.
+  const cleanMatrix = [
+    {
+      id: 'A1',
+      lane: 'A',
+      claim: 'synthetic clean row used to exercise the go/no-go verdict',
+      outcome: OUTCOMES.REQUIRED_PASSED,
+      evidence: [{ kind: 'issue', ref: 'OpenCoven/coven#805' }]
+    }
+  ];
+  const releaseContext = resolveCandidateContext({ channel: RELEASE_TAG_CHANNEL, tag: 'v9.9.9' });
+  assert.equal(
+    goNoGo(cleanMatrix, releaseContext, { reviewerDecision: null }).verdict,
+    'no-go',
+    'a release without an approved reviewer decision must be no-go'
+  );
+  assert.equal(
+    goNoGo(cleanMatrix, releaseContext, { reviewerDecision: 'approved' }).verdict,
+    'go'
+  );
+  assert.equal(goNoGo(cleanMatrix, sourceContext, { reviewerDecision: null }).verdict, 'go');
+});
+
+test('support inventory and row platform coverage form a bijection', () => {
+  const platformIds = SUPPORT_INVENTORY.platforms.map((platform) => platform.id);
+  assert.equal(new Set(platformIds).size, platformIds.length, 'platform ids must be unique');
+  assert.ok(SUPPORT_INVENTORY.platforms.length > 0);
+
+  const covered = new Set();
+  for (const row of CERTIFICATION_MATRIX) {
+    if (row.platforms === undefined) {
+      continue;
+    }
+    for (const platform of row.platforms) {
+      assert.ok(
+        platformIds.includes(platform),
+        `row ${row.id} claims platform ${platform} which the support inventory does not declare`
+      );
+      covered.add(platform);
+    }
+  }
+  for (const platform of platformIds) {
+    assert.ok(
+      covered.has(platform),
+      `support inventory platform ${platform} is not covered by any certification row`
+    );
   }
 });

--- a/scripts/certification-receipt-test.mjs
+++ b/scripts/certification-receipt-test.mjs
@@ -437,3 +437,38 @@ test('support inventory and row platform coverage form a bijection', () => {
     );
   }
 });
+
+test('rows never claim release coverage a runner does not provide', () => {
+  const platformById = new Map(SUPPORT_INVENTORY.platforms.map((platform) => [platform.id, platform]));
+  for (const row of CERTIFICATION_MATRIX) {
+    if (row.platforms === undefined) {
+      continue;
+    }
+    const claimsReleaseCoverage = /at release tags?|release-time coverage|tag-built/i.test(row.claim);
+    const claimedUnknown = row.outcome === OUTCOMES.REQUIRED_UNKNOWN;
+    for (const platformId of row.platforms) {
+      const platform = platformById.get(platformId);
+      assert.ok(platform.releaseBuildRunner, `row ${row.id}: ${platformId} has no release build runner`);
+      if (platform.releaseOnboardingRunner === null && claimsReleaseCoverage && !claimedUnknown) {
+        assert.fail(
+          `row ${row.id} claims release coverage for ${platformId} but the inventory has no release onboarding leg for it (${platform.releaseBuildRunner} builds, nobody verifies)`
+        );
+      }
+      if (platform.releaseOnboardingRunner === null && claimedUnknown) {
+        assert.ok(
+          /releaseOnboardingRunner: null|dry-runs them on ubuntu-latest|dry-run/.test(row.justification),
+          `row ${row.id} must explain that ${platformId} has no release onboarding leg`
+        );
+      }
+    }
+  }
+
+  // The macOS rows are the review finding: they must be explicit unknowns
+  // owned by release authorization until matching-runner release legs exist.
+  for (const rowId of ['B3', 'B4']) {
+    const row = CERTIFICATION_MATRIX.find((candidate) => candidate.id === rowId);
+    assert.equal(row.outcome, OUTCOMES.REQUIRED_UNKNOWN, `${rowId} must stay an explicit unknown`);
+    assert.equal(row.ownerIssue, 805, `${rowId} must be owned by release authorization`);
+    assert.match(row.justification, /dry-runs them on ubuntu-latest|dry-runs the tag-built/);
+  }
+});

--- a/scripts/certification-receipt-test.mjs
+++ b/scripts/certification-receipt-test.mjs
@@ -1,0 +1,288 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  ALL_OUTCOMES,
+  CERTIFICATION_MATRIX,
+  EVIDENCE_KINDS,
+  LANES,
+  OUTCOMES,
+  OUTCOME_LABELS,
+  SUPPORT_MATRIX_VERSION,
+  TERMINAL_OUTCOMES,
+  certificationBlockers,
+  matrixSummary,
+  validateMatrix
+} from './certification-matrix.mjs';
+import { buildReceipt, parseArgs, resolveCandidate } from './certification-receipt.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const CI_WORKFLOW = readFileSync(path.join(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+
+function evidenceRepoPath(entry) {
+  return entry.ref.split('#')[0];
+}
+
+function ciJobExists(jobName) {
+  return CI_WORKFLOW.includes(`\n  ${jobName}:\n`);
+}
+
+test('certification matrix is internally consistent', () => {
+  assert.deepEqual(validateMatrix(), []);
+});
+
+test('every declared lane carries at least one certification row', () => {
+  for (const lane of LANES) {
+    const rows = CERTIFICATION_MATRIX.filter((row) => row.lane === lane.id);
+    assert.ok(rows.length > 0, `lane ${lane.id} (${lane.title}) has no rows`);
+  }
+});
+
+test('every row only cites evidence kinds that resolve', () => {
+  for (const row of CERTIFICATION_MATRIX) {
+    assert.ok(row.evidence.length > 0, `row ${row.id} has no evidence`);
+    for (const entry of row.evidence) {
+      assert.ok(EVIDENCE_KINDS[entry.kind], `row ${row.id} cites unknown evidence kind ${entry.kind}`);
+      if (entry.kind === 'issue') {
+        assert.match(entry.ref, /^OpenCoven\/coven#\d+$/, `row ${row.id} cites a malformed issue ref`);
+      } else if (entry.kind === 'ci-job') {
+        const [workflow, jobName] = entry.ref.split('#');
+        assert.equal(workflow, 'ci.yml', `row ${row.id} cites a ci-job outside ci.yml`);
+        assert.ok(ciJobExists(jobName), `row ${row.id} cites ci job ${jobName} which is not defined in ci.yml`);
+      } else {
+        const repoPath = evidenceRepoPath(entry);
+        assert.ok(
+          existsSync(path.join(repoRoot, repoPath)),
+          `row ${row.id} cites evidence ${repoPath} which does not exist in the repo`
+        );
+      }
+    }
+  }
+});
+
+test('non-terminal rows are accountable: owner issue and justification', () => {
+  for (const row of CERTIFICATION_MATRIX) {
+    if (!TERMINAL_OUTCOMES.has(row.outcome)) {
+      assert.ok(row.ownerIssue, `row ${row.id} is non-terminal without an owner issue`);
+      assert.ok(row.justification, `row ${row.id} is non-terminal without a justification`);
+    }
+    if (row.outcome === OUTCOMES.DEFERRED) {
+      assert.ok(row.ownerIssue, `deferred row ${row.id} must name its owner issue`);
+    }
+  }
+});
+
+test('the certification rule is executable: unknown and failed required rows are blockers', () => {
+  const unknownRows = CERTIFICATION_MATRIX.filter((row) => row.outcome === OUTCOMES.REQUIRED_UNKNOWN);
+  const failedRows = CERTIFICATION_MATRIX.filter((row) => row.outcome === OUTCOMES.REQUIRED_FAILED);
+  const blockers = certificationBlockers();
+  assert.equal(
+    blockers.length,
+    unknownRows.length + failedRows.length,
+    'blockers must be exactly the unknown/failed required rows'
+  );
+  for (const row of unknownRows) {
+    assert.ok(
+      blockers.some((blocker) => blocker.id === row.id && blocker.reason.includes('unknown disposition')),
+      `row ${row.id} should be an explicit unknown blocker`
+    );
+  }
+});
+
+test('outcome vocabulary never includes skipped', () => {
+  for (const outcome of ALL_OUTCOMES) {
+    assert.ok(!/skip/i.test(outcome), `'${outcome}' must not be a skipped-shaped outcome`);
+  }
+  assert.ok(!OUTCOME_LABELS.deferred.match(/skip/i));
+});
+
+test('docs/reference/certification.md stays in lockstep with the matrix', () => {
+  const docsPath = path.join(repoRoot, 'docs/reference/certification.md');
+  assert.ok(existsSync(docsPath), 'docs/reference/certification.md must exist');
+  const docsText = readFileSync(docsPath, 'utf8');
+
+  const labelPattern = Object.values(OUTCOME_LABELS)
+    .map((label) => label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+  const rowPattern = new RegExp(`^\\| ([A-K]\\d+) \\|.*\\| (${labelPattern}) \\|`, 'gm');
+
+  const docRows = new Map();
+  for (const match of docsText.matchAll(rowPattern)) {
+    assert.ok(!docRows.has(match[1]), `docs table repeats row ${match[1]}`);
+    docRows.set(match[1], match[2]);
+  }
+
+  const matrixRows = new Map(
+    CERTIFICATION_MATRIX.map((row) => [row.id, OUTCOME_LABELS[row.outcome]])
+  );
+  assert.equal(
+    docRows.size,
+    matrixRows.size,
+    `docs table has ${docRows.size} rows but the matrix has ${matrixRows.size}`
+  );
+  for (const [id, label] of matrixRows) {
+    assert.ok(docRows.has(id), `docs table is missing row ${id}`);
+    assert.equal(docRows.get(id), label, `docs table outcome for ${id} drifted from the matrix`);
+  }
+
+  assert.ok(
+    docsText.includes(String(SUPPORT_MATRIX_VERSION)),
+    'docs must state the support-matrix version'
+  );
+  assert.ok(
+    docsText.includes('scripts/certification-receipt.mjs'),
+    'docs must point at the receipt generator'
+  );
+});
+
+test('ci.yml runs the certification receipt test suite in the policy guard', () => {
+  assert.ok(
+    CI_WORKFLOW.includes('node --test scripts/certification-receipt-test.mjs'),
+    'policy-guard must run scripts/certification-receipt-test.mjs so the matrix cannot drift silently'
+  );
+});
+
+test('receipt is deterministic, keyless, and structurally complete', () => {
+  const pinnedCandidate = {
+    sourceCommit: '0'.repeat(40),
+    sourceTreeDigest: '1'.repeat(40),
+    tag: null,
+    channel: 'source-checkout'
+  };
+  const first = buildReceipt({ candidate: pinnedCandidate });
+  const second = buildReceipt({ candidate: pinnedCandidate });
+  assert.equal(JSON.stringify(first), JSON.stringify(second), 'receipt must be deterministic');
+
+  assert.equal(first.receiptVersion, 1);
+  assert.equal(typeof first.supportMatrixVersion, 'string');
+  assert.equal(first.reviewerDecision, null, 'the receipt never self-certifies');
+
+  const laneIds = first.lanes.map((lane) => lane.id);
+  assert.deepEqual(laneIds, LANES.map((lane) => lane.id));
+
+  const receiptRows = first.lanes.flatMap((lane) => lane.rows);
+  assert.equal(receiptRows.length, CERTIFICATION_MATRIX.length);
+  for (const row of receiptRows) {
+    assert.ok(ALL_OUTCOMES.has(row.outcome), `receipt row ${row.id} has an out-of-vocabulary outcome`);
+    assert.ok('evidence' in row && 'claim' in row);
+  }
+
+  assert.equal(first.summary.total, CERTIFICATION_MATRIX.length);
+  assert.equal(
+    first.summary.requiredPassed +
+      first.summary.requiredFailed +
+      first.summary.requiredUnknown +
+      first.summary.notApplicable +
+      first.summary.experimentalDisabled +
+      first.summary.deferred,
+    first.summary.total,
+    'summary must partition every row exactly once'
+  );
+
+  const serialized = JSON.stringify(first);
+  assert.doesNotMatch(serialized, /"token"|"password"|"secret"|"credential"/i);
+  assert.match(first.candidate.sourceCommit, /^[0-9a-f]{40}$/);
+  assert.match(first.candidate.sourceTreeDigest, /^[0-9a-f]{40}$/);
+});
+
+test('receipt fail-closed: unknown and failed required rows become blockers', () => {
+  const base = {
+    id: 'A1',
+    lane: 'A',
+    claim: 'synthetic row used to exercise blocker accounting',
+    evidence: [{ kind: 'issue', ref: 'OpenCoven/coven#807' }]
+  };
+  const syntheticUnknown = buildReceipt({
+    matrix: [{ ...base, outcome: OUTCOMES.REQUIRED_UNKNOWN, ownerIssue: 807, justification: 'unknown' }],
+    candidate: { sourceCommit: '0'.repeat(40), sourceTreeDigest: '1'.repeat(40), tag: null, channel: 'source-checkout' }
+  });
+  assert.equal(syntheticUnknown.releaseBlockers.length, 1);
+  assert.equal(syntheticUnknown.summary.requiredUnknown, 1);
+
+  const syntheticFailed = buildReceipt({
+    matrix: [{ ...base, outcome: OUTCOMES.REQUIRED_FAILED, justification: 'proven broken' }],
+    candidate: { sourceCommit: '0'.repeat(40), sourceTreeDigest: '1'.repeat(40), tag: null, channel: 'source-checkout' }
+  });
+  assert.equal(syntheticFailed.releaseBlockers.length, 1);
+  assert.match(syntheticFailed.releaseBlockers[0].reason, /proven failed/);
+});
+
+test('receipt generation refuses an inconsistent matrix', () => {
+  assert.throws(
+    () =>
+      buildReceipt({
+        matrix: [
+          {
+            id: 'nope',
+            lane: 'A',
+            claim: 'this id is malformed on purpose',
+            outcome: OUTCOMES.REQUIRED_PASSED,
+            evidence: [{ kind: 'issue', ref: 'OpenCoven/coven#807' }]
+          }
+        ]
+      }),
+    /internally inconsistent/
+  );
+});
+
+test('resolveCandidate trims git output and survives a missing repo', () => {
+  const trimmed = resolveCandidate({ execFile: () => 'abc123def\n' });
+  assert.equal(trimmed.sourceCommit, 'abc123def');
+  assert.equal(trimmed.sourceTreeDigest, 'abc123def');
+
+  const missing = resolveCandidate({
+    execFile: () => {
+      throw new Error('not a repository');
+    }
+  });
+  assert.equal(missing.sourceCommit, null);
+  assert.equal(missing.sourceTreeDigest, null);
+
+  const pinned = resolveCandidate({
+    sourceCommit: 'f'.repeat(40),
+    execFile: () => '0'.repeat(40)
+  });
+  assert.equal(pinned.sourceCommit, 'f'.repeat(40));
+});
+
+test('resolveCandidate reads the real checkout when unpinned', () => {
+  const candidate = resolveCandidate();
+  assert.match(candidate.sourceCommit ?? '', /^[0-9a-f]{40}$/);
+  assert.match(candidate.sourceTreeDigest ?? '', /^[0-9a-f]{40}$/);
+});
+
+test('cli flags parse; unknown flags are rejected', () => {
+  const parsed = parseArgs(['--out', 'receipt.json', '--strict', '--force', '--tag', 'v1.2.3', '--channel', 'npm']);
+  assert.deepEqual(parsed, {
+    out: 'receipt.json',
+    strict: true,
+    force: true,
+    channel: 'npm',
+    sourceCommit: null,
+    sourceTreeDigest: null,
+    tag: 'v1.2.3'
+  });
+  assert.equal(parseArgs(['--bogus']), null);
+});
+
+test('strict cli exits nonzero while the matrix carries open blockers', () => {
+  const script = pathToFileURL(path.join(repoRoot, 'scripts/certification-receipt.mjs'));
+  const result = spawnSync(process.execPath, [script.pathname, '--strict'], {
+    encoding: 'utf8',
+    cwd: repoRoot
+  });
+  const blockers = certificationBlockers();
+  if (blockers.length > 0) {
+    assert.equal(result.status, 1, 'strict mode must fail closed on open blockers');
+    assert.match(result.stderr, /open blocker/);
+  } else {
+    assert.equal(result.status, 0);
+  }
+});

--- a/scripts/certification-receipt.mjs
+++ b/scripts/certification-receipt.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Build the structured certification receipt for the Coven end-to-end
+// certification matrix (issue OpenCoven/coven#779).
+//
+//   node scripts/certification-receipt.mjs                     # print receipt
+//   node scripts/certification-receipt.mjs --out receipt.json  # write to file
+//   node scripts/certification-receipt.mjs --strict            # fail closed
+//
+// The receipt is keyed by exact source digests (commit + tree) and carries one
+// entry per certification row with its outcome, evidence references, and — for
+// non-terminal rows — the named owner issue and justification. It contains no
+// prompts, credentials, or unrestricted terminal output, so it is safe to
+// attach to a release record.
+//
+// Fail-closed behavior: `--strict` exits nonzero when any required row is
+// proven failed or carries an explicit unknown disposition. That is the
+// certification rule from the issue, executable: `unknown` is an explicit
+// receipt disposition, never a terminal outcome for a required row.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import process from 'node:process';
+
+import {
+  CERTIFICATION_MATRIX,
+  RECEIPT_VERSION,
+  SUPPORT_MATRIX_VERSION,
+  certificationBlockers,
+  matrixSummary,
+  receiptLanes,
+  validateMatrix
+} from './certification-matrix.mjs';
+
+// Deterministic by construction: no wall-clock timestamp. The receipt is keyed
+// by the candidate digests, so the same candidate always yields the same bytes
+// and an independent reviewer can regenerate and diff it. `reviewerDecision`
+// stays null until release authorization (#805) sets it after human review —
+// the receipt never self-certifies.
+export function buildReceipt({
+  matrix = CERTIFICATION_MATRIX,
+  candidate = { sourceCommit: null, sourceTreeDigest: null, tag: null, channel: 'source-checkout' },
+  platform = { os: process.platform, arch: process.arch },
+  tooling = { node: process.versions.node }
+} = {}) {
+  const integrityErrors = validateMatrix(matrix);
+  if (integrityErrors.length > 0) {
+    throw new Error(
+      `certification matrix is internally inconsistent:\n${formatIntegrityErrors(integrityErrors)}`
+    );
+  }
+  return {
+    receiptVersion: RECEIPT_VERSION,
+    supportMatrixVersion: SUPPORT_MATRIX_VERSION,
+    candidate,
+    platform,
+    tooling,
+    lanes: receiptLanes(matrix),
+    summary: matrixSummary(matrix),
+    releaseBlockers: certificationBlockers(matrix),
+    // Set by release authorization (#805) after human review; the receipt
+    // never self-certifies.
+    reviewerDecision: null
+  };
+}
+
+// Resolve the candidate identity from the surrounding checkout. Every input
+// can be pinned explicitly: artifact/tag receipts key off the published
+// artifact, not whatever checkout happens to be present.
+export function resolveCandidate({
+  sourceCommit = null,
+  sourceTreeDigest = null,
+  tag = null,
+  channel = 'source-checkout',
+  execFile = (args) => execFileSync('git', args, { encoding: 'utf8' })
+} = {}) {
+  const resolve = (args) => {
+    try {
+      const value = execFile(args);
+      return typeof value === 'string' ? value.trim() : null;
+    } catch {
+      return null;
+    }
+  };
+  return {
+    sourceCommit: sourceCommit ?? resolve(['rev-parse', 'HEAD']),
+    sourceTreeDigest: sourceTreeDigest ?? resolve(['rev-parse', 'HEAD^{tree}']),
+    tag,
+    channel
+  };
+}
+
+function formatBlockers(blockers) {
+  return blockers
+    .map((blocker) => `  - ${blocker.id} (${blocker.lane}): ${blocker.reason}`)
+    .join('\n');
+}
+
+function formatIntegrityErrors(errors) {
+  return errors.map((line) => `  - ${line}`).join('\n');
+}
+
+function writeReceipt(outPath, json, { force }) {
+  if (existsSync(outPath) && !force) {
+    // Mirrors the coven report publication contract: fail-if-exists, never a
+    // silent overwrite of an evidence artifact.
+    throw new Error(`refusing to overwrite ${outPath}: move it aside or pass --force`);
+  }
+  writeFileSync(outPath, json, 'utf8');
+  process.stderr.write(`receipt written to ${outPath}\n`);
+}
+
+export function parseArgs(argv) {
+  const options = {
+    out: null,
+    strict: false,
+    force: false,
+    channel: 'source-checkout',
+    sourceCommit: null,
+    sourceTreeDigest: null,
+    tag: null
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--out') options.out = argv[(index += 1)];
+    else if (arg === '--strict') options.strict = true;
+    else if (arg === '--force') options.force = true;
+    else if (arg === '--source-commit') options.sourceCommit = argv[(index += 1)];
+    else if (arg === '--source-tree-digest') options.sourceTreeDigest = argv[(index += 1)];
+    else if (arg === '--tag') options.tag = argv[(index += 1)];
+    else if (arg === '--channel') options.channel = argv[(index += 1)];
+    else return null;
+  }
+  return options;
+}
+
+function runCli(argv) {
+  const options = parseArgs(argv);
+  if (!options) {
+    process.stderr.write(
+      'usage: node scripts/certification-receipt.mjs [--out FILE] [--strict] [--force]\n' +
+        '       [--channel NAME] [--source-commit SHA] [--source-tree-digest DIGEST] [--tag TAG]\n'
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const integrityErrors = validateMatrix();
+  if (integrityErrors.length > 0) {
+    process.stderr.write(
+      `certification matrix is internally inconsistent:\n${formatIntegrityErrors(integrityErrors)}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const receipt = buildReceipt({ candidate: resolveCandidate(options) });
+  const json = `${JSON.stringify(receipt, null, 2)}\n`;
+
+  if (options.out) {
+    writeReceipt(options.out, json, { force: options.force });
+  } else {
+    process.stdout.write(json);
+  }
+
+  const blockers = certificationBlockers();
+  if (blockers.length > 0) {
+    process.stderr.write(`certification is not complete: ${blockers.length} open blocker(s)\n`);
+    for (const blocker of blockers) {
+      process.stderr.write(`  - ${blocker.id} (${blocker.lane}): ${blocker.reason}\n`);
+    }
+    if (options.strict) {
+      process.exitCode = 1;
+    }
+  }
+}
+
+const isMainModule = (argv1 = process.argv[1], moduleUrl = import.meta.url) =>
+  Boolean(argv1) && moduleUrl === pathToFileURL(argv1).href;
+
+if (isMainModule()) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Defines the end-to-end certification matrix for Coven (issue #779) as one
machine-readable source of truth plus a fail-closed receipt generator, and
wires an anti-drift suite into the `policy-guard` CI job.

- `scripts/certification-matrix.mjs` — lanes A–K from #779, 64 certification
  rows with outcomes (`required / passed`, `required / failed`,
  `required / unknown (open blocker)`, `not applicable`,
  `experimental / disabled`, `deferred`), evidence references, owner issues,
  and justifications. The certification rule — `skipped`/`unknown` is never a
  terminal outcome for a required row — is executable via
  `certificationBlockers()`.
- `scripts/certification-receipt.mjs` — deterministic structured receipt keyed
  by the candidate source commit + tree digest; `--strict` fails closed on
  open blockers; `reviewerDecision` stays `null` for release authorization
  (#805) to set after human review.
- `scripts/certification-receipt-test.mjs` — matrix integrity, evidence
  resolution (repo paths exist, `ci.yml` jobs are declared, issue refs are
  well-formed), doc/matrix parity, receipt determinism, credential-free
  structure, and the strict-CLI fail-closed contract.
- `docs/reference/certification.md` — the rendered matrix with evidence links.
  Real-hardware confirmation (B5), real-credential provider packets (C7), the
  installed-artifact mount gate (F2), and the deployed-docs/browser journey
  (I1/I2) are documented as **external operator lanes**, per the issue's
  non-goal of not blocking every PR on real cloud/provider/device tests.

Current honest state: 33 rows required/passed on standing CI + suites; 9
required rows carry explicit unknown dispositions (recovery/API-boundary/docs
gaps in lanes A, D, H, I, owned by #807/#778) instead of being silently
skipped; 13 deferred with owner issues; 7 not applicable with justification;
2 experimental/disabled (AgentFS mount).

This is **slice 1 of N**: it defines the matrix, the receipt, and the
fail-closed rule, and surfaces the open blockers explicitly. Executing the
operator lanes (B5 real hardware, C7 real credentials, F2 artifact mount gate)
and attaching release-authorization evidence (#805) remains with the owner
issues; the receipt is the instrument they report into.

## Issue

Closes #779

## Test plan

- [x] `node --test scripts/certification-receipt-test.mjs` — 15/15 pass
- [x] `python scripts/check-secrets.py` — clean
- [x] `python3 scripts/check-coven-privacy.py --staged` — clean (5 files)
- [x] `python3 scripts/check-ci-workflow-test.py` (9) / `check-workflows-test.py` (8) / `classify-ci-changes-test.py` (19) — pass
- [x] `bash scripts/check-workflows.sh` (actionlint on the ci.yml edit) — pass
- [x] `node scripts/certification-receipt.mjs` generates the receipt; `--strict` exits nonzero while the 9 open blockers exist (fail-closed verified)
- [ ] `cargo fmt/clippy/test` — no Rust toolchain in this environment; deferred to CI (no Rust code touched)

> **Vehicle note:** opened in the fork CompleteDotTech/coven as the CI vehicle — this token cannot write to OpenCoven/coven. Re-target upstream once write access is restored. Refs OpenCoven/coven#779.

---

> Recreated upstream from https://github.com/CompleteDotTech/coven/pull/19, preserving source head 8b8585950b1072fdf652cf98a038a3eb4d63bdaf and branch agent/issue-779-test-certify-coven-end-to-end.