### PR TITLE
fix: settle automation runs from terminal evidence

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -336,6 +336,17 @@ pub trait SessionRuntime {
         }
         result
     }
+    /// Launches an adopted session whose complete process tree must be
+    /// strictly contained before execution. Automation deadlines use this
+    /// path so a successful kill is also a quiescence proof.
+    fn launch_contained_adopted_session(
+        &self,
+        launch: &SessionLaunch,
+        writer: Option<crate::maintenance_gate::WriterLease>,
+        ownership_established: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<()> {
+        self.launch_adopted_session(launch, writer, ownership_established)
+    }
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()>;
     fn kill_session(&self, session_id: &str) -> Result<()>;
 
@@ -10746,7 +10757,7 @@ mod tests {
     }
 
     #[test]
-    fn control_action_runs_a_routine_through_the_ledger() -> anyhow::Result<()> {
+    fn control_action_reports_launch_as_running_until_completion_evidence() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let create_body = json!({
             "action": "coven.automations.create",
@@ -10790,7 +10801,7 @@ mod tests {
         )?;
         assert_eq!(response.status, 200);
         assert!(
-            response.body.contains(r#""status":"succeeded""#),
+            response.body.contains(r#""status":"running""#),
             "{}",
             response.body
         );
@@ -10815,7 +10826,7 @@ mod tests {
         assert_eq!(response.status, 200);
         assert!(response.body.contains(r#""runs":[{""#), "{}", response.body);
         assert!(
-            response.body.contains(r#""status":"succeeded""#),
+            response.body.contains(r#""status":"running""#),
             "{}",
             response.body
         );

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -1,10 +1,7 @@
 //! Daemon-side automations tick (coven#816).
 //!
-//! The daemon runs the planning/recovery/claim tick on a 60-second cadence.
-//! Dispatch of claimed occurrences is intentionally NOT wired into this tick
-//! yet: the tick fences and claims so the ledger reflects reality, and the
-//! dispatch path (part 4's run_routine_now) currently serves manual runs
-//! while occurrence execution lands behind the same SessionLaunch seam.
+//! The daemon reconciles terminal session evidence before planning, recovering,
+//! claiming, and dispatching occurrences on a 60-second cadence.
 
 use std::path::Path;
 use std::time::Duration;
@@ -22,12 +19,35 @@ pub fn process_automations_tick(
     let store_path = crate::api::store_path(coven_home);
     let conn = crate::store::open_store(&store_path)?;
     let now = chrono::Utc::now();
+    reconcile_automation_runs(coven_home, &conn, runtime, now)?;
     let report = super::occurrences::tick(&conn, now)?;
-    if !report.claimed.is_empty() {
-        let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime, now)
-            .map_err(anyhow::Error::msg)?;
-    }
+    let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime, now)
+        .map_err(anyhow::Error::msg)?;
     Ok(report)
+}
+
+fn reconcile_automation_runs(
+    coven_home: &Path,
+    conn: &rusqlite::Connection,
+    runtime: &dyn crate::api::SessionRuntime,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    super::runner::recover_restart_containment(coven_home, conn, now, false)
+        .map_err(anyhow::Error::msg)?;
+    for failure in
+        super::runner::recover_abandoned_launches(conn, runtime, now).map_err(anyhow::Error::msg)?
+    {
+        crate::daemon::append_daemon_recovery_log(coven_home, &failure);
+    }
+    for failure in
+        super::runner::enforce_run_timeouts(conn, runtime, now).map_err(anyhow::Error::msg)?
+    {
+        crate::daemon::append_daemon_recovery_log(coven_home, &failure);
+    }
+    super::runner::settle_finished_runs(conn, now).map_err(anyhow::Error::msg)?;
+    super::runner::cleanup_terminal_containment_receipts(coven_home, conn)
+        .map_err(anyhow::Error::msg)?;
+    Ok(())
 }
 
 /// Starts the automations scheduler thread on the daemon's 60s cadence.
@@ -35,6 +55,14 @@ pub fn start_automations_scheduler(
     coven_home: &Path,
     runtime: std::sync::Arc<dyn crate::api::SessionRuntime + Send + Sync>,
 ) -> Result<()> {
+    let store_path = crate::api::store_path(coven_home);
+    let conn = crate::store::open_store(&store_path)?;
+    let now = chrono::Utc::now();
+    super::runner::recover_restart_containment(coven_home, &conn, now, true)
+        .map_err(anyhow::Error::msg)?;
+    reconcile_automation_runs(coven_home, &conn, runtime.as_ref(), now)?;
+    let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime.as_ref(), now)
+        .map_err(anyhow::Error::msg)?;
     let home = coven_home.to_path_buf();
     std::thread::Builder::new()
         .name("coven-automations-scheduler".into())
@@ -105,11 +133,53 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        // The tick claims and then dispatches through the (noop) runtime, so
-        // the occurrence settles as succeeded and the ledger records the run.
-        assert_eq!(state, "succeeded");
+        // A launch acknowledgement proves only that the runtime accepted the
+        // session. Terminal settlement waits for completion evidence.
+        assert_eq!(state, "running");
         let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs.len(), 1);
-        assert_eq!(runs[0].status, "succeeded");
+        assert_eq!(runs[0].status, "running");
+        assert!(runs[0].session_id.is_some());
+        assert_eq!(runs[0].finished_at, None);
+    }
+
+    #[test]
+    fn tick_dispatches_a_preexisting_daemon_claim_without_new_claims() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+        crate::store::initialize_store(&home.join("coven.sqlite3")).unwrap();
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        let routine = definition("preclaimed");
+        insert_definition(&conn, &routine).unwrap();
+        let now = chrono::Utc::now();
+        assert!(super::super::occurrences::insert_claimed_occurrence(
+            &conn,
+            "preexisting-daemon-claim",
+            &routine.id,
+            "daemon",
+            60,
+            now,
+        )
+        .unwrap());
+        drop(conn);
+
+        let report = process_automations_tick(home, &crate::api::NoopSessionRuntime).unwrap();
+        assert!(report.claimed.is_empty());
+
+        let conn = crate::store::open_store(&home.join("coven.sqlite3")).unwrap();
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = 'preexisting-daemon-claim'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
+        assert_eq!(
+            super::super::runs::list_runs(&conn, &routine.id, 10)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }

--- a/crates/coven-cli/src/automations/daemon_tick.rs
+++ b/crates/coven-cli/src/automations/daemon_tick.rs
@@ -19,7 +19,7 @@ pub fn process_automations_tick(
     let store_path = crate::api::store_path(coven_home);
     let conn = crate::store::open_store(&store_path)?;
     let now = chrono::Utc::now();
-    reconcile_automation_runs(coven_home, &conn, runtime, now)?;
+    reconcile_automation_runs(coven_home, &conn, runtime, now, false)?;
     let report = super::occurrences::tick(&conn, now)?;
     let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime, now)
         .map_err(anyhow::Error::msg)?;
@@ -31,8 +31,9 @@ fn reconcile_automation_runs(
     conn: &rusqlite::Connection,
     runtime: &dyn crate::api::SessionRuntime,
     now: chrono::DateTime<chrono::Utc>,
+    startup: bool,
 ) -> Result<()> {
-    super::runner::recover_restart_containment(coven_home, conn, now, false)
+    super::runner::recover_restart_containment(coven_home, conn, now, startup)
         .map_err(anyhow::Error::msg)?;
     for failure in
         super::runner::recover_abandoned_launches(conn, runtime, now).map_err(anyhow::Error::msg)?
@@ -58,9 +59,7 @@ pub fn start_automations_scheduler(
     let store_path = crate::api::store_path(coven_home);
     let conn = crate::store::open_store(&store_path)?;
     let now = chrono::Utc::now();
-    super::runner::recover_restart_containment(coven_home, &conn, now, true)
-        .map_err(anyhow::Error::msg)?;
-    reconcile_automation_runs(coven_home, &conn, runtime.as_ref(), now)?;
+    reconcile_automation_runs(coven_home, &conn, runtime.as_ref(), now, true)?;
     let _dispatch = super::runner::dispatch_claimed_occurrences(&conn, runtime.as_ref(), now)
         .map_err(anyhow::Error::msg)?;
     let home = coven_home.to_path_buf();

--- a/crates/coven-cli/src/automations/occurrences.rs
+++ b/crates/coven-cli/src/automations/occurrences.rs
@@ -98,6 +98,14 @@ pub fn claim_due_occurrence(
              WHERE automation_id = ?1
                AND state = 'planned'
                AND scheduled_for <= ?2
+               AND NOT EXISTS (
+                   SELECT 1 FROM automation_occurrences
+                   WHERE automation_id = ?1 AND state IN ('claimed', 'running')
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM automation_runs
+                   WHERE automation_id = ?1 AND status = 'running'
+               )
                AND id = (
                    SELECT id FROM automation_occurrences
                    WHERE automation_id = ?1
@@ -122,8 +130,45 @@ pub fn claim_due_occurrence(
     Ok(Some(id))
 }
 
-/// Marks occurrences whose lease has expired as failed with a stale reason.
-/// A stale lease must never render as live work (coven#816).
+/// Creates a manually requested occurrence already claimed by its caller.
+/// The single insert prevents a scheduler connection from claiming the row
+/// between manual fencing and ownership publication.
+pub fn insert_claimed_occurrence(
+    conn: &Connection,
+    occurrence_id: &str,
+    automation_id: &str,
+    owner: &str,
+    lease_minutes: i64,
+    now: DateTime<Utc>,
+) -> Result<bool, String> {
+    if lease_minutes <= 0 || lease_minutes > 24 * 60 {
+        return Err("lease minutes must be 1..=1440".to_string());
+    }
+    let expires = now + chrono::Duration::minutes(lease_minutes);
+    let now_iso = iso(now);
+    let expires_iso = iso(expires);
+    conn.execute(
+        "INSERT OR IGNORE INTO automation_occurrences
+            (id, automation_id, scheduled_for, state, lease_owner,
+             lease_expires_at, attempt, created_at, updated_at)
+         SELECT ?1, ?2, ?5, 'claimed', ?3, ?4, 1, ?5, ?5
+         WHERE NOT EXISTS (
+             SELECT 1 FROM automation_occurrences
+             WHERE automation_id = ?2 AND state IN ('claimed', 'running')
+         )
+           AND NOT EXISTS (
+             SELECT 1 FROM automation_runs
+             WHERE automation_id = ?2 AND status = 'running'
+         )",
+        params![occurrence_id, automation_id, owner, expires_iso, now_iso],
+    )
+    .map(|inserted| inserted == 1)
+    .map_err(|error| format!("failed to insert claimed occurrence `{occurrence_id}`: {error}"))
+}
+
+/// Marks pre-dispatch claims whose lease has expired as failed. Once runtime
+/// ownership is published, only terminal session evidence may settle the
+/// occurrence; an execution lease is not completion evidence.
 pub fn recover_expired_leases(conn: &Connection, now: DateTime<Utc>) -> Result<usize, String> {
     let now_iso = iso(now);
     let changed = conn
@@ -134,9 +179,14 @@ pub fn recover_expired_leases(conn: &Connection, now: DateTime<Utc>) -> Result<u
                  lease_owner = NULL,
                  lease_expires_at = NULL,
                  updated_at = ?1
-             WHERE state IN ('claimed', 'running')
+             WHERE state = 'claimed'
                AND lease_expires_at IS NOT NULL
-               AND lease_expires_at < ?1",
+               AND lease_expires_at < ?1
+               AND NOT EXISTS (
+                   SELECT 1 FROM automation_runs
+                   WHERE automation_runs.occurrence_id = automation_occurrences.id
+                     AND automation_runs.status = 'running'
+               )",
             params![now_iso],
         )
         .map_err(|error| format!("failed to recover expired leases: {error}"))?;
@@ -171,6 +221,24 @@ pub fn settle_occurrence(
             params![occurrence_id, terminal_state, failure_reason, now_iso],
         )
         .map_err(|error| format!("failed to settle occurrence: {error}"))?;
+    Ok(changed > 0)
+}
+
+/// Publishes runtime ownership for a claimed occurrence without settling it.
+/// The lease remains attached until terminal session evidence is reconciled.
+pub fn mark_occurrence_running(
+    conn: &Connection,
+    occurrence_id: &str,
+    now: DateTime<Utc>,
+) -> Result<bool, String> {
+    let changed = conn
+        .execute(
+            "UPDATE automation_occurrences
+             SET state = 'running', updated_at = ?2
+             WHERE id = ?1 AND state = 'claimed'",
+            params![occurrence_id, iso(now)],
+        )
+        .map_err(|error| format!("failed to mark occurrence running: {error}"))?;
     Ok(changed > 0)
 }
 
@@ -521,6 +589,33 @@ mod tests {
     }
 
     #[test]
+    fn overlap_forbid_does_not_claim_while_an_occurrence_is_running() {
+        let (_temp, conn) = temp_store();
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+             VALUES
+                ('running', 'daily', '2020-01-01T00:00:00.000Z', 'running', 1,
+                 '2020-01-01T00:00:00.000Z', '2020-01-01T00:00:00.000Z'),
+                ('next', 'daily', '2020-01-01T00:01:00.000Z', 'planned', 0,
+                 '2020-01-01T00:01:00.000Z', '2020-01-01T00:01:00.000Z')",
+            [],
+        )
+        .unwrap();
+
+        let claimed = claim_due_occurrence(&conn, "daily", "daemon", 60, real_now()).unwrap();
+        assert!(claimed.is_none());
+        let next_state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = 'next'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(next_state, "planned");
+    }
+
+    #[test]
     fn recovers_expired_leases_to_failed() {
         let (_temp, conn) = temp_store();
         insert_definition(&conn, &definition("daily", "ACTIVE", "FREQ=DAILY;BYHOUR=9")).unwrap();
@@ -551,6 +646,31 @@ mod tests {
             )
             .unwrap();
         assert_eq!(state, "failed");
+    }
+
+    #[test]
+    fn does_not_fail_running_work_when_its_claim_lease_expires() {
+        let (_temp, conn) = temp_store();
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, lease_owner, lease_expires_at,
+                 attempt, created_at, updated_at)
+             VALUES ('occ-running', 'daily', '2020-01-01T00:00:00.000Z', 'running',
+                     'daemon-a', '2020-01-01T01:00:00.000Z', 1,
+                     '2020-01-01T00:00:00.000Z', '2020-01-01T00:00:00.000Z')",
+            [],
+        )
+        .unwrap();
+
+        assert_eq!(recover_expired_leases(&conn, real_now()).unwrap(), 0);
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = 'occ-running'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -1,21 +1,152 @@
 //! Routine run dispatch (coven#816).
 //!
-//! A run is a claimed occurrence dispatched through the exact session-launch
-//! path every other launch uses: the definition is re-read, the familiar and
-//! runtime are re-validated per run, a SessionLaunch is built, and the
-//! occurrence plus the run ledger settle together. Coven (not a harness home)
-//! owns the record.
+//! A run is a claimed occurrence dispatched through the shared session-launch
+//! seam. The occurrence, run, and session correlation is persisted before
+//! runtime ownership begins; terminal settlement happens only after the
+//! session ledger contains completion evidence.
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    cell::{Cell, RefCell},
+    path::{Path, PathBuf},
+};
 
 use chrono::{DateTime, Utc};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
+use uuid::Uuid;
 
 use super::definition::RoutineDefinition;
-use super::occurrences::{settle_occurrence, PlanOutcome};
-use super::runs::{record_run_finish, record_run_start, RunFinish};
+use super::occurrences::{insert_claimed_occurrence, mark_occurrence_running, settle_occurrence};
+use super::runs::{record_run_finish, record_run_start, RunFinish, RunStart};
 use crate::api::{SessionLaunch, SessionRuntime};
 use crate::harness::HarnessLaunchMode;
+
+pub(crate) fn containment_receipt_path(coven_home: &Path, session_id: &str) -> PathBuf {
+    coven_home
+        .join("runtime")
+        .join("automation-containment")
+        .join(format!("{session_id}.receipt"))
+}
+
+pub(crate) fn recover_restart_containment(
+    coven_home: &Path,
+    conn: &Connection,
+    now: DateTime<Utc>,
+    startup: bool,
+) -> Result<usize, String> {
+    let candidates: Vec<String> = {
+        let mut statement = conn
+            .prepare(
+                "SELECT r.session_id
+                 FROM automation_runs AS r
+                 JOIN sessions AS s ON s.id = r.session_id
+                 WHERE r.status = 'running'
+                   AND s.status IN ('created', 'orphaned')",
+            )
+            .map_err(|error| format!("failed to prepare containment recovery query: {error}"))?;
+        let candidates = statement
+            .query_map([], |row| row.get(0))
+            .map_err(|error| format!("failed to query containment recovery candidates: {error}"))?
+            .collect::<Result<_, _>>()
+            .map_err(|error| format!("failed to read containment recovery candidate: {error}"))?;
+        candidates
+    };
+    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let mut recovered = 0;
+    for session_id in candidates {
+        let path = containment_receipt_path(coven_home, &session_id);
+        let disposition_proven = if cfg!(windows) {
+            startup
+        } else {
+            match std::fs::read(&path) {
+                Ok(receipt) => {
+                    receipt == crate::pty_runner::CONTAINMENT_QUIESCENT_RECEIPT
+                        || receipt == crate::pty_runner::CONTAINMENT_NO_PROCESS_RECEIPT
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => startup,
+                Err(error) => {
+                    return Err(format!(
+                        "failed to read containment receipt `{}`: {error}",
+                        path.display()
+                    ));
+                }
+            }
+        };
+        if !disposition_proven {
+            continue;
+        }
+        if crate::store::update_session_terminal_if_active(
+            conn,
+            &session_id,
+            "killed",
+            None,
+            &now_iso,
+        )
+        .map_err(|error| {
+            format!("failed to record restart containment for session `{session_id}`: {error}")
+        })? {
+            recovered += 1;
+        }
+    }
+    Ok(recovered)
+}
+
+pub(crate) fn cleanup_terminal_containment_receipts(
+    coven_home: &Path,
+    conn: &Connection,
+) -> Result<usize, String> {
+    let directory = coven_home.join("runtime").join("automation-containment");
+    let entries = match std::fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(0);
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to list containment receipts in `{}`: {error}",
+                directory.display()
+            ));
+        }
+    };
+    let mut removed = 0;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to read containment receipt entry in `{}`: {error}",
+                directory.display()
+            )
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("receipt") {
+            continue;
+        }
+        let Some(session_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        let terminal = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sessions
+                    WHERE id = ?1
+                      AND status IN ('completed', 'failed', 'cancelled', 'killed', 'idle')
+                 )",
+                [session_id],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|error| {
+                format!("failed to inspect session `{session_id}` for receipt cleanup: {error}")
+            })?;
+        if terminal {
+            std::fs::remove_file(&path).map_err(|error| {
+                format!(
+                    "failed to remove terminal containment receipt `{}`: {error}",
+                    path.display()
+                )
+            })?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunOutcome {
@@ -26,17 +157,271 @@ pub struct RunOutcome {
 }
 
 fn fresh_id(prefix: &str) -> String {
-    let millis = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .unwrap_or(0);
-    format!("{prefix}-{millis}")
+    format!("{prefix}-{}", Uuid::new_v4().simple())
+}
+
+fn persist_launch(
+    conn: &Connection,
+    run_id: &str,
+    occurrence_id: &str,
+    definition: &RoutineDefinition,
+    launch: &SessionLaunch,
+    now: DateTime<Utc>,
+) -> Result<(), String> {
+    let transaction = conn
+        .unchecked_transaction()
+        .map_err(|error| format!("failed to begin durable automation launch: {error}"))?;
+    let overlapping_run: bool = transaction
+        .query_row(
+            "SELECT EXISTS (
+                 SELECT 1 FROM automation_runs
+                 WHERE automation_id = ?1 AND status = 'running'
+             )",
+            rusqlite::params![definition.id],
+            |row| row.get(0),
+        )
+        .map_err(|error| format!("failed to enforce automation overlap policy: {error}"))?;
+    if overlapping_run {
+        return Err("routine already has a nonterminal run; overlap is forbidden".to_string());
+    }
+    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let session =
+        crate::session_launch::new_session_record(crate::session_launch::NewSessionParams {
+            id: launch.id.clone(),
+            project_root: launch.project_root.clone(),
+            harness: launch.harness.clone(),
+            title: launch.title.clone(),
+            status: "created".to_string(),
+            now: now_iso,
+            conversation_id: None,
+            familiar_id: launch.familiar_id.clone(),
+            execution_binding: None,
+            labels: Vec::new(),
+            visibility: None,
+        });
+    crate::store::insert_session(&transaction, &session)
+        .map_err(|error| format!("failed to persist automation session: {error:#}"))?;
+    record_run_start(
+        &transaction,
+        run_id,
+        RunStart {
+            automation_id: &definition.id,
+            occurrence_id: Some(occurrence_id),
+            session_id: Some(&launch.id),
+            familiar_id: definition.familiar_id.as_deref(),
+            runtime: &definition.runtime,
+            timeout_at: now + chrono::Duration::minutes(i64::from(definition.timeout_minutes)),
+        },
+        now,
+    )
+    .map_err(|error| format!("failed to record run start: {error:#}"))?;
+    transaction
+        .commit()
+        .map_err(|error| format!("failed to commit durable automation launch: {error}"))
+}
+
+fn publish_runtime_ownership(
+    conn: &Connection,
+    occurrence_id: &str,
+    session_id: &str,
+    now: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    let transaction = conn.unchecked_transaction()?;
+    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let ownership_published = crate::store::update_session_status_if_current(
+        &transaction,
+        session_id,
+        "created",
+        "running",
+        None,
+        &now_iso,
+    )?;
+    if !ownership_published {
+        let status = crate::store::get_session(&transaction, session_id)?
+            .map(|session| session.status)
+            .ok_or_else(|| {
+                anyhow::anyhow!("automation session vanished before ownership publication")
+            })?;
+        if !matches!(
+            status.as_str(),
+            "running" | "completed" | "failed" | "cancelled" | "killed" | "idle" | "orphaned"
+        ) {
+            anyhow::bail!(
+                "automation session changed to `{status}` before runtime ownership was published"
+            );
+        }
+    }
+    if !mark_occurrence_running(&transaction, occurrence_id, now).map_err(anyhow::Error::msg)? {
+        let state: Option<String> = transaction
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = ?1",
+                rusqlite::params![occurrence_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if !state
+            .as_deref()
+            .is_some_and(|state| matches!(state, "running" | "succeeded" | "failed"))
+        {
+            anyhow::bail!("automation occurrence changed before runtime ownership was published");
+        }
+    }
+    transaction.commit()?;
+    Ok(())
+}
+
+fn settle_rejected_launch(
+    conn: &Connection,
+    occurrence_id: &str,
+    run_id: &str,
+    session_id: &str,
+    reason: &str,
+    now: DateTime<Utc>,
+) -> Result<(), String> {
+    let transaction = conn
+        .unchecked_transaction()
+        .map_err(|error| format!("failed to begin launch rejection settlement: {error}"))?;
+    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    crate::store::update_session_terminal_if_active(
+        &transaction,
+        session_id,
+        "failed",
+        None,
+        &now_iso,
+    )
+    .map_err(|error| format!("failed to settle rejected session: {error:#}"))?;
+    if !settle_occurrence(&transaction, occurrence_id, "failed", Some(reason), now)? {
+        return Err("failed to settle rejected occurrence".to_string());
+    }
+    if !record_run_finish(
+        &transaction,
+        run_id,
+        RunFinish {
+            status: "failed",
+            exit_code: None,
+            session_id: Some(session_id.to_string()),
+            log_json: None,
+            output_commit: None,
+        },
+        now,
+    )
+    .map_err(|error| format!("failed to settle rejected run: {error:#}"))?
+    {
+        return Err("failed to settle rejected run".to_string());
+    }
+    transaction
+        .commit()
+        .map_err(|error| format!("failed to commit launch rejection settlement: {error}"))
+}
+
+fn dispatch_occurrence(
+    conn: &Connection,
+    runtime: &dyn SessionRuntime,
+    definition: &RoutineDefinition,
+    occurrence_id: &str,
+    cwd: &str,
+    now: DateTime<Utc>,
+) -> Result<RunOutcome, String> {
+    let run_id = fresh_id("run");
+    let launch = build_session_launch(definition, cwd)?;
+    persist_launch(conn, &run_id, occurrence_id, definition, &launch, now)?;
+
+    let ownership_published = Cell::new(false);
+    let ownership_publication_error = RefCell::new(None);
+    let mut ownership_established =
+        || match publish_runtime_ownership(conn, occurrence_id, &launch.id, now) {
+            Ok(()) => {
+                ownership_published.set(true);
+                Ok(())
+            }
+            Err(error) => {
+                *ownership_publication_error.borrow_mut() = Some(format!("{error:#}"));
+                Err(anyhow::Error::new(
+                    crate::api::RuntimeOwnershipPublicationError,
+                ))
+            }
+        };
+    match runtime.launch_contained_adopted_session(&launch, None, &mut ownership_established) {
+        Ok(()) if ownership_published.get() => Ok(RunOutcome {
+            run_id,
+            status: "running".to_string(),
+            session_id: Some(launch.id),
+            error: None,
+        }),
+        result if ownership_published.get() => {
+            let error = match result {
+                Ok(()) => None,
+                Err(error) => Some(format!(
+                    "runtime ownership was established but launch acknowledgement failed: {error:#}"
+                )),
+            };
+            Ok(RunOutcome {
+                run_id,
+                status: "running".to_string(),
+                session_id: Some(launch.id),
+                error,
+            })
+        }
+        Ok(()) => {
+            let publication_error =
+                publish_runtime_ownership(conn, occurrence_id, &launch.id, now).err();
+            Ok(RunOutcome {
+                run_id,
+                status: "running".to_string(),
+                session_id: Some(launch.id),
+                error: publication_error.map(|error| {
+                    format!(
+                        "runtime accepted launch without publishing ownership; completion is ambiguous: {error:#}"
+                    )
+                }),
+            })
+        }
+        Err(error)
+            if error
+                .downcast_ref::<crate::daemon::RuntimeOwnershipRetainedError>()
+                .is_some()
+                || error
+                    .downcast_ref::<crate::api::RuntimeOwnershipPublicationError>()
+                    .is_some() =>
+        {
+            let publication_error =
+                publish_runtime_ownership(conn, occurrence_id, &launch.id, now).err();
+            let callback_error = ownership_publication_error.borrow().clone();
+            let error = match (callback_error, publication_error) {
+                (Some(callback_error), Some(retry_error)) => {
+                    format!("{error:#}: {callback_error}; retry failed: {retry_error:#}")
+                }
+                (Some(callback_error), None) => format!("{error:#}: {callback_error}"),
+                (None, Some(retry_error)) => format!(
+                    "{error:#}; failed to publish retained runtime ownership: {retry_error:#}"
+                ),
+                (None, None) => format!("{error:#}"),
+            };
+            Ok(RunOutcome {
+                run_id,
+                status: "running".to_string(),
+                session_id: Some(launch.id),
+                error: Some(error),
+            })
+        }
+        Err(error) => {
+            let reason = format!("{error:#}");
+            settle_rejected_launch(conn, occurrence_id, &run_id, &launch.id, &reason, now)?;
+            Ok(RunOutcome {
+                run_id,
+                status: "failed".to_string(),
+                session_id: None,
+                error: Some(reason),
+            })
+        }
+    }
 }
 
 /// Runs a routine once, now: fences and claims an immediate occurrence,
-/// records a ledger row, dispatches through the shared session-launch path,
-/// and settles occurrence + ledger together. A missing cwd fails the run
-/// with a recorded reason instead of guessing a project.
+/// durably links its session, and dispatches through the shared session-launch
+/// path. A launch acknowledgement leaves the run in flight; a later
+/// reconciliation pass settles terminal session evidence. A missing cwd fails
+/// without guessing a project.
 pub fn run_routine_now(
     conn: &Connection,
     runtime: &dyn SessionRuntime,
@@ -58,83 +443,16 @@ pub fn run_routine_now(
     };
 
     let occurrence_id = fresh_id("occ");
-    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    let inserted = conn
-        .execute(
-            "INSERT OR IGNORE INTO automation_occurrences
-                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
-             VALUES (?1, ?2, ?3, 'planned', 0, ?3, ?3)",
-            rusqlite::params![occurrence_id, definition.id, now_iso],
-        )
-        .map_err(|error| format!("failed to fence immediate occurrence: {error}"))?;
-    if inserted == 0 {
-        return Err("immediate occurrence fence collided; retry".to_string());
+    if !insert_claimed_occurrence(conn, &occurrence_id, &definition.id, "manual", 60, now)? {
+        return Ok(RunOutcome {
+            run_id: String::new(),
+            status: "failed".to_string(),
+            session_id: None,
+            error: Some("routine already has a nonterminal run; overlap is forbidden".to_string()),
+        });
     }
-    let _ = PlanOutcome::Planned; // keep the import meaningful if API changes
 
-    let claimed =
-        super::occurrences::claim_due_occurrence(conn, &definition.id, "manual", 60, now)?;
-    let occurrence_id = claimed.unwrap_or(occurrence_id);
-
-    let run_id = fresh_id("run");
-    record_run_start(
-        conn,
-        &run_id,
-        &definition.id,
-        Some(&occurrence_id),
-        definition.familiar_id.as_deref(),
-        &definition.runtime,
-        now,
-    )
-    .map_err(|error| format!("failed to record run start: {error:#}"))?;
-
-    let launch = build_session_launch(definition, cwd)?;
-
-    match runtime.launch_session(&launch) {
-        Ok(()) => {
-            let _ = settle_occurrence(conn, &occurrence_id, "succeeded", None, now);
-            let _ = record_run_finish(
-                conn,
-                &run_id,
-                RunFinish {
-                    status: "succeeded",
-                    exit_code: Some(0),
-                    session_id: Some(launch.id.clone()),
-                    log_json: None,
-                    output_commit: None,
-                },
-                now,
-            );
-            Ok(RunOutcome {
-                run_id,
-                status: "succeeded".to_string(),
-                session_id: Some(launch.id),
-                error: None,
-            })
-        }
-        Err(error) => {
-            let reason = format!("{error:#}");
-            let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
-            let _ = record_run_finish(
-                conn,
-                &run_id,
-                RunFinish {
-                    status: "failed",
-                    exit_code: None,
-                    session_id: None,
-                    log_json: None,
-                    output_commit: None,
-                },
-                now,
-            );
-            Ok(RunOutcome {
-                run_id,
-                status: "failed".to_string(),
-                session_id: None,
-                error: Some(reason),
-            })
-        }
-    }
+    dispatch_occurrence(conn, runtime, definition, &occurrence_id, cwd, now)
 }
 
 /// Builds the shared SessionLaunch for a routine run. Every run — manual or
@@ -166,23 +484,26 @@ pub struct DispatchReport {
     pub failed: Vec<String>,
 }
 
-/// Dispatches every claimed occurrence that the scheduler has fenced: builds
-/// the launch, records the ledger row, launches through the shared runtime
-/// path, and settles occurrence + ledger together. Claimed occurrences whose
-/// routine has no cwd fail with a recorded reason instead of guessing a
-/// project.
+/// Dispatches every claimed occurrence through the same durable launch
+/// primitive as manual runs. Successful launch acknowledgements remain
+/// nonterminal until session evidence is reconciled.
 pub fn dispatch_claimed_occurrences(
     conn: &Connection,
     runtime: &dyn SessionRuntime,
-    now: DateTime<Utc>,
+    _now: DateTime<Utc>,
 ) -> Result<DispatchReport, String> {
     let mut report = DispatchReport::default();
 
     let claimed: Vec<(String, String)> = {
         let mut statement = conn
             .prepare(
-                "SELECT id, automation_id FROM automation_occurrences
-                 WHERE state = 'claimed' ORDER BY scheduled_for ASC",
+                "SELECT o.id, o.automation_id FROM automation_occurrences AS o
+                 WHERE o.state = 'claimed'
+                   AND o.lease_owner = 'daemon'
+                   AND NOT EXISTS (
+                       SELECT 1 FROM automation_runs AS r WHERE r.occurrence_id = o.id
+                   )
+                 ORDER BY o.scheduled_for ASC",
             )
             .map_err(|error| format!("failed to list claimed occurrences: {error}"))?;
         let rows = statement
@@ -196,9 +517,10 @@ pub fn dispatch_claimed_occurrences(
     };
 
     for (occurrence_id, automation_id) in claimed {
+        let now = Utc::now();
         let Some(definition) = load_definition_for_run(conn, &automation_id)? else {
             let reason = format!("routine `{automation_id}` vanished during dispatch");
-            let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
+            settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now)?;
             report.failed.push(reason);
             continue;
         };
@@ -210,64 +532,329 @@ pub fn dispatch_claimed_occurrences(
             .filter(|cwd| !cwd.is_empty())
         else {
             let reason = format!("{automation_id}: routine has no cwd; add a cwd before running");
-            let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
+            settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now)?;
             report.failed.push(reason);
             continue;
         };
 
-        let run_id = fresh_id("run");
-        let started = record_run_start(
+        match dispatch_occurrence(conn, runtime, &definition, &occurrence_id, cwd, now) {
+            Ok(outcome) if outcome.status == "running" => {
+                report.dispatched.push(outcome.run_id);
+            }
+            Ok(outcome) => {
+                report.failed.push(format!(
+                    "{automation_id}: {}",
+                    outcome
+                        .error
+                        .unwrap_or_else(|| "launch did not enter running state".to_string())
+                ));
+            }
+            Err(reason) => {
+                settle_occurrence(
+                    conn,
+                    &occurrence_id,
+                    "failed",
+                    Some("dispatch failed before runtime ownership"),
+                    now,
+                )?;
+                report.failed.push(format!("{automation_id}: {reason}"));
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SettlementReport {
+    pub succeeded: usize,
+    pub failed: usize,
+}
+
+/// Requests strict termination for an abandoned pre-publication launch once
+/// its claim lease expires. Lease age selects work for recovery but never
+/// proves process death; failed termination therefore remains nonterminal.
+pub fn recover_abandoned_launches(
+    conn: &Connection,
+    runtime: &dyn SessionRuntime,
+    now: DateTime<Utc>,
+) -> Result<Vec<String>, String> {
+    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let candidates: Vec<(String, String)> = {
+        let mut statement = conn
+            .prepare(
+                "SELECT r.id, r.session_id
+                 FROM automation_runs AS r
+                 JOIN sessions AS s ON s.id = r.session_id
+                 JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+                 WHERE r.status = 'running'
+                   AND s.status = 'created'
+                   AND o.state = 'claimed'
+                   AND o.lease_expires_at IS NOT NULL
+                   AND o.lease_expires_at < ?1
+                   AND (r.timeout_at IS NULL OR r.timeout_at > ?1)",
+            )
+            .map_err(|error| format!("failed to prepare abandoned automation recovery: {error}"))?;
+        let rows = statement
+            .query_map(rusqlite::params![now_iso], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .map_err(|error| format!("failed to query abandoned automation launches: {error}"))?;
+        let mut candidates = Vec::new();
+        for row in rows {
+            candidates
+                .push(row.map_err(|error| format!("failed to read abandoned launch: {error}"))?);
+        }
+        candidates
+    };
+
+    let mut failures = Vec::new();
+    for (run_id, session_id) in candidates {
+        if let Err(error) = runtime.kill_session(&session_id) {
+            failures.push(format!(
+                "abandoned automation run `{run_id}` has unproven session `{session_id}` termination: {error:#}"
+            ));
+            continue;
+        }
+        crate::store::update_session_terminal_if_active(
             conn,
-            &run_id,
-            &automation_id,
-            Some(&occurrence_id),
-            definition.familiar_id.as_deref(),
-            &definition.runtime,
-            now,
-        );
-        if let Err(error) = started {
-            report.failed.push(format!("{automation_id}: {error:#}"));
+            &session_id,
+            "killed",
+            None,
+            &now_iso,
+        )
+        .map_err(|error| {
+            format!("failed to persist abandoned session `{session_id}` termination: {error:#}")
+        })?;
+    }
+    Ok(failures)
+}
+
+/// Requests termination for runs that exceeded their definition's wall-clock
+/// budget. A successful strict kill is persisted as terminal session evidence;
+/// an unproven kill remains running and is returned for daemon diagnostics.
+pub fn enforce_run_timeouts(
+    conn: &Connection,
+    runtime: &dyn SessionRuntime,
+    now: DateTime<Utc>,
+) -> Result<Vec<String>, String> {
+    let candidates: Vec<(String, String, String)> = {
+        let mut statement = conn
+            .prepare(
+                "SELECT r.id, r.session_id, r.timeout_at, r.automation_id
+                 FROM automation_runs AS r
+                 JOIN sessions AS s ON s.id = r.session_id
+                 WHERE r.status = 'running'
+                   AND s.status IN ('created', 'running', 'orphaned')
+                   AND r.timeout_at IS NOT NULL",
+            )
+            .map_err(|error| format!("failed to prepare automation timeout query: {error}"))?;
+        let mapped = statement
+            .query_map([], |row| {
+                let run_id: String = row.get(0)?;
+                let session_id: String = row.get(1)?;
+                let timeout_at: String = row.get(2)?;
+                let automation_id: String = row.get(3)?;
+                Ok((run_id, session_id, timeout_at, automation_id))
+            })
+            .map_err(|error| format!("failed to query automation timeouts: {error}"))?;
+        let mut candidates = Vec::new();
+        for row in mapped {
+            let (run_id, session_id, timeout_at, automation_id) =
+                row.map_err(|error| format!("failed to read automation timeout row: {error}"))?;
+            let timeout_at = DateTime::parse_from_rfc3339(&timeout_at)
+                .map_err(|error| format!("run `{run_id}` has invalid timeout_at: {error}"))?
+                .with_timezone(&Utc);
+            if timeout_at <= now {
+                candidates.push((run_id, session_id, automation_id));
+            }
+        }
+        candidates
+    };
+
+    let mut failures = Vec::new();
+    for (run_id, session_id, definition_name) in candidates {
+        if let Err(error) = runtime.kill_session(&session_id) {
+            failures.push(format!(
+                "automation `{definition_name}` run `{run_id}` exceeded its timeout, but session `{session_id}` termination is unproven: {error:#}"
+            ));
+            continue;
+        }
+        let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        crate::store::update_session_terminal_if_active(
+            conn,
+            &session_id,
+            "killed",
+            None,
+            &now_iso,
+        )
+        .map_err(|error| {
+            format!("failed to persist timeout for session `{session_id}`: {error:#}")
+        })?;
+    }
+    Ok(failures)
+}
+
+/// Reconciles nonterminal automation rows against the authoritative session
+/// ledger. Only a completed session with an explicit zero exit code can
+/// produce success; every other terminal session disposition is a failure.
+pub fn settle_finished_runs(
+    conn: &Connection,
+    now: DateTime<Utc>,
+) -> Result<SettlementReport, String> {
+    type RunningRow = (
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<i64>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    );
+
+    let rows: Vec<RunningRow> = {
+        let mut statement = conn
+            .prepare(
+                "SELECT r.id, r.occurrence_id, r.session_id, s.status, s.exit_code,
+                        o.state, r.timeout_at,
+                        COALESCE(
+                            (
+                                SELECT e.created_at
+                                FROM events AS e
+                                WHERE e.session_id = s.id AND e.kind = 'exit'
+                                ORDER BY e.created_at DESC, e.id DESC
+                                LIMIT 1
+                            ),
+                            s.updated_at
+                        )
+                 FROM automation_runs AS r
+                 LEFT JOIN sessions AS s ON s.id = r.session_id
+                 LEFT JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+                 WHERE r.status = 'running'
+                 ORDER BY r.started_at ASC",
+            )
+            .map_err(|error| format!("failed to prepare automation reconciliation: {error}"))?;
+        let mapped = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                ))
+            })
+            .map_err(|error| format!("failed to query automation reconciliation: {error}"))?;
+        let mut rows = Vec::new();
+        for row in mapped {
+            rows.push(
+                row.map_err(|error| format!("failed to read automation reconciliation: {error}"))?,
+            );
+        }
+        rows
+    };
+
+    let mut report = SettlementReport::default();
+    for (
+        run_id,
+        occurrence_id,
+        session_id,
+        session_status,
+        exit_code,
+        occurrence_state,
+        timeout_at,
+        terminal_at,
+    ) in rows
+    {
+        let terminal_session = session_status.as_deref().is_some_and(|status| {
+            matches!(
+                status,
+                "completed" | "failed" | "cancelled" | "killed" | "idle"
+            )
+        });
+        if !terminal_session {
             continue;
         }
 
-        match build_session_launch(&definition, cwd).and_then(|launch| {
-            runtime
-                .launch_session(&launch)
-                .map(|()| launch)
-                .map_err(|error| format!("{error:#}"))
-        }) {
-            Ok(launch) => {
-                let _ = settle_occurrence(conn, &occurrence_id, "succeeded", None, now);
-                let _ = record_run_finish(
-                    conn,
-                    &run_id,
-                    RunFinish {
-                        status: "succeeded",
-                        exit_code: Some(0),
-                        session_id: Some(launch.id),
-                        log_json: None,
-                        output_commit: None,
-                    },
-                    now,
-                );
-                report.dispatched.push(run_id);
+        let completed_after_timeout = match (timeout_at.as_deref(), terminal_at.as_deref()) {
+            (Some(timeout_at), Some(terminal_at)) => {
+                let timeout_at = DateTime::parse_from_rfc3339(timeout_at)
+                    .map_err(|error| format!("run `{run_id}` has invalid timeout_at: {error}"))?;
+                let terminal_at = DateTime::parse_from_rfc3339(terminal_at).map_err(|error| {
+                    format!("session for run `{run_id}` has invalid terminal timestamp: {error}")
+                })?;
+                terminal_at > timeout_at
             }
-            Err(reason) => {
-                let _ = settle_occurrence(conn, &occurrence_id, "failed", Some(&reason), now);
-                let _ = record_run_finish(
-                    conn,
-                    &run_id,
-                    RunFinish {
-                        status: "failed",
-                        exit_code: None,
-                        session_id: None,
-                        log_json: None,
-                        output_commit: None,
-                    },
-                    now,
-                );
-                report.failed.push(format!("{automation_id}: {reason}"));
+            _ => false,
+        };
+        let succeeded = session_status.as_deref() == Some("completed")
+            && exit_code == Some(0)
+            && !completed_after_timeout;
+        let status = if succeeded { "succeeded" } else { "failed" };
+        let reason = if succeeded {
+            None
+        } else if completed_after_timeout {
+            Some("session completed after automation timeout".to_string())
+        } else {
+            Some(match (&session_status, exit_code) {
+                (Some(session_status), Some(exit_code)) => {
+                    format!("session {session_status} (exit code {exit_code})")
+                }
+                (Some(session_status), None) => format!("session {session_status}"),
+                (None, _) => unreachable!("terminal_session requires a session status"),
+            })
+        };
+
+        let transaction = conn
+            .unchecked_transaction()
+            .map_err(|error| format!("failed to begin automation settlement: {error}"))?;
+        let Some(occurrence_id) = occurrence_id.as_deref() else {
+            return Err(format!(
+                "running automation run `{run_id}` has no occurrence"
+            ));
+        };
+        if occurrence_state.as_deref() != Some(status) {
+            if matches!(occurrence_state.as_deref(), Some("succeeded" | "failed")) {
+                return Err(format!(
+                    "automation occurrence `{occurrence_id}` is already `{}` but terminal session evidence requires `{status}`",
+                    occurrence_state.as_deref().unwrap_or("missing")
+                ));
             }
+            if !settle_occurrence(&transaction, occurrence_id, status, reason.as_deref(), now)? {
+                return Err(format!(
+                    "automation occurrence `{occurrence_id}` changed during settlement"
+                ));
+            }
+        }
+        if !record_run_finish(
+            &transaction,
+            &run_id,
+            RunFinish {
+                status,
+                exit_code,
+                session_id,
+                log_json: None,
+                output_commit: None,
+            },
+            now,
+        )
+        .map_err(|error| format!("failed to settle automation run `{run_id}`: {error:#}"))?
+        {
+            return Err(format!(
+                "automation run `{run_id}` changed during settlement"
+            ));
+        }
+        transaction
+            .commit()
+            .map_err(|error| format!("failed to commit automation settlement: {error}"))?;
+        if succeeded {
+            report.succeeded += 1;
+        } else {
+            report.failed += 1;
         }
     }
 
@@ -317,6 +904,219 @@ mod tests {
         }
     }
 
+    struct ContainedRuntime;
+
+    impl SessionRuntime for ContainedRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("automation dispatch must use strict containment")
+        }
+
+        fn launch_contained_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            ownership_established()
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct DelayedContainedRuntime {
+        launches: std::sync::atomic::AtomicUsize,
+    }
+
+    impl SessionRuntime for DelayedContainedRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("automation dispatch must use strict containment")
+        }
+
+        fn launch_contained_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            ownership_established()?;
+            if self
+                .launches
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+                == 0
+            {
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            Ok(())
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct OwnershipThenFailureRuntime;
+
+    impl SessionRuntime for OwnershipThenFailureRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("launch_adopted_session is overridden")
+        }
+
+        fn launch_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            ownership_established()?;
+            anyhow::bail!("synthetic failure after ownership")
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct RetainedOwnershipWithoutCallbackRuntime;
+
+    impl SessionRuntime for RetainedOwnershipWithoutCallbackRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("launch_adopted_session is overridden")
+        }
+
+        fn launch_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            _ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            Err(crate::daemon::RuntimeOwnershipRetainedError.into())
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct TerminalBeforeOwnershipRuntime<'a> {
+        conn: &'a Connection,
+    }
+
+    impl SessionRuntime for TerminalBeforeOwnershipRuntime<'_> {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("launch_adopted_session is overridden")
+        }
+
+        fn launch_adopted_session(
+            &self,
+            launch: &SessionLaunch,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            self.conn.execute(
+                "UPDATE sessions SET status = 'completed', exit_code = 0 WHERE id = ?1",
+                rusqlite::params![launch.id],
+            )?;
+            ownership_established()
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailedKillRuntime;
+
+    impl SessionRuntime for FailedKillRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("timeout test does not launch")
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            anyhow::bail!("synthetic unproven termination")
+        }
+    }
+
+    struct RetainedPublicationErrorRuntime;
+
+    impl SessionRuntime for RetainedPublicationErrorRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("launch_adopted_session is overridden")
+        }
+
+        fn launch_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            _ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            Err(anyhow::Error::new(
+                crate::api::RuntimeOwnershipPublicationError,
+            ))
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     fn definition(id: &str) -> RoutineDefinition {
         RoutineDefinition::from_json(&json!({
             "schemaVersion": 1,
@@ -345,23 +1145,71 @@ mod tests {
     }
 
     #[test]
-    fn successful_run_settles_occurrence_and_ledger() {
+    fn accepted_launch_keeps_occurrence_and_run_running() {
         let (_temp, conn) = temp_store();
         insert_definition(&conn, &definition("daily")).unwrap();
-        let outcome = run_routine_now(
-            &conn,
-            &crate::api::NoopSessionRuntime,
-            &definition("daily"),
-            Utc::now(),
-        )
-        .unwrap();
-        assert_eq!(outcome.status, "succeeded");
+        let launched_at = Utc::now();
+        let outcome =
+            run_routine_now(&conn, &ContainedRuntime, &definition("daily"), launched_at).unwrap();
+        assert_eq!(outcome.status, "running");
         assert!(outcome.session_id.is_some());
 
         let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs.len(), 1);
-        assert_eq!(runs[0].status, "succeeded");
+        assert_eq!(runs[0].status, "running");
+        assert_eq!(runs[0].session_id, outcome.session_id);
+        assert_eq!(runs[0].exit_code, None);
+        assert_eq!(runs[0].finished_at, None);
         assert_eq!(runs[0].familiar_id.as_deref(), Some("charm"));
+
+        let session =
+            crate::store::get_session(&conn, outcome.session_id.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            session.as_ref().map(|row| row.status.as_str()),
+            Some("running")
+        );
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
+    }
+
+    #[test]
+    fn completed_session_evidence_settles_run_successfully() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            launched_at,
+        )
+        .unwrap();
+        let session_id = outcome.session_id.as_deref().unwrap();
+        let finished_at = launched_at + chrono::Duration::seconds(5);
+        crate::store::update_session_terminal_if_active(
+            &conn,
+            session_id,
+            "completed",
+            Some(0),
+            &finished_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        )
+        .unwrap();
+
+        let report = settle_finished_runs(&conn, finished_at).unwrap();
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(report.failed, 0);
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs[0].status, "succeeded");
+        assert_eq!(runs[0].exit_code, Some(0));
+        assert!(runs[0].finished_at.is_some());
 
         let state: String = conn
             .query_row(
@@ -371,6 +1219,287 @@ mod tests {
             )
             .unwrap();
         assert_eq!(state, "succeeded");
+    }
+
+    #[test]
+    fn orphaned_session_is_not_terminal_automation_evidence() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            launched_at,
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE sessions SET status = 'orphaned' WHERE id = ?1",
+            rusqlite::params![outcome.session_id.as_deref().unwrap()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            settle_finished_runs(&conn, launched_at + chrono::Duration::seconds(1)).unwrap(),
+            SettlementReport::default()
+        );
+        assert_eq!(
+            super::super::runs::list_runs(&conn, "daily", 10).unwrap()[0].status,
+            "running"
+        );
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_containment_receipt_recovers_an_orphaned_run() {
+        let (temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            launched_at,
+        )
+        .unwrap();
+        let session_id = outcome.session_id.as_deref().unwrap();
+        conn.execute(
+            "UPDATE sessions SET status = 'orphaned' WHERE id = ?1",
+            rusqlite::params![session_id],
+        )
+        .unwrap();
+        let receipt = containment_receipt_path(temp.path(), session_id);
+        std::fs::create_dir_all(receipt.parent().unwrap()).unwrap();
+        std::fs::write(&receipt, crate::pty_runner::CONTAINMENT_QUIESCENT_RECEIPT).unwrap();
+
+        let recovered = recover_restart_containment(
+            temp.path(),
+            &conn,
+            launched_at + chrono::Duration::seconds(1),
+            false,
+        )
+        .unwrap();
+        assert_eq!(recovered, 1);
+        let report =
+            settle_finished_runs(&conn, launched_at + chrono::Duration::seconds(1)).unwrap();
+        assert_eq!(report.failed, 1);
+        assert_eq!(
+            super::super::runs::list_runs(&conn, "daily", 10).unwrap()[0].status,
+            "failed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn empty_containment_receipt_preserves_unknown_disposition() {
+        let (temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            launched_at,
+        )
+        .unwrap();
+        let session_id = outcome.session_id.as_deref().unwrap();
+        conn.execute(
+            "UPDATE sessions SET status = 'orphaned' WHERE id = ?1",
+            rusqlite::params![session_id],
+        )
+        .unwrap();
+        let receipt = containment_receipt_path(temp.path(), session_id);
+        std::fs::create_dir_all(receipt.parent().unwrap()).unwrap();
+        std::fs::write(receipt, b"").unwrap();
+
+        assert_eq!(
+            recover_restart_containment(temp.path(), &conn, launched_at, true).unwrap(),
+            0
+        );
+        assert_eq!(
+            super::super::runs::list_runs(&conn, "daily", 10).unwrap()[0].status,
+            "running"
+        );
+    }
+
+    #[test]
+    fn receipt_cleanup_removes_only_terminal_session_evidence() {
+        let (temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let launched_at = Utc::now();
+        let terminal = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            launched_at,
+        )
+        .unwrap();
+        let terminal_id = terminal.session_id.as_deref().unwrap();
+        crate::store::update_session_terminal_if_active(
+            &conn,
+            terminal_id,
+            "completed",
+            Some(0),
+            &launched_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        )
+        .unwrap();
+        let terminal_receipt = containment_receipt_path(temp.path(), terminal_id);
+        std::fs::create_dir_all(terminal_receipt.parent().unwrap()).unwrap();
+        std::fs::write(
+            &terminal_receipt,
+            crate::pty_runner::CONTAINMENT_QUIESCENT_RECEIPT,
+        )
+        .unwrap();
+        let active_receipt = containment_receipt_path(temp.path(), "active-session");
+        std::fs::write(&active_receipt, b"").unwrap();
+
+        assert_eq!(
+            cleanup_terminal_containment_receipts(temp.path(), &conn).unwrap(),
+            1
+        );
+        assert!(!terminal_receipt.exists());
+        assert!(active_receipt.exists());
+    }
+
+    #[test]
+    fn completion_after_immutable_deadline_settles_as_failed() {
+        let (_temp, conn) = temp_store();
+        let mut routine = definition("daily");
+        routine.timeout_minutes = 1;
+        insert_definition(&conn, &routine).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &routine,
+            launched_at,
+        )
+        .unwrap();
+        let completed_at =
+            launched_at + chrono::Duration::minutes(1) + chrono::Duration::milliseconds(1);
+        crate::store::update_session_terminal_if_active(
+            &conn,
+            outcome.session_id.as_deref().unwrap(),
+            "completed",
+            Some(0),
+            &completed_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        )
+        .unwrap();
+
+        let report = settle_finished_runs(&conn, completed_at).unwrap();
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 1);
+        let run = super::super::runs::list_runs(&conn, "daily", 10)
+            .unwrap()
+            .remove(0);
+        assert_eq!(run.status, "failed");
+        let reason: String = conn
+            .query_row(
+                "SELECT failure_reason FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(reason, "session completed after automation timeout");
+    }
+
+    #[test]
+    fn expired_claim_lease_does_not_preempt_later_session_success() {
+        let (_temp, conn) = temp_store();
+        let mut routine = definition("daily");
+        routine.timeout_minutes = 120;
+        insert_definition(&conn, &routine).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &routine,
+            launched_at,
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE automation_occurrences
+             SET lease_expires_at = '2020-01-01T00:00:00.000Z'
+             WHERE automation_id = 'daily'",
+            [],
+        )
+        .unwrap();
+
+        let after_lease = launched_at + chrono::Duration::minutes(61);
+        assert_eq!(
+            super::super::occurrences::recover_expired_leases(&conn, after_lease).unwrap(),
+            0
+        );
+        assert_eq!(
+            settle_finished_runs(&conn, after_lease).unwrap(),
+            SettlementReport::default()
+        );
+
+        let session_id = outcome.session_id.as_deref().unwrap();
+        let finished_at = after_lease + chrono::Duration::seconds(5);
+        crate::store::update_session_terminal_if_active(
+            &conn,
+            session_id,
+            "completed",
+            Some(0),
+            &finished_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        )
+        .unwrap();
+        let report = settle_finished_runs(&conn, finished_at).unwrap();
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(
+            super::super::runs::list_runs(&conn, "daily", 10).unwrap()[0].status,
+            "succeeded"
+        );
+    }
+
+    #[test]
+    fn failed_session_evidence_settles_run_as_failed() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            launched_at,
+        )
+        .unwrap();
+        let session_id = outcome.session_id.as_deref().unwrap();
+        let finished_at = launched_at + chrono::Duration::seconds(5);
+        crate::store::update_session_terminal_if_active(
+            &conn,
+            session_id,
+            "failed",
+            Some(17),
+            &finished_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        )
+        .unwrap();
+
+        let report = settle_finished_runs(&conn, finished_at).unwrap();
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 1);
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs[0].status, "failed");
+        assert_eq!(runs[0].exit_code, Some(17));
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "failed");
     }
 
     #[test]
@@ -393,6 +1522,450 @@ mod tests {
             )
             .unwrap();
         assert_eq!(state, "failed");
+    }
+
+    #[test]
+    fn failure_after_runtime_ownership_remains_nonterminal() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let outcome = run_routine_now(
+            &conn,
+            &OwnershipThenFailureRuntime,
+            &definition("daily"),
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "running");
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("after ownership")));
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs[0].status, "running");
+        assert!(runs[0].finished_at.is_none());
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
+    }
+
+    #[test]
+    fn retained_runtime_ownership_without_callback_remains_nonterminal() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let outcome = run_routine_now(
+            &conn,
+            &RetainedOwnershipWithoutCallbackRuntime,
+            &definition("daily"),
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "running");
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("runtime ownership")));
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs[0].status, "running");
+        assert!(runs[0].finished_at.is_none());
+        let session = crate::store::get_session(
+            &conn,
+            runs[0].session_id.as_deref().expect("linked session"),
+        )
+        .unwrap()
+        .expect("persisted session");
+        assert_eq!(session.status, "running");
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
+    }
+
+    #[test]
+    fn retained_ownership_after_publication_error_remains_nonterminal() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let outcome = run_routine_now(
+            &conn,
+            &RetainedPublicationErrorRuntime,
+            &definition("daily"),
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "running");
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("could not be published")));
+
+        let run = super::super::runs::list_runs(&conn, "daily", 10)
+            .unwrap()
+            .remove(0);
+        assert_eq!(run.status, "running");
+        let session = crate::store::get_session(&conn, run.session_id.as_deref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "running");
+    }
+
+    #[test]
+    fn terminal_session_before_ownership_publication_reconciles_successfully() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &TerminalBeforeOwnershipRuntime { conn: &conn },
+            &definition("daily"),
+            launched_at,
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "running");
+
+        let report =
+            settle_finished_runs(&conn, launched_at + chrono::Duration::seconds(1)).unwrap();
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(report.failed, 0);
+
+        let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
+        assert_eq!(runs[0].status, "succeeded");
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "succeeded");
+    }
+
+    #[test]
+    fn manual_run_claims_the_occurrence_it_just_created() {
+        let (_temp, conn) = temp_store();
+        insert_definition(&conn, &definition("daily")).unwrap();
+        let now = Utc::now();
+        let old_scheduled_for =
+            (now - chrono::Duration::hours(1)).to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+             VALUES ('scheduled-earlier', 'daily', ?1, 'planned', 0, ?1, ?1)",
+            rusqlite::params![old_scheduled_for],
+        )
+        .unwrap();
+
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &definition("daily"),
+            now,
+        )
+        .unwrap();
+        assert_eq!(outcome.status, "running");
+        let old_state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = 'scheduled-earlier'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(old_state, "planned");
+    }
+
+    #[test]
+    fn daemon_dispatch_never_touches_a_manual_claim() {
+        let (temp, conn) = temp_store();
+        let routine = definition("daily");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc::now();
+        assert!(insert_claimed_occurrence(
+            &conn,
+            "manual-occurrence",
+            &routine.id,
+            "manual",
+            60,
+            now,
+        )
+        .unwrap());
+        let daemon_conn = crate::store::open_store(&temp.path().join("store.sqlite")).unwrap();
+
+        let report =
+            dispatch_claimed_occurrences(&daemon_conn, &crate::api::NoopSessionRuntime, now)
+                .unwrap();
+        assert!(report.dispatched.is_empty());
+        assert!(report.failed.is_empty());
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = 'manual-occurrence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "claimed");
+    }
+
+    #[test]
+    fn batch_dispatch_assigns_each_run_its_own_launch_timestamp() {
+        let (_temp, conn) = temp_store();
+        let first = definition("first");
+        let second = definition("second");
+        insert_definition(&conn, &first).unwrap();
+        insert_definition(&conn, &second).unwrap();
+        let now = Utc::now();
+        for routine in [&first, &second] {
+            assert!(insert_claimed_occurrence(
+                &conn,
+                &format!("{}-occurrence", routine.id),
+                &routine.id,
+                "daemon",
+                60,
+                now,
+            )
+            .unwrap());
+        }
+
+        let runtime = DelayedContainedRuntime {
+            launches: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let report = dispatch_claimed_occurrences(&conn, &runtime, now).unwrap();
+        assert_eq!(report.dispatched.len(), 2);
+        let mut statement = conn
+            .prepare("SELECT started_at FROM automation_runs ORDER BY started_at ASC")
+            .unwrap();
+        let started: Vec<String> = statement
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        let first_started = DateTime::parse_from_rfc3339(&started[0]).unwrap();
+        let second_started = DateTime::parse_from_rfc3339(&started[1]).unwrap();
+        assert!(
+            second_started - first_started >= chrono::Duration::milliseconds(20),
+            "serial launches shared or truncated their dispatch timestamp: {started:?}"
+        );
+    }
+
+    #[test]
+    fn overlap_forbid_rejects_a_second_manual_run_atomically() {
+        let (_temp, conn) = temp_store();
+        let routine = definition("daily");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc::now();
+        let first = run_routine_now(&conn, &crate::api::NoopSessionRuntime, &routine, now).unwrap();
+        assert_eq!(first.status, "running");
+
+        let second = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &routine,
+            now + chrono::Duration::seconds(1),
+        )
+        .unwrap();
+        assert_eq!(second.status, "failed");
+        assert!(second
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("overlap is forbidden")));
+
+        let occurrence_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM automation_occurrences WHERE automation_id = 'daily'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(occurrence_count, 1);
+        assert_eq!(
+            super::super::runs::list_runs(&conn, "daily", 10)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn expired_preownership_launch_recovers_run_and_occurrence_together() {
+        let (_temp, conn) = temp_store();
+        let mut routine = definition("daily");
+        routine.timeout_minutes = 120;
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc::now();
+        let launched_at = now - chrono::Duration::minutes(61);
+        let occurrence_id = "abandoned-occurrence";
+        let session_id = "abandoned-session";
+        let run_id = "abandoned-run";
+        assert!(insert_claimed_occurrence(
+            &conn,
+            occurrence_id,
+            &routine.id,
+            "daemon",
+            60,
+            launched_at,
+        )
+        .unwrap());
+        let mut launch = build_session_launch(&routine, routine.cwd.as_deref().unwrap()).unwrap();
+        launch.id = session_id.to_string();
+        persist_launch(&conn, run_id, occurrence_id, &routine, &launch, launched_at).unwrap();
+
+        assert_eq!(
+            crate::store::mark_stale_created_sessions_failed(
+                &conn,
+                &now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                &now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            )
+            .unwrap(),
+            0,
+            "generic stale recovery must defer correlated automation sessions"
+        );
+        let failures = recover_abandoned_launches(&conn, &FailedKillRuntime, now).unwrap();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(
+            super::super::occurrences::recover_expired_leases(&conn, now).unwrap(),
+            0,
+            "lease age cannot settle a launch with unproven process disposition"
+        );
+        assert_eq!(
+            crate::store::get_session(&conn, session_id)
+                .unwrap()
+                .unwrap()
+                .status,
+            "created"
+        );
+        assert!(
+            recover_abandoned_launches(&conn, &crate::api::NoopSessionRuntime, now)
+                .unwrap()
+                .is_empty()
+        );
+        let report = settle_finished_runs(&conn, now).unwrap();
+        assert_eq!(report.failed, 1);
+
+        let run = super::super::runs::list_runs(&conn, "daily", 10)
+            .unwrap()
+            .remove(0);
+        assert_eq!(run.status, "failed");
+        let session = crate::store::get_session(&conn, session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.status, "killed");
+        let occurrence_state: String = conn
+            .query_row(
+                "SELECT state FROM automation_occurrences WHERE id = ?1",
+                rusqlite::params![occurrence_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(occurrence_state, "failed");
+    }
+
+    #[test]
+    fn timeout_kills_session_before_settling_failure() {
+        let (_temp, conn) = temp_store();
+        let mut routine = definition("daily");
+        routine.timeout_minutes = 1;
+        insert_definition(&conn, &routine).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &routine,
+            launched_at,
+        )
+        .unwrap();
+        let timed_out_at = launched_at + chrono::Duration::minutes(1);
+
+        let failures =
+            enforce_run_timeouts(&conn, &crate::api::NoopSessionRuntime, timed_out_at).unwrap();
+        assert!(failures.is_empty());
+        let session = crate::store::get_session(
+            &conn,
+            outcome.session_id.as_deref().expect("linked session"),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(session.status, "killed");
+
+        let report = settle_finished_runs(&conn, timed_out_at).unwrap();
+        assert_eq!(report.failed, 1);
+        let run = super::super::runs::list_runs(&conn, "daily", 10)
+            .unwrap()
+            .remove(0);
+        assert_eq!(run.status, "failed");
+    }
+
+    #[test]
+    fn deleting_definition_does_not_disable_running_deadline() {
+        let (_temp, conn) = temp_store();
+        let mut routine = definition("daily");
+        routine.timeout_minutes = 1;
+        insert_definition(&conn, &routine).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &routine,
+            launched_at,
+        )
+        .unwrap();
+        assert!(super::super::store::delete_definition(&conn, "daily").unwrap());
+
+        let timed_out_at = launched_at + chrono::Duration::minutes(1);
+        assert!(
+            enforce_run_timeouts(&conn, &crate::api::NoopSessionRuntime, timed_out_at)
+                .unwrap()
+                .is_empty()
+        );
+        let session = crate::store::get_session(
+            &conn,
+            outcome.session_id.as_deref().expect("linked session"),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(session.status, "killed");
+    }
+
+    #[test]
+    fn unproven_timeout_termination_remains_running() {
+        let (_temp, conn) = temp_store();
+        let mut routine = definition("daily");
+        routine.timeout_minutes = 1;
+        insert_definition(&conn, &routine).unwrap();
+        let launched_at = Utc::now();
+        let outcome = run_routine_now(
+            &conn,
+            &crate::api::NoopSessionRuntime,
+            &routine,
+            launched_at,
+        )
+        .unwrap();
+        let timed_out_at = launched_at + chrono::Duration::minutes(1);
+
+        let failures = enforce_run_timeouts(&conn, &FailedKillRuntime, timed_out_at).unwrap();
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("termination is unproven"));
+
+        let session = crate::store::get_session(
+            &conn,
+            outcome.session_id.as_deref().expect("linked session"),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(session.status, "running");
+        let run = super::super::runs::list_runs(&conn, "daily", 10)
+            .unwrap()
+            .remove(0);
+        assert_eq!(run.status, "running");
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/runs.rs
+++ b/crates/coven-cli/src/automations/runs.rs
@@ -22,6 +22,7 @@ pub const AUTOMATION_RUNS_SCHEMA_SQL: &str = "
         log_json TEXT,
         output_commit TEXT,
         started_at TEXT NOT NULL,
+        timeout_at TEXT,
         finished_at TEXT,
         FOREIGN KEY (occurrence_id) REFERENCES automation_occurrences(id) ON DELETE SET NULL
     );
@@ -51,30 +52,40 @@ pub struct RunRecord {
     pub log_json: Option<String>,
     pub output_commit: Option<String>,
     pub started_at: String,
+    pub timeout_at: Option<String>,
     pub finished_at: Option<String>,
 }
 
 #[allow(dead_code)] // consumed by the part-4 dispatch path; tests cover it today
+pub struct RunStart<'a> {
+    pub automation_id: &'a str,
+    pub occurrence_id: Option<&'a str>,
+    pub session_id: Option<&'a str>,
+    pub familiar_id: Option<&'a str>,
+    pub runtime: &'a str,
+    pub timeout_at: DateTime<Utc>,
+}
+
 pub fn record_run_start(
     conn: &Connection,
     run_id: &str,
-    automation_id: &str,
-    occurrence_id: Option<&str>,
-    familiar_id: Option<&str>,
-    runtime: &str,
+    start: RunStart<'_>,
     now: DateTime<Utc>,
 ) -> Result<()> {
     conn.execute(
         "INSERT INTO automation_runs
-            (id, automation_id, occurrence_id, familiar_id, runtime, status, started_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, 'running', ?6)",
+            (id, automation_id, occurrence_id, session_id, familiar_id, runtime,
+             status, started_at, timeout_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running', ?7, ?8)",
         params![
             run_id,
-            automation_id,
-            occurrence_id,
-            familiar_id,
-            runtime,
-            iso(now)
+            start.automation_id,
+            start.occurrence_id,
+            start.session_id,
+            start.familiar_id,
+            start.runtime,
+            iso(now),
+            iso(start.timeout_at)
         ],
     )
     .context("failed to record run start")?;
@@ -150,7 +161,7 @@ pub fn list_runs(conn: &Connection, automation_id: &str, limit: i64) -> Result<V
     let mut statement = conn
         .prepare(
             "SELECT id, automation_id, occurrence_id, session_id, familiar_id, runtime,
-                    status, exit_code, log_json, output_commit, started_at, finished_at
+                    status, exit_code, log_json, output_commit, started_at, timeout_at, finished_at
              FROM automation_runs
              WHERE automation_id = ?1
              ORDER BY started_at DESC
@@ -171,7 +182,8 @@ pub fn list_runs(conn: &Connection, automation_id: &str, limit: i64) -> Result<V
                 log_json: row.get(8)?,
                 output_commit: row.get(9)?,
                 started_at: row.get(10)?,
-                finished_at: row.get(11)?,
+                timeout_at: row.get(11)?,
+                finished_at: row.get(12)?,
             })
         })
         .context("failed to list runs")?;
@@ -180,7 +192,32 @@ pub fn list_runs(conn: &Connection, automation_id: &str, limit: i64) -> Result<V
     for row in rows {
         records.push(row.context("failed to read run row")?);
     }
+
     Ok(records)
+}
+
+pub fn ensure_timeout_column(conn: &Connection) -> Result<()> {
+    let present = {
+        let mut statement = conn
+            .prepare("PRAGMA table_info(automation_runs)")
+            .context("failed to inspect automation_runs columns")?;
+        let columns = statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .context("failed to query automation_runs columns")?;
+        let mut present = false;
+        for column in columns {
+            if column.context("failed to read automation_runs column")? == "timeout_at" {
+                present = true;
+                break;
+            }
+        }
+        present
+    };
+    if !present {
+        conn.execute_batch("ALTER TABLE automation_runs ADD COLUMN timeout_at TEXT")
+            .context("failed to add automation_runs.timeout_at")?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -216,10 +253,14 @@ mod tests {
         record_run_start(
             &conn,
             "run-1",
-            "daily",
-            Some("occ-1"),
-            Some("charm"),
-            "coven-code",
+            RunStart {
+                automation_id: "daily",
+                occurrence_id: Some("occ-1"),
+                session_id: None,
+                familiar_id: Some("charm"),
+                runtime: "coven-code",
+                timeout_at: start + chrono::Duration::minutes(30),
+            },
             start,
         )
         .unwrap();
@@ -244,13 +285,30 @@ mod tests {
         assert_eq!(runs[0].status, "succeeded");
         assert_eq!(runs[0].session_id.as_deref(), Some("session-1"));
         assert_eq!(runs[0].familiar_id.as_deref(), Some("charm"));
+        assert_eq!(
+            runs[0].timeout_at.as_deref(),
+            Some("2026-08-28T09:30:00.000Z")
+        );
     }
 
     #[test]
     fn finishing_a_non_running_run_is_a_no_op() {
         let (_temp, conn) = temp_store();
         let start = utc(2026, 8, 28, 9, 0);
-        record_run_start(&conn, "run-2", "daily", None, None, "coven-code", start).unwrap();
+        record_run_start(
+            &conn,
+            "run-2",
+            RunStart {
+                automation_id: "daily",
+                occurrence_id: None,
+                session_id: None,
+                familiar_id: None,
+                runtime: "coven-code",
+                timeout_at: start + chrono::Duration::minutes(30),
+            },
+            start,
+        )
+        .unwrap();
         record_run_finish(
             &conn,
             "run-2",
@@ -288,7 +346,20 @@ mod tests {
     fn rejects_unknown_terminal_status() {
         let (_temp, conn) = temp_store();
         let start = utc(2026, 8, 28, 9, 0);
-        record_run_start(&conn, "run-3", "daily", None, None, "coven-code", start).unwrap();
+        record_run_start(
+            &conn,
+            "run-3",
+            RunStart {
+                automation_id: "daily",
+                occurrence_id: None,
+                session_id: None,
+                familiar_id: None,
+                runtime: "coven-code",
+                timeout_at: start + chrono::Duration::minutes(30),
+            },
+            start,
+        )
+        .unwrap();
         let error = record_run_finish(
             &conn,
             "run-3",

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -817,7 +817,7 @@ static CLAUDE_JSON_TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::At
 
 impl SessionRuntime for LiveSessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()> {
-        self.launch_session_inner(launch, None, None)
+        self.launch_session_inner(launch, None, None, false)
     }
 
     fn launch_session_with_writer(
@@ -825,7 +825,7 @@ impl SessionRuntime for LiveSessionRuntime {
         launch: &SessionLaunch,
         writer: crate::maintenance_gate::WriterLease,
     ) -> Result<()> {
-        self.launch_session_inner(launch, Some(writer), None)
+        self.launch_session_inner(launch, Some(writer), None, false)
     }
 
     fn launch_adopted_session(
@@ -834,7 +834,16 @@ impl SessionRuntime for LiveSessionRuntime {
         writer: Option<crate::maintenance_gate::WriterLease>,
         ownership_established: &mut dyn FnMut() -> Result<()>,
     ) -> Result<()> {
-        self.launch_session_inner(launch, writer, Some(ownership_established))
+        self.launch_session_inner(launch, writer, Some(ownership_established), false)
+    }
+
+    fn launch_contained_adopted_session(
+        &self,
+        launch: &SessionLaunch,
+        writer: Option<crate::maintenance_gate::WriterLease>,
+        ownership_established: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<()> {
+        self.launch_session_inner(launch, writer, Some(ownership_established), true)
     }
 
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()> {
@@ -960,6 +969,7 @@ impl LiveSessionRuntime {
         launch: &SessionLaunch,
         writer: Option<crate::maintenance_gate::WriterLease>,
         ownership_established: Option<&mut dyn FnMut() -> Result<()>>,
+        strict_containment: bool,
     ) -> Result<()> {
         anyhow::ensure!(
             !self.shutting_down.load(Ordering::Acquire),
@@ -1002,8 +1012,47 @@ impl LiveSessionRuntime {
                 launch_options,
             )?
         };
+        if strict_containment {
+            let coven_home = self
+                .coven_home
+                .as_deref()
+                .context("strict automation containment requires COVEN_HOME")?;
+            let receipt_path =
+                crate::automations::runner::containment_receipt_path(coven_home, &launch.id);
+            let receipt_dir = receipt_path
+                .parent()
+                .context("automation containment receipt path has no parent")?;
+            std::fs::create_dir_all(receipt_dir).with_context(|| {
+                format!(
+                    "failed creating automation containment receipt directory `{}`",
+                    receipt_dir.display()
+                )
+            })?;
+            match std::fs::remove_file(&receipt_path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed resetting automation containment receipt `{}`",
+                            receipt_path.display()
+                        )
+                    });
+                }
+            }
+            command.set_environment_override(
+                pty_runner::CONTAINMENT_RECEIPT_ENV,
+                Some(receipt_path.to_string_lossy().into_owned()),
+            );
+        }
         Self::apply_writer_participant(&mut command, writer.as_ref())?;
-        self.launch_prepared_session(launch, writer, command, ownership_established)
+        self.launch_prepared_session(
+            launch,
+            writer,
+            command,
+            ownership_established,
+            strict_containment,
+        )
     }
 
     fn launch_prepared_session(
@@ -1012,6 +1061,7 @@ impl LiveSessionRuntime {
         writer: Option<crate::maintenance_gate::WriterLease>,
         command: pty_runner::HarnessCommand,
         mut ownership_established: Option<&mut dyn FnMut() -> Result<()>>,
+        strict_containment: bool,
     ) -> Result<()> {
         let (observer, registration) =
             self.observer_for_session_with_writer(launch.id.clone(), writer);
@@ -1067,7 +1117,7 @@ impl LiveSessionRuntime {
         // bounded. Windows additionally routes every noninteractive harness
         // here because ConPTY can terminate those children immediately.
         if launch.launch_mode == crate::harness::HarnessLaunchMode::NonInteractive
-            && (cfg!(windows) || launch.harness == "codex")
+            && (strict_containment || cfg!(windows) || launch.harness == "codex")
         {
             let (piped, _provisional_killer) = launch_admission.spawn_owned(|publish| {
                 let piped = pty_runner::spawn_piped_with_observer(&command, observer, false)?;
@@ -5235,6 +5285,7 @@ fn serve_forever_with_lifetime_job_installer(
     initialize_daemon_store(coven_home)?;
     write_status(coven_home, &status)?;
     recover_orphaned_sessions(coven_home, &started_at)?;
+    recover_stale_created_sessions(coven_home, &started_at)?;
     recover_orphaned_afs_mounts(coven_home);
 
     let runtime = Arc::new(LiveSessionRuntime::try_with_coven_home(
@@ -5242,6 +5293,7 @@ fn serve_forever_with_lifetime_job_installer(
     )?);
     start_threads_proposal_scheduler(coven_home)?;
     start_store_maintenance_scheduler(coven_home)?;
+    crate::automations::daemon_tick::start_automations_scheduler(coven_home, runtime.clone())?;
 
     const MAX_INFLIGHT: usize = 64;
     let inflight = Arc::new(AtomicUsize::new(0));
@@ -7185,6 +7237,7 @@ mod tests {
                 None,
                 command,
                 Some(&mut publish_running),
+                false,
             );
             let _ = launch_tx.send(result);
         });

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -315,6 +315,14 @@ impl HarnessCommand {
             }
         }
     }
+
+    fn containment_receipt_path(&self) -> Option<PathBuf> {
+        self.env_overrides.iter().rev().find_map(|(name, value)| {
+            (name == CONTAINMENT_RECEIPT_ENV)
+                .then(|| value.as_ref().map(PathBuf::from))
+                .flatten()
+        })
+    }
 }
 
 pub fn build_harness_command(
@@ -1504,8 +1512,28 @@ impl SharedStrictChildProcessTree {
     }
 
     pub(crate) fn terminate_and_wait(&self, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
         let termination = self.terminate_tree().err();
         let wait_state = wait_for_piped_child_reap(&self.child_wait_state, timeout);
+        #[cfg(unix)]
+        let containment_quiescence = if wait_state == PIPED_CHILD_REAPED {
+            self.wait_for_unix_process_group_quiescence(
+                deadline.saturating_duration_since(Instant::now()),
+            )
+            .err()
+        } else {
+            None
+        };
+        #[cfg(not(unix))]
+        let containment_quiescence: Option<anyhow::Error> = None;
+        if let Some(error) = containment_quiescence {
+            return match termination {
+                Some(termination) => Err(error.context(format!(
+                    "process-tree termination also reported an error: {termination}"
+                ))),
+                None => Err(error),
+            };
+        }
         match (termination, wait_state) {
             (None, PIPED_CHILD_REAPED) => Ok(()),
             (Some(error), PIPED_CHILD_REAPED) => Err(anyhow::Error::new(error).context(
@@ -1530,6 +1558,15 @@ impl SharedStrictChildProcessTree {
                 ),
             },
         }
+    }
+
+    #[cfg(unix)]
+    fn wait_for_unix_process_group_quiescence(&self, timeout: Duration) -> Result<()> {
+        let pid = match self.process_tree.lock() {
+            Ok(process_tree) => process_tree.0.pid,
+            Err(poisoned) => poisoned.into_inner().0.pid,
+        };
+        wait_for_unix_process_group_exit(pid, timeout)
     }
 
     pub(crate) fn wait_for_quiescence(&self, timeout: Duration) -> Result<()> {
@@ -1883,6 +1920,9 @@ fn wait_at_windows_strict_preattach_test_barrier(child_pid: u32) -> io::Result<(
 }
 
 pub(crate) const PROCESS_SUPERVISOR_PROTOCOL: &str = "coven.process-supervisor.v1";
+pub(crate) const CONTAINMENT_RECEIPT_ENV: &str = "COVEN_CONTAINMENT_RECEIPT_PATH";
+pub(crate) const CONTAINMENT_QUIESCENT_RECEIPT: &[u8] = b"coven.containment.quiescent.v1\n";
+pub(crate) const CONTAINMENT_NO_PROCESS_RECEIPT: &[u8] = b"coven.containment.no-process.v1\n";
 const PROCESS_SUPERVISOR_CONTROL_PREFIX: &str = "COVEN_PROCESS_SUPERVISOR_V1 ";
 const PROCESS_SUPERVISOR_MAX_REQUEST_BYTES: usize = 256 * 1024;
 const PROCESS_SUPERVISOR_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -1957,6 +1997,7 @@ struct ProcessSupervisorGuardian {
     setup_ack_read: libc::c_int,
     pid: libc::pid_t,
     finished: bool,
+    receipt_path: Option<PathBuf>,
 }
 
 #[cfg(unix)]
@@ -2024,8 +2065,9 @@ unsafe fn guardian_remap_and_close_unrelated_fds(
     owner_read: libc::c_int,
     pid_read: libc::c_int,
     ack_write: libc::c_int,
+    receipt_write: Option<libc::c_int>,
     max_fd: libc::c_int,
-) -> Option<(libc::c_int, libc::c_int, libc::c_int)> {
+) -> Option<(libc::c_int, libc::c_int, libc::c_int, Option<libc::c_int>)> {
     // A guardian is forked from a multithreaded daemon and intentionally does
     // not exec. Without this close sweep it would retain accepted API sockets,
     // store locks, and listeners after the request handler dropped them. First
@@ -2034,21 +2076,32 @@ unsafe fn guardian_remap_and_close_unrelated_fds(
     let owner_temp = unsafe { libc::fcntl(owner_read, libc::F_DUPFD_CLOEXEC, 64) };
     let pid_temp = unsafe { libc::fcntl(pid_read, libc::F_DUPFD_CLOEXEC, 64) };
     let ack_temp = unsafe { libc::fcntl(ack_write, libc::F_DUPFD_CLOEXEC, 64) };
-    if owner_temp < 0 || pid_temp < 0 || ack_temp < 0 {
+    let receipt_temp =
+        receipt_write.map(|fd| unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 64) });
+    if owner_temp < 0 || pid_temp < 0 || ack_temp < 0 || receipt_temp.is_some_and(|fd| fd < 0) {
         return None;
     }
     if unsafe { libc::dup2(owner_temp, 3) } < 0
         || unsafe { libc::dup2(pid_temp, 4) } < 0
         || unsafe { libc::dup2(ack_temp, 5) } < 0
+        || receipt_temp.is_some_and(|fd| unsafe { libc::dup2(fd, 6) } < 0)
     {
         return None;
     }
+    let first_unrelated_fd = if receipt_temp.is_some() { 7 } else { 6 };
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
-        let closed = unsafe { libc::syscall(libc::SYS_close_range, 6_u32, u32::MAX, 0_u32) } == 0;
+        let closed = unsafe {
+            libc::syscall(
+                libc::SYS_close_range,
+                first_unrelated_fd as u32,
+                u32::MAX,
+                0_u32,
+            )
+        } == 0;
         if !closed {
-            for fd in 6..max_fd {
+            for fd in first_unrelated_fd..max_fd {
                 unsafe { libc::close(fd) };
             }
         }
@@ -2070,19 +2123,79 @@ unsafe fn guardian_remap_and_close_unrelated_fds(
         target_os = "netbsd",
         target_os = "dragonfly"
     )))]
-    for fd in 6..max_fd {
+    for fd in first_unrelated_fd..max_fd {
         unsafe { libc::close(fd) };
     }
     for fd in 0..3 {
         unsafe { libc::close(fd) };
     }
-    Some((3, 4, 5))
+    Some((3, 4, 5, receipt_temp.map(|_| 6)))
+}
+
+#[cfg(unix)]
+unsafe fn guardian_write_receipt(fd: libc::c_int, receipt: &[u8]) {
+    unsafe {
+        libc::ftruncate(fd, 0);
+        libc::lseek(fd, 0, libc::SEEK_SET);
+        if guardian_write_all(fd, receipt) {
+            libc::fsync(fd);
+        }
+        libc::close(fd);
+    }
+}
+
+#[cfg(unix)]
+unsafe fn guardian_wait_for_process_group_exit(pid: libc::pid_t) -> bool {
+    for _ in 0..3_000 {
+        let result = unsafe { libc::kill(-pid, 0) };
+        if result == -1 {
+            let code = io::Error::last_os_error().raw_os_error();
+            if code == Some(libc::ESRCH) || (cfg!(target_os = "macos") && code == Some(libc::EPERM))
+            {
+                return true;
+            }
+        }
+        unsafe { libc::usleep(10_000) };
+    }
+    false
+}
+
+fn write_containment_receipt(path: &Path, receipt: &[u8]) -> io::Result<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
+    file.write_all(receipt)?;
+    file.sync_all()
+}
+
+#[cfg(unix)]
+fn wait_for_unix_process_group_exit(pid: u32, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let result = unsafe { libc::kill(-(pid as libc::pid_t), 0) };
+        if result == -1 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::ESRCH)
+                || (cfg!(target_os = "macos") && error.raw_os_error() == Some(libc::EPERM))
+            {
+                return Ok(());
+            }
+            return Err(error).context("failed to inspect contained Unix process group");
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "contained Unix process group {pid} remained live after termination"
+        );
+        thread::sleep(Duration::from_millis(5));
+    }
 }
 
 #[cfg(unix)]
 impl ProcessSupervisorGuardian {
-    fn install(command: &mut std::process::Command) -> Result<Self> {
-        use std::os::unix::process::CommandExt;
+    fn install(command: &mut std::process::Command, receipt_path: Option<&Path>) -> Result<Self> {
+        use std::os::unix::{fs::OpenOptionsExt, process::CommandExt};
 
         let owner = cloexec_pipe().context("failed creating supervisor owner pipe")?;
         let pid_channel = match cloexec_pipe() {
@@ -2106,6 +2219,37 @@ impl ProcessSupervisorGuardian {
                 return Err(error).context("failed creating supervisor acknowledgement channel");
             }
         };
+        let receipt = match receipt_path
+            .map(|path| {
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .mode(0o600)
+                    .open(path)
+                    .with_context(|| {
+                        format!("failed arming containment receipt `{}`", path.display())
+                    })
+            })
+            .transpose()
+        {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                unsafe {
+                    for fd in [
+                        owner[0],
+                        owner[1],
+                        pid_channel[0],
+                        pid_channel[1],
+                        ack_channel[0],
+                        ack_channel[1],
+                    ] {
+                        libc::close(fd);
+                    }
+                }
+                return Err(error);
+            }
+        };
 
         let max_fd = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) }
             .clamp(64, libc::c_int::MAX as libc::c_long) as libc::c_int;
@@ -2124,6 +2268,9 @@ impl ProcessSupervisorGuardian {
                     libc::close(fd);
                 }
             }
+            if let Some(path) = receipt_path {
+                let _ = write_containment_receipt(path, CONTAINMENT_NO_PROCESS_RECEIPT);
+            }
             return Err(error).context("failed starting process-supervisor guardian");
         }
         if guardian_pid == 0 {
@@ -2140,11 +2287,12 @@ impl ProcessSupervisorGuardian {
                 libc::close(owner[1]);
                 libc::close(pid_channel[1]);
                 libc::close(ack_channel[0]);
-                let Some((owner_read, pid_read, ack_write)) =
+                let Some((owner_read, pid_read, ack_write, receipt_write)) =
                     guardian_remap_and_close_unrelated_fds(
                         owner[0],
                         pid_channel[0],
                         ack_channel[1],
+                        receipt.as_ref().map(std::os::fd::AsRawFd::as_raw_fd),
                         max_fd,
                     )
                 else {
@@ -2164,6 +2312,9 @@ impl ProcessSupervisorGuardian {
                             // Command implementation may already have reaped
                             // that failed child, so signaling the numeric PGID
                             // here would introduce a stale-id race.
+                            if let Some(fd) = receipt_write {
+                                guardian_write_receipt(fd, CONTAINMENT_NO_PROCESS_RECEIPT);
+                            }
                             break;
                         }
                         if count == 1 && byte == *b"K" {
@@ -2174,6 +2325,11 @@ impl ProcessSupervisorGuardian {
                             // Owner EOF means the supervisor/daemon died
                             // before it could perform orderly cleanup.
                             let _ = libc::kill(-target_pid, libc::SIGKILL);
+                            if let Some(fd) = receipt_write {
+                                if guardian_wait_for_process_group_exit(target_pid) {
+                                    guardian_write_receipt(fd, CONTAINMENT_QUIESCENT_RECEIPT);
+                                }
+                            }
                             break;
                         }
                         if count == -1
@@ -2188,6 +2344,8 @@ impl ProcessSupervisorGuardian {
                             break;
                         }
                     }
+                } else if let Some(fd) = receipt_write {
+                    guardian_write_receipt(fd, CONTAINMENT_NO_PROCESS_RECEIPT);
                 }
                 libc::_exit(0);
             }
@@ -2225,6 +2383,7 @@ impl ProcessSupervisorGuardian {
             setup_ack_read,
             pid: guardian_pid,
             finished: false,
+            receipt_path: receipt_path.map(Path::to_path_buf),
         })
     }
 
@@ -2271,6 +2430,9 @@ impl ProcessSupervisorGuardian {
 
     fn disarm(&mut self) {
         self.finish_with_command(b'D');
+        if let Some(path) = self.receipt_path.as_deref() {
+            let _ = write_containment_receipt(path, CONTAINMENT_NO_PROCESS_RECEIPT);
+        }
     }
 }
 
@@ -2304,7 +2466,7 @@ fn spawn_process_supervisor_target(
     #[cfg(unix)]
     {
         configure_child_process_tree_command(&mut command);
-        let mut guardian = ProcessSupervisorGuardian::install(&mut command)?;
+        let mut guardian = ProcessSupervisorGuardian::install(&mut command, None)?;
         let spawned = spawn_configured_strict_child_process_tree(&mut command);
         guardian.spawn_finished();
         let (child, process_tree) = match spawned {
@@ -4225,6 +4387,7 @@ pub fn spawn_piped_with_observer(
     use std::process::Command as StdCommand;
     use std::sync::{Arc, Mutex as StdMutex};
 
+    let containment_receipt_path = command.containment_receipt_path();
     let mut std_command = StdCommand::new(&command.program);
     std_command.args(&command.args);
     std_command.current_dir(&command.cwd);
@@ -4232,6 +4395,7 @@ pub fn spawn_piped_with_observer(
     std_command.stdout(Stdio::piped());
     std_command.stderr(Stdio::piped());
     command.apply_environment(&mut std_command);
+    std_command.env_remove(CONTAINMENT_RECEIPT_ENV);
     // Reuse strict containment. On Windows the console-subsystem child starts
     // suspended and hidden, enters a KILL_ON_JOB_CLOSE job before its first
     // instruction, and only then resumes. Unix additionally installs an
@@ -4241,7 +4405,10 @@ pub fn spawn_piped_with_observer(
     #[cfg(unix)]
     let (mut child, mut process_tree, mut guardian) = {
         configure_child_process_tree_command(&mut std_command);
-        let mut guardian = ProcessSupervisorGuardian::install(&mut std_command)?;
+        let mut guardian = ProcessSupervisorGuardian::install(
+            &mut std_command,
+            containment_receipt_path.as_deref(),
+        )?;
         let spawned = spawn_configured_strict_child_process_tree(&mut std_command);
         guardian.spawn_finished();
         match spawned {
@@ -4377,10 +4544,13 @@ pub fn spawn_piped_with_observer(
     // The wait thread owns `child`; cancellation uses the independently owned
     // process-group/Job Object handle, so it never needs to lock the `Child`
     // around a blocking wait.
+    #[cfg(unix)]
+    let process_group_pid = process_tree.0.pid;
     let child_wait_state = Arc::new(AtomicU8::new(PIPED_CHILD_WAIT_PENDING));
     let wait_state = Arc::clone(&child_wait_state);
     let exit_callback_complete = Arc::new(AtomicBool::new(false));
     let callback_complete = Arc::clone(&exit_callback_complete);
+    let wait_containment_receipt_path = containment_receipt_path;
     #[cfg(unix)]
     let process_tree = SharedStrictChildProcessTree::new(
         process_tree,
@@ -4456,6 +4626,19 @@ pub fn spawn_piped_with_observer(
                 PIPED_CHILD_WAIT_FAILED,
             ),
         };
+        #[cfg(unix)]
+        let process_group_quiescence_failed = state == PIPED_CHILD_REAPED
+            && wait_for_unix_process_group_exit(process_group_pid, PIPED_PROMPT_REAP_TIMEOUT)
+                .is_err();
+        #[cfg(not(unix))]
+        let process_group_quiescence_failed = false;
+        if state == PIPED_CHILD_REAPED && !process_group_quiescence_failed {
+            if let Some(path) = wait_containment_receipt_path.as_deref() {
+                if write_containment_receipt(path, CONTAINMENT_QUIESCENT_RECEIPT).is_err() {
+                    state = PIPED_CHILD_WAIT_FAILED;
+                }
+            }
+        }
         // A successful cancellation response is a quiescence boundary for
         // consumers such as Cave: do not publish completion until both pipe
         // drains have reached EOF. Otherwise a descendant that inherited
@@ -4464,6 +4647,7 @@ pub fn spawn_piped_with_observer(
             || stderr_drain_failed
             || pre_reap_wait_failed
             || containment_cleanup_failed
+            || process_group_quiescence_failed
         {
             state = PIPED_CHILD_WAIT_FAILED;
         }
@@ -5847,6 +6031,36 @@ mod tests {
             "successful root exit left closed-pipe descendant {descendant_pid} running"
         );
         drop(process_tree);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strict_termination_waits_for_closed_pipe_descendant_exit() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("strict-closed-pipe-descendant.pid");
+        let mut command = piped_prompt_probe_command(
+            temp_dir.path(),
+            "closed-descendant",
+            &pid_file.to_string_lossy(),
+            None,
+            Vec::new(),
+        )?;
+        let receipt_path = temp_dir.path().join("containment.receipt");
+        command.set_environment_override(
+            CONTAINMENT_RECEIPT_ENV,
+            Some(receipt_path.to_string_lossy().into_owned()),
+        );
+        let session = spawn_piped_with_observer(&command, None, false)?;
+        let descendant_pid = await_piped_descendant_pid(&pid_file)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+
+        process_tree.terminate_and_wait(Duration::from_secs(2))?;
+        assert!(
+            wait_for_piped_process_exit(descendant_pid, Duration::ZERO),
+            "strict termination returned while closed-pipe descendant {descendant_pid} remained"
+        );
+        assert_eq!(std::fs::read(receipt_path)?, CONTAINMENT_QUIESCENT_RECEIPT);
         Ok(())
     }
 

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -1514,7 +1514,10 @@ impl SharedStrictChildProcessTree {
     pub(crate) fn terminate_and_wait(&self, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
         let termination = self.terminate_tree().err();
-        let wait_state = wait_for_piped_child_reap(&self.child_wait_state, timeout);
+        let wait_state = wait_for_piped_child_reap(
+            &self.child_wait_state,
+            deadline.saturating_duration_since(Instant::now()),
+        );
         #[cfg(unix)]
         let containment_quiescence = if wait_state == PIPED_CHILD_REAPED {
             self.wait_for_unix_process_group_quiescence(

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -977,6 +977,7 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
         .context("failed to initialize automation_occurrences schema")?;
     conn.execute_batch(crate::automations::runs::AUTOMATION_RUNS_SCHEMA_SQL)
         .context("failed to initialize automation_runs schema")?;
+    crate::automations::runs::ensure_timeout_column(conn)?;
 
     backfill_events_fts_if_needed(conn)?;
 
@@ -2588,7 +2589,7 @@ pub fn update_session_terminal_if_active(
         .execute(
             "UPDATE sessions
              SET status = ?2, exit_code = ?3, updated_at = ?4
-             WHERE id = ?1 AND status IN ('created', 'running')",
+             WHERE id = ?1 AND status IN ('created', 'running', 'orphaned')",
             params![session_id, status, exit_code, updated_at],
         )
         .with_context(|| format!("failed to update session {session_id}"))?;
@@ -2639,9 +2640,9 @@ pub fn mark_running_sessions_orphaned(conn: &Connection, updated_at: &str) -> Re
 /// those two writes (fork exhaustion, missing adapter, crash) leaves a row
 /// no process owns, so only age can prove it dead. Rows created before the
 /// cutoff become `failed`; newer rows stay untouched so a slow-but-live
-/// launch is never clobbered. A launch adoption or historical launch
-/// reservation is durable ownership evidence, so those rows are excluded
-/// regardless of age.
+/// launch is never clobbered. Launch adoptions, historical reservations, and
+/// correlated automation runs are durable ownership evidence, so those rows
+/// are excluded regardless of age.
 pub fn mark_stale_created_sessions_failed(
     conn: &Connection,
     created_before: &str,
@@ -2657,6 +2658,11 @@ pub fn mark_stale_created_sessions_failed(
                  SELECT 1 FROM request_adoptions
                  WHERE request_adoptions.session_id = sessions.id
                   AND request_adoptions.operation = 'launch'
+               )
+               AND NOT EXISTS (
+                 SELECT 1 FROM automation_runs
+                 WHERE automation_runs.session_id = sessions.id
+                   AND automation_runs.status = 'running'
                )",
             params![created_before, updated_at],
         )

--- a/crates/coven-cli/tests/fixtures/piped_prompt_probe.rs
+++ b/crates/coven-cli/tests/fixtures/piped_prompt_probe.rs
@@ -198,6 +198,18 @@ fn main() {
             // Exit successfully while the descendant remains alive and has
             // already closed every pipe observed by the supervisor.
         }
+        "closed-descendant" => {
+            let pid_file = required_arg("first");
+            let child = Command::new(env::current_exe().expect("current executable"))
+                .arg("output-child")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn closed-pipe descendant");
+            fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
+            thread::sleep(Duration::from_secs(120));
+        }
         "output-child" => loop {
             io::stdout().write_all(b"stdout-tick\n").expect("stdout tick");
             io::stdout().flush().expect("flush stdout tick");


### PR DESCRIPTION
## Context

- Summary: Make native automation run settlement reflect authoritative session/process evidence instead of launch acknowledgement.
- Files changed: automation run/occurrence persistence and reconciliation, daemon runtime containment, session recovery, and lifecycle regressions.
- Closes #816

## Implementation

- Approach: Persist occurrence/run/session correlation and immutable deadlines before launch; keep accepted launches running; reconcile only terminal session evidence; fence daemon/manual claims and overlap atomically; enforce timeouts through strict process-tree termination; persist cross-restart containment receipts.
- User-visible behavior: Automation history no longer reports success merely because a harness accepted a launch. Late, failed, timed-out, ambiguous, and restart-interrupted runs settle conservatively with correlated evidence.
- Compatibility notes: Existing automation tables migrate idempotently with `session_id` and `timeout_at`; runtime adapters remain replaceable workers and do not own scheduling.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: staged privacy guard, staged diff check, 66 focused automation tests, strict closed-descriptor descendant termination regression, three independent blocker reviews.

## Risk and Rollback

- Risk level: Medium-high; this changes scheduler lifecycle and process-containment settlement, with focused race/restart regressions and full workspace coverage.
- Rollback plan: Revert commit `08318bc`; the schema additions are nullable/idempotent and safe to leave in existing SQLite stores.

## Agent Handoff

- Current state: Locally complete and verified; awaiting required CI.
- Follow-ups: Broader v1 authority/attempt/receipt/cancellation protocol remains tracked in #855-#858.
- Known gaps: Atomic output delivery and full v1 conformance remain outside this patch.
