### PR TITLE
ci: stop a slow runner cancelling the perf baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,10 @@ jobs:
     needs: changes
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Baseline collection is I/O bound (it seeds 10k-session and 10k-event
+    # fixtures), so wall time swings with shared-runner disk speed. A healthy
+    # job finishes in ~9 minutes; a slow runner has been observed at ~2.6x that.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-node@v7
@@ -276,6 +279,13 @@ jobs:
       - name: Validate benchmark runner
         run: node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs
       - name: Collect non-gating baseline artifact
+        # Non-gating in name and now in behaviour: a wedged or very slow
+        # collection is bounded here so it cannot burn the whole job budget and
+        # cancel the run. `continue-on-error` matches the concurrent-runtime
+        # step below; `Validate benchmark runner` above stays gating, so real
+        # harness breakage is still caught.
+        timeout-minutes: 20
+        continue-on-error: true
         run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
       - name: Collect concurrent runtime baseline artifact
         continue-on-error: true

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -154,7 +154,10 @@ jobs:
   performance-baseline:
     name: Release performance baseline
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Same I/O-bound fixture seeding as the CI baseline, and this job gates
+    # publish, so it keeps failing loudly - it just gets honest headroom for a
+    # slow shared runner instead of being cancelled at the cap.
+    timeout-minutes: 30
     needs: [verify, verify-tag]
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

`CLI performance baseline` was **cancelled on `main`** at `c5a4651`, hitting its 20-minute job cap inside `Collect non-gating baseline artifact`.

## This is runner speed, not a code regression

In the same run, `cargo build -p coven-cli` — which shares nothing with the benchmark harness — slowed by the *same* factor:

| step | healthy `16827e6` | cancelled `c5a4651` | ratio |
|---|---|---|---|
| Build coven | 17s | 44s | 2.6x |
| Collect non-gating baseline | 7m11s | 18m29s (killed) | 2.6x+ |

Running the identical command locally at `c5a4651` completes in **9m01s**, of which only **8.6s is user CPU**. The job is I/O bound on fixture seeding (10k sessions, 10k events) — exactly the profile that swings with shared-runner disk speed. Measured scenario times sum to roughly 3 seconds.

The other recent cancelled `main` runs (`c703693`, `9847960`, `a3e1a4a`) have no cancelled job-level entries — those were run-level supersession from rapid pushes. `c5a4651` is the first genuine timeout.

## Why it was fatal rather than merely slow

1. **Thin headroom** — a healthy 7m11s step under a 20-minute job cap.
2. **The step is named "non-gating" but had no `continue-on-error`**, unlike the concurrent-runtime step directly below it.

## Why `continue-on-error` alone would not have fixed it

A **job-level** timeout cancels the job outright; it does not respect per-step `continue-on-error`. The proof is in the cancelled run itself — the chaos step *already* has `continue-on-error: true` and still shows as `skipped`. Bounding the step with its own `timeout-minutes` is what keeps a wedge off the job budget.

## Change

`.github/workflows/ci.yml` — `CLI performance baseline`:
- job `timeout-minutes` 20 -> 30 (covers a 2.6x slow runner: ~23m projected)
- `Collect non-gating baseline artifact` gains `timeout-minutes: 20` + `continue-on-error: true`

A slow-but-working runner now finishes normally; a genuine wedge is bounded, reported red, and the run still completes and uploads. `Validate benchmark runner` stays gating, so real harness breakage is still caught.

`.github/workflows/release-npm.yml` — `Release performance baseline`:
- job `timeout-minutes` 20 -> 30 **only**

Same I/O-bound work, same cap, but this job **gates npm publish** (`needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]`). It deliberately does *not* get `continue-on-error` — it keeps failing loudly, it just gets honest headroom instead of being cancelled.

`if-no-files-found: error` is safe to leave alone: it fires only when *zero* files match across all paths, and the two remaining artifacts are still produced.

## Verification

- `python3 scripts/check-ci-workflow-test.py` — 9 tests OK
- `python3 scripts/check-workflows-test.py` — 8 tests OK
- `python3 scripts/classify-ci-changes-test.py` — 19 tests OK
- `scripts/check-workflows.sh` (actionlint 1.7.12) — clean
- Secret guard clean, privacy guard clean

The `timeout-minutes: 20` count assertion in `check-ci-workflow-test.py` still holds: **13 >= 10** (one removed from the job, one added to the step).
