### PR TITLE
docs: enforce public documentation ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,21 @@ jobs:
       - run: python scripts/check-secrets-test.py
       - run: python3 scripts/check-api-contract-docs-test.py
       - run: python3 scripts/check-api-contract-docs.py
+      - run: python3 scripts/check-docs-ownership-test.py
       - run: python scripts/check-secrets.py
+      - name: Documentation ownership guard (pull request changes)
+        if: github.event_name == 'pull_request'
+        run: python3 scripts/check-docs-ownership.py --range "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+      - name: Documentation ownership guard (pushed changes)
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          if ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            BEFORE_SHA="$(git hash-object -t tree -w --stdin </dev/null)"
+          fi
+          python3 scripts/check-docs-ownership.py --range "${BEFORE_SHA}..${AFTER_SHA}"
       - name: Coven privacy guard (pull request changes)
         if: github.event_name == 'pull_request'
         run: python scripts/check-coven-privacy.py --range "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"

--- a/docs/DOCS-MAINTENANCE.md
+++ b/docs/DOCS-MAINTENANCE.md
@@ -55,9 +55,17 @@ The repository's public-doc directories may contain only two kinds of pages:
 
 - **Source-adjacent exceptions** — a page that must evolve with the code
   (contracts, maintainer source maps, verification procedures). Every retained
-  page states its source-adjacent ownership reason, either in the page itself
-  or in the ownership table in [`README.md`](../README.md) and
-  [`docs/index.md`](index.md).
+  page changed after this policy landed states its ownership reason in
+  frontmatter:
+
+  ```yaml
+  source_adjacent_reason: "Tracks the daemon API implemented in this repository."
+  ```
+
+  The ownership guard intentionally applies to changed pages. Historical
+  public guidance remains migration debt until its canonical target is
+  verified; touching one requires converting it to a pointer or declaring a
+  truthful source-adjacent reason.
 
 Public-doc directories today: `docs/install/`, `docs/platforms/`,
 `docs/start/`, `docs/help/`, `docs/harnesses/`, `docs/models/`,
@@ -134,6 +142,8 @@ Update docs in the same change when you modify:
 For docs-only changes:
 
 ```sh
+python3 scripts/check-docs-ownership-test.py
+python3 scripts/check-docs-ownership.py --range origin/main...HEAD
 python scripts/check-secrets.py
 git diff --check
 ```

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -49,6 +49,8 @@ class CheckCiWorkflowTests(unittest.TestCase):
             'python3 scripts/classify-ci-changes-test.py',
             'python3 scripts/check-workflows-test.py',
             'python3 scripts/check-ci-workflow-test.py',
+            'python3 scripts/check-docs-ownership-test.py',
+            'python3 scripts/check-docs-ownership.py --range',
             'scripts/check-workflows.sh',
             'node --test scripts/package-github-release-test.mjs',
             'node --test scripts/release-stress-test.mjs',

--- a/scripts/check-docs-ownership-test.py
+++ b/scripts/check-docs-ownership-test.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("check-docs-ownership.py")
+SPEC = importlib.util.spec_from_file_location("check_docs_ownership", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+class DocsOwnershipTests(unittest.TestCase):
+    def test_short_canonical_pointer_is_allowed(self) -> None:
+        content = """---
+title: Install
+description: Pointer to canonical install guidance.
+---
+
+Canonical install guidance: **https://docs.opencoven.ai/docs/guide/install**
+"""
+        self.assertEqual(module.validate_page("docs/install/index.md", content), [])
+
+    def test_source_adjacent_page_requires_a_reason(self) -> None:
+        content = """---
+title: Socket API
+source_adjacent_reason: Tracks the daemon API implemented in this repository.
+---
+
+Normative contract.
+"""
+        self.assertEqual(module.validate_page("docs/daemon/socket-api.md", content), [])
+
+    def test_long_public_guidance_without_ownership_fails(self) -> None:
+        content = "---\ntitle: Install\n---\n\n" + "\n".join(["Duplicate guidance."] * 30)
+        errors = module.validate_page("docs/install/new-guide.md", content)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("source_adjacent_reason", errors[0])
+
+    def test_empty_source_adjacent_reason_fails(self) -> None:
+        content = """---
+title: Socket API
+source_adjacent_reason:
+---
+
+Normative contract.
+"""
+        errors = module.validate_page("docs/daemon/socket-api.md", content)
+        self.assertEqual(len(errors), 1)
+
+    def test_non_public_docs_are_ignored(self) -> None:
+        self.assertEqual(
+            module.validate_page("docs/development/source-map.md", "Maintainer detail."),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check-docs-ownership.py
+++ b/scripts/check-docs-ownership.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PUBLIC_DOC_DIRS = (
+    "docs/install/",
+    "docs/platforms/",
+    "docs/start/",
+    "docs/help/",
+    "docs/harnesses/",
+    "docs/models/",
+    "docs/memory/",
+    "docs/guides/",
+    "docs/reference/",
+    "docs/daemon/",
+)
+CANONICAL_PREFIX = "https://docs.opencoven.ai/docs/"
+SOURCE_ADJACENT_FIELD = "source_adjacent_reason:"
+MAX_POINTER_LINES = 25
+
+
+def is_public_doc(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return normalized.endswith(".md") and normalized.startswith(PUBLIC_DOC_DIRS)
+
+
+def validate_page(path: str, content: str) -> list[str]:
+    if not is_public_doc(path):
+        return []
+
+    errors = []
+    line_count = len(content.splitlines())
+    if CANONICAL_PREFIX in content and line_count <= MAX_POINTER_LINES:
+        return []
+
+    source_reason = next(
+        (
+            line.partition(":")[2].strip().strip("\"'")
+            for line in content.splitlines()
+            if line.strip().lower().startswith(SOURCE_ADJACENT_FIELD)
+        ),
+        "",
+    )
+    if source_reason:
+        return []
+
+    errors.append(
+        f"{path}: public docs must be a short canonical pointer "
+        f"(at most {MAX_POINTER_LINES} lines with {CANONICAL_PREFIX}) or declare "
+        "a non-empty source_adjacent_reason in frontmatter"
+    )
+    return errors
+
+
+def changed_paths(revision_range: str) -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            revision_range,
+            "--",
+            "docs",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Enforce canonical-pointer or source-adjacent ownership for changed public docs."
+    )
+    parser.add_argument(
+        "--range",
+        required=True,
+        dest="revision_range",
+        help="Git revision range to inspect, for example BASE...HEAD.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    errors = []
+    for path in changed_paths(args.revision_range):
+        if not is_public_doc(path):
+            continue
+        full_path = ROOT / path
+        if not full_path.is_file():
+            continue
+        errors.extend(validate_page(path, full_path.read_text(encoding="utf-8")))
+
+    if errors:
+        print("Documentation ownership check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a fail-closed policy guard for changed pages in repository public-doc directories
- require each changed page to be either a short canonical `docs.opencoven.ai` pointer or to declare a truthful `source_adjacent_reason`
- run the guard for pull-request and push ranges and lock the workflow wiring with tests
- document how historical guidance is migrated when touched rather than falsely classifying it as source-adjacent

Together with #870, this completes the actionable #776 cleanup: the README is concise, verified duplicates were replaced with canonical pointers, and CI now prevents duplicate guidance from returning.

Closes #776.

## Validation

- `python3 scripts/check-docs-ownership-test.py`
- `python3 scripts/check-ci-workflow-test.py`
- `python3 scripts/check-workflows-test.py`
- `python3 scripts/classify-ci-changes-test.py`
- `bash scripts/check-workflows.sh`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `git diff --check`

## Risk and recovery

Low policy-only risk. Revert the commit to remove the new guard.