### PR TITLE
ci: give the perf baseline collection a usable 30-minute bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,12 @@ jobs:
     runs-on: ubuntu-latest
     # Baseline collection is I/O bound (it seeds 10k-session and 10k-event
     # fixtures), so wall time swings with shared-runner disk speed. A healthy
-    # job finishes in ~9 minutes; a slow runner has been observed at ~2.6x that.
-    timeout-minutes: 30
+    # job finishes in ~9 minutes; a slow runner has been observed at ~2.8x that.
+    # This cap must stay comfortably above the collection step's own bound
+    # below, otherwise the job is cancelled before that bound can fire and the
+    # step bound is inert. Everything outside collection measured ~2 minutes on
+    # a slow runner, so 40 leaves ~10 minutes of setup/build/upload headroom.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-node@v7
@@ -297,8 +301,10 @@ jobs:
         # collection is bounded here so it cannot burn the whole job budget and
         # cancel the run. `continue-on-error` matches the concurrent-runtime
         # step below; `Validate benchmark runner` above stays gating, so real
-        # harness breakage is still caught.
-        timeout-minutes: 20
+        # harness breakage is still caught. The last slow runner spent 20m12s
+        # here against a 20-minute bound, so 30 restores real headroom while
+        # staying below the job cap that makes this bound effective at all.
+        timeout-minutes: 30
         continue-on-error: true
         run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
       - name: Collect concurrent runtime baseline artifact

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -156,8 +156,9 @@ jobs:
     runs-on: ubuntu-latest
     # Same I/O-bound fixture seeding as the CI baseline, and this job gates
     # publish, so it keeps failing loudly - it just gets honest headroom for a
-    # slow shared runner instead of being cancelled at the cap.
-    timeout-minutes: 30
+    # slow shared runner instead of being cancelled at the cap. Held level with
+    # the CI baseline job so the two mirror jobs cannot drift apart.
+    timeout-minutes: 40
     needs: [verify, verify-tag]
     permissions:
       contents: read


### PR DESCRIPTION
## Why

After #897 the `Collect non-gating baseline artifact` step carried a 20-minute bound. The first post-merge run used **20m12s** of it. It passed, but with **0% headroom** — the next slightly slower runner trips it.

## What changed

| | before | after |
|---|---|---|
| `ci.yml` job `performance-baseline` | 30 min | **40 min** |
| `ci.yml` step `Collect non-gating baseline artifact` | 20 min | **30 min** |
| `release-npm.yml` job `performance-baseline` | 30 min | **40 min** |

## Why the job cap moved too

A step bound is only meaningful if the job can outlive it. Measured from the last slow run (job 22m05s, collect step 20m12s), everything outside collection costs **~1.9 min**.

So under a 30-minute job cap, a 30-minute step bound is **inert**: the job is cancelled at 30 while the step is only at ~28.1. The step timeout could never fire, and a wedged collection would cancel the whole run again — exactly the failure #897 fixed. 40 keeps ~10 minutes of setup/build/upload room, ~5x the observed overhead.

Invariant asserted against the parsed YAML: **job cap (40) > every step bound (30)**.

## release-npm.yml

The mirror job runs identical I/O-bound work and gates `npm-publish` (`needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]`). Held level at 40 so the two cannot drift. It deliberately keeps **no** step bound and **no** `continue-on-error` — a release baseline should fail loudly.

## Verification

- `check-ci-workflow-test.py` PASS — its `timeout-minutes: 20` count assertion needs >=10; now **12**
- `check-workflows-test.py` PASS
- `classify-ci-changes-test.py` PASS
- `check-secrets.py` PASS (gitleaks, no leaks)
- `check-coven-privacy.py --staged` PASS
- `scripts/check-workflows.sh` (pinned actionlint 1.7.12) PASS

## Known follow-up (not in this PR)

Because the collect step is `continue-on-error: true`, if it *does* trip its bound the job still reports success with `coven-perf.json` missing or partial. `if-no-files-found: error` will not catch that — it only fires when zero files match across all paths, and the chaos/TUI artifacts would still exist. A presence assertion on `coven-perf.json` would turn that silent gap into a visible one. Happy to send it separately.

The underlying ~2.8x runner slowdown is chronic (seen on two commits hours apart), and the benchmark's wall time is almost entirely fixture seeding — 9m01s wall for **8.6s** of user CPU. Cutting fixture cost is the real fix; this is headroom.