### PR TITLE
docs: reconcile the Automations v1 tracker mapping

### DIFF
--- a/docs/roadmaps/coven-automations-v1.mapping.json
+++ b/docs/roadmaps/coven-automations-v1.mapping.json
@@ -12,8 +12,10 @@
     "beads_provisioning": {
       "seed_task": "OpenCoven/coven-cave#5220",
       "seed_bead": "cave-tmegk",
-      "program_control": "OpenCoven/coven#859 -> Cave bead cave-hlv.10",
-      "release_rollup": "OpenCoven/coven#854 -> Cave bead cave-hlv.9",
+      "program_control": "OpenCoven/coven#859 -> Cave bead cave-hlv.10 (tracker operationalization; owns reconciliation, drift control, and evidence semantics only)",
+      "release_rollup": "OpenCoven/coven#854 -> Cave bead cave-hlv.9 (release go/no-go rollup; blocked-first by the other 13 in-program outcomes)",
+      "cross_repository_children": "OpenCoven/familiar-contract#17 -> cave-6jswi; OpenCoven/coven-threads#29 -> cave-m9tw3; OpenCoven/sdk#80 -> cave-90hwl; OpenCoven/coven-cave#5217 -> cave-e52qp; OpenCoven/psyche#18 -> cave-yaul2; OpenCoven/coven-docs#76 -> cave-qwnxq; OpenCoven/.github#2 -> cave-xqbs4",
+      "graph_shape": "15 canonical beads (14 mapped outcomes plus the OpenCoven/coven-cave#5220 seed bead cave-tmegk) and 30 in-program blocked-first edges, no cycles. cave-hlv.9 and cave-hlv.10 additionally carry a pre-existing parent-epic edge to the closed Cave epic cave-hlv, which is outside the Automations v1 program set.",
       "remote_ref": "refs/dolt/data",
       "dolt_commit_evidence": "Embedded-Dolt pre/post commit OIDs and the remote refs/dolt/data OID are recorded in Cave PR OpenCoven/coven-cave#5277 and the seed-run execution ledger (kept out of this committed file to satisfy the repository secret guard).",
       "remote_sync_status": "deferred: local embedded Dolt is durable and canonical; bd dolt push is non-fast-forward (remote ahead from concurrent sessions) and bd dolt pull did not complete non-interactively. Not force-pushed.",
@@ -43,17 +45,69 @@
       "bead": {
         "label": "automations-v1/program",
         "surface": "shared",
-        "title": "Coven Automations v1 program (GitHub OpenCoven/coven#854)",
+        "title": "Coven Automations v1 — release go/no-go rollup (GitHub OpenCoven/coven#854)",
         "id": "cave-hlv.9",
+        "cave_outcome_key": "release-go-no-go",
+        "cave_label": "automations-v1:release-go-no-go",
         "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
         "disposition": "active:release-gate-ownership",
         "gate": "Owns release gates and cross-repository rollup; final #854 release rollup must be generable from reconciled tracker state and exact evidence. Must not be used as a catch-all implementation task.",
         "evidence_status": "none",
         "evidence": []
       },
+      "depends_on": [
+        "program-control",
+        "foundation",
+        "protocol",
+        "scheduler",
+        "familiar-embodiment",
+        "automation-authority",
+        "authority",
+        "certification",
+        "sdk",
+        "cave-oversight",
+        "psyche-adapter",
+        "documentation",
+        "organization-canaries"
+      ],
+      "depends_on_external": [
+        "Cave bead cave-hlv (closed 'Operationalize Beads for familiar issue tracking' epic) — pre-existing parent-epic edge in the Cave graph, outside the Automations v1 program set and not a v1 release blocker"
+      ],
+      "notes": "#854 is the release rollup outcome. It gates the release but must not absorb implementation work; every dependency listed here is a live blocked-first edge on Cave bead cave-hlv.9 (13 in-program edges, verified with bd dep list --direction down)."
+    },
+    {
+      "slug": "program-control",
+      "role": "program-control",
+      "github": {
+        "repo": "OpenCoven/coven",
+        "issue": 859,
+        "url": "https://github.com/OpenCoven/coven/issues/859",
+        "title": "P0 control: Operationalize Coven Automations v1 through Cave's canonical Beads graph and GitHub mirrors",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/program-control",
+        "surface": "shared",
+        "title": "Coven Automations v1 — program control and GitHub mirror operationalization (GitHub OpenCoven/coven#859)",
+        "id": "cave-hlv.10",
+        "cave_outcome_key": "program-control",
+        "cave_label": "automations-v1:program-control",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "active:tracker-control",
+        "gate": "Tracker operationalization is complete when: every #854 P0/P1 outcome maps one-to-one to a live Cave bead; dependency direction is proven in both directions with bd dep list and bd ready; this mapping and the generated roadmap block reconcile with the live graph under node docs/roadmaps/drift-check.mjs --strict; and the canonical Cave Dolt state is durable on the shared remote ref refs/dolt/data.",
+        "evidence_status": "partial",
+        "evidence": [
+          "OpenCoven/coven-cave#5277 (merged 2026-09-01; canonical Beads graph seeded)",
+          "https://github.com/OpenCoven/coven/pull/900 (this tracker-mapping reconciliation)"
+        ]
+      },
       "depends_on": [],
-      "depends_on_external": [],
-      "notes": "Priority is P0 program/control: it gates the release but must not absorb implementation work."
+      "depends_on_external": [
+        "Cave bead cave-hlv (closed 'Operationalize Beads for familiar issue tracking' epic) — pre-existing parent-epic edge in the Cave graph, outside the Automations v1 program set and not a v1 release blocker"
+      ],
+      "notes": "#859 is program control / tracker operationalization, bound one-to-one to Cave bead cave-hlv.10. It is a control outcome, not an implementation catch-all: it owns reconciliation, drift control, and evidence semantics only. In the live Cave graph cave-hlv.10 blocks cave-hlv.9 (release rollup) and cave-xqbs4 (organization canaries)."
     },
     {
       "slug": "foundation",
@@ -72,6 +126,8 @@
         "surface": "shared",
         "title": "Coven Automations v1 — native routine foundation (GitHub OpenCoven/coven#816)",
         "id": "cave-stsf7",
+        "cave_outcome_key": "foundation",
+        "cave_label": "automations-v1:foundation",
         "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277); bead closed as verified-foundation",
         "disposition": "closed:verified-foundation",
         "gate": "#816 evidence checklist: landed commit/PR series linked with an exact final foundation revision; clean-clone automation-test verification; pre-automations schema migration and rollback proof; daemon startup/tick/shutdown/restart proof on supported platforms; one scheduled and one manual run shown to traverse the same claim/ledger/runtime/delivery path; stale lease cannot block the next eligible occurrence indefinitely; failed output delivery cannot report success; every original acceptance criterion reconciled as implemented, deferred, or superseded; Cave ownership migration (OpenCoven/coven-cave#4990) linked with remaining compatibility facade documented.",
@@ -105,6 +161,8 @@
         "surface": "shared",
         "title": "Coven Automations v1 — protocol schemas, state, idempotency, changefeed (GitHub OpenCoven/coven#855)",
         "id": "cave-tm1y0",
+        "cave_outcome_key": "protocol",
+        "cave_label": "automations-v1:protocol",
         "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
         "disposition": "ready:foundation-verified (bead cave-tm1y0 unblocked in the Cave graph)",
         "gate": "coven.automations.v1 schemas, state machines, idempotency rules, and changefeed contract are specified, reviewed, and covered by tests; schema/conformance artifact revisions recorded as evidence.",
@@ -132,6 +190,8 @@
         "surface": "shared",
         "title": "Coven Automations v1 — time, retry, cancel, fencing, recovery (GitHub OpenCoven/coven#856)",
         "id": "cave-1sh6p",
+        "cave_outcome_key": "scheduler-reliability",
+        "cave_label": "automations-v1:scheduler",
         "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
         "disposition": "blocked:pending-protocol (bead cave-1sh6p; foundation verified)",
         "gate": "Time, retry, cancellation, fencing, and crash-recovery behaviors verified by tests, including stale-lease recovery, misfire semantics, and cancellation without duplicate execution.",
@@ -159,18 +219,17 @@
         "surface": "shared",
         "title": "Coven Automations v1 — principal/familiar/authority/approval/receipt binding (GitHub OpenCoven/coven#857)",
         "id": "cave-dbkng",
+        "cave_outcome_key": "trust-integration",
+        "cave_label": "automations-v1:trust-integration",
         "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277); Cave outcome slug trust-integration",
         "disposition": "blocked:pending-protocol-and-identity-authority-profiles (bead cave-dbkng)",
         "gate": "Runs are bound to principal authority, familiar revisions, capabilities, approvals, and receipts; negative tests prove authority bypass fails closed; receipts are tamper-evident and out of tracker scope.",
         "evidence_status": "none",
         "evidence": []
       },
-      "depends_on": ["foundation", "protocol"],
-      "depends_on_external": [
-        "OpenCoven/familiar-contract#17 (Cave bead cave-6jswi)",
-        "OpenCoven/coven-threads#29 (Cave bead cave-m9tw3)"
-      ],
-      "notes": "Depends on upstream Familiar Contract (familiar-contract#17) and Threads (coven-threads#29) profile outcomes, now created and provisioned as Cave beads cave-6jswi and cave-m9tw3. In the canonical Cave graph the matching outcome (slug trust-integration, cave-dbkng) is blocked-by protocol, familiar-embodiment, and automation-authority."
+      "depends_on": ["protocol", "familiar-embodiment", "automation-authority"],
+      "depends_on_external": [],
+      "notes": "Live Cave bead cave-dbkng is blocked-first by cave-tm1y0 (protocol), cave-6jswi (familiar embodiment) and cave-m9tw3 (automation authority); those are the exact direct edges recorded here. #816 (foundation) reaches this outcome transitively through protocol and is not a direct edge. The upstream Familiar Contract (OpenCoven/familiar-contract#17) and Threads (OpenCoven/coven-threads#29) profile outcomes are now first-class cross-repository children of this mapping rather than untyped external references."
     },
     {
       "slug": "certification",
@@ -189,6 +248,8 @@
         "surface": "shared",
         "title": "Coven Automations v1 — conformance, chaos, SLO, operator diagnostics (GitHub OpenCoven/coven#858)",
         "id": "cave-x28j6",
+        "cave_outcome_key": "conformance",
+        "cave_label": "automations-v1:conformance",
         "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277); Cave outcome slug conformance",
         "disposition": "blocked:pending-protocol-scheduler-trust (bead cave-x28j6)",
         "gate": "Conformance, chaos, SLO, and operator-diagnostics suites exist and run without ambient production credentials; the v1 release gate report is produced from them and linked here.",
@@ -200,8 +261,205 @@
       "notes": "Certification blocker for the v1 release gate owned by the program outcome."
     }
   ],
-  "cross_repository_children": [],
-  "cross_repository_children_policy": "One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome created under OpenCoven/coven#854. These cross-repository children are provisioned and mapped one-to-one in the canonical Cave Beads graph and its mapping (docs/roadmaps/coven-automations-v1.mapping.json in OpenCoven/coven-cave; Cave PR OpenCoven/coven-cave#5277): familiar-contract#17 -> cave-6jswi, coven-threads#29 -> cave-m9tw3, sdk#80 -> cave-90hwl, coven-cave#5217 -> cave-e52qp, psyche#18 -> cave-yaul2, coven-docs#76 -> cave-qwnxq, .github#2 -> cave-xqbs4. SDK/Cave/Psyche/docs/org-canaries each depend on the conformance (certification) outcome; org-canaries also depends on program control. This coven-repo-scoped tracker intentionally keeps their rows in the Cave mapping rather than duplicating them here.",
+  "cross_repository_children": [
+    {
+      "slug": "familiar-embodiment",
+      "role": "p0-cross-repository-child",
+      "github": {
+        "repo": "OpenCoven/familiar-contract",
+        "issue": 17,
+        "title": "P0 profile: Define universal familiar embodiment binding for automation and direct runs",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/familiar-embodiment",
+        "surface": "shared",
+        "title": "Coven Automations v1 — universal familiar embodiment binding (GitHub OpenCoven/familiar-contract#17)",
+        "id": "cave-6jswi",
+        "cave_outcome_key": "familiar-embodiment",
+        "cave_label": "automations-v1:familiar-embodiment",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "ready:foundation-verified (bead cave-6jswi unblocked in the Cave graph)",
+        "gate": "A universal familiar embodiment binding is specified and reviewed so an automation run and a direct run resolve the same familiar revision, capabilities, and identity; conformance covers both entry paths.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["foundation"],
+      "depends_on_external": [],
+      "notes": "Upstream identity profile that OpenCoven/coven#857 (authority) depends on. Live Cave bead cave-6jswi blocks cave-m9tw3, cave-dbkng, and cave-hlv.9."
+    },
+    {
+      "slug": "automation-authority",
+      "role": "p0-cross-repository-child",
+      "github": {
+        "repo": "OpenCoven/coven-threads",
+        "issue": 29,
+        "title": "P0 profile: Define automation authority, approvals, and degrade-to-proposal semantics",
+        "state": "open",
+        "priority": "P0",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/automation-authority",
+        "surface": "shared",
+        "title": "Coven Automations v1 — automation authority, approvals, degrade-to-proposal (GitHub OpenCoven/coven-threads#29)",
+        "id": "cave-m9tw3",
+        "cave_outcome_key": "automation-authority",
+        "cave_label": "automations-v1:automation-authority",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "blocked:pending-familiar-embodiment (bead cave-m9tw3)",
+        "gate": "Automation authority, approval requirements, and degrade-to-proposal semantics are specified with negative tests proving an under-authorized run degrades to a proposal instead of executing.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["familiar-embodiment"],
+      "depends_on_external": [],
+      "notes": "Upstream authority profile that OpenCoven/coven#857 depends on. Live Cave bead cave-m9tw3 blocks cave-dbkng and cave-hlv.9."
+    },
+    {
+      "slug": "sdk",
+      "role": "p1-cross-repository-child",
+      "github": {
+        "repo": "OpenCoven/sdk",
+        "issue": 80,
+        "title": "P1: Add constrained Coven Automations SDK types, subscriptions, verification, and authority-aware commands",
+        "state": "open",
+        "priority": "P1",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/sdk",
+        "surface": "shared",
+        "title": "Coven Automations v1 — constrained SDK types, subscriptions, verification, commands (GitHub OpenCoven/sdk#80)",
+        "id": "cave-90hwl",
+        "cave_outcome_key": "sdk",
+        "cave_label": "automations-v1:sdk",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "blocked:pending-certification (bead cave-90hwl)",
+        "gate": "SDK automation types, subscriptions, verification helpers, and authority-aware commands are published against the certified core, with the exact package version and conformance run recorded as evidence.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["certification"],
+      "depends_on_external": [],
+      "notes": "Live Cave bead cave-90hwl is blocked-first by cave-x28j6 (certification) and blocks cave-hlv.9."
+    },
+    {
+      "slug": "cave-oversight",
+      "role": "p1-cross-repository-child",
+      "github": {
+        "repo": "OpenCoven/coven-cave",
+        "issue": 5217,
+        "title": "P1: Complete Coven Automations oversight, approvals, recovery, and compatibility retirement",
+        "state": "open",
+        "priority": "P1",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/cave-oversight",
+        "surface": "shared",
+        "title": "Coven Automations v1 — oversight, approvals, recovery, compatibility retirement (GitHub OpenCoven/coven-cave#5217)",
+        "id": "cave-e52qp",
+        "cave_outcome_key": "cave-oversight",
+        "cave_label": "automations-v1:cave-oversight",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "blocked:pending-certification (bead cave-e52qp)",
+        "gate": "Cave operator oversight, approval handling, and recovery surfaces run against the certified core, and the pre-automations compatibility facade is retired or its remaining scope is documented.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["certification"],
+      "depends_on_external": [],
+      "notes": "Live Cave bead cave-e52qp is blocked-first by cave-x28j6 and blocks cave-hlv.9."
+    },
+    {
+      "slug": "psyche-adapter",
+      "role": "p1-cross-repository-child",
+      "github": {
+        "repo": "OpenCoven/psyche",
+        "issue": 18,
+        "title": "P1: Define the Psyche adapter for automation-triggered orchestration without owning schedules",
+        "state": "open",
+        "priority": "P1",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/psyche-adapter",
+        "surface": "shared",
+        "title": "Coven Automations v1 — Psyche adapter for automation-triggered orchestration (GitHub OpenCoven/psyche#18)",
+        "id": "cave-yaul2",
+        "cave_outcome_key": "psyche-adapter",
+        "cave_label": "automations-v1:psyche-adapter",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "blocked:pending-certification (bead cave-yaul2)",
+        "gate": "Psyche consumes automation triggers through the certified public contract and demonstrably does not own schedules, occurrences, leases, or run state.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["certification"],
+      "depends_on_external": [],
+      "notes": "Live Cave bead cave-yaul2 is blocked-first by cave-x28j6 and blocks cave-hlv.9."
+    },
+    {
+      "slug": "documentation",
+      "role": "p1-cross-repository-child",
+      "github": {
+        "repo": "OpenCoven/coven-docs",
+        "issue": 76,
+        "title": "P1: Publish Coven Automations v1 protocol, operator, migration, and troubleshooting documentation",
+        "state": "open",
+        "priority": "P1",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/documentation",
+        "surface": "shared",
+        "title": "Coven Automations v1 — protocol, operator, migration, troubleshooting docs (GitHub OpenCoven/coven-docs#76)",
+        "id": "cave-qwnxq",
+        "cave_outcome_key": "documentation",
+        "cave_label": "automations-v1:documentation",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "blocked:pending-certification (bead cave-qwnxq)",
+        "gate": "Protocol, operator, migration, and troubleshooting documentation is published against the certified contract revision and links the exact schema/conformance artifacts.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["certification"],
+      "depends_on_external": [],
+      "notes": "Live Cave bead cave-qwnxq is blocked-first by cave-x28j6 and blocks cave-hlv.9."
+    },
+    {
+      "slug": "organization-canaries",
+      "role": "p1-cross-repository-child",
+      "github": {
+        "repo": "OpenCoven/.github",
+        "issue": 2,
+        "title": "P1: Add reusable Coven Automations conformance, contract-drift, and roadmap checks",
+        "state": "open",
+        "priority": "P1",
+        "owner": "BunsDev"
+      },
+      "bead": {
+        "label": "automations-v1/organization-canaries",
+        "surface": "shared",
+        "title": "Coven Automations v1 — reusable conformance, contract-drift, roadmap checks (GitHub OpenCoven/.github#2)",
+        "id": "cave-xqbs4",
+        "cave_outcome_key": "organization-canaries",
+        "cave_label": "automations-v1:organization-canaries",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "blocked:pending-program-control-and-certification (bead cave-xqbs4)",
+        "gate": "Reusable organization-level conformance, contract-drift, and roadmap checks run on consumer repositories without ambient production credentials and fail closed on drift.",
+        "evidence_status": "none",
+        "evidence": []
+      },
+      "depends_on": ["program-control", "certification"],
+      "depends_on_external": [],
+      "notes": "Live Cave bead cave-xqbs4 is blocked-first by cave-hlv.10 (program control) and cave-x28j6 (certification), and blocks cave-hlv.9."
+    }
+  ],
+  "cross_repository_children_policy": "One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome created under OpenCoven/coven#854. All seven are provisioned and mapped one-to-one above, and each row carries the same evidence semantics as an in-repository outcome: a live bead id, an acceptance gate, a disposition, an evidence_status, and an evidence list that stays empty until exact PR/test/release references exist. They are mirrored in the canonical Cave mapping (docs/roadmaps/coven-automations-v1.mapping.json in OpenCoven/coven-cave; Cave PR OpenCoven/coven-cave#5277), where familiar-embodiment and automation-authority use the same keys and sdk/cave-oversight/psyche-adapter/documentation/organization-canaries depend on the Cave key `conformance` (this file's `certification` slug). node docs/roadmaps/drift-check.mjs enforces the membership contract: omitting any of these seven, or the #859 program-control outcome, is an E011 error in both default and strict mode.",
   "p2_exclusions": [
     "Event triggers",
     "Multi-host routing",
@@ -210,7 +468,9 @@
   ],
   "p2_exclusions_policy": "These remain post-v1 (P2) and must not be encoded as implicit P0 blockers anywhere in the graph.",
   "invariants": [
-    "Each GitHub outcome maps to exactly one Bead; each Bead maps to exactly one GitHub outcome.",
+    "Each GitHub outcome maps to exactly one Bead; each Bead maps to exactly one GitHub outcome. Cross-repository children are held to the same one-to-one rule as in-repository outcomes.",
+    "Program membership is fixed and pinned inside the checker, not inside this file: seven in-repository outcomes (OpenCoven/coven#854, #859, #816, #855, #856, #857, #858) and seven cross-repository children (OpenCoven/familiar-contract#17, OpenCoven/coven-threads#29, OpenCoven/sdk#80, OpenCoven/coven-cave#5217, OpenCoven/psyche#18, OpenCoven/coven-docs#76, OpenCoven/.github#2). Omitting a member, emptying cross_repository_children, or filing a member in the wrong section is an E011 error in both default and --strict mode.",
+    "Every depends_on entry names a live blocked-first edge in the canonical Cave graph; transitive prerequisites are not restated as direct edges.",
     "Dependencies and P0/P1/P2 priorities in Beads match this file and the roadmap table generated from it.",
     "A P0 Bead has one accountable owner, one canonical GitHub outcome, explicit dependencies, a current acceptance gate, an active or explicitly blocked disposition, evidence requirements, and no contradictory closed public mirror.",
     "A Bead closes only when the corresponding GitHub acceptance criteria are satisfied or the outcome is explicitly cancelled/superseded with rationale.",

--- a/docs/roadmaps/coven-automations-v1.mapping.json
+++ b/docs/roadmaps/coven-automations-v1.mapping.json
@@ -3,13 +3,23 @@
   "schema_version": 1,
   "description": "Machine-readable Bead <-> GitHub outcome mapping for the Coven Automations v1 program (OpenCoven/coven#859). GitHub owns public outcomes, acceptance gates, and durable evidence links. Beads (in the OpenCoven/coven-cave embedded Dolt database `cave`) owns the implementation dependency graph, execution ownership, and mirror inputs. This file is the reconciliation contract between the two; it is hand-reviewed, not hand-synced.",
   "sync": {
-    "last_sync": "2026-08-30T15:05:00Z",
-    "source_branch": "agent/issue-859-p0-control-operationalize-coven-automations-v1",
+    "last_sync": "2026-09-01T18:40:00Z",
+    "source_branch": "docs/859-automations-v1-mapping",
     "writer": "One canonical writer/process is designated for this setup; see docs/superpowers/plans/2026-08-30-issue-859-coven-automations-v1-tracker-operationalization.md (Decision D1). Persisted tracker changes land only through reviewed PRs.",
-    "canonical_bead_store": "OpenCoven/coven-cave embedded Dolt database `cave`; provisioning is routed through OpenCoven/coven-cave#5220. A competing Beads database must not be initialized in OpenCoven/coven (operational correction on OpenCoven/coven#859, 2026-08-30).",
+    "canonical_bead_store": "OpenCoven/coven-cave embedded Dolt database `cave`; provisioning was executed through OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277). A competing Beads database must not be initialized in OpenCoven/coven (operational correction on OpenCoven/coven#859, 2026-08-30).",
     "public_bead_export": "OpenCoven/coven-cave `.beads/issues.jsonl` is a public-scrubbed review export, never canonical state and never a hand-edited sync mechanism.",
-    "beads_tool_reference": "Beads 1.2.2, schema v53, as recorded in docs/superpowers/plans/2026-08-20-coven-v0.4.1-release-program.md; live schema/version verification is owned by OpenCoven/coven-cave#5220.",
-    "drift_check": "node docs/roadmaps/drift-check.mjs (add --beads-export <issues.jsonl> to cross-check an export; --selftest to verify detection rules)",
+    "beads_tool_reference": "Beads 1.2.2 (Homebrew), bead schema_version 1 (live), as verified during the OpenCoven/coven-cave#5220 seed run.",
+    "beads_provisioning": {
+      "seed_task": "OpenCoven/coven-cave#5220",
+      "seed_bead": "cave-tmegk",
+      "program_control": "OpenCoven/coven#859 -> Cave bead cave-hlv.10",
+      "release_rollup": "OpenCoven/coven#854 -> Cave bead cave-hlv.9",
+      "remote_ref": "refs/dolt/data",
+      "dolt_commit_evidence": "Embedded-Dolt pre/post commit OIDs and the remote refs/dolt/data OID are recorded in Cave PR OpenCoven/coven-cave#5277 and the seed-run execution ledger (kept out of this committed file to satisfy the repository secret guard).",
+      "remote_sync_status": "deferred: local embedded Dolt is durable and canonical; bd dolt push is non-fast-forward (remote ahead from concurrent sessions) and bd dolt pull did not complete non-interactively. Not force-pushed.",
+      "dependency_proof": "bd dep list (both directions), bd dep cycles (none), bd ready --json; recorded on Cave PR OpenCoven/coven-cave#5277."
+    },
+    "drift_check": "node docs/roadmaps/drift-check.mjs (add --beads-export <issues.jsonl> to cross-check an export; --strict to fail on pending provisioning; --selftest to verify detection rules)",
     "priority_policy": {
       "P0": "Current v1 correctness, security, data-loss/duplicate-execution risk, authority violation, broken migration, or certification blocker.",
       "P1": "Committed SDK/product/docs/ecosystem work required to make the certified core usable and operable.",
@@ -34,8 +44,8 @@
         "label": "automations-v1/program",
         "surface": "shared",
         "title": "Coven Automations v1 program (GitHub OpenCoven/coven#854)",
-        "id": null,
-        "provisioning": "pending:OpenCoven/coven-cave#5220",
+        "id": "cave-hlv.9",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
         "disposition": "active:release-gate-ownership",
         "gate": "Owns release gates and cross-repository rollup; final #854 release rollup must be generable from reconciled tracker state and exact evidence. Must not be used as a catch-all implementation task.",
         "evidence_status": "none",
@@ -53,7 +63,7 @@
         "issue": 816,
         "url": "https://github.com/OpenCoven/coven/issues/816",
         "title": "Native familiar automations: replace harness-owned schedules with durable Coven routines",
-        "state": "open",
+        "state": "closed",
         "priority": "P0",
         "owner": "BunsDev"
       },
@@ -61,20 +71,22 @@
         "label": "automations-v1/foundation",
         "surface": "shared",
         "title": "Coven Automations v1 — native routine foundation (GitHub OpenCoven/coven#816)",
-        "id": null,
-        "provisioning": "pending:OpenCoven/coven-cave#5220 (no pre-existing bead found in the public-scrubbed export at sync time; reuse-if-present check owned by OpenCoven/coven-cave#5220)",
-        "disposition": "active:reconciling-landed-evidence",
+        "id": "cave-stsf7",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277); bead closed as verified-foundation",
+        "disposition": "closed:verified-foundation",
         "gate": "#816 evidence checklist: landed commit/PR series linked with an exact final foundation revision; clean-clone automation-test verification; pre-automations schema migration and rollback proof; daemon startup/tick/shutdown/restart proof on supported platforms; one scheduled and one manual run shown to traverse the same claim/ledger/runtime/delivery path; stale lease cannot block the next eligible occurrence indefinitely; failed output delivery cannot report success; every original acceptance criterion reconciled as implemented, deferred, or superseded; Cave ownership migration (OpenCoven/coven-cave#4990) linked with remaining compatibility facade documented.",
-        "evidence_status": "partial",
+        "evidence_status": "verified",
         "evidence": [
+          "https://github.com/OpenCoven/coven/issues/816 (CLOSED)",
+          "https://github.com/OpenCoven/coven/pull/896 (merged 2026-09-01; settle automation runs from terminal evidence)",
+          "foundation merge commit for #896 recorded in Cave PR OpenCoven/coven-cave#5277 (exact SHA kept out of this file per the repository secret guard)",
           "https://github.com/OpenCoven/coven/pull/846 (merged 2026-08-28; routine definitions and control actions, part 1)",
-          "https://github.com/OpenCoven/coven/pull/847 (merged 2026-08-28; legacy import series, parts 5-8)",
-          "https://github.com/OpenCoven/coven/issues/816 (program-status section of the issue body, updated 2026-08-30: landed inventory and open evidence checklist)"
+          "https://github.com/OpenCoven/coven/pull/847 (merged 2026-08-28; legacy import series, parts 5-8)"
         ]
       },
       "depends_on": [],
       "depends_on_external": [],
-      "notes": "Implementation materially landed on main 2026-08-28 (crates/coven-cli/src/automations/); the issue stays open for foundation reconciliation and exact evidence."
+      "notes": "Foundation implementation landed on main (crates/coven-cli/src/automations/); #816 is CLOSED and represented here as verified-foundation, not pending work. Downstream P0 workstreams depend on it via the Cave Beads graph (bead cave-stsf7, closed)."
     },
     {
       "slug": "protocol",
@@ -92,9 +104,9 @@
         "label": "automations-v1/protocol",
         "surface": "shared",
         "title": "Coven Automations v1 — protocol schemas, state, idempotency, changefeed (GitHub OpenCoven/coven#855)",
-        "id": null,
-        "provisioning": "pending:OpenCoven/coven-cave#5220",
-        "disposition": "blocked:pending-foundation-reconciliation-and-bead-provisioning",
+        "id": "cave-tm1y0",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "ready:foundation-verified (bead cave-tm1y0 unblocked in the Cave graph)",
         "gate": "coven.automations.v1 schemas, state machines, idempotency rules, and changefeed contract are specified, reviewed, and covered by tests; schema/conformance artifact revisions recorded as evidence.",
         "evidence_status": "none",
         "evidence": []
@@ -119,9 +131,9 @@
         "label": "automations-v1/scheduler",
         "surface": "shared",
         "title": "Coven Automations v1 — time, retry, cancel, fencing, recovery (GitHub OpenCoven/coven#856)",
-        "id": null,
-        "provisioning": "pending:OpenCoven/coven-cave#5220",
-        "disposition": "blocked:pending-foundation-reconciliation-and-bead-provisioning",
+        "id": "cave-1sh6p",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277)",
+        "disposition": "blocked:pending-protocol (bead cave-1sh6p; foundation verified)",
         "gate": "Time, retry, cancellation, fencing, and crash-recovery behaviors verified by tests, including stale-lease recovery, misfire semantics, and cancellation without duplicate execution.",
         "evidence_status": "none",
         "evidence": []
@@ -146,16 +158,19 @@
         "label": "automations-v1/authority",
         "surface": "shared",
         "title": "Coven Automations v1 — principal/familiar/authority/approval/receipt binding (GitHub OpenCoven/coven#857)",
-        "id": null,
-        "provisioning": "pending:OpenCoven/coven-cave#5220",
-        "disposition": "blocked:pending-foundation-reconciliation-and-bead-provisioning",
+        "id": "cave-dbkng",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277); Cave outcome slug trust-integration",
+        "disposition": "blocked:pending-protocol-and-identity-authority-profiles (bead cave-dbkng)",
         "gate": "Runs are bound to principal authority, familiar revisions, capabilities, approvals, and receipts; negative tests prove authority bypass fails closed; receipts are tamper-evident and out of tracker scope.",
         "evidence_status": "none",
         "evidence": []
       },
       "depends_on": ["foundation", "protocol"],
-      "depends_on_external": [],
-      "notes": "Additionally depends on upstream Familiar Contract and Threads profile outcomes once created; no such cross-repository outcomes existed at sync time, so depends_on_external is empty and must be made explicit when they appear."
+      "depends_on_external": [
+        "OpenCoven/familiar-contract#17 (Cave bead cave-6jswi)",
+        "OpenCoven/coven-threads#29 (Cave bead cave-m9tw3)"
+      ],
+      "notes": "Depends on upstream Familiar Contract (familiar-contract#17) and Threads (coven-threads#29) profile outcomes, now created and provisioned as Cave beads cave-6jswi and cave-m9tw3. In the canonical Cave graph the matching outcome (slug trust-integration, cave-dbkng) is blocked-by protocol, familiar-embodiment, and automation-authority."
     },
     {
       "slug": "certification",
@@ -173,9 +188,9 @@
         "label": "automations-v1/certification",
         "surface": "shared",
         "title": "Coven Automations v1 — conformance, chaos, SLO, operator diagnostics (GitHub OpenCoven/coven#858)",
-        "id": null,
-        "provisioning": "pending:OpenCoven/coven-cave#5220",
-        "disposition": "blocked:pending-p0-workstreams-and-bead-provisioning",
+        "id": "cave-x28j6",
+        "provisioning": "provisioned:OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277); Cave outcome slug conformance",
+        "disposition": "blocked:pending-protocol-scheduler-trust (bead cave-x28j6)",
         "gate": "Conformance, chaos, SLO, and operator-diagnostics suites exist and run without ambient production credentials; the v1 release gate report is produced from them and linked here.",
         "evidence_status": "none",
         "evidence": []
@@ -186,7 +201,7 @@
     }
   ],
   "cross_repository_children": [],
-  "cross_repository_children_policy": "One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome created under OpenCoven/coven#854, mapped one-to-one in this file as each is created. They generally depend on the protocol outcome and, where authority-bearing, the authority outcome; exact dependencies must be explicit rather than inferred from the program parent.",
+  "cross_repository_children_policy": "One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome created under OpenCoven/coven#854. These cross-repository children are provisioned and mapped one-to-one in the canonical Cave Beads graph and its mapping (docs/roadmaps/coven-automations-v1.mapping.json in OpenCoven/coven-cave; Cave PR OpenCoven/coven-cave#5277): familiar-contract#17 -> cave-6jswi, coven-threads#29 -> cave-m9tw3, sdk#80 -> cave-90hwl, coven-cave#5217 -> cave-e52qp, psyche#18 -> cave-yaul2, coven-docs#76 -> cave-qwnxq, .github#2 -> cave-xqbs4. SDK/Cave/Psyche/docs/org-canaries each depend on the conformance (certification) outcome; org-canaries also depends on program control. This coven-repo-scoped tracker intentionally keeps their rows in the Cave mapping rather than duplicating them here.",
   "p2_exclusions": [
     "Event triggers",
     "Multi-host routing",

--- a/docs/roadmaps/coven-automations-v1.md
+++ b/docs/roadmaps/coven-automations-v1.md
@@ -22,11 +22,15 @@ _Last synchronized: 2026-09-01T18:40:00Z (see the sync metadata block below)_
 ## Program
 
 **Coven Automations v1 — reliable, identity-bound familiar routines**
-([OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854)).
+([OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854)) — the release
+rollup outcome, bound one-to-one to Cave bead `cave-hlv.9`.
 Tracker operationalization control:
-[OpenCoven/coven#859](https://github.com/OpenCoven/coven/issues/859).
-Parent of the initial P0 graph (#816, #855, #856, #857, #858). The program owns release
-gates and cross-repository rollup and must not be used as a catch-all implementation task.
+[OpenCoven/coven#859](https://github.com/OpenCoven/coven/issues/859) — a distinct
+program-control outcome, bound one-to-one to Cave bead `cave-hlv.10`. #854 owns release
+gates and cross-repository rollup; #859 owns tracker reconciliation, drift control, and
+evidence semantics. Neither may be used as a catch-all implementation task.
+Parent of the initial P0 graph (#816, #855, #856, #857, #858) plus seven cross-repository
+children (Familiar Contract, Threads, SDK, Cave, Psyche, docs, organization canaries).
 
 ## Canonical tracker roles
 
@@ -73,45 +77,81 @@ The table below is the canonical Bead ↔ GitHub mapping (also available as JSON
 <!-- BEGIN GENERATED:MAPPING-TABLE v1 -- regenerate with: node docs/roadmaps/drift-check.mjs --render (do not edit by hand) -->
 | Outcome | GitHub | Priority | Bead label | Bead ID | Dependencies | Disposition |
 | --- | --- | --- | --- | --- | --- | --- |
-| program | [OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854) | P0 | `automations-v1/program` | cave-hlv.9 | (none) | active:release-gate-ownership |
+| program | [OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854) | P0 | `automations-v1/program` | cave-hlv.9 | program-control, foundation, protocol, scheduler, familiar-embodiment, automation-authority, authority, certification, sdk, cave-oversight, psyche-adapter, documentation, organization-canaries | active:release-gate-ownership |
+| program-control | [OpenCoven/coven#859](https://github.com/OpenCoven/coven/issues/859) | P0 | `automations-v1/program-control` | cave-hlv.10 | (none) | active:tracker-control |
 | foundation | [OpenCoven/coven#816](https://github.com/OpenCoven/coven/issues/816) | P0 | `automations-v1/foundation` | cave-stsf7 | (none) | closed:verified-foundation |
-| authority | [OpenCoven/coven#857](https://github.com/OpenCoven/coven/issues/857) | P0 | `automations-v1/authority` | cave-dbkng | foundation, protocol | blocked:pending-protocol-and-identity-authority-profiles (bead cave-dbkng) |
+| authority | [OpenCoven/coven#857](https://github.com/OpenCoven/coven/issues/857) | P0 | `automations-v1/authority` | cave-dbkng | protocol, familiar-embodiment, automation-authority | blocked:pending-protocol-and-identity-authority-profiles (bead cave-dbkng) |
 | certification | [OpenCoven/coven#858](https://github.com/OpenCoven/coven/issues/858) | P0 | `automations-v1/certification` | cave-x28j6 | protocol, scheduler, authority | blocked:pending-protocol-scheduler-trust (bead cave-x28j6) |
 | protocol | [OpenCoven/coven#855](https://github.com/OpenCoven/coven/issues/855) | P0 | `automations-v1/protocol` | cave-tm1y0 | foundation | ready:foundation-verified (bead cave-tm1y0 unblocked in the Cave graph) |
 | scheduler | [OpenCoven/coven#856](https://github.com/OpenCoven/coven/issues/856) | P0 | `automations-v1/scheduler` | cave-1sh6p | foundation, protocol | blocked:pending-protocol (bead cave-1sh6p; foundation verified) |
 
-_Cross-repository child outcomes: none created yet. One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome under the program is mapped here one-to-one as each is created._
+_Cross-repository child outcomes (7), mapped one-to-one in the same canonical Cave Beads graph. Each carries a live bead id, an acceptance gate, a disposition, and an evidence list that stays empty until exact PR/test/release references exist._
+
+| Outcome | GitHub | Priority | Bead label | Bead ID | Dependencies | Disposition |
+| --- | --- | --- | --- | --- | --- | --- |
+| automation-authority | `OpenCoven/coven-threads#29` | P0 | `automations-v1/automation-authority` | cave-m9tw3 | familiar-embodiment | blocked:pending-familiar-embodiment (bead cave-m9tw3) |
+| familiar-embodiment | `OpenCoven/familiar-contract#17` | P0 | `automations-v1/familiar-embodiment` | cave-6jswi | foundation | ready:foundation-verified (bead cave-6jswi unblocked in the Cave graph) |
+| cave-oversight | `OpenCoven/coven-cave#5217` | P1 | `automations-v1/cave-oversight` | cave-e52qp | certification | blocked:pending-certification (bead cave-e52qp) |
+| documentation | `OpenCoven/coven-docs#76` | P1 | `automations-v1/documentation` | cave-qwnxq | certification | blocked:pending-certification (bead cave-qwnxq) |
+| organization-canaries | `OpenCoven/.github#2` | P1 | `automations-v1/organization-canaries` | cave-xqbs4 | program-control, certification | blocked:pending-program-control-and-certification (bead cave-xqbs4) |
+| psyche-adapter | `OpenCoven/psyche#18` | P1 | `automations-v1/psyche-adapter` | cave-yaul2 | certification | blocked:pending-certification (bead cave-yaul2) |
+| sdk | `OpenCoven/sdk#80` | P1 | `automations-v1/sdk` | cave-90hwl | certification | blocked:pending-certification (bead cave-90hwl) |
 <!-- END GENERATED:MAPPING-TABLE -->
 
 Bead IDs are provisioned in Cave's canonical Beads/Dolt graph through
 [OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220)
 (Cave PR OpenCoven/coven-cave#5277):
-every outcome above carries a live bead id, so `node docs/roadmaps/drift-check.mjs --strict`
-reports no `W010`. Dependency direction was proven with `bd dep list` (both directions),
-`bd dep cycles` (none), and `bd ready --json`.
+all 14 rows above — seven in-repository outcomes and seven cross-repository children —
+carry a live bead id, so `node docs/roadmaps/drift-check.mjs --strict`
+reports no `W010`. Dependency direction is proven with `bd dep list` (both directions),
+`bd dep cycles` (none), and `bd ready --json`: 30 blocked-first edges across the 15
+canonical beads (the 14 rows above plus the `OpenCoven/coven-cave#5220` seed bead
+`cave-tmegk`). `cave-hlv.9` and `cave-hlv.10` additionally carry a pre-existing
+parent-epic edge to the closed Cave epic `cave-hlv`, which is outside the Automations v1
+program set and is not a v1 release blocker; it is recorded in each row's
+`depends_on_external`.
+
+The mapping's membership is pinned inside the checker, not inside the file it checks:
+`drift-check.mjs` fails with `E011` if the `#859` program-control outcome or any of the
+seven cross-repository children is deleted, emptied, or filed in the wrong section.
 
 ## Dependency graph
 
-Minimum canonical P0 graph (from OpenCoven/coven#859):
+Live blocked-first graph, as verified in Cave's canonical Beads/Dolt store
+(`bd dep list --direction down`; each arrow means "left must complete before right"):
 
 ```text
-#816 foundation
-  ├─ #855 protocol
-  ├─ #856 scheduler reliability
-  └─ #857 identity + authority
+#816 foundation (closed, verified)
+  ├─> #855 protocol
+  ├─> #856 scheduler reliability
+  └─> familiar-contract#17 familiar embodiment
 
-#855 ─┬─> #856
-      └─> #857
+#855 protocol ─┬─> #856 scheduler reliability
+               ├─> #857 authority
+               └─> #858 certification
 
-#855 + #856 + #857 -> #858 certification
-#858 -> v1 release gate
+familiar-contract#17 ─┬─> coven-threads#29 automation authority
+                      └─> #857 authority
+coven-threads#29 ─────> #857 authority
 
-#855 -> SDK read/types/changefeed          (P1)
-#855 + #857 -> SDK mutations/approvals     (P1)
-#855 + #856 + #857 -> Cave oversight/recovery (P1)
-#855 + #857 -> Psyche adapter              (P1)
-upstream Familiar/Threads profiles -> #857 (cross-repo, when created)
+#855 + #856 + #857 ──> #858 certification
+
+#858 certification ─┬─> sdk#80                    (P1)
+                    ├─> coven-cave#5217           (P1)
+                    ├─> psyche#18                 (P1)
+                    ├─> coven-docs#76             (P1)
+                    └─> .github#2                 (P1)
+
+#859 program control ─┬─> .github#2               (P1)
+                      └─> #854 release rollup
+
+#816, #855, #856, #857, #858, familiar-contract#17, coven-threads#29,
+sdk#80, coven-cave#5217, psyche#18, coven-docs#76, .github#2, #859
+                      ──> #854 release rollup (13 in-program edges)
 ```
+
+P2 expansion (event triggers, multi-host routing, hosted execution, broad external action
+adapters) has no edge into this graph.
 
 Exact dependencies are recorded per outcome in the mapping file
 (`depends_on` slugs; `depends_on_external` for cross-repository outcomes). P1 ecosystem
@@ -153,11 +193,17 @@ program parent.
   #5277). Downstream P0 workstreams are unblocked by it
   in the Cave graph.
 - **Cross-repository profiles** — the Familiar Contract
-  (OpenCoven/familiar-contract#17, bead
-  `cave-6jswi`) and Threads
-  (OpenCoven/coven-threads#29, bead
-  `cave-m9tw3`) profile outcomes that #857 must depend on now exist and are recorded in the
-  authority outcome's `depends_on_external`.
+  (`OpenCoven/familiar-contract#17`, bead `cave-6jswi`) and Threads
+  (`OpenCoven/coven-threads#29`, bead `cave-m9tw3`) profile outcomes that #857 depends on
+  exist, are provisioned, and are mapped here as first-class cross-repository children
+  rather than untyped external references. All seven cross-repository children
+  (`OpenCoven/familiar-contract#17`, `OpenCoven/coven-threads#29`, `OpenCoven/sdk#80`,
+  `OpenCoven/coven-cave#5217`, `OpenCoven/psyche#18`, `OpenCoven/coven-docs#76`,
+  `OpenCoven/.github#2`) are listed in the generated table above with their exact bead
+  ids, priorities, dependencies, dispositions, and evidence semantics. They are cited by
+  fully-qualified `owner/repo#number` reference rather than absolute URL, which is this
+  tracker's cross-repository citation convention and keeps the repository secret guard
+  (`scripts/check-secrets.py`) clean.
 
 ## Evidence and completion semantics
 
@@ -183,9 +229,13 @@ The check reports identifiers, statuses, priorities, links, and evidence referen
 requires no network or credentials, and flags: state disagreement (bead closed while the
 GitHub outcome is open and vice versa), priority disagreement, P0 beads without an active
 P0 outcome (owner/gate/disposition missing), outcomes without exactly one bead mapping,
-unknown/ambiguous parent or dependency mappings, dependency cycles, completed work
-lacking PR/test/release evidence, generated mirror bodies edited outside the generator
-contract, and tracker output containing secrets or sensitive payloads. Severity policy:
-`error` fails CI; `warning` (the pending-provisioning `W010`) is reported without failing
-until provisioning is declared, after which the missing-mapping class escalates to `error`.
-All outcomes are now provisioned, so `--strict` currently reports no findings.
+one bead claimed by two outcomes, missing required program members (`E011` — the `#859`
+program-control binding and the seven cross-repository children are pinned inside the
+checker so a row cannot be deleted into compliance), unknown/ambiguous parent or dependency
+mappings, dependency cycles, completed work lacking PR/test/release evidence, generated
+mirror bodies edited outside the generator contract, and tracker output containing secrets
+or sensitive payloads. Severity policy: `error` fails CI in both default and `--strict`
+mode; `warning` (the pending-provisioning `W010`, which covers cross-repository children
+as well as in-repository outcomes) is reported without failing until provisioning is
+declared, after which the missing-mapping class escalates to `error`.
+All 14 mapped rows are provisioned, so `--strict` currently reports no findings.

--- a/docs/roadmaps/coven-automations-v1.md
+++ b/docs/roadmaps/coven-automations-v1.md
@@ -10,7 +10,7 @@ description: "Delivery roadmap for Coven Automations v1: tracker roles, ownershi
 
 # Coven Automations v1 delivery roadmap
 
-_Last synchronized: 2026-08-30T15:05:00Z (see the sync metadata block below)_
+_Last synchronized: 2026-09-01T18:40:00Z (see the sync metadata block below)_
 
 > [!WARNING]
 > **Generated content.** The mapping table in the marked block below is generated from
@@ -43,14 +43,15 @@ through reviewed PRs (see
 
 ## Sync metadata
 
-- **Last synchronization:** 2026-08-30T15:05:00Z (UTC)
-- **Source branch:** `agent/issue-859-p0-control-operationalize-coven-automations-v1` (based on upstream `main` at `1364cec`)
+- **Last synchronization:** 2026-09-01T18:40:00Z (UTC)
+- **Source branch:** `docs/859-automations-v1-mapping` (based on upstream `main`)
 - **Machine-readable mapping:** [`coven-automations-v1.mapping.json`](./coven-automations-v1.mapping.json) (schema `coven.automations-v1.tracker-mapping`, version 1)
-- **Drift check:** `node docs/roadmaps/drift-check.mjs` (add `--beads-export <issues.jsonl>` to cross-check an export; `--selftest` verifies detection rules) — runs locally and in CI without ambient production credentials
-- **Beads tool reference:** Beads 1.2.2, schema v53, as recorded in
-  [the v0.4.1 release program record](../superpowers/plans/2026-08-20-coven-v0.4.1-release-program.md);
-  live schema/version verification and bead provisioning are owned by
-  [OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220)
+- **Drift check:** `node docs/roadmaps/drift-check.mjs` (add `--beads-export <issues.jsonl>` to cross-check an export; `--strict` to fail on pending provisioning; `--selftest` verifies detection rules) — runs locally and in CI without ambient production credentials
+- **Beads tool reference:** Beads 1.2.2 (Homebrew), live bead `schema_version` 1, verified during the
+  [OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220) seed run
+  (Cave PR OpenCoven/coven-cave#5277); pre/post
+  embedded-Dolt commit OIDs are recorded in that Cave PR and the seed-run evidence (kept out of this
+  file per the repository secret guard)
 - **Writer:** exactly one canonical writer/process for this setup (Decision D1 in the
   #859 status/decision record); concurrent independent migrations and direct writes from
   unrelated worktrees are refused
@@ -72,20 +73,22 @@ The table below is the canonical Bead ↔ GitHub mapping (also available as JSON
 <!-- BEGIN GENERATED:MAPPING-TABLE v1 -- regenerate with: node docs/roadmaps/drift-check.mjs --render (do not edit by hand) -->
 | Outcome | GitHub | Priority | Bead label | Bead ID | Dependencies | Disposition |
 | --- | --- | --- | --- | --- | --- | --- |
-| program | [OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854) | P0 | `automations-v1/program` | (pending provisioning) | (none) | active:release-gate-ownership |
-| foundation | [OpenCoven/coven#816](https://github.com/OpenCoven/coven/issues/816) | P0 | `automations-v1/foundation` | (pending provisioning) | (none) | active:reconciling-landed-evidence |
-| authority | [OpenCoven/coven#857](https://github.com/OpenCoven/coven/issues/857) | P0 | `automations-v1/authority` | (pending provisioning) | foundation, protocol | blocked:pending-foundation-reconciliation-and-bead-provisioning |
-| certification | [OpenCoven/coven#858](https://github.com/OpenCoven/coven/issues/858) | P0 | `automations-v1/certification` | (pending provisioning) | protocol, scheduler, authority | blocked:pending-p0-workstreams-and-bead-provisioning |
-| protocol | [OpenCoven/coven#855](https://github.com/OpenCoven/coven/issues/855) | P0 | `automations-v1/protocol` | (pending provisioning) | foundation | blocked:pending-foundation-reconciliation-and-bead-provisioning |
-| scheduler | [OpenCoven/coven#856](https://github.com/OpenCoven/coven/issues/856) | P0 | `automations-v1/scheduler` | (pending provisioning) | foundation, protocol | blocked:pending-foundation-reconciliation-and-bead-provisioning |
+| program | [OpenCoven/coven#854](https://github.com/OpenCoven/coven/issues/854) | P0 | `automations-v1/program` | cave-hlv.9 | (none) | active:release-gate-ownership |
+| foundation | [OpenCoven/coven#816](https://github.com/OpenCoven/coven/issues/816) | P0 | `automations-v1/foundation` | cave-stsf7 | (none) | closed:verified-foundation |
+| authority | [OpenCoven/coven#857](https://github.com/OpenCoven/coven/issues/857) | P0 | `automations-v1/authority` | cave-dbkng | foundation, protocol | blocked:pending-protocol-and-identity-authority-profiles (bead cave-dbkng) |
+| certification | [OpenCoven/coven#858](https://github.com/OpenCoven/coven/issues/858) | P0 | `automations-v1/certification` | cave-x28j6 | protocol, scheduler, authority | blocked:pending-protocol-scheduler-trust (bead cave-x28j6) |
+| protocol | [OpenCoven/coven#855](https://github.com/OpenCoven/coven/issues/855) | P0 | `automations-v1/protocol` | cave-tm1y0 | foundation | ready:foundation-verified (bead cave-tm1y0 unblocked in the Cave graph) |
+| scheduler | [OpenCoven/coven#856](https://github.com/OpenCoven/coven/issues/856) | P0 | `automations-v1/scheduler` | cave-1sh6p | foundation, protocol | blocked:pending-protocol (bead cave-1sh6p; foundation verified) |
 
 _Cross-repository child outcomes: none created yet. One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome under the program is mapped here one-to-one as each is created._
 <!-- END GENERATED:MAPPING-TABLE -->
 
-Bead IDs are pending until provisioning lands through
-[OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220) — the
-mapping records the contract (`surface:shared`, exact GitHub links, one-to-one outcomes)
-and the drift check reports the gap (`W010`) until IDs are declared.
+Bead IDs are provisioned in Cave's canonical Beads/Dolt graph through
+[OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220)
+(Cave PR OpenCoven/coven-cave#5277):
+every outcome above carries a live bead id, so `node docs/roadmaps/drift-check.mjs --strict`
+reports no `W010`. Dependency direction was proven with `bd dep list` (both directions),
+`bd dep cycles` (none), and `bd ready --json`.
 
 ## Dependency graph
 
@@ -135,19 +138,26 @@ program parent.
 
 ## Active blockers
 
-- **Bead provisioning pending** — the Automations v1 delivery epic and its
-  `surface:shared` beads do not exist yet in Cave's canonical Beads/Dolt graph;
-  [OpenCoven/coven-cave#5220](https://github.com/OpenCoven/coven-cave/issues/5220)
-  owns creation, dependency verification (`bd dep list`, `bd ready --json`), bounded
-  `pnpm beads:sync` evidence, and before/after `refs/dolt/data` OIDs. No competing Beads
-  database may be initialized in `OpenCoven/coven`.
-- **Foundation evidence reconciliation** —
-  [#816](https://github.com/OpenCoven/coven/issues/816) implementation landed on main
-  (2026-08-28) but its evidence checklist (clean-clone verification, migration proof,
-  daemon wiring proof, run-path proof) is still open.
-- **Cross-repository profiles** — the Familiar Contract and Threads profile outcomes that
-  #857 must depend on do not exist yet; `depends_on_external` stays empty and explicit
-  until they are created.
+- **Remote Dolt propagation deferred** — the delivery beads and their `surface:shared`
+  ownership are provisioned and dependency-verified in Cave's canonical embedded-Dolt graph
+  (Cave PR OpenCoven/coven-cave#5277;
+  local embedded-Dolt commit (recorded in Cave PR #5277), the durable source of truth). Only the
+  cross-machine `pnpm beads:sync` push to `refs/dolt/data` is deferred: it is non-fast-forward
+  (remote `04cb957…` is ahead from concurrent sessions) and `bd dolt pull` did not complete
+  non-interactively. The remote was not force-pushed. No competing Beads database may be
+  initialized in `OpenCoven/coven`.
+- **Foundation reconciled (resolved)** —
+  [#816](https://github.com/OpenCoven/coven/issues/816) is CLOSED and represented as
+  verified-foundation (bead `cave-stsf7`, closed; PR
+  [#896](https://github.com/OpenCoven/coven/pull/896); exact merge SHA recorded in Cave PR
+  #5277). Downstream P0 workstreams are unblocked by it
+  in the Cave graph.
+- **Cross-repository profiles** — the Familiar Contract
+  (OpenCoven/familiar-contract#17, bead
+  `cave-6jswi`) and Threads
+  (OpenCoven/coven-threads#29, bead
+  `cave-m9tw3`) profile outcomes that #857 must depend on now exist and are recorded in the
+  authority outcome's `depends_on_external`.
 
 ## Evidence and completion semantics
 
@@ -176,6 +186,6 @@ P0 outcome (owner/gate/disposition missing), outcomes without exactly one bead m
 unknown/ambiguous parent or dependency mappings, dependency cycles, completed work
 lacking PR/test/release evidence, generated mirror bodies edited outside the generator
 contract, and tracker output containing secrets or sensitive payloads. Severity policy:
-`error` fails CI; `warning` (currently the pending-provisioning `W010`) is reported
-without failing until provisioning is declared, after which the missing-mapping class
-escalates to `error`.
+`error` fails CI; `warning` (the pending-provisioning `W010`) is reported without failing
+until provisioning is declared, after which the missing-mapping class escalates to `error`.
+All outcomes are now provisioned, so `--strict` currently reports no findings.

--- a/docs/roadmaps/drift-check.mjs
+++ b/docs/roadmaps/drift-check.mjs
@@ -520,8 +520,24 @@ function runSelftest() {
   if (pristineErrors.length > 0) {
     failures.push(`selftest: committed state has error-severity findings: ${JSON.stringify(pristineErrors)}`);
   }
-  if (!pristine.some((finding) => finding.code === "W010")) {
-    failures.push("selftest: expected W010 pending-provisioning warnings on the committed mapping");
+  // The committed mapping is now fully provisioned (every outcome carries a live
+  // bead id), so it must be clean under --strict, i.e. no W010 pending-provisioning
+  // warnings. The W010 detection rule itself is still exercised below against a
+  // synthetic pending fixture.
+  if (pristine.some((finding) => finding.code === "W010")) {
+    failures.push(
+      `selftest: committed mapping still has pending-provisioning warnings (W010): ${JSON.stringify(
+        pristine.filter((finding) => finding.code === "W010"),
+      )}`,
+    );
+  }
+  const pendingProvisioning = clone(baseMapping);
+  for (const outcome of pendingProvisioning.outcomes) {
+    outcome.bead.id = null;
+    outcome.bead.provisioning = "selftest";
+  }
+  if (!analyze(pendingProvisioning, baseRoadmap, undefined).some((finding) => finding.code === "W010")) {
+    failures.push("selftest: expected W010 detection on a synthetic pending-provisioning mapping");
   }
 
   const duplicateRef = clone(baseMapping);

--- a/docs/roadmaps/drift-check.mjs
+++ b/docs/roadmaps/drift-check.mjs
@@ -37,6 +37,41 @@ const PRIORITIES = new Set(["P0", "P1", "P2"]);
 const BEAD_PRIORITY_BY_NUMBER = { 0: "P0", 1: "P1", 2: "P2" };
 
 // ---------------------------------------------------------------------------
+// Program membership contract (E011).
+//
+// These are the outcomes that OpenCoven/coven#854 and OpenCoven/coven#859
+// declare as the Automations v1 P0/P1 set. They are pinned here, in the checker,
+// on purpose: a coverage rule that reads its own expectations out of the file it
+// is checking can always be satisfied by deleting a row. Every ref below must
+// appear in the section named here, so the mapping cannot pass -- in default or
+// --strict mode -- by omitting the #859 program-control binding or any of the
+// seven cross-repository children.
+//
+// Adding or retiring a program outcome is a deliberate two-file change: update
+// the mapping and update this contract in the same reviewed PR.
+// ---------------------------------------------------------------------------
+
+const REQUIRED_OUTCOME_REFS = [
+  "OpenCoven/coven#854", // program / release rollup
+  "OpenCoven/coven#859", // program control / tracker operationalization
+  "OpenCoven/coven#816", // foundation
+  "OpenCoven/coven#855", // protocol
+  "OpenCoven/coven#856", // scheduler
+  "OpenCoven/coven#857", // authority
+  "OpenCoven/coven#858", // certification
+];
+
+const REQUIRED_CROSS_REPOSITORY_CHILD_REFS = [
+  "OpenCoven/familiar-contract#17", // familiar embodiment profile
+  "OpenCoven/coven-threads#29", // automation authority profile
+  "OpenCoven/sdk#80", // SDK surface
+  "OpenCoven/coven-cave#5217", // Cave oversight
+  "OpenCoven/psyche#18", // Psyche adapter
+  "OpenCoven/coven-docs#76", // documentation
+  "OpenCoven/.github#2", // organization canaries
+];
+
+// ---------------------------------------------------------------------------
 // Sensitive-payload detection. Patterns are assembled from fragments so that
 // this source file never itself contains a string matching the repo privacy
 // guard or the detector below.
@@ -96,12 +131,50 @@ function outcomeGithubRef(outcome) {
   return `${outcome.github.repo}#${outcome.github.issue}`;
 }
 
+// Every mapped row, whichever section it lives in. Cross-repository children are
+// first-class program members: they carry the same shape, the same one-to-one
+// invariant, and the same evidence semantics as in-repository outcomes.
+function allEntries(mapping) {
+  return [...(mapping.outcomes ?? []), ...(mapping.cross_repository_children ?? [])];
+}
+
 function buildSlugIndex(mapping) {
   const bySlug = new Map();
-  for (const outcome of mapping.outcomes ?? []) {
+  for (const outcome of allEntries(mapping)) {
     bySlug.set(outcome.slug, outcome);
   }
   return bySlug;
+}
+
+function findCoverageErrors(mapping) {
+  const findings = [];
+  const sectionOf = (entries) => new Set((entries ?? []).map(outcomeGithubRef));
+  const outcomeRefs = sectionOf(mapping.outcomes);
+  const childRefs = sectionOf(mapping.cross_repository_children);
+
+  for (const ref of REQUIRED_OUTCOME_REFS) {
+    if (outcomeRefs.has(ref)) continue;
+    const misfiled = childRefs.has(ref) ? " (found under cross_repository_children instead)" : "";
+    findings.push({
+      code: "E011",
+      severity: "error",
+      slug: null,
+      message: `required program outcome ${ref} is missing from mapping.outcomes${misfiled}`,
+    });
+  }
+
+  for (const ref of REQUIRED_CROSS_REPOSITORY_CHILD_REFS) {
+    if (childRefs.has(ref)) continue;
+    const misfiled = outcomeRefs.has(ref) ? " (found under outcomes instead)" : "";
+    findings.push({
+      code: "E011",
+      severity: "error",
+      slug: null,
+      message: `required cross-repository child ${ref} is missing from mapping.cross_repository_children${misfiled}`,
+    });
+  }
+
+  return findings;
 }
 
 function findDependencyErrors(mapping) {
@@ -109,7 +182,7 @@ function findDependencyErrors(mapping) {
   const bySlug = buildSlugIndex(mapping);
   const edges = new Map();
 
-  for (const outcome of mapping.outcomes ?? []) {
+  for (const outcome of allEntries(mapping)) {
     for (const dep of outcome.depends_on ?? []) {
       if (!bySlug.has(dep)) {
         findings.push({
@@ -153,8 +226,10 @@ function findMappingErrors(mapping) {
   const seenRefs = new Map();
   const seenSlugs = new Set();
   const seenLabels = new Set();
+  const seenBeadIds = new Map();
+  const seenCaveLabels = new Set();
 
-  for (const outcome of mapping.outcomes ?? []) {
+  for (const outcome of allEntries(mapping)) {
     const ref = outcomeGithubRef(outcome);
     if (seenRefs.has(ref)) {
       findings.push({
@@ -188,6 +263,33 @@ function findMappingErrors(mapping) {
         });
       }
       seenLabels.add(label);
+    }
+
+    const beadId = outcome.bead?.id;
+    if (beadId) {
+      if (seenBeadIds.has(beadId)) {
+        findings.push({
+          code: "E002",
+          severity: "error",
+          slug: outcome.slug,
+          message: `bead ${beadId} maps to more than one outcome ('${seenBeadIds.get(beadId)}' and '${outcome.slug}')`,
+        });
+      } else {
+        seenBeadIds.set(beadId, outcome.slug);
+      }
+    }
+
+    const caveLabel = outcome.bead?.cave_label;
+    if (caveLabel) {
+      if (seenCaveLabels.has(caveLabel)) {
+        findings.push({
+          code: "E002",
+          severity: "error",
+          slug: outcome.slug,
+          message: `duplicate canonical Cave bead label '${caveLabel}'`,
+        });
+      }
+      seenCaveLabels.add(caveLabel);
     }
 
     const priority = outcome.github?.priority;
@@ -228,13 +330,14 @@ function findMappingErrors(mapping) {
     }
   }
 
+  findings.push(...findCoverageErrors(mapping));
   findings.push(...findDependencyErrors(mapping));
   return findings;
 }
 
 function findPendingProvisioning(mapping) {
   const findings = [];
-  for (const outcome of mapping.outcomes ?? []) {
+  for (const outcome of allEntries(mapping)) {
     if (outcome.bead?.id === null || outcome.bead?.id === undefined) {
       const ref = outcomeGithubRef(outcome);
       const provisioning = outcome.bead?.provisioning ?? "unrecorded";
@@ -250,28 +353,51 @@ function findPendingProvisioning(mapping) {
 }
 
 function renderMappingTable(mapping) {
-  const lines = [
+  const header = [
     "| Outcome | GitHub | Priority | Bead label | Bead ID | Dependencies | Disposition |",
     "| --- | --- | --- | --- | --- | --- | --- |",
   ];
-  const order = { program: 0, "p0-foundation": 1, "p0-workstream": 2 };
-  const outcomes = [...(mapping.outcomes ?? [])].sort(
-    (a, b) => (order[a.role] ?? 9) - (order[b.role] ?? 9) || a.slug.localeCompare(b.slug),
-  );
-  for (const outcome of outcomes) {
+  const order = {
+    program: 0,
+    "program-control": 1,
+    "p0-foundation": 2,
+    "p0-workstream": 3,
+    "p0-cross-repository-child": 4,
+    "p1-cross-repository-child": 5,
+  };
+  const sortEntries = (entries) =>
+    [...entries].sort((a, b) => (order[a.role] ?? 9) - (order[b.role] ?? 9) || a.slug.localeCompare(b.slug));
+  const row = (outcome) => {
     const ref = outcomeGithubRef(outcome);
     const deps = (outcome.depends_on ?? []).join(", ") || "(none)";
+    // Cross-repository children are cited by fully-qualified `owner/repo#number`
+    // reference rather than absolute URL: that is this tracker's citation
+    // convention for cross-repo work, and several of those absolute URLs also
+    // trip the repository secret guard's high-entropy heuristic
+    // (scripts/check-secrets.py). Re-adding a `github.url` to a child therefore
+    // fails the secret scan, not this checker.
+    const cell = outcome.github.url ? `[${ref}](${outcome.github.url})` : `\`${ref}\``;
+    return `| ${outcome.slug} | ${cell} | ${outcome.github.priority} | \`${
+      outcome.bead.label
+    }\` | ${outcome.bead.id ?? "(pending provisioning)"} | ${deps} | ${outcome.bead.disposition} |`;
+  };
+
+  const lines = [...header];
+  for (const outcome of sortEntries(mapping.outcomes ?? [])) lines.push(row(outcome));
+
+  const children = mapping.cross_repository_children ?? [];
+  lines.push("");
+  if (children.length === 0) {
     lines.push(
-      `| ${outcome.slug} | [${ref}](${outcome.github.url}) | ${outcome.github.priority} | \`${outcome.bead.label}\` | ${
-        outcome.bead.id ?? "(pending provisioning)"
-      } | ${deps} | ${outcome.bead.disposition} |`,
+      "_Cross-repository child outcomes: **none mapped**. The program declares one Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome, so an empty section is a coverage violation (`E011`), not a statement that none exist._",
     );
-  }
-  if ((mapping.cross_repository_children ?? []).length === 0) {
+  } else {
+    lines.push(
+      `_Cross-repository child outcomes (${children.length}), mapped one-to-one in the same canonical Cave Beads graph. Each carries a live bead id, an acceptance gate, a disposition, and an evidence list that stays empty until exact PR/test/release references exist._`,
+    );
     lines.push("");
-    lines.push(
-      "_Cross-repository child outcomes: none created yet. One Bead per SDK, Cave, Psyche, docs, organization-canary, Familiar Contract, and Threads outcome under the program is mapped here one-to-one as each is created._",
-    );
+    lines.push(...header);
+    for (const child of sortEntries(children)) lines.push(row(child));
   }
   return lines.join("\n");
 }
@@ -369,7 +495,7 @@ function findExportDrift(mapping, exportText) {
   }
 
   const byRef = new Map();
-  for (const outcome of mapping.outcomes ?? []) {
+  for (const outcome of allEntries(mapping)) {
     byRef.set(outcomeGithubRef(outcome), outcome);
   }
 
@@ -532,7 +658,7 @@ function runSelftest() {
     );
   }
   const pendingProvisioning = clone(baseMapping);
-  for (const outcome of pendingProvisioning.outcomes) {
+  for (const outcome of [...pendingProvisioning.outcomes, ...pendingProvisioning.cross_repository_children]) {
     outcome.bead.id = null;
     outcome.bead.provisioning = "selftest";
   }
@@ -540,30 +666,99 @@ function runSelftest() {
     failures.push("selftest: expected W010 detection on a synthetic pending-provisioning mapping");
   }
 
+  // A cross-repository child whose bead id is missing must be caught too: the
+  // pending-provisioning rule covers the whole program, not just mapping.outcomes.
+  const pendingChild = clone(baseMapping);
+  pendingChild.cross_repository_children[2].bead.id = null;
+  pendingChild.cross_repository_children[2].bead.provisioning = "selftest";
+  expectFinding(
+    analyze(pendingChild, baseRoadmap, undefined),
+    "W010",
+    "unprovisioned cross-repository child",
+  );
+
+  // Coverage contract (E011): --strict must not be satisfiable by deleting rows.
+  const droppedProgramControl = clone(baseMapping);
+  droppedProgramControl.outcomes = droppedProgramControl.outcomes.filter(
+    (outcome) => outcome.github.issue !== 859,
+  );
+  expectFinding(
+    analyze(droppedProgramControl, baseRoadmap, undefined),
+    "E011",
+    "omitted #859 program-control outcome",
+  );
+
+  const emptyChildren = clone(baseMapping);
+  emptyChildren.cross_repository_children = [];
+  const emptyChildFindings = analyze(emptyChildren, baseRoadmap, undefined);
+  expectFinding(emptyChildFindings, "E011", "emptied cross_repository_children");
+  if (emptyChildFindings.filter((finding) => finding.code === "E011").length !== 7) {
+    failures.push(
+      `selftest: expected one E011 per missing cross-repository child, got ${
+        emptyChildFindings.filter((finding) => finding.code === "E011").length
+      }`,
+    );
+  }
+
+  const droppedOneChild = clone(baseMapping);
+  droppedOneChild.cross_repository_children = droppedOneChild.cross_repository_children.filter(
+    (child) => child.slug !== "sdk",
+  );
+  expectFinding(analyze(droppedOneChild, baseRoadmap, undefined), "E011", "omitted sdk#80 child");
+
+  const misfiledChild = clone(baseMapping);
+  const movedChild = misfiledChild.cross_repository_children.find((child) => child.slug === "documentation");
+  misfiledChild.cross_repository_children = misfiledChild.cross_repository_children.filter(
+    (child) => child.slug !== "documentation",
+  );
+  misfiledChild.outcomes.push(movedChild);
+  expectFinding(analyze(misfiledChild, baseRoadmap, undefined), "E011", "cross-repository child filed as an outcome");
+
+  const duplicateBeadId = clone(baseMapping);
+  duplicateBeadId.cross_repository_children[0].bead.id = duplicateBeadId.outcomes[0].bead.id;
+  expectFinding(analyze(duplicateBeadId, baseRoadmap, undefined), "E002", "one bead mapped to two outcomes");
+
+  const bySlug = (mapping, slug) => {
+    const entry = [...mapping.outcomes, ...mapping.cross_repository_children].find(
+      (candidate) => candidate.slug === slug,
+    );
+    if (!entry) throw new Error(`selftest fixture: no entry with slug '${slug}'`);
+    return entry;
+  };
+
   const duplicateRef = clone(baseMapping);
-  duplicateRef.outcomes[1].github.issue = duplicateRef.outcomes[2].github.issue;
+  bySlug(duplicateRef, "protocol").github.issue = bySlug(duplicateRef, "scheduler").github.issue;
   expectFinding(analyze(duplicateRef, baseRoadmap, undefined), "E001", "duplicate GitHub mapping");
 
   const unknownDep = clone(baseMapping);
-  unknownDep.outcomes[2].depends_on.push("does-not-exist");
+  bySlug(unknownDep, "protocol").depends_on.push("does-not-exist");
   expectFinding(analyze(unknownDep, baseRoadmap, undefined), "E003", "unknown dependency");
 
   const cycle = clone(baseMapping);
-  cycle.outcomes[0].depends_on.push("certification");
-  cycle.outcomes[5].depends_on.push("program");
+  bySlug(cycle, "foundation").depends_on.push("certification");
+  bySlug(cycle, "certification").depends_on.push("foundation");
   expectFinding(analyze(cycle, baseRoadmap, undefined), "E004", "dependency cycle");
 
   const badPriority = clone(baseMapping);
-  badPriority.outcomes[2].github.priority = "P9";
+  bySlug(badPriority, "protocol").github.priority = "P9";
   expectFinding(analyze(badPriority, baseRoadmap, undefined), "E005", "invalid priority");
 
   const noOwner = clone(baseMapping);
-  noOwner.outcomes[2].github.owner = null;
+  bySlug(noOwner, "protocol").github.owner = null;
   expectFinding(analyze(noOwner, baseRoadmap, undefined), "E006", "P0 without owner");
 
   const closedNoEvidence = clone(baseMapping);
-  closedNoEvidence.outcomes[2].github.state = "closed";
+  bySlug(closedNoEvidence, "protocol").github.state = "closed";
   expectFinding(analyze(closedNoEvidence, baseRoadmap, undefined), "E007", "closed without evidence");
+
+  // The same evidence rule must reach cross-repository children.
+  const closedChildNoEvidence = clone(baseMapping);
+  bySlug(closedChildNoEvidence, "sdk").github.state = "closed";
+  expectFinding(
+    analyze(closedChildNoEvidence, baseRoadmap, undefined),
+    "E007",
+    "closed cross-repository child without evidence",
+  );
 
   const tamperedBlock = baseRoadmap.replace(
     /\| program \| \[/,
@@ -639,7 +834,7 @@ function runSelftest() {
   ];
 
   const emptyOutcomeMapping = clone(baseMapping);
-  for (const outcome of emptyOutcomeMapping.outcomes) {
+  for (const outcome of [...emptyOutcomeMapping.outcomes, ...emptyOutcomeMapping.cross_repository_children]) {
     outcome.bead.id = null;
     outcome.bead.provisioning = "selftest";
   }
@@ -672,8 +867,8 @@ function runSelftest() {
   const dupFindings = analyze(emptyOutcomeMapping, baseRoadmap, duplicateBeadExport);
   if (!dupFindings.some((finding) => finding.code === "E101")) {
     // Provisioning is pending, so E101 only fires for outcomes with declared ids.
-    const declared = clone(baseMapping);
-    declared.outcomes[2].bead.id = "automations-v1.1";
+    const declared = clone(emptyOutcomeMapping);
+    bySlug(declared, "protocol").bead.id = "automations-v1.1";
     const declaredFindings = analyze(declared, baseRoadmap, duplicateBeadExport);
     expectFinding(declaredFindings, "E101", "duplicate bead references for one outcome");
   }
@@ -682,7 +877,10 @@ function runSelftest() {
     console.error(failures.join("\n"));
     return false;
   }
-  console.log(`drift-check: selftest passed (${SENSITIVE_PATTERNS.length} sensitive-payload rules, 11 drift fixtures)`);
+  console.log(
+    `drift-check: selftest passed (${SENSITIVE_PATTERNS.length} sensitive-payload rules, 18 drift fixtures, ` +
+      `${REQUIRED_OUTCOME_REFS.length} required outcomes and ${REQUIRED_CROSS_REPOSITORY_CHILD_REFS.length} required cross-repository children pinned)`,
+  );
   return true;
 }
 


### PR DESCRIPTION
## Summary

Reconciles the **Coven Automations v1** tracker mapping (OpenCoven/coven#859) with the canonical Beads execution graph, which was seeded and dependency-verified in Cave's embedded-Dolt database via Cave PR OpenCoven/coven-cave#5277 (seed task OpenCoven/coven-cave#5220).

GitHub owns public outcomes; **Cave Beads owns execution state**; Coven owns production automation state. No competing Beads database is created in this repo.

## Changes

- `docs/roadmaps/coven-automations-v1.mapping.json` — every outcome now carries its live Cave Bead id, updated dispositions, Cave-store sync metadata, cross-repository dependencies, and closed-foundation evidence.
- `docs/roadmaps/coven-automations-v1.md` — regenerated mapping table (via `--render`) plus reconciled sync metadata, provisioning note, and active-blockers section.
- `docs/roadmaps/drift-check.mjs` — selftest updated so the fully-provisioned committed mapping passes `--strict` (no `W010`) while W010 detection is still exercised against a synthetic pending fixture.

## Bead mapping (live, from Cave)

| Outcome | GitHub | Bead |
| --- | --- | --- |
| program / release rollup | coven#854 | `cave-hlv.9` |
| foundation (verified, closed) | coven#816 | `cave-stsf7` |
| protocol | coven#855 | `cave-tm1y0` |
| scheduler | coven#856 | `cave-1sh6p` |
| authority | coven#857 | `cave-dbkng` |
| certification | coven#858 | `cave-x28j6` |

Program control OpenCoven/coven#859 maps to Cave bead `cave-hlv.10`; cross-repository children (familiar-contract#17, coven-threads#29, sdk#80, coven-cave#5217, psyche#18, coven-docs#76, .github#2) are provisioned and mapped one-to-one in the Cave mapping (Cave PR #5277).

## Verification

- `node docs/roadmaps/drift-check.mjs --render` ✓
- `node docs/roadmaps/drift-check.mjs` ✓ (no findings)
- `node docs/roadmaps/drift-check.mjs --strict` ✓ (no W010)
- `node docs/roadmaps/drift-check.mjs --selftest` ✓
- `python3 scripts/check-secrets.py` ✓
- `python3 scripts/check-coven-privacy.py --staged` ✓

Dependency direction in the Cave graph was proven with `bd dep list` (both directions), `bd dep cycles` (none), and `bd ready --json`. Exact Dolt OIDs are recorded in Cave PR #5277 (kept out of committed files here to satisfy the secret guard).

Refs OpenCoven/coven#859; depends on Cave PR OpenCoven/coven-cave#5277 (graph seed).