### PR TITLE
docs: correct stale post-sync narrative for Automations v1 tracker (#859)

### DIFF
--- a/docs/roadmaps/coven-automations-v1.mapping.json
+++ b/docs/roadmaps/coven-automations-v1.mapping.json
@@ -3,7 +3,7 @@
   "schema_version": 1,
   "description": "Machine-readable Bead <-> GitHub outcome mapping for the Coven Automations v1 program (OpenCoven/coven#859). GitHub owns public outcomes, acceptance gates, and durable evidence links. Beads (in the OpenCoven/coven-cave embedded Dolt database `cave`) owns the implementation dependency graph, execution ownership, and mirror inputs. This file is the reconciliation contract between the two; it is hand-reviewed, not hand-synced.",
   "sync": {
-    "last_sync": "2026-09-01T18:40:00Z",
+    "last_sync": "2026-09-01T20:15:00Z",
     "source_branch": "docs/859-automations-v1-mapping",
     "writer": "One canonical writer/process is designated for this setup; see docs/superpowers/plans/2026-08-30-issue-859-coven-automations-v1-tracker-operationalization.md (Decision D1). Persisted tracker changes land only through reviewed PRs.",
     "canonical_bead_store": "OpenCoven/coven-cave embedded Dolt database `cave`; provisioning was executed through OpenCoven/coven-cave#5220 (Cave PR OpenCoven/coven-cave#5277). A competing Beads database must not be initialized in OpenCoven/coven (operational correction on OpenCoven/coven#859, 2026-08-30).",
@@ -17,8 +17,8 @@
       "cross_repository_children": "OpenCoven/familiar-contract#17 -> cave-6jswi; OpenCoven/coven-threads#29 -> cave-m9tw3; OpenCoven/sdk#80 -> cave-90hwl; OpenCoven/coven-cave#5217 -> cave-e52qp; OpenCoven/psyche#18 -> cave-yaul2; OpenCoven/coven-docs#76 -> cave-qwnxq; OpenCoven/.github#2 -> cave-xqbs4",
       "graph_shape": "15 canonical beads (14 mapped outcomes plus the OpenCoven/coven-cave#5220 seed bead cave-tmegk) and 30 in-program blocked-first edges, no cycles. cave-hlv.9 and cave-hlv.10 additionally carry a pre-existing parent-epic edge to the closed Cave epic cave-hlv, which is outside the Automations v1 program set.",
       "remote_ref": "refs/dolt/data",
-      "dolt_commit_evidence": "Embedded-Dolt pre/post commit OIDs and the remote refs/dolt/data OID are recorded in Cave PR OpenCoven/coven-cave#5277 and the seed-run execution ledger (kept out of this committed file to satisfy the repository secret guard).",
-      "remote_sync_status": "deferred: local embedded Dolt is durable and canonical; bd dolt push is non-fast-forward (remote ahead from concurrent sessions) and bd dolt pull did not complete non-interactively. Not force-pushed.",
+      "dolt_commit_evidence": "Embedded-Dolt pre/post commit OIDs, the reconciled local/remote Dolt commit, and the durable refs/dolt/data git OID are recorded in Cave PR OpenCoven/coven-cave#5277 and the seed-run execution ledger (exact transient OIDs are kept out of this committed file so this reconciliation contract cannot go stale against a moving remote; the ledger is the exact-evidence surface).",
+      "remote_sync_status": "synchronized: the documented wrapper `pnpm beads:sync` completed pull+push (exit 0, ~24s) on 2026-09-01; local embedded Dolt `main` and `remotes/origin/main` are equal, `dolt diff --summary` is empty, and the shared remote `refs/dolt/data` carries the seeded 15-bead / 30-edge graph. No force-push occurred and no concurrent Dolt commit was discarded; local state was re-verified intact afterward. This is the canonical graph-sync receipt and is distinct from the Cave-side mapping follow-up (see the roadmap Active blockers section), which remains blocked on a schema-v66-capable bd for managed-worktree admission.",
       "dependency_proof": "bd dep list (both directions), bd dep cycles (none), bd ready --json; recorded on Cave PR OpenCoven/coven-cave#5277."
     },
     "drift_check": "node docs/roadmaps/drift-check.mjs (add --beads-export <issues.jsonl> to cross-check an export; --strict to fail on pending provisioning; --selftest to verify detection rules)",
@@ -100,7 +100,9 @@
         "evidence_status": "partial",
         "evidence": [
           "OpenCoven/coven-cave#5277 (merged 2026-09-01; canonical Beads graph seeded)",
-          "https://github.com/OpenCoven/coven/pull/900 (this tracker-mapping reconciliation)"
+          "https://github.com/OpenCoven/coven/pull/900 (initial tracker-mapping reconciliation)",
+          "canonical graph sync durable: `pnpm beads:sync` pull+push exit 0 (~24s) on 2026-09-01; local Dolt `main` == `remotes/origin/main`, empty `dolt diff --summary`, `refs/dolt/data` carries the seeded graph, no force-push (exact OIDs in the seed-run ledger and Cave PR OpenCoven/coven-cave#5277)",
+          "remaining: the Cave-side mapping follow-up PR is blocked on a schema-v66-capable bd for managed-worktree admission, so #859 stays open until it lands"
         ]
       },
       "depends_on": [],

--- a/docs/roadmaps/coven-automations-v1.md
+++ b/docs/roadmaps/coven-automations-v1.md
@@ -10,7 +10,7 @@ description: "Delivery roadmap for Coven Automations v1: tracker roles, ownershi
 
 # Coven Automations v1 delivery roadmap
 
-_Last synchronized: 2026-09-01T18:40:00Z (see the sync metadata block below)_
+_Last synchronized: 2026-09-01T20:15:00Z (see the sync metadata block below)_
 
 > [!WARNING]
 > **Generated content.** The mapping table in the marked block below is generated from
@@ -47,7 +47,7 @@ through reviewed PRs (see
 
 ## Sync metadata
 
-- **Last synchronization:** 2026-09-01T18:40:00Z (UTC)
+- **Last synchronization:** 2026-09-01T20:15:00Z (UTC)
 - **Source branch:** `docs/859-automations-v1-mapping` (based on upstream `main`)
 - **Machine-readable mapping:** [`coven-automations-v1.mapping.json`](./coven-automations-v1.mapping.json) (schema `coven.automations-v1.tracker-mapping`, version 1)
 - **Drift check:** `node docs/roadmaps/drift-check.mjs` (add `--beads-export <issues.jsonl>` to cross-check an export; `--strict` to fail on pending provisioning; `--selftest` verifies detection rules) — runs locally and in CI without ambient production credentials
@@ -178,14 +178,22 @@ program parent.
 
 ## Active blockers
 
-- **Remote Dolt propagation deferred** — the delivery beads and their `surface:shared`
+- **Remote Dolt propagation (resolved)** — the delivery beads and their `surface:shared`
   ownership are provisioned and dependency-verified in Cave's canonical embedded-Dolt graph
-  (Cave PR OpenCoven/coven-cave#5277;
-  local embedded-Dolt commit (recorded in Cave PR #5277), the durable source of truth). Only the
-  cross-machine `pnpm beads:sync` push to `refs/dolt/data` is deferred: it is non-fast-forward
-  (remote `04cb957…` is ahead from concurrent sessions) and `bd dolt pull` did not complete
-  non-interactively. The remote was not force-pushed. No competing Beads database may be
-  initialized in `OpenCoven/coven`.
+  (Cave PR OpenCoven/coven-cave#5277). Cross-machine propagation is now durable: the documented
+  wrapper `pnpm beads:sync` completed pull+push (exit 0, ~24s) on 2026-09-01, local embedded Dolt
+  `main` and `remotes/origin/main` are equal, `dolt diff --summary` is empty, and the shared remote
+  `refs/dolt/data` carries the seeded 15-bead / 30-edge graph. The remote was not force-pushed, no
+  concurrent Dolt commit was discarded, and local state was re-verified intact afterward. Exact
+  transient OIDs live in the seed-run execution ledger and Cave PR #5277, not in this file. No
+  competing Beads database may be initialized in `OpenCoven/coven`.
+- **Cave-side mapping follow-up (open)** — canonical graph sync above is complete, but the
+  Cave-repo mapping reconciliation PR (which lands the prepared reconcile script into Cave's own
+  roadmap surfaces) has not merged yet. It is gated on obtaining a schema-v66-capable `bd` so
+  Cave's managed worktree lifecycle can admit the follow-up; Homebrew `bd` 1.2.2 knows only up to
+  schema v53. Until that PR merges, Cave bead `cave-tmegk` stays `in_progress` and
+  `OpenCoven/coven-cave#5220` stays open. This is a Cave-side follow-up and does not reopen the
+  canonical graph-sync receipt.
 - **Foundation reconciled (resolved)** —
   [#816](https://github.com/OpenCoven/coven/issues/816) is CLOSED and represented as
   verified-foundation (bead `cave-stsf7`, closed; PR

--- a/docs/roadmaps/drift-check.mjs
+++ b/docs/roadmaps/drift-check.mjs
@@ -589,9 +589,9 @@ function findSyncNarrativeDrift(mapping, roadmapText) {
       slug: null,
       message:
         `remote sync state is inconsistent across artifacts: ` +
-        `mapping.sync.remote_sync_status is ${statusUnresolved ? "unresolved (deferred/blocked)" : "resolved"} ` +
+        `mapping.sync.beads_provisioning.remote_sync_status is ${statusUnresolved ? "unresolved (deferred/blocked)" : "resolved"} ` +
         `but the roadmap Active blockers narrative is ${narrativeUnresolved ? "unresolved (deferred/blocked)" : "resolved"}. ` +
-        `Update docs/roadmaps/coven-automations-v1.mapping.json and coven-automations-v1.md together.`,
+        `Update docs/roadmaps/coven-automations-v1.mapping.json and docs/roadmaps/coven-automations-v1.md together.`,
     },
   ];
 }

--- a/docs/roadmaps/drift-check.mjs
+++ b/docs/roadmaps/drift-check.mjs
@@ -569,10 +569,38 @@ function findExportDrift(mapping, exportText) {
   return findings;
 }
 
+function findSyncNarrativeDrift(mapping, roadmapText) {
+  // Truth-critical invariant: the machine-readable remote sync status
+  // (mapping.sync.beads_provisioning.remote_sync_status) and the roadmap's
+  // Active blockers narrative must agree on whether remote Dolt propagation is
+  // still an open blocker. This exists because a real successful sync once left
+  // one artifact corrected while the other silently claimed propagation was
+  // deferred. It pins no transient OID -- it only enforces cross-artifact
+  // agreement, so either both are updated together or the check fails.
+  if (typeof roadmapText !== "string") return [];
+  const status = String(mapping.sync?.beads_provisioning?.remote_sync_status ?? "");
+  const statusUnresolved = /^\s*(deferred|blocked)\b/i.test(status);
+  const narrativeUnresolved = /remote dolt propagation[^\n]*\b(deferred|blocked)\b/i.test(roadmapText);
+  if (statusUnresolved === narrativeUnresolved) return [];
+  return [
+    {
+      code: "E012",
+      severity: "error",
+      slug: null,
+      message:
+        `remote sync state is inconsistent across artifacts: ` +
+        `mapping.sync.remote_sync_status is ${statusUnresolved ? "unresolved (deferred/blocked)" : "resolved"} ` +
+        `but the roadmap Active blockers narrative is ${narrativeUnresolved ? "unresolved (deferred/blocked)" : "resolved"}. ` +
+        `Update docs/roadmaps/coven-automations-v1.mapping.json and coven-automations-v1.md together.`,
+    },
+  ];
+}
+
 function analyze(mapping, roadmapText, exportText) {
   const findings = [
     ...findMappingErrors(mapping),
     ...findGeneratedBlockDrift(mapping, roadmapText),
+    ...findSyncNarrativeDrift(mapping, roadmapText),
     ...findPendingProvisioning(mapping),
   ];
   if (typeof roadmapText === "string") {
@@ -771,6 +799,23 @@ function runSelftest() {
     "missing generated block",
   );
 
+  // E012: the machine-readable remote sync status and the roadmap narrative must
+  // agree. Both directions of disagreement must be caught.
+  const staleStatus = clone(baseMapping);
+  staleStatus.sync.beads_provisioning.remote_sync_status =
+    "deferred: bd dolt push is non-fast-forward and pull did not complete.";
+  expectFinding(
+    analyze(staleStatus, baseRoadmap, undefined),
+    "E012",
+    "mapping says remote sync deferred while roadmap says resolved",
+  );
+  const staleNarrative = `${baseRoadmap}\n- Remote Dolt propagation blocked (synthetic selftest line)\n`;
+  expectFinding(
+    analyze(baseMapping, staleNarrative, undefined),
+    "E012",
+    "roadmap says remote propagation blocked while mapping says resolved",
+  );
+
   const sensitiveMapping = clone(baseMapping);
   sensitiveMapping.outcomes[0].notes = [
     "operator note: ",
@@ -878,7 +923,7 @@ function runSelftest() {
     return false;
   }
   console.log(
-    `drift-check: selftest passed (${SENSITIVE_PATTERNS.length} sensitive-payload rules, 18 drift fixtures, ` +
+    `drift-check: selftest passed (${SENSITIVE_PATTERNS.length} sensitive-payload rules, 20 drift fixtures, ` +
       `${REQUIRED_OUTCOME_REFS.length} required outcomes and ${REQUIRED_CROSS_REPOSITORY_CHILD_REFS.length} required cross-repository children pinned)`,
   );
   return true;


### PR DESCRIPTION
## Summary

Follow-up to #900. After #900 merged, the canonical Cave embedded-Dolt graph
sync **later succeeded** (`pnpm beads:sync` pull+push, exit 0, ~24s): local Dolt
`main` equals `remotes/origin/main`, `dolt diff --summary` is empty, and the
shared remote `refs/dolt/data` carries the seeded 15-bead / 30-edge graph with no
force-push and no discarded concurrent commit. The committed roadmap mapping and
prose still claimed remote propagation was **deferred/blocked** at a now-stale
remote OID (`04cb957…`). This PR corrects that stale narrative.

## Changes

- `coven-automations-v1.mapping.json`: bump `last_sync`; rewrite
  `remote_sync_status` from *deferred* to *synchronized* with the exact success
  receipt (no transient OID embedded — exact OIDs stay in the seed-run ledger /
  Cave PR OpenCoven/coven-cave#5277); refresh `dolt_commit_evidence`; add the
  durable-sync evidence line to program-control while keeping `evidence_status:
  partial` because the Cave-side follow-up is still open.
- `coven-automations-v1.md`: bump both sync timestamps; replace the *Remote Dolt
  propagation deferred* blocker with a **resolved** entry, and add a distinct
  **Cave-side mapping follow-up (open)** blocker so the completed canonical graph
  sync is clearly separated from the still-blocked Cave mapping PR (gated on a
  schema-v66-capable `bd` for managed-worktree admission).
- `drift-check.mjs`: add a small robust invariant **E012** that fails when
  `remote_sync_status` (machine-readable) and the roadmap Active blockers
  narrative disagree on whether remote Dolt propagation is resolved, so this class
  of stale metadata cannot silently survive a PR again. No transient hash is
  hardcoded. Two new selftest fixtures cover both directions.

## Validation

- `drift-check --render` idempotent (stable md5, generated table unchanged)
- `drift-check` default (0), `--strict` (0), `--selftest` (0; 20 drift fixtures)
- `check-secrets.py` (0), `check-coven-privacy.py --staged` (0),
  `check-docs-ownership.py --range origin/main...HEAD` (0)

Refs #859.