### PR TITLE
ci: fail loudly when the perf baseline artifact never gets collected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,38 @@ jobs:
             coven-chaos.json
             coven-tui-metrics.txt
           if-no-files-found: error
+      - name: Verify baseline collection produced its artifact
+        # `Collect non-gating baseline artifact` is `continue-on-error`, so a
+        # wedged or timed-out collection would otherwise leave this job green
+        # with `coven-perf.json` missing and nobody the wiser. The upload's
+        # `if-no-files-found: error` does not catch that: it only fires when
+        # *zero* paths match, and the chaos/TUI outputs would still be present.
+        #
+        # This runs after the upload on purpose, so whatever partial output
+        # exists is still preserved for diagnosis before the job goes red.
+        # `performance-baseline` is push-only and `pr-gate` sees it as skipped
+        # on pull requests, so failing here surfaces the gap on main without
+        # blocking anyone's PR.
+        run: |
+          set -uo pipefail
+          status=0
+          if [ ! -s coven-perf.json ]; then
+            echo "::error::coven-perf.json is missing or empty - the baseline collection step did not complete (timed out, wedged, or failed)"
+            status=1
+          elif ! python3 -c 'import json,sys; json.load(open("coven-perf.json"))' 2>/dev/null; then
+            echo "::error::coven-perf.json exists but is not valid JSON - the baseline collection step was interrupted mid-write"
+            status=1
+          else
+            echo "coven-perf.json present and parseable"
+          fi
+          # The remaining outputs keep their existing tolerant behaviour; a
+          # warning records the gap without changing what they gate.
+          for optional in coven-chaos.json coven-tui-metrics.txt; do
+            if [ ! -s "$optional" ]; then
+              echo "::warning::${optional} is missing or empty"
+            fi
+          done
+          exit "$status"
 
   channels:
     name: Channels package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,12 +330,12 @@ jobs:
         # on pull requests, so failing here surfaces the gap on main without
         # blocking anyone's PR.
         run: |
-          set -uo pipefail
+          set -euo pipefail
           status=0
           if [ ! -s coven-perf.json ]; then
             echo "::error::coven-perf.json is missing or empty - the baseline collection step did not complete (timed out, wedged, or failed)"
             status=1
-          elif ! python3 -c 'import json,sys; json.load(open("coven-perf.json"))' 2>/dev/null; then
+          elif ! python3 -c 'import json; json.load(open("coven-perf.json"))' 2>/dev/null; then
             echo "::error::coven-perf.json exists but is not valid JSON - the baseline collection step was interrupted mid-write"
             status=1
           else


### PR DESCRIPTION
Closes the silent-loss gap flagged in #899. Independent of it — the two touch different lines of the same job and merge cleanly in either order (verified with `git merge-tree`).

## The gap

`Collect non-gating baseline artifact` is `continue-on-error`. If it wedges or trips its timeout, the job still reports **success** with `coven-perf.json` missing — and nothing says the baseline stopped being collected.

The upload's `if-no-files-found: error` does **not** cover this. It fires only when *zero* paths match, and `coven-chaos.json` + `coven-tui-metrics.txt` would still be present. So the artifact uploads green while missing the one measurement the job exists to produce.

## The fix

A verification step asserting `coven-perf.json` is present, non-empty, and parseable JSON — catching both a collection that never ran and one interrupted mid-write.

Two deliberate design points:

1. **It runs after the upload, not before.** If it ran first, a failure would skip the upload and destroy the partial output that tells you *why* collection died. This way the artifact is preserved, then the job goes red.
2. **It blocks nobody.** `performance-baseline` is `if: github.event_name == 'push'`, and `pr-gate` is `if: github.event_name == 'pull_request'` and accepts `skipped`. So this job never gates a PR; failing it reddens the main push run, which is exactly the signal that was missing.

`coven-chaos.json` and `coven-tui-metrics.txt` keep their existing tolerant behaviour and only emit `::warning::` — this PR does not change what they gate.

## Verification

The shell logic was exercised locally across all five paths before commit:

| case | result |
|---|---|
| all outputs present | `rc=0` |
| `coven-perf.json` missing | `rc=1` + `::error::` |
| `coven-perf.json` empty | `rc=1` + `::error::` |
| `coven-perf.json` truncated mid-write | `rc=1` + distinct `::error::` |
| perf ok, optional outputs missing | `rc=0` + two `::warning::` |

Step ordering asserted against the **parsed** YAML (verify index > upload index), not the text.

Gates: `check-ci-workflow-test.py`, `check-workflows-test.py`, `classify-ci-changes-test.py`, `check-secrets.py` (gitleaks), `check-coven-privacy.py --staged`, and `scripts/check-workflows.sh` (pinned actionlint 1.7.12, which shellchecks `run:` blocks) — all PASS. `timeout-minutes: 20` count unchanged at 13.

## Note on what this does not fix

This makes the failure *visible*; it does not make it *rarer*. The benchmark spends 9m01s wall for **8.6s** of user CPU — nearly all of it seeding 10k-session/10k-event fixtures, against ~1.5-3s of actual measured signal. Cutting fixture cost is the real remedy.