### PR TITLE
feat: publish Automations v1 Rust protocol contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "serde",
+ "serde_jcs",
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
@@ -4127,6 +4128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4249,6 +4256,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -49,6 +49,7 @@ qrcode = { version = "0.14", default-features = false }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_jcs = "0.2"
 serde_yaml_ng = "0.10"
 sha2 = "0.11"
 similar = "2"

--- a/crates/coven-cli/src/automations/contract/canonical_json.rs
+++ b/crates/coven-cli/src/automations/contract/canonical_json.rs
@@ -21,8 +21,8 @@ where
     serde_jcs::to_vec(value).context("JCS canonicalization failed")
 }
 
-/// Serialize after removing every `integrity` member, as prescribed by the
-/// published Automations v1 digest recipe.
+/// Serialize after removing only the covered object's top-level `integrity`
+/// member, as prescribed by the published Automations v1 digest recipe.
 pub fn canonicalize_without_integrity(value: &Value) -> anyhow::Result<Vec<u8>> {
     let mut covered = value.clone();
     if let Value::Object(object) = &mut covered {

--- a/crates/coven-cli/src/automations/contract/canonical_json.rs
+++ b/crates/coven-cli/src/automations/contract/canonical_json.rs
@@ -1,0 +1,64 @@
+//! RFC 8785 JSON Canonicalization Scheme helpers.
+
+use anyhow::Context;
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Serialize `value` according to RFC 8785 / JCS.
+///
+/// `serde_jcs` rejects values, such as NaN and infinity, that JSON and JCS
+/// cannot represent.
+pub fn canonicalize<T>(value: &T) -> anyhow::Result<Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    serde_jcs::to_vec(value).context("JCS canonicalization failed")
+}
+
+/// Serialize after removing every `integrity` member, as prescribed by the
+/// published Automations v1 digest recipe.
+pub fn canonicalize_without_integrity(value: &Value) -> anyhow::Result<Vec<u8>> {
+    let mut covered = value.clone();
+    remove_integrity_members(&mut covered);
+    canonicalize(&covered)
+}
+
+/// Return the lowercase SHA-256 digest of RFC 8785 canonical bytes.
+pub fn sha256_digest<T>(value: &T) -> anyhow::Result<String>
+where
+    T: Serialize + ?Sized,
+{
+    let canonical = canonicalize(value)?;
+    Ok(sha256_hex(&canonical))
+}
+
+/// Return a lowercase SHA-256 digest for an already canonical byte sequence.
+#[must_use]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+fn remove_integrity_members(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            object.remove("integrity");
+            for child in object.values_mut() {
+                remove_integrity_members(child);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                remove_integrity_members(child);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}

--- a/crates/coven-cli/src/automations/contract/canonical_json.rs
+++ b/crates/coven-cli/src/automations/contract/canonical_json.rs
@@ -5,6 +5,9 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+/// RFC 8785 interoperates through ECMAScript's IEEE-754 number model.
+pub const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
 /// Serialize `value` according to RFC 8785 / JCS.
 ///
 /// `serde_jcs` rejects values, such as NaN and infinity, that JSON and JCS
@@ -13,6 +16,8 @@ pub fn canonicalize<T>(value: &T) -> anyhow::Result<Vec<u8>>
 where
     T: Serialize + ?Sized,
 {
+    let json = serde_json::to_value(value).context("value cannot be represented as JSON")?;
+    reject_lossy_integers(&json)?;
     serde_jcs::to_vec(value).context("JCS canonicalization failed")
 }
 
@@ -61,4 +66,45 @@ fn remove_integrity_members(value: &mut Value) {
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
     }
+}
+
+fn reject_lossy_integers(value: &Value) -> anyhow::Result<()> {
+    match value {
+        Value::Number(number) => {
+            if let Some(unsigned) = number.as_u64() {
+                anyhow::ensure!(
+                    unsigned <= MAX_SAFE_INTEGER,
+                    "JCS cannot represent integer {unsigned} without IEEE-754 precision loss"
+                );
+            } else if let Some(signed) = number.as_i64() {
+                anyhow::ensure!(
+                    signed.unsigned_abs() <= MAX_SAFE_INTEGER,
+                    "JCS cannot represent integer {signed} without IEEE-754 precision loss"
+                );
+            } else if let Some(float) = number.as_f64() {
+                anyhow::ensure!(
+                    float.is_finite(),
+                    "non-finite values must be rejected by serde_json before JCS canonicalization"
+                );
+                if float.fract() == 0.0 {
+                    anyhow::ensure!(
+                        float.abs() <= MAX_SAFE_INTEGER as f64,
+                        "JCS cannot represent integer {float} without IEEE-754 precision loss"
+                    );
+                }
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                reject_lossy_integers(child)?;
+            }
+        }
+        Value::Object(object) => {
+            for child in object.values() {
+                reject_lossy_integers(child)?;
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::String(_) => {}
+    }
+    Ok(())
 }

--- a/crates/coven-cli/src/automations/contract/canonical_json.rs
+++ b/crates/coven-cli/src/automations/contract/canonical_json.rs
@@ -25,7 +25,9 @@ where
 /// published Automations v1 digest recipe.
 pub fn canonicalize_without_integrity(value: &Value) -> anyhow::Result<Vec<u8>> {
     let mut covered = value.clone();
-    remove_integrity_members(&mut covered);
+    if let Value::Object(object) = &mut covered {
+        object.remove("integrity");
+    }
     canonicalize(&covered)
 }
 
@@ -49,23 +51,6 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
         output.push(char::from(HEX[usize::from(byte & 0x0f)]));
     }
     output
-}
-
-fn remove_integrity_members(value: &mut Value) {
-    match value {
-        Value::Object(object) => {
-            object.remove("integrity");
-            for child in object.values_mut() {
-                remove_integrity_members(child);
-            }
-        }
-        Value::Array(values) => {
-            for child in values {
-                remove_integrity_members(child);
-            }
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
-    }
 }
 
 fn reject_lossy_integers(value: &Value) -> anyhow::Result<()> {

--- a/crates/coven-cli/src/automations/contract/error.rs
+++ b/crates/coven-cli/src/automations/contract/error.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::types::{AdoptionKey, PositiveInteger};
+use super::types::{AdoptionKey, ErrorMessage, PositiveInteger, StringConstraintError};
 
 /// Every error code frozen by `error-envelope.schema.json`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -108,7 +108,7 @@ impl ErrorCode {
 pub struct ErrorEnvelope {
     code: ErrorCode,
     http_status: u16,
-    pub message: String,
+    pub message: ErrorMessage,
     pub retryable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<BTreeMap<String, Value>>,
@@ -120,16 +120,28 @@ pub struct ErrorEnvelope {
 
 impl ErrorEnvelope {
     #[must_use]
-    pub fn new(code: ErrorCode, message: impl Into<String>, retryable: bool) -> Self {
+    pub fn new(code: ErrorCode, message: ErrorMessage, retryable: bool) -> Self {
         Self {
             code,
             http_status: code.http_status(),
-            message: message.into(),
+            message,
             retryable,
             details: None,
             adoption: None,
             current_revision: None,
         }
+    }
+
+    pub fn try_new(
+        code: ErrorCode,
+        message: impl Into<String>,
+        retryable: bool,
+    ) -> Result<Self, StringConstraintError> {
+        Ok(Self::new(
+            code,
+            ErrorMessage::new(message.into())?,
+            retryable,
+        ))
     }
 
     #[must_use]
@@ -171,7 +183,7 @@ impl<'de> Deserialize<'de> for ErrorEnvelope {
         struct Raw {
             code: ErrorCode,
             http_status: u16,
-            message: String,
+            message: ErrorMessage,
             retryable: bool,
             details: Option<BTreeMap<String, Value>>,
             adoption: Option<ErrorAdoption>,

--- a/crates/coven-cli/src/automations/contract/error.rs
+++ b/crates/coven-cli/src/automations/contract/error.rs
@@ -197,9 +197,10 @@ impl<'de> Deserialize<'de> for ErrorEnvelope {
 
         let raw = Raw::deserialize(deserializer)?;
         if raw.http_status != raw.code.http_status() {
+            let code = serde_json::to_string(&raw.code).unwrap_or_else(|_| "error code".to_owned());
             return Err(serde::de::Error::custom(format!(
                 "{} requires HTTP status {}",
-                serde_json::to_string(&raw.code).unwrap_or_else(|_| "error code".to_owned()),
+                code.trim_matches('"'),
                 raw.code.http_status()
             )));
         }

--- a/crates/coven-cli/src/automations/contract/error.rs
+++ b/crates/coven-cli/src/automations/contract/error.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::types::AdoptionKey;
+use super::types::{AdoptionKey, PositiveInteger};
 
 /// Every error code frozen by `error-envelope.schema.json`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -106,7 +106,7 @@ impl ErrorCode {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ErrorEnvelope {
-    pub code: ErrorCode,
+    code: ErrorCode,
     http_status: u16,
     pub message: String,
     pub retryable: bool,
@@ -115,7 +115,7 @@ pub struct ErrorEnvelope {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adoption: Option<ErrorAdoption>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_revision: Option<u64>,
+    pub current_revision: Option<PositiveInteger>,
 }
 
 impl ErrorEnvelope {
@@ -130,6 +130,11 @@ impl ErrorEnvelope {
             adoption: None,
             current_revision: None,
         }
+    }
+
+    #[must_use]
+    pub const fn code(&self) -> ErrorCode {
+        self.code
     }
 
     #[must_use]
@@ -150,7 +155,7 @@ impl ErrorEnvelope {
     }
 
     #[must_use]
-    pub fn with_current_revision(mut self, current_revision: u64) -> Self {
+    pub fn with_current_revision(mut self, current_revision: PositiveInteger) -> Self {
         self.current_revision = Some(current_revision);
         self
     }
@@ -170,7 +175,7 @@ impl<'de> Deserialize<'de> for ErrorEnvelope {
             retryable: bool,
             details: Option<BTreeMap<String, Value>>,
             adoption: Option<ErrorAdoption>,
-            current_revision: Option<u64>,
+            current_revision: Option<PositiveInteger>,
         }
 
         let raw = Raw::deserialize(deserializer)?;

--- a/crates/coven-cli/src/automations/contract/error.rs
+++ b/crates/coven-cli/src/automations/contract/error.rs
@@ -5,7 +5,9 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::types::{AdoptionKey, ErrorMessage, PositiveInteger, StringConstraintError};
+use super::types::{
+    deserialize_non_null_option, AdoptionKey, ErrorMessage, PositiveInteger, StringConstraintError,
+};
 
 /// Every error code frozen by `error-envelope.schema.json`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -185,8 +187,11 @@ impl<'de> Deserialize<'de> for ErrorEnvelope {
             http_status: u16,
             message: ErrorMessage,
             retryable: bool,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             details: Option<BTreeMap<String, Value>>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             adoption: Option<ErrorAdoption>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             current_revision: Option<PositiveInteger>,
         }
 
@@ -214,7 +219,11 @@ impl<'de> Deserialize<'de> for ErrorEnvelope {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ErrorAdoption {
     pub key: AdoptionKey,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub conflict_outcome: Option<AdoptionConflictOutcome>,
 }
 

--- a/crates/coven-cli/src/automations/contract/error.rs
+++ b/crates/coven-cli/src/automations/contract/error.rs
@@ -1,0 +1,209 @@
+//! Frozen error envelope and status mapping for Automations v1.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::types::AdoptionKey;
+
+/// Every error code frozen by `error-envelope.schema.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ErrorCode {
+    #[serde(rename = "SCHEMA_VERSION_UNSUPPORTED")]
+    SchemaVersionUnsupported,
+    #[serde(rename = "VALIDATION_FAILED")]
+    ValidationFailed,
+    #[serde(rename = "ADOPTION_REPLAY_MISMATCH")]
+    AdoptionReplayMismatch,
+    #[serde(rename = "REVISION_CONFLICT")]
+    RevisionConflict,
+    #[serde(rename = "NOT_FOUND")]
+    NotFound,
+    #[serde(rename = "GONE_TOMBSTONED")]
+    GoneTombstoned,
+    #[serde(rename = "CAPABILITY_UNSUPPORTED")]
+    CapabilityUnsupported,
+    #[serde(rename = "ILLEGAL_TRANSITION")]
+    IllegalTransition,
+    #[serde(rename = "AUTHORITY_REQUIRED")]
+    AuthorityRequired,
+    #[serde(rename = "APPROVAL_REQUIRED")]
+    ApprovalRequired,
+    #[serde(rename = "CANCEL_PENDING")]
+    CancelPending,
+    #[serde(rename = "OVERLAP_FORBIDDEN")]
+    OverlapForbidden,
+    #[serde(rename = "RETRY_DISPOSITION_INVALID")]
+    RetryDispositionInvalid,
+    #[serde(rename = "AMBIGUOUS_RETRY_FORBIDDEN")]
+    AmbiguousRetryForbidden,
+    #[serde(rename = "CURSOR_EXPIRED")]
+    CursorExpired,
+    #[serde(rename = "STREAM_OUT_OF_ORDER")]
+    StreamOutOfOrder,
+    #[serde(rename = "PAYLOAD_TOO_LARGE")]
+    PayloadTooLarge,
+    #[serde(rename = "DEADLINE_EXCEEDED")]
+    DeadlineExceeded,
+    #[serde(rename = "CONCURRENCY_LIMIT")]
+    ConcurrencyLimit,
+    #[serde(rename = "INTERNAL")]
+    Internal,
+}
+
+impl ErrorCode {
+    /// The HTTP status pinned for this code by the published contract.
+    #[must_use]
+    pub const fn http_status(self) -> u16 {
+        match self {
+            Self::SchemaVersionUnsupported | Self::ValidationFailed => 400,
+            Self::AdoptionReplayMismatch
+            | Self::RevisionConflict
+            | Self::CancelPending
+            | Self::OverlapForbidden
+            | Self::StreamOutOfOrder => 409,
+            Self::NotFound => 404,
+            Self::GoneTombstoned | Self::CursorExpired => 410,
+            Self::CapabilityUnsupported
+            | Self::IllegalTransition
+            | Self::RetryDispositionInvalid
+            | Self::AmbiguousRetryForbidden => 422,
+            Self::AuthorityRequired | Self::ApprovalRequired => 403,
+            Self::PayloadTooLarge => 413,
+            Self::DeadlineExceeded => 504,
+            Self::ConcurrencyLimit => 429,
+            Self::Internal => 500,
+        }
+    }
+
+    /// The complete frozen v1 error vocabulary.
+    pub const ALL: [Self; 20] = [
+        Self::SchemaVersionUnsupported,
+        Self::ValidationFailed,
+        Self::AdoptionReplayMismatch,
+        Self::RevisionConflict,
+        Self::NotFound,
+        Self::GoneTombstoned,
+        Self::CapabilityUnsupported,
+        Self::IllegalTransition,
+        Self::AuthorityRequired,
+        Self::ApprovalRequired,
+        Self::CancelPending,
+        Self::OverlapForbidden,
+        Self::RetryDispositionInvalid,
+        Self::AmbiguousRetryForbidden,
+        Self::CursorExpired,
+        Self::StreamOutOfOrder,
+        Self::PayloadTooLarge,
+        Self::DeadlineExceeded,
+        Self::ConcurrencyLimit,
+        Self::Internal,
+    ];
+}
+
+/// A typed error cannot be constructed with a status that differs from its code.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ErrorEnvelope {
+    pub code: ErrorCode,
+    http_status: u16,
+    pub message: String,
+    pub retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<BTreeMap<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adoption: Option<ErrorAdoption>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_revision: Option<u64>,
+}
+
+impl ErrorEnvelope {
+    #[must_use]
+    pub fn new(code: ErrorCode, message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            code,
+            http_status: code.http_status(),
+            message: message.into(),
+            retryable,
+            details: None,
+            adoption: None,
+            current_revision: None,
+        }
+    }
+
+    #[must_use]
+    pub const fn http_status(&self) -> u16 {
+        self.http_status
+    }
+
+    #[must_use]
+    pub fn with_details(mut self, details: BTreeMap<String, Value>) -> Self {
+        self.details = Some(details);
+        self
+    }
+
+    #[must_use]
+    pub fn with_adoption(mut self, adoption: ErrorAdoption) -> Self {
+        self.adoption = Some(adoption);
+        self
+    }
+
+    #[must_use]
+    pub fn with_current_revision(mut self, current_revision: u64) -> Self {
+        self.current_revision = Some(current_revision);
+        self
+    }
+}
+
+impl<'de> Deserialize<'de> for ErrorEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            code: ErrorCode,
+            http_status: u16,
+            message: String,
+            retryable: bool,
+            details: Option<BTreeMap<String, Value>>,
+            adoption: Option<ErrorAdoption>,
+            current_revision: Option<u64>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        if raw.http_status != raw.code.http_status() {
+            return Err(serde::de::Error::custom(format!(
+                "{} requires HTTP status {}",
+                serde_json::to_string(&raw.code).unwrap_or_else(|_| "error code".to_owned()),
+                raw.code.http_status()
+            )));
+        }
+        Ok(Self {
+            code: raw.code,
+            http_status: raw.http_status,
+            message: raw.message,
+            retryable: raw.retryable,
+            details: raw.details,
+            adoption: raw.adoption,
+            current_revision: raw.current_revision,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ErrorAdoption {
+    pub key: AdoptionKey,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conflict_outcome: Option<AdoptionConflictOutcome>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdoptionConflictOutcome {
+    Committed,
+    Rejected,
+}

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -361,6 +361,16 @@ mod tests {
         reverse_dns_extension["extensions"] = json!({"com-acme.tools.feature": true});
         assert_round_trip::<AutomationDefinition>(reverse_dns_extension);
 
+        let mut reverse_dns_x_prefix_extension = fixture("definition.golden");
+        reverse_dns_x_prefix_extension["extensions"] = json!({"x-acme.tools.feature": true});
+        assert_round_trip::<AutomationDefinition>(reverse_dns_x_prefix_extension);
+
+        let mut malformed_x_prefix_extension = fixture("definition.golden");
+        malformed_x_prefix_extension["extensions"] = json!({"x-acme.tools": true});
+        assert!(
+            serde_json::from_value::<AutomationDefinition>(malformed_x_prefix_extension).is_err()
+        );
+
         let mut duplicate_capability = fixture("definition.golden");
         duplicate_capability["runtimeRequirements"]["capabilities"] =
             json!(["sessions.launch", "sessions.launch"]);
@@ -410,6 +420,22 @@ mod tests {
         assert!(
             serde_json::from_value::<AutomationReceipt>(duplicate_exercised_capability).is_err()
         );
+
+        let mut lease_note_at_limit = fixture("attempt.golden");
+        lease_note_at_limit["leaseObservations"] = json!([{
+            "observedAt": "2026-08-30T09:00:00.000Z",
+            "heartbeatOk": true,
+            "note": "a".repeat(200)
+        }]);
+        assert_round_trip::<AutomationAttempt>(lease_note_at_limit);
+
+        let mut oversized_lease_note = fixture("attempt.golden");
+        oversized_lease_note["leaseObservations"] = json!([{
+            "observedAt": "2026-08-30T09:00:00.000Z",
+            "heartbeatOk": true,
+            "note": "a".repeat(201)
+        }]);
+        assert!(serde_json::from_value::<AutomationAttempt>(oversized_lease_note).is_err());
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -58,6 +58,33 @@ mod tests {
             .clone()
     }
 
+    fn with_definition_integrity(mut value: Value) -> Value {
+        let digest = sha256_hex(
+            &canonicalize_without_integrity(&value).expect("canonicalize definition body"),
+        );
+        value["integrity"]["value"] = json!(digest);
+        value
+    }
+
+    fn with_receipt_integrity(mut value: Value) -> Value {
+        let digest =
+            sha256_hex(&canonicalize_without_integrity(&value).expect("canonicalize receipt body"));
+        value["integrity"]["value"] = json!(digest);
+        value
+    }
+
+    fn with_event_integrity(mut value: Value) -> Value {
+        value["integrity"] = json!({
+            "algorithm": "sha256",
+            "canonicalization": "jcs-rfc8785",
+            "value": "0".repeat(64)
+        });
+        let digest =
+            sha256_hex(&canonicalize_without_integrity(&value).expect("canonicalize event body"));
+        value["integrity"]["value"] = json!(digest);
+        value
+    }
+
     fn assert_round_trip<T>(value: Value)
     where
         T: DeserializeOwned + Serialize,
@@ -340,7 +367,7 @@ mod tests {
                 .expect("receipt fixture is an object")
                 .remove(field);
         }
-        assert_round_trip::<AutomationReceipt>(receipt);
+        assert_round_trip::<AutomationReceipt>(with_receipt_integrity(receipt));
     }
 
     #[test]
@@ -359,11 +386,13 @@ mod tests {
 
         let mut reverse_dns_extension = fixture("definition.golden");
         reverse_dns_extension["extensions"] = json!({"com-acme.tools.feature": true});
-        assert_round_trip::<AutomationDefinition>(reverse_dns_extension);
+        assert_round_trip::<AutomationDefinition>(with_definition_integrity(reverse_dns_extension));
 
         let mut reverse_dns_x_prefix_extension = fixture("definition.golden");
         reverse_dns_x_prefix_extension["extensions"] = json!({"x-acme.tools.feature": true});
-        assert_round_trip::<AutomationDefinition>(reverse_dns_x_prefix_extension);
+        assert_round_trip::<AutomationDefinition>(with_definition_integrity(
+            reverse_dns_x_prefix_extension,
+        ));
 
         let mut malformed_x_prefix_extension = fixture("definition.golden");
         malformed_x_prefix_extension["extensions"] = json!({"x-acme.tools": true});
@@ -520,6 +549,10 @@ mod tests {
             .remove("terminalDisposition");
         assert!(serde_json::from_value::<AutomationRun>(no_terminal_disposition).is_err());
 
+        let mut mismatched_terminal_outcome = fixture("run.golden");
+        mismatched_terminal_outcome["terminalDisposition"]["outcome"] = json!("failed");
+        assert!(serde_json::from_value::<AutomationRun>(mismatched_terminal_outcome).is_err());
+
         let mut running = fixture("run.golden");
         running["state"] = json!("running");
         running
@@ -615,5 +648,164 @@ mod tests {
             "retryable": false
         });
         assert!(serde_json::from_value::<ErrorEnvelope>(oversized_error_message).is_err());
+    }
+
+    #[test]
+    fn schema_optional_fields_reject_explicit_null() {
+        let mut definition = fixture("definition.golden");
+        definition["display"]["description"] = Value::Null;
+        assert!(
+            serde_json::from_value::<AutomationDefinition>(with_definition_integrity(definition))
+                .is_err()
+        );
+
+        let mut occurrence = fixture("occurrence.golden");
+        occurrence["observedAt"] = Value::Null;
+        assert!(serde_json::from_value::<AutomationOccurrence>(occurrence).is_err());
+
+        let mut run = fixture("run.golden");
+        run["stateReason"] = Value::Null;
+        assert!(serde_json::from_value::<AutomationRun>(run).is_err());
+
+        let mut attempt = fixture("attempt.golden");
+        attempt["workerCorrelation"] = Value::Null;
+        assert!(serde_json::from_value::<AutomationAttempt>(attempt).is_err());
+
+        let mut receipt = fixture("receipt.golden");
+        receipt["authority"] = Value::Null;
+        assert!(
+            serde_json::from_value::<AutomationReceipt>(with_receipt_integrity(receipt)).is_err()
+        );
+
+        let mut command = fixture("command.create.golden");
+        command["origin"]["authenticationClass"] = Value::Null;
+        assert!(serde_json::from_value::<CommandRequest>(command).is_err());
+
+        let response = json!({
+            "schemaVersion": "coven.automations.v1",
+            "command": "definition.get.v1",
+            "adoptionKey": "adopt:get-0001",
+            "outcome": "committed",
+            "revision": null,
+            "result": {}
+        });
+        assert!(serde_json::from_value::<CommandResponse>(response).is_err());
+
+        let mut event = event_fixture();
+        event["causation"] = Value::Null;
+        assert!(serde_json::from_value::<EventEnvelope>(event).is_err());
+
+        let error = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "No such automation.",
+            "retryable": false,
+            "details": null
+        });
+        assert!(serde_json::from_value::<ErrorEnvelope>(error).is_err());
+
+        let nested_error = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "No such automation.",
+            "retryable": false,
+            "adoption": {
+                "key": "adopt:get-0001",
+                "conflictOutcome": null
+            }
+        });
+        assert!(serde_json::from_value::<ErrorEnvelope>(nested_error).is_err());
+    }
+
+    #[test]
+    fn integrity_bearing_objects_reject_tampered_bodies() {
+        let mut definition = fixture("definition.golden");
+        definition["display"]["name"] = json!("Tampered definition");
+        assert!(serde_json::from_value::<AutomationDefinition>(definition).is_err());
+
+        let mut receipt = fixture("receipt.golden");
+        receipt["outcome"]["detail"] = json!("tampered receipt");
+        assert!(serde_json::from_value::<AutomationReceipt>(receipt).is_err());
+
+        let event = with_event_integrity(event_fixture());
+        assert_round_trip::<EventEnvelope>(event.clone());
+        let mut tampered_event = event;
+        tampered_event["summary"] = json!("tampered event");
+        assert!(serde_json::from_value::<EventEnvelope>(tampered_event).is_err());
+    }
+
+    #[test]
+    fn schema_counters_reject_values_outside_the_jcs_safe_domain() {
+        let unsafe_integer = MAX_SAFE_INTEGER + 1;
+
+        let mut occurrence_first = fixture("occurrence.golden");
+        occurrence_first["eventWindow"]["firstSequence"] = json!(unsafe_integer);
+        assert!(serde_json::from_value::<AutomationOccurrence>(occurrence_first).is_err());
+
+        let mut occurrence_last = fixture("occurrence.golden");
+        occurrence_last["eventWindow"]["lastSequence"] = json!(unsafe_integer);
+        assert!(serde_json::from_value::<AutomationOccurrence>(occurrence_last).is_err());
+
+        let mut attempt_event = fixture("attempt.golden");
+        attempt_event["outputCursors"]["eventCursor"] = json!(unsafe_integer);
+        assert!(serde_json::from_value::<AutomationAttempt>(attempt_event).is_err());
+
+        let mut attempt_log = fixture("attempt.golden");
+        attempt_log["outputCursors"]["logCursor"] = json!(unsafe_integer);
+        assert!(serde_json::from_value::<AutomationAttempt>(attempt_log).is_err());
+
+        let events_read = json!({
+            "schemaVersion": "coven.automations.v1",
+            "command": "events.read.v1",
+            "adoptionKey": "adopt:events-read-0001",
+            "origin": {
+                "principal": {"principalId": "principal:tim"},
+                "channel": "cli"
+            },
+            "intent": {"statement": "Read the event stream."},
+            "payload": {
+                "stream": {"kind": "feed", "id": "all"},
+                "after": unsafe_integer
+            }
+        });
+        assert!(serde_json::from_value::<CommandRequest>(events_read).is_err());
+
+        let events_subscribe = json!({
+            "schemaVersion": "coven.automations.v1",
+            "command": "events.subscribe.v1",
+            "adoptionKey": "adopt:events-subscribe-0001",
+            "origin": {
+                "principal": {"principalId": "principal:tim"},
+                "channel": "cli"
+            },
+            "intent": {"statement": "Subscribe to the event stream."},
+            "payload": {
+                "stream": {"kind": "feed", "id": "all"},
+                "after": unsafe_integer
+            }
+        });
+        assert!(serde_json::from_value::<CommandRequest>(events_subscribe).is_err());
+
+        let response = json!({
+            "schemaVersion": "coven.automations.v1",
+            "command": "definition.get.v1",
+            "adoptionKey": "adopt:get-0001",
+            "outcome": "committed",
+            "result": {},
+            "eventRef": {"stream": "feed", "sequence": unsafe_integer}
+        });
+        assert!(serde_json::from_value::<CommandResponse>(response).is_err());
+
+        let mut event = event_fixture();
+        event["sequence"] = json!(unsafe_integer);
+        assert!(serde_json::from_value::<EventEnvelope>(event).is_err());
+
+        let mut snapshot = event_fixture();
+        snapshot["kind"] = json!("feed.snapshot");
+        snapshot["payload"] = json!({
+            "throughSequence": unsafe_integer,
+            "state": {}
+        });
+        assert!(serde_json::from_value::<EventEnvelope>(snapshot).is_err());
     }
 }

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -237,6 +237,24 @@ mod tests {
             sha256_digest(&first).expect("digest first"),
             sha256_digest(&second).expect("digest second")
         );
+
+        let nested_integrity_a = json!({
+            "integrity": {"ignored": "top-level"},
+            "extensions": {"x-example": {"integrity": "nested-a"}}
+        });
+        let nested_integrity_b = json!({
+            "integrity": {"ignored": "top-level"},
+            "extensions": {"x-example": {"integrity": "nested-b"}}
+        });
+        let digest_a = sha256_hex(
+            &canonicalize_without_integrity(&nested_integrity_a)
+                .expect("canonicalize nested integrity collision"),
+        );
+        let digest_b = sha256_hex(
+            &canonicalize_without_integrity(&nested_integrity_b)
+                .expect("canonicalize changed nested integrity collision"),
+        );
+        assert_ne!(digest_a, digest_b);
     }
 
     #[test]
@@ -421,6 +439,33 @@ mod tests {
         let mut empty_summary = event_fixture();
         empty_summary["summary"] = json!("");
         assert!(serde_json::from_value::<EventEnvelope>(empty_summary).is_err());
+
+        let mut empty_rrule = fixture("definition.golden");
+        empty_rrule["trigger"]["schedule"]["rrule"] = json!("");
+        assert!(serde_json::from_value::<AutomationDefinition>(empty_rrule).is_err());
+
+        let mut empty_prompt = fixture("definition.golden");
+        empty_prompt["action"]["prompt"] = json!("");
+        assert!(serde_json::from_value::<AutomationDefinition>(empty_prompt).is_err());
+
+        let mut oversized_cwd = fixture("definition.golden");
+        oversized_cwd["action"]["cwd"] = json!("a".repeat(1_025));
+        assert!(serde_json::from_value::<AutomationDefinition>(oversized_cwd).is_err());
+
+        let mut invalid_occurrence_key = fixture("occurrence.golden");
+        invalid_occurrence_key["occurrenceKey"] = json!("not a key");
+        assert!(serde_json::from_value::<AutomationOccurrence>(invalid_occurrence_key).is_err());
+
+        let mut empty_state_reason = fixture("occurrence.golden");
+        empty_state_reason["stateReason"] = json!("");
+        assert!(serde_json::from_value::<AutomationOccurrence>(empty_state_reason).is_err());
+
+        let mut oversized_command_reason = fixture("command.create.golden");
+        oversized_command_reason["command"] = json!("definition.pause.v1");
+        oversized_command_reason["expectedRevision"] = json!(1);
+        oversized_command_reason["payload"] =
+            json!({"automationId": "daily-notes", "reason": "a".repeat(501)});
+        assert!(serde_json::from_value::<CommandRequest>(oversized_command_reason).is_err());
     }
 
     #[test]
@@ -450,6 +495,30 @@ mod tests {
             .expect("run fixture is an object")
             .remove("terminalDisposition");
         assert_round_trip::<AutomationRun>(running);
+
+        let mut running_with_finished_at = fixture("run.golden");
+        running_with_finished_at["state"] = json!("running");
+        running_with_finished_at
+            .as_object_mut()
+            .expect("run fixture is an object")
+            .remove("terminalDisposition");
+        assert!(serde_json::from_value::<AutomationRun>(running_with_finished_at).is_err());
+
+        let mut accepted_with_terminal_disposition = fixture("run.golden");
+        accepted_with_terminal_disposition["state"] = json!("accepted");
+        accepted_with_terminal_disposition
+            .as_object_mut()
+            .expect("run fixture is an object")
+            .remove("finishedAt");
+        assert!(
+            serde_json::from_value::<AutomationRun>(accepted_with_terminal_disposition).is_err()
+        );
+
+        let mut retry_without_prior_disposition = fixture("attempt.golden");
+        retry_without_prior_disposition["attemptNumber"] = json!(2);
+        assert!(
+            serde_json::from_value::<AutomationAttempt>(retry_without_prior_disposition).is_err()
+        );
 
         let base = json!({
             "schemaVersion": "coven.automations.v1",

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -1,0 +1,269 @@
+//! Typed projections of the published Coven Automations v1 protocol.
+
+// The protocol surface lands before the command router that consumes it.
+#[allow(dead_code)]
+pub mod canonical_json;
+// The typed envelope is part of the public contract before routing lands.
+#[allow(dead_code)]
+pub mod error;
+// These projections are intentionally available to the following protocol slices.
+#[allow(dead_code)]
+pub mod types;
+
+// This binary crate has no external consumer yet; these define the intended
+// contract surface for the later routing and SDK integration slices.
+#[allow(unused_imports)]
+pub use canonical_json::{canonicalize, canonicalize_without_integrity, sha256_digest, sha256_hex};
+#[allow(unused_imports)]
+pub use error::{ErrorCode, ErrorEnvelope};
+#[allow(unused_imports)]
+pub use types::{
+    AutomationAttempt, AutomationDefinition, AutomationOccurrence, AutomationReceipt,
+    AutomationRun, CommandRequest, CommandResponse, EventEnvelope,
+};
+
+#[cfg(test)]
+mod tests {
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
+    use serde_json::{json, Value};
+
+    use super::canonical_json::{
+        canonicalize, canonicalize_without_integrity, sha256_digest, sha256_hex,
+    };
+    use super::error::{ErrorCode, ErrorEnvelope};
+    use super::types::{
+        AutomationAttempt, AutomationDefinition, AutomationOccurrence, AutomationReceipt,
+        AutomationRun, CommandRequest, CommandResponse, EventEnvelope,
+    };
+
+    const VECTORS: &str =
+        include_str!("../../../../../spec/coven-automations/v1/test-vectors.json");
+
+    fn vectors() -> Value {
+        serde_json::from_str(VECTORS).expect("checked-in test vectors must be JSON")
+    }
+
+    fn fixture(name: &str) -> Value {
+        vectors()["fixtures"][name].clone()
+    }
+
+    fn event_fixture() -> Value {
+        vectors()["cases"]
+            .as_array()
+            .expect("cases is an array")
+            .iter()
+            .find(|case| case["name"] == "event-golden-valid")
+            .expect("event golden fixture is present")["object"]
+            .clone()
+    }
+
+    fn assert_round_trip<T>(value: Value)
+    where
+        T: DeserializeOwned + Serialize,
+    {
+        let projection: T = serde_json::from_value(value.clone()).expect("valid projection");
+        assert_eq!(
+            serde_json::to_value(projection).expect("serialize projection"),
+            value
+        );
+    }
+
+    #[test]
+    fn checked_in_schema_artifacts_and_representative_vectors_load() {
+        for artifact in [
+            "automation-definition.schema.json",
+            "automation-occurrence.schema.json",
+            "automation-run.schema.json",
+            "automation-attempt.schema.json",
+            "automation-receipt.schema.json",
+            "command-envelope.schema.json",
+            "error-envelope.schema.json",
+            "event-envelope.schema.json",
+        ] {
+            let path = format!("../../../../../spec/coven-automations/v1/{artifact}");
+            let schema: Value = match artifact {
+                "automation-definition.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/automation-definition.schema.json"
+                )),
+                "automation-occurrence.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/automation-occurrence.schema.json"
+                )),
+                "automation-run.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/automation-run.schema.json"
+                )),
+                "automation-attempt.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/automation-attempt.schema.json"
+                )),
+                "automation-receipt.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/automation-receipt.schema.json"
+                )),
+                "command-envelope.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/command-envelope.schema.json"
+                )),
+                "error-envelope.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/error-envelope.schema.json"
+                )),
+                "event-envelope.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/event-envelope.schema.json"
+                )),
+                _ => unreachable!("artifact list is closed"),
+            }
+            .unwrap_or_else(|error| panic!("{path} must be JSON: {error}"));
+            assert!(schema.get("title").is_some() || schema.get("$ref").is_some());
+        }
+
+        assert_round_trip::<AutomationDefinition>(fixture("definition.golden"));
+        assert_round_trip::<AutomationOccurrence>(fixture("occurrence.golden"));
+        assert_round_trip::<AutomationRun>(fixture("run.golden"));
+        assert_round_trip::<AutomationAttempt>(fixture("attempt.golden"));
+        assert_round_trip::<AutomationReceipt>(fixture("receipt.golden"));
+        assert_round_trip::<CommandRequest>(fixture("command.create.golden"));
+        assert_round_trip::<EventEnvelope>(event_fixture());
+    }
+
+    #[test]
+    fn closed_projections_reject_unknown_fields() {
+        let mut definition = fixture("definition.golden");
+        definition["unknown"] = json!(true);
+        assert!(serde_json::from_value::<AutomationDefinition>(definition).is_err());
+
+        let mut nested_definition = fixture("definition.golden");
+        nested_definition["display"]["unknown"] = json!(true);
+        assert!(serde_json::from_value::<AutomationDefinition>(nested_definition).is_err());
+
+        let mut occurrence = fixture("occurrence.golden");
+        occurrence["unknown"] = json!(true);
+        assert!(serde_json::from_value::<AutomationOccurrence>(occurrence).is_err());
+
+        let mut run = fixture("run.golden");
+        run["unknown"] = json!(true);
+        assert!(serde_json::from_value::<AutomationRun>(run).is_err());
+
+        let mut attempt = fixture("attempt.golden");
+        attempt["unknown"] = json!(true);
+        assert!(serde_json::from_value::<AutomationAttempt>(attempt).is_err());
+
+        let mut receipt = fixture("receipt.golden");
+        receipt["unknown"] = json!(true);
+        assert!(serde_json::from_value::<AutomationReceipt>(receipt).is_err());
+
+        let mut command = fixture("command.create.golden");
+        command["unknown"] = json!(true);
+        assert!(serde_json::from_value::<CommandRequest>(command).is_err());
+
+        let mut event = event_fixture();
+        event["unknown"] = json!(true);
+        assert!(serde_json::from_value::<EventEnvelope>(event).is_err());
+
+        let error = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "No such automation.",
+            "retryable": false,
+            "unknown": true
+        });
+        assert!(serde_json::from_value::<ErrorEnvelope>(error).is_err());
+
+        let nested_error = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "No such automation.",
+            "retryable": false,
+            "adoption": {"key": "adopt:get-0001", "unknown": true}
+        });
+        assert!(serde_json::from_value::<ErrorEnvelope>(nested_error).is_err());
+    }
+
+    #[test]
+    fn every_error_code_has_its_frozen_http_status() {
+        let expected = [
+            (ErrorCode::SchemaVersionUnsupported, 400),
+            (ErrorCode::ValidationFailed, 400),
+            (ErrorCode::AdoptionReplayMismatch, 409),
+            (ErrorCode::RevisionConflict, 409),
+            (ErrorCode::NotFound, 404),
+            (ErrorCode::GoneTombstoned, 410),
+            (ErrorCode::CapabilityUnsupported, 422),
+            (ErrorCode::IllegalTransition, 422),
+            (ErrorCode::AuthorityRequired, 403),
+            (ErrorCode::ApprovalRequired, 403),
+            (ErrorCode::CancelPending, 409),
+            (ErrorCode::OverlapForbidden, 409),
+            (ErrorCode::RetryDispositionInvalid, 422),
+            (ErrorCode::AmbiguousRetryForbidden, 422),
+            (ErrorCode::CursorExpired, 410),
+            (ErrorCode::StreamOutOfOrder, 409),
+            (ErrorCode::PayloadTooLarge, 413),
+            (ErrorCode::DeadlineExceeded, 504),
+            (ErrorCode::ConcurrencyLimit, 429),
+            (ErrorCode::Internal, 500),
+        ];
+        assert_eq!(ErrorCode::ALL.len(), expected.len());
+
+        for (code, status) in expected {
+            let envelope = ErrorEnvelope::new(code, "safe message", false);
+            assert_eq!(code.http_status(), status);
+            assert_eq!(envelope.http_status(), status);
+
+            let mut mismatched = serde_json::to_value(envelope).expect("serialize error");
+            mismatched["httpStatus"] = json!(status + 1);
+            assert!(serde_json::from_value::<ErrorEnvelope>(mismatched).is_err());
+        }
+    }
+
+    #[test]
+    fn pinned_jcs_sha256_vectors_match_and_key_order_is_ignored() {
+        for name in ["definition.golden", "receipt.golden"] {
+            let value = fixture(name);
+            let expected = value["integrity"]["value"]
+                .as_str()
+                .expect("fixture integrity digest")
+                .to_owned();
+            let canonical =
+                canonicalize_without_integrity(&value).expect("canonicalize digest preimage");
+            assert_eq!(sha256_hex(&canonical), expected, "{name}");
+        }
+
+        let first = serde_json::from_str::<Value>(r#"{"z":1,"a":{"y":2,"x":3}}"#)
+            .expect("first JSON object");
+        let second = serde_json::from_str::<Value>(r#"{"a":{"x":3,"y":2},"z":1}"#)
+            .expect("second JSON object");
+        assert_eq!(
+            sha256_digest(&first).expect("digest first"),
+            sha256_digest(&second).expect("digest second")
+        );
+    }
+
+    #[test]
+    fn jcs_refuses_non_finite_numbers() {
+        assert!(canonicalize(&f64::NAN).is_err());
+        assert!(canonicalize(&f64::INFINITY).is_err());
+        assert!(canonicalize(&f64::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn command_response_round_trips_a_typed_error() {
+        let response = json!({
+            "schemaVersion": "coven.automations.v1",
+            "command": "definition.get.v1",
+            "adoptionKey": "adopt:get-0001",
+            "outcome": "rejected",
+            "error": {
+                "code": "NOT_FOUND",
+                "httpStatus": 404,
+                "message": "No such automation.",
+                "retryable": false,
+                "details": {"automationId": "missing"}
+            }
+        });
+        assert_round_trip::<CommandResponse>(response);
+        assert_round_trip::<ErrorEnvelope>(json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "No such automation.",
+            "retryable": false,
+            "details": {"automationId": "missing"}
+        }));
+    }
+}

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -72,6 +72,7 @@ mod tests {
     #[test]
     fn checked_in_schema_artifacts_and_representative_vectors_load() {
         for artifact in [
+            "common.schema.json",
             "automation-definition.schema.json",
             "automation-occurrence.schema.json",
             "automation-run.schema.json",
@@ -83,6 +84,9 @@ mod tests {
         ] {
             let path = format!("../../../../../spec/coven-automations/v1/{artifact}");
             let schema: Value = match artifact {
+                "common.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/common.schema.json"
+                )),
                 "automation-definition.schema.json" => serde_json::from_str(include_str!(
                     "../../../../../spec/coven-automations/v1/automation-definition.schema.json"
                 )),
@@ -265,5 +269,106 @@ mod tests {
             "retryable": false,
             "details": {"automationId": "missing"}
         }));
+    }
+
+    #[test]
+    fn command_payloads_and_expected_revisions_are_command_correlated() {
+        let mut wrong_payload = fixture("command.create.golden");
+        wrong_payload["command"] = json!("run.cancel.v1");
+        assert!(serde_json::from_value::<CommandRequest>(wrong_payload).is_err());
+
+        let mut missing_revision = fixture("command.create.golden");
+        missing_revision["command"] = json!("definition.revise.v1");
+        assert!(serde_json::from_value::<CommandRequest>(missing_revision).is_err());
+
+        let mut forbidden_revision = fixture("command.create.golden");
+        forbidden_revision["expectedRevision"] = json!(1);
+        assert!(serde_json::from_value::<CommandRequest>(forbidden_revision).is_err());
+
+        let mut zero_revision = fixture("command.create.golden");
+        zero_revision["command"] = json!("definition.revise.v1");
+        zero_revision["expectedRevision"] = json!(0);
+        assert!(serde_json::from_value::<CommandRequest>(zero_revision).is_err());
+
+        let mut unknown_payload_field = fixture("command.create.golden");
+        unknown_payload_field["payload"]["unexpected"] = json!(true);
+        assert!(serde_json::from_value::<CommandRequest>(unknown_payload_field).is_err());
+    }
+
+    #[test]
+    fn receipt_optional_fields_remain_optional() {
+        let mut receipt = fixture("receipt.golden");
+        for field in [
+            "definitionDigest",
+            "occurrenceFenceGeneration",
+            "attemptNumber",
+            "runtime",
+        ] {
+            receipt
+                .as_object_mut()
+                .expect("receipt fixture is an object")
+                .remove(field);
+        }
+        assert_round_trip::<AutomationReceipt>(receipt);
+    }
+
+    #[test]
+    fn common_constraints_and_definition_conditionals_fail_closed() {
+        let mut invalid_id = fixture("definition.golden");
+        invalid_id["automationId"] = json!("-daily-notes");
+        assert!(serde_json::from_value::<AutomationDefinition>(invalid_id).is_err());
+
+        let mut invalid_timestamp = fixture("occurrence.golden");
+        invalid_timestamp["scheduledFor"] = json!("2026-08-30T09:00:00+00:00");
+        assert!(serde_json::from_value::<AutomationOccurrence>(invalid_timestamp).is_err());
+
+        let mut invalid_extension = fixture("definition.golden");
+        invalid_extension["extensions"] = json!({"not-namespaced": true});
+        assert!(serde_json::from_value::<AutomationDefinition>(invalid_extension).is_err());
+
+        let mut duplicate_capability = fixture("definition.golden");
+        duplicate_capability["runtimeRequirements"]["capabilities"] =
+            json!(["sessions.launch", "sessions.launch"]);
+        assert!(serde_json::from_value::<AutomationDefinition>(duplicate_capability).is_err());
+
+        let mut oversized_capability = fixture("definition.golden");
+        oversized_capability["runtimeRequirements"]["capabilities"] =
+            json!([format!("x{}", "a".repeat(96))]);
+        assert!(serde_json::from_value::<AutomationDefinition>(oversized_capability).is_err());
+
+        let mut missing_runtime = fixture("definition.golden");
+        missing_runtime
+            .as_object_mut()
+            .expect("definition fixture is an object")
+            .remove("runtimeRequirements");
+        assert!(serde_json::from_value::<AutomationDefinition>(missing_runtime).is_err());
+
+        let mut missing_familiar = fixture("definition.golden");
+        missing_familiar["binding"]
+            .as_object_mut()
+            .expect("binding fixture is an object")
+            .remove("familiarId");
+        assert!(serde_json::from_value::<AutomationDefinition>(missing_familiar).is_err());
+
+        let mut fixed_backoff_without_seconds = fixture("definition.golden");
+        fixed_backoff_without_seconds["policies"]["retry"]["backoffPolicy"] = json!("fixed");
+        fixed_backoff_without_seconds["policies"]["retry"]
+            .as_object_mut()
+            .expect("retry fixture is an object")
+            .remove("backoffSeconds");
+        assert!(
+            serde_json::from_value::<AutomationDefinition>(fixed_backoff_without_seconds).is_err()
+        );
+
+        let mut invalid_digest = fixture("definition.golden");
+        invalid_digest["integrity"]["value"] = json!("not-a-sha256");
+        assert!(serde_json::from_value::<AutomationDefinition>(invalid_digest).is_err());
+
+        let mut duplicate_exercised_capability = fixture("receipt.golden");
+        duplicate_exercised_capability["exercisedCapabilities"] =
+            json!(["sessions.launch", "sessions.launch"]);
+        assert!(
+            serde_json::from_value::<AutomationReceipt>(duplicate_exercised_capability).is_err()
+        );
     }
 }

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -735,6 +735,42 @@ mod tests {
     }
 
     #[test]
+    fn event_kind_and_payload_must_agree() {
+        let mut receipt_kind_with_transition_payload = event_fixture();
+        receipt_kind_with_transition_payload["kind"] = json!("receipt.recorded");
+        assert!(
+            serde_json::from_value::<EventEnvelope>(receipt_kind_with_transition_payload).is_err()
+        );
+
+        let mut run_kind_with_occurrence_entity = event_fixture();
+        run_kind_with_occurrence_entity["kind"] = json!("run.transitioned");
+        assert!(serde_json::from_value::<EventEnvelope>(run_kind_with_occurrence_entity).is_err());
+
+        let mut run_transition = event_fixture();
+        run_transition["kind"] = json!("run.transitioned");
+        run_transition["payload"]["entity"] = json!("run");
+        assert_round_trip::<EventEnvelope>(run_transition);
+    }
+
+    #[test]
+    fn error_status_mismatch_names_the_unquoted_code() {
+        let mismatch = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 500,
+            "message": "No such automation.",
+            "retryable": false
+        });
+        let error = serde_json::from_value::<ErrorEnvelope>(mismatch)
+            .expect_err("mismatched status must be rejected")
+            .to_string();
+        assert!(
+            error.contains("NOT_FOUND requires HTTP status 404"),
+            "{error}"
+        );
+        assert!(!error.contains("\"NOT_FOUND\""), "{error}");
+    }
+
+    #[test]
     fn schema_counters_reject_values_outside_the_jcs_safe_domain() {
         let unsafe_integer = MAX_SAFE_INTEGER + 1;
 

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -29,12 +29,12 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::canonical_json::{
-        canonicalize, canonicalize_without_integrity, sha256_digest, sha256_hex,
+        canonicalize, canonicalize_without_integrity, sha256_digest, sha256_hex, MAX_SAFE_INTEGER,
     };
     use super::error::{ErrorCode, ErrorEnvelope};
     use super::types::{
         AutomationAttempt, AutomationDefinition, AutomationOccurrence, AutomationReceipt,
-        AutomationRun, CommandRequest, CommandResponse, EventEnvelope,
+        AutomationRun, CommandRequest, CommandResponse, EventEnvelope, PositiveInteger,
     };
 
     const VECTORS: &str =
@@ -247,6 +247,18 @@ mod tests {
     }
 
     #[test]
+    fn jcs_rejects_integers_outside_the_safe_ieee_754_domain() {
+        assert!(canonicalize(&MAX_SAFE_INTEGER).is_ok());
+        assert!(PositiveInteger::new(MAX_SAFE_INTEGER).is_ok());
+
+        let unsafe_integer = MAX_SAFE_INTEGER + 1;
+        assert!(PositiveInteger::new(unsafe_integer).is_err());
+        assert!(canonicalize(&unsafe_integer).is_err());
+        assert!(canonicalize(&u64::MAX).is_err());
+        assert!(sha256_digest(&unsafe_integer).is_err());
+    }
+
+    #[test]
     fn command_response_round_trips_a_typed_error() {
         let response = json!({
             "schemaVersion": "coven.automations.v1",
@@ -370,5 +382,109 @@ mod tests {
         assert!(
             serde_json::from_value::<AutomationReceipt>(duplicate_exercised_capability).is_err()
         );
+    }
+
+    #[test]
+    fn definition_display_and_event_envelope_bounds_fail_closed() {
+        let mut empty_name = fixture("definition.golden");
+        empty_name["display"]["name"] = json!("");
+        assert!(serde_json::from_value::<AutomationDefinition>(empty_name).is_err());
+
+        let mut oversized_description = fixture("definition.golden");
+        oversized_description["display"]["description"] = json!("a".repeat(2_001));
+        assert!(serde_json::from_value::<AutomationDefinition>(oversized_description).is_err());
+
+        let mut duplicate_tags = fixture("definition.golden");
+        duplicate_tags["display"]["tags"] = json!(["notes", "notes"]);
+        assert!(serde_json::from_value::<AutomationDefinition>(duplicate_tags).is_err());
+
+        let mut oversized_tag = fixture("definition.golden");
+        oversized_tag["display"]["tags"] = json!([format!("x{}", "a".repeat(64))]);
+        assert!(serde_json::from_value::<AutomationDefinition>(oversized_tag).is_err());
+
+        let mut oversized_tags = fixture("definition.golden");
+        oversized_tags["display"]["tags"] = json!(vec!["tag"; 65]);
+        assert!(serde_json::from_value::<AutomationDefinition>(oversized_tags).is_err());
+
+        let mut short_event_id = event_fixture();
+        short_event_id["eventId"] = json!("short");
+        assert!(serde_json::from_value::<EventEnvelope>(short_event_id).is_err());
+
+        let mut invalid_event_id = event_fixture();
+        invalid_event_id["eventId"] = json!("event-id-with-hyphen-00001");
+        assert!(serde_json::from_value::<EventEnvelope>(invalid_event_id).is_err());
+
+        let mut oversized_stream_id = event_fixture();
+        oversized_stream_id["stream"]["id"] = json!("a".repeat(321));
+        assert!(serde_json::from_value::<EventEnvelope>(oversized_stream_id).is_err());
+
+        let mut empty_summary = event_fixture();
+        empty_summary["summary"] = json!("");
+        assert!(serde_json::from_value::<EventEnvelope>(empty_summary).is_err());
+    }
+
+    #[test]
+    fn run_and_command_response_outcome_conditionals_fail_closed() {
+        let mut no_finished_at = fixture("run.golden");
+        no_finished_at
+            .as_object_mut()
+            .expect("run fixture is an object")
+            .remove("finishedAt");
+        assert!(serde_json::from_value::<AutomationRun>(no_finished_at).is_err());
+
+        let mut no_terminal_disposition = fixture("run.golden");
+        no_terminal_disposition
+            .as_object_mut()
+            .expect("run fixture is an object")
+            .remove("terminalDisposition");
+        assert!(serde_json::from_value::<AutomationRun>(no_terminal_disposition).is_err());
+
+        let mut running = fixture("run.golden");
+        running["state"] = json!("running");
+        running
+            .as_object_mut()
+            .expect("run fixture is an object")
+            .remove("finishedAt");
+        running
+            .as_object_mut()
+            .expect("run fixture is an object")
+            .remove("terminalDisposition");
+        assert_round_trip::<AutomationRun>(running);
+
+        let base = json!({
+            "schemaVersion": "coven.automations.v1",
+            "command": "definition.get.v1",
+            "adoptionKey": "adopt:get-0001"
+        });
+        let mut committed_without_result = base.clone();
+        committed_without_result["outcome"] = json!("committed");
+        assert!(serde_json::from_value::<CommandResponse>(committed_without_result).is_err());
+
+        let mut committed_with_error = base.clone();
+        committed_with_error["outcome"] = json!("committed");
+        committed_with_error["result"] = json!({});
+        committed_with_error["error"] = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "No such automation.",
+            "retryable": false
+        });
+        assert!(serde_json::from_value::<CommandResponse>(committed_with_error).is_err());
+
+        let mut replayed_without_replay = base.clone();
+        replayed_without_replay["outcome"] = json!("replayed");
+        replayed_without_replay["result"] = json!({});
+        assert!(serde_json::from_value::<CommandResponse>(replayed_without_replay).is_err());
+
+        let mut rejected_with_result = base;
+        rejected_with_result["outcome"] = json!("rejected");
+        rejected_with_result["result"] = json!({});
+        rejected_with_result["error"] = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "No such automation.",
+            "retryable": false
+        });
+        assert!(serde_json::from_value::<CommandResponse>(rejected_with_result).is_err());
     }
 }

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -206,7 +206,8 @@ mod tests {
         assert_eq!(ErrorCode::ALL.len(), expected.len());
 
         for (code, status) in expected {
-            let envelope = ErrorEnvelope::new(code, "safe message", false);
+            let envelope = ErrorEnvelope::try_new(code, "safe message", false)
+                .expect("safe message is within the schema bound");
             assert_eq!(code.http_status(), status);
             assert_eq!(envelope.http_status(), status);
 
@@ -356,6 +357,10 @@ mod tests {
         invalid_extension["extensions"] = json!({"not-namespaced": true});
         assert!(serde_json::from_value::<AutomationDefinition>(invalid_extension).is_err());
 
+        let mut reverse_dns_extension = fixture("definition.golden");
+        reverse_dns_extension["extensions"] = json!({"com-acme.tools.feature": true});
+        assert_round_trip::<AutomationDefinition>(reverse_dns_extension);
+
         let mut duplicate_capability = fixture("definition.golden");
         duplicate_capability["runtimeRequirements"]["capabilities"] =
             json!(["sessions.launch", "sessions.launch"]);
@@ -389,6 +394,11 @@ mod tests {
         assert!(
             serde_json::from_value::<AutomationDefinition>(fixed_backoff_without_seconds).is_err()
         );
+
+        let mut duplicate_retryable_class = fixture("definition.golden");
+        duplicate_retryable_class["policies"]["retry"]["retryableClasses"] =
+            json!(["transient_dispatch", "transient_dispatch"]);
+        assert!(serde_json::from_value::<AutomationDefinition>(duplicate_retryable_class).is_err());
 
         let mut invalid_digest = fixture("definition.golden");
         invalid_digest["integrity"]["value"] = json!("not-a-sha256");
@@ -520,6 +530,14 @@ mod tests {
             serde_json::from_value::<AutomationAttempt>(retry_without_prior_disposition).is_err()
         );
 
+        let mut first_attempt_with_prior_disposition = fixture("attempt.golden");
+        first_attempt_with_prior_disposition["priorDisposition"] =
+            json!({"attemptNumber": 1, "outcome": "failed"});
+        assert!(
+            serde_json::from_value::<AutomationAttempt>(first_attempt_with_prior_disposition)
+                .is_err()
+        );
+
         let base = json!({
             "schemaVersion": "coven.automations.v1",
             "command": "definition.get.v1",
@@ -555,5 +573,21 @@ mod tests {
             "retryable": false
         });
         assert!(serde_json::from_value::<CommandResponse>(rejected_with_result).is_err());
+
+        let empty_error_message = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "",
+            "retryable": false
+        });
+        assert!(serde_json::from_value::<ErrorEnvelope>(empty_error_message).is_err());
+
+        let oversized_error_message = json!({
+            "code": "NOT_FOUND",
+            "httpStatus": 404,
+            "message": "a".repeat(1_001),
+            "retryable": false
+        });
+        assert!(serde_json::from_value::<ErrorEnvelope>(oversized_error_message).is_err());
     }
 }

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -262,6 +262,44 @@ fn matches_event_ref_stream(value: &str) -> bool {
     (1..=400).contains(&value.chars().count())
 }
 
+fn matches_rrule(value: &str) -> bool {
+    (1..=512).contains(&value.chars().count())
+}
+
+fn matches_rrule_reference(value: &str) -> bool {
+    value.chars().count() <= 512
+}
+
+fn matches_prompt(value: &str) -> bool {
+    (1..=100_000).contains(&value.chars().count())
+}
+
+fn matches_working_directory(value: &str) -> bool {
+    value.chars().count() <= 1_024
+}
+
+fn matches_occurrence_key(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 320
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'@' | b':' | b'-')
+        })
+}
+
+fn matches_state_reason(value: &str) -> bool {
+    (1..=500).contains(&value.chars().count())
+}
+
+fn matches_reason(value: &str) -> bool {
+    value.chars().count() <= 500
+}
+
+fn matches_artifact_reference(value: &str) -> bool {
+    (1..=512).contains(&value.chars().count())
+}
+
 validated_string!(Timestamp, matches_timestamp);
 validated_string!(AutomationId, matches_automation_id);
 validated_string!(OccurrenceId, matches_entity_id);
@@ -290,6 +328,14 @@ validated_string!(ComponentName, matches_component_name);
 validated_string!(InstanceId, matches_instance_id);
 validated_string!(ImplementationVersion, matches_implementation_version);
 validated_string!(EventRefStream, matches_event_ref_stream);
+validated_string!(Rrule, matches_rrule);
+validated_string!(RruleReference, matches_rrule_reference);
+validated_string!(InvocationPrompt, matches_prompt);
+validated_string!(WorkingDirectory, matches_working_directory);
+validated_string!(OccurrenceKey, matches_occurrence_key);
+validated_string!(StateReason, matches_state_reason);
+validated_string!(CommandReason, matches_reason);
+validated_string!(ArtifactReference, matches_artifact_reference);
 
 macro_rules! validated_integer {
     ($name:ident, $minimum:expr, $maximum:expr) => {
@@ -827,7 +873,7 @@ pub struct DefinitionDeletion {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested_by: Option<PrincipalRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub reason: Option<CommandReason>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -882,7 +928,7 @@ pub enum ScheduleVariant {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Schedule {
-    pub rrule: String,
+    pub rrule: Rrule,
     pub timezone: Timezone,
 }
 
@@ -898,9 +944,9 @@ pub enum Timezone {
 pub struct FamiliarInvocationAction {
     pub variant: FamiliarInvocationVariant,
     pub version: VersionOne,
-    pub prompt: String,
+    pub prompt: InvocationPrompt,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cwd: Option<String>,
+    pub cwd: Option<WorkingDirectory>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -997,7 +1043,7 @@ pub enum MisfirePolicyDisposition {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeliveryPolicy {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub output_target: Option<String>,
+    pub output_target: Option<WorkingDirectory>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<DeliveryMode>,
 }
@@ -1054,14 +1100,14 @@ pub struct AutomationOccurrence {
     pub automation_id: AutomationId,
     pub automation_revision: PositiveInteger,
     pub trigger_identity: TriggerIdentity,
-    pub occurrence_key: String,
+    pub occurrence_key: OccurrenceKey,
     pub scheduled_for: Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observed_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eligible_at: Option<Timestamp>,
     pub state: OccurrenceState,
-    pub state_reason: String,
+    pub state_reason: StateReason,
     pub fence: OccurrenceFence,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub misfire_disposition: Option<MisfireDisposition>,
@@ -1086,7 +1132,7 @@ pub struct AutomationOccurrence {
 pub struct TriggerIdentity {
     pub kind: TriggerIdentityKind,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub rrule_ref: Option<String>,
+    pub rrule_ref: Option<RruleReference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested_by: Option<PrincipalRef>,
 }
@@ -1185,7 +1231,7 @@ pub struct AutomationRun {
     pub binding: RunBinding,
     state: RunState,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state_reason: Option<String>,
+    pub state_reason: Option<StateReason>,
     pub attempt_count: RunAttemptCount,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_attempt_id: Option<AttemptId>,
@@ -1221,17 +1267,22 @@ impl AutomationRun {
     }
 
     fn validate(&self) -> Result<(), StringConstraintError> {
-        if matches!(
+        let terminal = matches!(
             self.state,
             RunState::Succeeded
                 | RunState::Failed
                 | RunState::Cancelled
                 | RunState::TimedOut
                 | RunState::Ambiguous
-        ) && (self.finished_at.is_none() || self.terminal_disposition.is_none())
-        {
+        );
+        if terminal && (self.finished_at.is_none() || self.terminal_disposition.is_none()) {
             return Err(StringConstraintError(
                 "terminal runs require finishedAt and terminalDisposition",
+            ));
+        }
+        if !terminal && (self.finished_at.is_some() || self.terminal_disposition.is_some()) {
+            return Err(StringConstraintError(
+                "nonterminal runs must not contain finishedAt or terminalDisposition",
             ));
         }
         Ok(())
@@ -1253,7 +1304,7 @@ impl<'de> Deserialize<'de> for AutomationRun {
             automation_revision: PositiveInteger,
             binding: RunBinding,
             state: RunState,
-            state_reason: Option<String>,
+            state_reason: Option<StateReason>,
             attempt_count: RunAttemptCount,
             current_attempt_id: Option<AttemptId>,
             terminal_disposition: Option<TerminalDisposition>,
@@ -1344,7 +1395,7 @@ pub enum TerminalFailureClass {
 pub struct RunDelivery {
     pub status: RunDeliveryStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target: Option<String>,
+    pub target: Option<WorkingDirectory>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifact_refs: Option<Vec<ArtifactRef>>,
 }
@@ -1362,7 +1413,7 @@ pub enum RunDeliveryStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArtifactRef {
-    pub r#ref: String,
+    pub r#ref: ArtifactReference,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub digest: Option<DigestValue>,
 }
@@ -1381,17 +1432,17 @@ pub enum AttemptState {
     Ambiguous,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AutomationAttempt {
     pub schema_version: SchemaVersion,
     pub attempt_id: AttemptId,
     pub run_id: RunId,
     pub occurrence_id: OccurrenceId,
-    pub attempt_number: PositiveInteger,
+    attempt_number: PositiveInteger,
     pub adoption_key: AdoptionKey,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub prior_disposition: Option<PriorDisposition>,
+    prior_disposition: Option<PriorDisposition>,
     pub dispatch_fence: DispatchFence,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worker_correlation: Option<WorkerCorrelation>,
@@ -1403,13 +1454,86 @@ pub struct AutomationAttempt {
     pub output_cursors: Option<OutputCursors>,
     pub state: AttemptState,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state_reason: Option<String>,
+    pub state_reason: Option<StateReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opened_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settled_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<ExtensionBag>,
+}
+
+impl AutomationAttempt {
+    #[must_use]
+    pub const fn attempt_number(&self) -> PositiveInteger {
+        self.attempt_number
+    }
+
+    #[must_use]
+    pub fn prior_disposition(&self) -> Option<&PriorDisposition> {
+        self.prior_disposition.as_ref()
+    }
+
+    fn validate(&self) -> Result<(), StringConstraintError> {
+        if self.attempt_number.get() > 1 && self.prior_disposition.is_none() {
+            return Err(StringConstraintError(
+                "attempts after the first require priorDisposition",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for AutomationAttempt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            schema_version: SchemaVersion,
+            attempt_id: AttemptId,
+            run_id: RunId,
+            occurrence_id: OccurrenceId,
+            attempt_number: PositiveInteger,
+            adoption_key: AdoptionKey,
+            prior_disposition: Option<PriorDisposition>,
+            dispatch_fence: DispatchFence,
+            worker_correlation: Option<WorkerCorrelation>,
+            retry_classification: Option<RetryClassification>,
+            lease_observations: Option<Vec<LeaseObservation>>,
+            output_cursors: Option<OutputCursors>,
+            state: AttemptState,
+            state_reason: Option<StateReason>,
+            opened_at: Option<Timestamp>,
+            settled_at: Option<Timestamp>,
+            extensions: Option<ExtensionBag>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let attempt = Self {
+            schema_version: raw.schema_version,
+            attempt_id: raw.attempt_id,
+            run_id: raw.run_id,
+            occurrence_id: raw.occurrence_id,
+            attempt_number: raw.attempt_number,
+            adoption_key: raw.adoption_key,
+            prior_disposition: raw.prior_disposition,
+            dispatch_fence: raw.dispatch_fence,
+            worker_correlation: raw.worker_correlation,
+            retry_classification: raw.retry_classification,
+            lease_observations: raw.lease_observations,
+            output_cursors: raw.output_cursors,
+            state: raw.state,
+            state_reason: raw.state_reason,
+            opened_at: raw.opened_at,
+            settled_at: raw.settled_at,
+            extensions: raw.extensions,
+        };
+        attempt.validate().map_err(serde::de::Error::custom)?;
+        Ok(attempt)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1861,7 +1985,7 @@ pub struct DefinitionMutationPayload {
 pub struct DefinitionTargetPayload {
     pub automation_id: AutomationId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub reason: Option<CommandReason>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1879,7 +2003,7 @@ pub struct RunNowPayload {
 pub struct OccurrenceCancelPayload {
     pub occurrence_id: OccurrenceId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub reason: Option<CommandReason>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1887,7 +2011,7 @@ pub struct OccurrenceCancelPayload {
 pub struct RunCancelPayload {
     pub run_id: RunId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub reason: Option<CommandReason>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1895,7 +2019,7 @@ pub struct RunCancelPayload {
 pub struct AttemptCancelPayload {
     pub attempt_id: AttemptId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub reason: Option<CommandReason>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -3,21 +3,415 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::ser::{SerializeStruct, Serializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 use super::error::ErrorEnvelope;
 
-pub type Timestamp = String;
-pub type AutomationId = String;
-pub type OccurrenceId = String;
-pub type RunId = String;
-pub type AttemptId = String;
-pub type ReceiptId = String;
-pub type AdoptionKey = String;
-pub type CorrelationId = String;
-pub type ExtensionBag = BTreeMap<String, Value>;
 pub type JsonObject = BTreeMap<String, Value>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringConstraintError(&'static str);
+
+impl fmt::Display for StringConstraintError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl std::error::Error for StringConstraintError {}
+
+macro_rules! validated_string {
+    ($name:ident, $validator:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: String) -> Result<Self, StringConstraintError> {
+                if $validator(&value) {
+                    Ok(Self(value))
+                } else {
+                    Err(StringConstraintError(stringify!($name)))
+                }
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+fn matches_identifier(value: &str, maximum: usize) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= maximum
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..]
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn matches_adoption_key(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 8
+        && bytes.len() <= 200
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..]
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
+}
+
+fn matches_correlation_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 200
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..]
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
+}
+
+fn matches_principal_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 128
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'@' | b'-')
+        })
+}
+
+fn matches_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let separators = match bytes.len() {
+        20 if matches!(
+            bytes,
+            [
+                _,
+                _,
+                _,
+                _,
+                b'-',
+                _,
+                _,
+                b'-',
+                _,
+                _,
+                b'T',
+                _,
+                _,
+                b':',
+                _,
+                _,
+                b':',
+                _,
+                _,
+                b'Z'
+            ]
+        ) =>
+        {
+            [4, 7, 10, 13, 16, 19].as_slice()
+        }
+        24 if matches!(
+            bytes,
+            [
+                _,
+                _,
+                _,
+                _,
+                b'-',
+                _,
+                _,
+                b'-',
+                _,
+                _,
+                b'T',
+                _,
+                _,
+                b':',
+                _,
+                _,
+                b':',
+                _,
+                _,
+                b'.',
+                _,
+                _,
+                _,
+                b'Z'
+            ]
+        ) =>
+        {
+            [4, 7, 10, 13, 16, 19, 23].as_slice()
+        }
+        _ => return false,
+    };
+    bytes
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !separators.contains(index))
+        .all(|(_, byte)| byte.is_ascii_digit())
+}
+
+fn matches_automation_id(value: &str) -> bool {
+    matches_identifier(value, 96)
+}
+
+fn matches_entity_id(value: &str) -> bool {
+    matches_identifier(value, 160)
+}
+
+fn matches_familiar_id(value: &str) -> bool {
+    !value.is_empty() && value.chars().count() <= 64
+}
+
+fn matches_runtime_id(value: &str) -> bool {
+    !value.is_empty() && value.chars().count() <= 64
+}
+
+fn matches_approval_policy_ref(value: &str) -> bool {
+    !value.is_empty() && value.chars().count() <= 200
+}
+
+fn matches_capability(value: &str) -> bool {
+    !value.is_empty() && value.chars().count() <= 96
+}
+
+fn matches_approval_record_ref(value: &str) -> bool {
+    value.chars().count() <= 200
+}
+
+fn matches_runtime_model(value: &str) -> bool {
+    value.chars().count() <= 128
+}
+
+fn matches_sha256_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+validated_string!(Timestamp, matches_timestamp);
+validated_string!(AutomationId, matches_automation_id);
+validated_string!(OccurrenceId, matches_entity_id);
+validated_string!(RunId, matches_entity_id);
+validated_string!(AttemptId, matches_entity_id);
+validated_string!(ReceiptId, matches_entity_id);
+validated_string!(AdoptionKey, matches_adoption_key);
+validated_string!(CorrelationId, matches_correlation_id);
+validated_string!(PrincipalId, matches_principal_id);
+validated_string!(FamiliarId, matches_familiar_id);
+validated_string!(RuntimeId, matches_runtime_id);
+validated_string!(ApprovalPolicyRef, matches_approval_policy_ref);
+validated_string!(Capability, matches_capability);
+validated_string!(Sha256Digest, matches_sha256_digest);
+validated_string!(ApprovalRecordRef, matches_approval_record_ref);
+validated_string!(RuntimeModel, matches_runtime_model);
+
+macro_rules! validated_integer {
+    ($name:ident, $minimum:expr, $maximum:expr) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct $name(u64);
+
+        impl $name {
+            pub fn new(value: u64) -> Result<Self, StringConstraintError> {
+                if ($minimum..=$maximum).contains(&value) {
+                    Ok(Self(value))
+                } else {
+                    Err(StringConstraintError(stringify!($name)))
+                }
+            }
+
+            #[must_use]
+            pub const fn get(self) -> u64 {
+                self.0
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_u64(self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Self::new(u64::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+validated_integer!(PositiveInteger, 1, u64::MAX);
+validated_integer!(TimeoutMinutes, 1, 44_640);
+validated_integer!(MaximumAttempts, 1, 10);
+validated_integer!(BackoffSeconds, 1, 86_400);
+validated_integer!(LeaseMinutes, 1, 1_440);
+validated_integer!(RunAttemptCount, 1, 100);
+validated_integer!(CommandListLimit, 1, 100);
+validated_integer!(EventReadLimit, 1, 1_000);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionBag(BTreeMap<String, Value>);
+
+impl ExtensionBag {
+    pub fn new(values: BTreeMap<String, Value>) -> Result<Self, StringConstraintError> {
+        if values.keys().all(|key| matches_extension_key(key)) {
+            Ok(Self(values))
+        } else {
+            Err(StringConstraintError("ExtensionBag"))
+        }
+    }
+}
+
+impl Serialize for ExtensionBag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionBag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(BTreeMap::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+fn matches_extension_key(key: &str) -> bool {
+    if let Some(suffix) = key.strip_prefix("x-") {
+        return !suffix.is_empty()
+            && suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-');
+    }
+    let mut parts = key.rsplitn(3, '.');
+    let Some(last) = parts.next() else {
+        return false;
+    };
+    let Some(middle) = parts.next() else {
+        return false;
+    };
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    !first.is_empty()
+        && !middle.is_empty()
+        && !last.is_empty()
+        && first
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'.')
+        && middle
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && last
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilities(Vec<Capability>);
+
+impl RuntimeCapabilities {
+    fn new(values: Vec<Capability>) -> Result<Self, StringConstraintError> {
+        let mut seen = std::collections::BTreeSet::new();
+        if values.iter().all(|value| seen.insert(value.as_str())) {
+            Ok(Self(values))
+        } else {
+            Err(StringConstraintError("RuntimeCapabilities must be unique"))
+        }
+    }
+}
+
+impl Serialize for RuntimeCapabilities {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RuntimeCapabilities {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(Vec::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExercisedCapabilities(Vec<Capability>);
+
+impl ExercisedCapabilities {
+    fn new(values: Vec<Capability>) -> Result<Self, StringConstraintError> {
+        if values.len() > 128 {
+            return Err(StringConstraintError(
+                "ExercisedCapabilities must contain at most 128 entries",
+            ));
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        if values.iter().all(|value| seen.insert(value.as_str())) {
+            Ok(Self(values))
+        } else {
+            Err(StringConstraintError(
+                "ExercisedCapabilities must be unique",
+            ))
+        }
+    }
+}
+
+impl Serialize for ExercisedCapabilities {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExercisedCapabilities {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(Vec::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SchemaVersion {
@@ -86,7 +480,7 @@ impl<'de> Deserialize<'de> for EmptyConditions {
 pub struct DigestValue {
     pub algorithm: DigestAlgorithm,
     pub canonicalization: Canonicalization,
-    pub value: String,
+    pub value: Sha256Digest,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -104,7 +498,7 @@ pub enum Canonicalization {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PrincipalRef {
-    pub principal_id: String,
+    pub principal_id: PrincipalId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 }
@@ -112,24 +506,24 @@ pub struct PrincipalRef {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FamiliarRef {
-    pub familiar_id: String,
+    pub familiar_id: FamiliarId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RuntimeDescriptor {
-    pub runtime_id: String,
-    pub capabilities: Vec<String>,
+    pub runtime_id: RuntimeId,
+    pub capabilities: RuntimeCapabilities,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
+    pub model: Option<RuntimeModel>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ApprovalRef {
-    pub approval_policy_ref: String,
+    pub approval_policy_ref: ApprovalPolicyRef,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub approval_record_ref: Option<String>,
+    pub approval_record_ref: Option<ApprovalRecordRef>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -199,14 +593,14 @@ pub enum DefinitionLifecycleState {
     Invalid,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AutomationDefinition {
     pub schema_version: SchemaVersion,
     pub automation_id: AutomationId,
-    pub revision: u64,
+    pub revision: PositiveInteger,
     pub integrity: DigestValue,
-    pub lifecycle_state: DefinitionLifecycleState,
+    lifecycle_state: DefinitionLifecycleState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deletion: Option<DefinitionDeletion>,
     pub display: DefinitionDisplay,
@@ -214,16 +608,118 @@ pub struct AutomationDefinition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conditions: Option<EmptyConditions>,
     pub action: FamiliarInvocationAction,
-    pub binding: DefinitionBinding,
+    binding: DefinitionBinding,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub runtime_requirements: Option<RuntimeDescriptor>,
-    pub policies: DefinitionPolicies,
+    runtime_requirements: Option<RuntimeDescriptor>,
+    policies: DefinitionPolicies,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<Provenance>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub activation: Option<ActivationWindow>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<ExtensionBag>,
+}
+
+impl AutomationDefinition {
+    #[must_use]
+    pub const fn lifecycle_state(&self) -> DefinitionLifecycleState {
+        self.lifecycle_state
+    }
+
+    #[must_use]
+    pub fn binding(&self) -> &DefinitionBinding {
+        &self.binding
+    }
+
+    #[must_use]
+    pub fn runtime_requirements(&self) -> Option<&RuntimeDescriptor> {
+        self.runtime_requirements.as_ref()
+    }
+
+    #[must_use]
+    pub fn policies(&self) -> &DefinitionPolicies {
+        &self.policies
+    }
+
+    fn validate(&self) -> Result<(), StringConstraintError> {
+        if matches!(
+            self.lifecycle_state,
+            DefinitionLifecycleState::Active
+                | DefinitionLifecycleState::Paused
+                | DefinitionLifecycleState::Disabled
+        ) && (self.runtime_requirements.is_none() || self.binding.familiar_id.is_none())
+        {
+            return Err(StringConstraintError(
+                "active, paused, and disabled definitions require runtimeRequirements and binding.familiarId",
+            ));
+        }
+        if self.policies.retry.backoff_policy == BackoffPolicy::Fixed
+            && self.policies.retry.backoff_seconds.is_none()
+        {
+            return Err(StringConstraintError(
+                "fixed retry backoff requires backoffSeconds",
+            ));
+        }
+        if self
+            .policies
+            .delivery
+            .as_ref()
+            .is_some_and(|delivery| delivery.output_target.is_some() && delivery.mode.is_none())
+        {
+            return Err(StringConstraintError("delivery outputTarget requires mode"));
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for AutomationDefinition {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            schema_version: SchemaVersion,
+            automation_id: AutomationId,
+            revision: PositiveInteger,
+            integrity: DigestValue,
+            lifecycle_state: DefinitionLifecycleState,
+            deletion: Option<DefinitionDeletion>,
+            display: DefinitionDisplay,
+            trigger: ScheduleTrigger,
+            conditions: Option<EmptyConditions>,
+            action: FamiliarInvocationAction,
+            binding: DefinitionBinding,
+            runtime_requirements: Option<RuntimeDescriptor>,
+            policies: DefinitionPolicies,
+            provenance: Option<Provenance>,
+            activation: Option<ActivationWindow>,
+            extensions: Option<ExtensionBag>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let definition = Self {
+            schema_version: raw.schema_version,
+            automation_id: raw.automation_id,
+            revision: raw.revision,
+            integrity: raw.integrity,
+            lifecycle_state: raw.lifecycle_state,
+            deletion: raw.deletion,
+            display: raw.display,
+            trigger: raw.trigger,
+            conditions: raw.conditions,
+            action: raw.action,
+            binding: raw.binding,
+            runtime_requirements: raw.runtime_requirements,
+            policies: raw.policies,
+            provenance: raw.provenance,
+            activation: raw.activation,
+            extensions: raw.extensions,
+        };
+        definition.validate().map_err(serde::de::Error::custom)?;
+        Ok(definition)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -321,7 +817,7 @@ pub enum FamiliarInvocationVariant {
 pub struct DefinitionBinding {
     pub familiar_binding_policy: FamiliarBindingPolicy,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub familiar_id: Option<String>,
+    pub familiar_id: Option<FamiliarId>,
     pub authority: ApprovalRef,
 }
 
@@ -346,16 +842,16 @@ pub struct DefinitionPolicies {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TimeoutPolicy {
-    pub per_run_minutes: u64,
+    pub per_run_minutes: TimeoutMinutes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RetryPolicy {
-    pub max_attempts: u64,
+    pub max_attempts: MaximumAttempts,
     pub backoff_policy: BackoffPolicy,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub backoff_seconds: Option<u64>,
+    pub backoff_seconds: Option<BackoffSeconds>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retryable_classes: Option<Vec<RetryableClass>>,
 }
@@ -403,8 +899,10 @@ pub enum MisfirePolicyDisposition {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeliveryPolicy {
-    pub output_target: String,
-    pub mode: DeliveryMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<DeliveryMode>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -457,7 +955,7 @@ pub struct AutomationOccurrence {
     pub schema_version: SchemaVersion,
     pub occurrence_id: OccurrenceId,
     pub automation_id: AutomationId,
-    pub automation_revision: u64,
+    pub automation_revision: PositiveInteger,
     pub trigger_identity: TriggerIdentity,
     pub occurrence_key: String,
     pub scheduled_for: Timestamp,
@@ -507,7 +1005,7 @@ pub enum TriggerIdentityKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OccurrenceFence {
-    pub generation: u64,
+    pub generation: PositiveInteger,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub claimed_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -518,7 +1016,7 @@ pub struct OccurrenceFence {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClaimMetadata {
     pub claimed_at: Timestamp,
-    pub lease_minutes: u64,
+    pub lease_minutes: LeaseMinutes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -586,12 +1084,12 @@ pub struct AutomationRun {
     pub run_id: RunId,
     pub occurrence_id: OccurrenceId,
     pub automation_id: AutomationId,
-    pub automation_revision: u64,
+    pub automation_revision: PositiveInteger,
     pub binding: RunBinding,
     pub state: RunState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_reason: Option<String>,
-    pub attempt_count: u64,
+    pub attempt_count: RunAttemptCount,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_attempt_id: Option<AttemptId>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -707,7 +1205,7 @@ pub struct AutomationAttempt {
     pub attempt_id: AttemptId,
     pub run_id: RunId,
     pub occurrence_id: OccurrenceId,
-    pub attempt_number: u64,
+    pub attempt_number: PositiveInteger,
     pub adoption_key: AdoptionKey,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prior_disposition: Option<PriorDisposition>,
@@ -734,7 +1232,7 @@ pub struct AutomationAttempt {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PriorDisposition {
-    pub attempt_number: u64,
+    pub attempt_number: PositiveInteger,
     pub outcome: PriorAttemptOutcome,
 }
 
@@ -750,8 +1248,8 @@ pub enum PriorAttemptOutcome {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DispatchFence {
-    pub occurrence_fence_generation: u64,
-    pub dispatch_generation: u64,
+    pub occurrence_fence_generation: PositiveInteger,
+    pub dispatch_generation: PositiveInteger,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -817,23 +1315,27 @@ pub struct AutomationReceipt {
     pub schema_version: SchemaVersion,
     pub receipt_id: ReceiptId,
     pub automation_id: AutomationId,
-    pub automation_revision: u64,
-    pub definition_digest: DigestValue,
+    pub automation_revision: PositiveInteger,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition_digest: Option<DigestValue>,
     pub occurrence_id: OccurrenceId,
-    pub occurrence_fence_generation: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurrence_fence_generation: Option<PositiveInteger>,
     pub run_id: RunId,
     pub attempt_id: AttemptId,
-    pub attempt_number: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempt_number: Option<PositiveInteger>,
     pub identity: FamiliarRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority: Option<ReceiptAuthority>,
-    pub runtime: RuntimeDescriptor,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<RuntimeDescriptor>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delivery_digest: Option<DigestValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_digest: Option<DigestValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exercised_capabilities: Option<Vec<String>>,
+    pub exercised_capabilities: Option<ExercisedCapabilities>,
     pub side_effect_class: SideEffectClass,
     pub outcome: ReceiptOutcome,
     pub produced_at: Timestamp,
@@ -886,7 +1388,7 @@ pub enum ReceiptRecoveryDisposition {
 pub struct ReceiptIntegrity {
     pub algorithm: DigestAlgorithm,
     pub canonicalization: Canonicalization,
-    pub value: String,
+    pub value: Sha256Digest,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ReceiptAuthentication>,
 }
@@ -950,18 +1452,386 @@ pub enum CommandName {
     LegacyImport,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandRequest {
+    schema_version: SchemaVersion,
+    adoption_key: AdoptionKey,
+    expected_revision: Option<PositiveInteger>,
+    origin: CommandOrigin,
+    intent: CommandIntent,
+    payload: CommandPayload,
+}
+
+impl CommandRequest {
+    pub fn new(
+        schema_version: SchemaVersion,
+        adoption_key: AdoptionKey,
+        expected_revision: Option<PositiveInteger>,
+        origin: CommandOrigin,
+        intent: CommandIntent,
+        payload: CommandPayload,
+    ) -> Result<Self, StringConstraintError> {
+        let revision_is_required = payload.requires_expected_revision();
+        if revision_is_required != expected_revision.is_some() {
+            return Err(StringConstraintError(
+                "expectedRevision is required only for definition revise/activate/pause/disable/tombstone commands",
+            ));
+        }
+        Ok(Self {
+            schema_version,
+            adoption_key,
+            expected_revision,
+            origin,
+            intent,
+            payload,
+        })
+    }
+
+    #[must_use]
+    pub const fn command(&self) -> CommandName {
+        self.payload.command()
+    }
+
+    #[must_use]
+    pub const fn expected_revision(&self) -> Option<PositiveInteger> {
+        self.expected_revision
+    }
+
+    #[must_use]
+    pub fn payload(&self) -> &CommandPayload {
+        &self.payload
+    }
+}
+
+impl Serialize for CommandRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let field_count = if self.expected_revision.is_some() {
+            7
+        } else {
+            6
+        };
+        let mut state = serializer.serialize_struct("CommandRequest", field_count)?;
+        state.serialize_field("schemaVersion", &self.schema_version)?;
+        state.serialize_field("command", &self.command())?;
+        state.serialize_field("adoptionKey", &self.adoption_key)?;
+        if let Some(expected_revision) = self.expected_revision {
+            state.serialize_field("expectedRevision", &expected_revision)?;
+        }
+        state.serialize_field("origin", &self.origin)?;
+        state.serialize_field("intent", &self.intent)?;
+        state.serialize_field("payload", &self.payload)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CommandRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            schema_version: SchemaVersion,
+            command: CommandName,
+            adoption_key: AdoptionKey,
+            expected_revision: Option<PositiveInteger>,
+            origin: CommandOrigin,
+            intent: CommandIntent,
+            payload: Value,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let payload = CommandPayload::from_value(raw.command, raw.payload)
+            .map_err(serde::de::Error::custom)?;
+        Self::new(
+            raw.schema_version,
+            raw.adoption_key,
+            raw.expected_revision,
+            raw.origin,
+            raw.intent,
+            payload,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum CommandPayload {
+    DefinitionCreate(DefinitionMutationPayload),
+    DefinitionRevise(DefinitionMutationPayload),
+    DefinitionActivate(DefinitionTargetPayload),
+    DefinitionPause(DefinitionTargetPayload),
+    DefinitionDisable(DefinitionTargetPayload),
+    DefinitionTombstone(DefinitionTargetPayload),
+    OccurrenceRunNow(RunNowPayload),
+    OccurrenceCancel(OccurrenceCancelPayload),
+    RunCancel(RunCancelPayload),
+    AttemptCancel(AttemptCancelPayload),
+    AttemptRetry(AttemptRetryPayload),
+    OccurrenceRecover(OccurrenceRecoverPayload),
+    DefinitionList(DefinitionListPayload),
+    DefinitionGet(DefinitionGetPayload),
+    RunHistory(RunHistoryPayload),
+    DefinitionHealth(DefinitionHealthPayload),
+    EventsRead(EventsReadPayload),
+    EventsSubscribe(EventsSubscribePayload),
+    LegacyImport(LegacyImportPayload),
+}
+
+impl CommandPayload {
+    fn from_value(command: CommandName, value: Value) -> Result<Self, serde_json::Error> {
+        match command {
+            CommandName::DefinitionCreate => {
+                Ok(Self::DefinitionCreate(serde_json::from_value(value)?))
+            }
+            CommandName::DefinitionRevise => {
+                Ok(Self::DefinitionRevise(serde_json::from_value(value)?))
+            }
+            CommandName::DefinitionActivate => {
+                Ok(Self::DefinitionActivate(serde_json::from_value(value)?))
+            }
+            CommandName::DefinitionPause => {
+                Ok(Self::DefinitionPause(serde_json::from_value(value)?))
+            }
+            CommandName::DefinitionDisable => {
+                Ok(Self::DefinitionDisable(serde_json::from_value(value)?))
+            }
+            CommandName::DefinitionTombstone => {
+                Ok(Self::DefinitionTombstone(serde_json::from_value(value)?))
+            }
+            CommandName::OccurrenceRunNow => {
+                Ok(Self::OccurrenceRunNow(serde_json::from_value(value)?))
+            }
+            CommandName::OccurrenceCancel => {
+                Ok(Self::OccurrenceCancel(serde_json::from_value(value)?))
+            }
+            CommandName::RunCancel => Ok(Self::RunCancel(serde_json::from_value(value)?)),
+            CommandName::AttemptCancel => Ok(Self::AttemptCancel(serde_json::from_value(value)?)),
+            CommandName::AttemptRetry => Ok(Self::AttemptRetry(serde_json::from_value(value)?)),
+            CommandName::OccurrenceRecover => {
+                Ok(Self::OccurrenceRecover(serde_json::from_value(value)?))
+            }
+            CommandName::DefinitionList => Ok(Self::DefinitionList(serde_json::from_value(value)?)),
+            CommandName::DefinitionGet => Ok(Self::DefinitionGet(serde_json::from_value(value)?)),
+            CommandName::RunHistory => Ok(Self::RunHistory(serde_json::from_value(value)?)),
+            CommandName::DefinitionHealth => {
+                Ok(Self::DefinitionHealth(serde_json::from_value(value)?))
+            }
+            CommandName::EventsRead => Ok(Self::EventsRead(serde_json::from_value(value)?)),
+            CommandName::EventsSubscribe => {
+                Ok(Self::EventsSubscribe(serde_json::from_value(value)?))
+            }
+            CommandName::LegacyImport => Ok(Self::LegacyImport(serde_json::from_value(value)?)),
+        }
+    }
+
+    #[must_use]
+    pub const fn command(&self) -> CommandName {
+        match self {
+            Self::DefinitionCreate(_) => CommandName::DefinitionCreate,
+            Self::DefinitionRevise(_) => CommandName::DefinitionRevise,
+            Self::DefinitionActivate(_) => CommandName::DefinitionActivate,
+            Self::DefinitionPause(_) => CommandName::DefinitionPause,
+            Self::DefinitionDisable(_) => CommandName::DefinitionDisable,
+            Self::DefinitionTombstone(_) => CommandName::DefinitionTombstone,
+            Self::OccurrenceRunNow(_) => CommandName::OccurrenceRunNow,
+            Self::OccurrenceCancel(_) => CommandName::OccurrenceCancel,
+            Self::RunCancel(_) => CommandName::RunCancel,
+            Self::AttemptCancel(_) => CommandName::AttemptCancel,
+            Self::AttemptRetry(_) => CommandName::AttemptRetry,
+            Self::OccurrenceRecover(_) => CommandName::OccurrenceRecover,
+            Self::DefinitionList(_) => CommandName::DefinitionList,
+            Self::DefinitionGet(_) => CommandName::DefinitionGet,
+            Self::RunHistory(_) => CommandName::RunHistory,
+            Self::DefinitionHealth(_) => CommandName::DefinitionHealth,
+            Self::EventsRead(_) => CommandName::EventsRead,
+            Self::EventsSubscribe(_) => CommandName::EventsSubscribe,
+            Self::LegacyImport(_) => CommandName::LegacyImport,
+        }
+    }
+
+    const fn requires_expected_revision(&self) -> bool {
+        matches!(
+            self,
+            Self::DefinitionRevise(_)
+                | Self::DefinitionActivate(_)
+                | Self::DefinitionPause(_)
+                | Self::DefinitionDisable(_)
+                | Self::DefinitionTombstone(_)
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct CommandRequest {
-    pub schema_version: SchemaVersion,
-    pub command: CommandName,
-    pub adoption_key: AdoptionKey,
+pub struct DefinitionMutationPayload {
+    pub definition: AutomationDefinition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionTargetPayload {
+    pub automation_id: AutomationId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expected_revision: Option<u64>,
-    pub origin: CommandOrigin,
-    pub intent: CommandIntent,
-    /// Per-command payloads are a schema-defined object bag.
-    pub payload: JsonObject,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RunNowPayload {
+    pub automation_id: AutomationId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bypass_eligibility: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OccurrenceCancelPayload {
+    pub occurrence_id: OccurrenceId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RunCancelPayload {
+    pub run_id: RunId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AttemptCancelPayload {
+    pub attempt_id: AttemptId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AttemptRetryPayload {
+    pub run_id: RunId,
+    pub prior_attempt_number: PositiveInteger,
+    pub prior_disposition: RetryPriorDisposition,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryPriorDisposition {
+    Failed,
+    TimedOut,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OccurrenceRecoverPayload {
+    pub occurrence_id: OccurrenceId,
+    pub evidence_determination: EvidenceDetermination,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statement: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceDetermination {
+    FailedDeterministic,
+    RetryWithNewAttempt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionListPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_state: Option<ListLifecycleState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<CommandListLimit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ListLifecycleState {
+    Draft,
+    Paused,
+    Active,
+    Disabled,
+    Invalid,
+    Tombstoned,
+    All,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionGetPayload {
+    pub automation_id: AutomationId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<PositiveInteger>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RunHistoryPayload {
+    pub automation_id: AutomationId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurrence_id: Option<OccurrenceId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<CommandListLimit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionHealthPayload {
+    pub automation_id: AutomationId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EventsReadPayload {
+    pub stream: StreamRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<EventReadLimit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EventsSubscribePayload {
+    pub stream: StreamRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LegacyImportPayload {
+    pub source: LegacyImportSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LegacyImportSource {
+    #[serde(rename = "codex-automation-toml")]
+    CodexAutomationToml,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1017,7 +1887,7 @@ pub struct CommandResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replay: Option<ReplayMetadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revision: Option<u64>,
+    pub revision: Option<PositiveInteger>,
     /// Committed result bodies are explicitly open in the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<JsonObject>,
@@ -1142,7 +2012,7 @@ pub enum EventPayload {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionLifecyclePayload {
-    pub revision: u64,
+    pub revision: PositiveInteger,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub definition_digest: Option<DigestValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1170,9 +2040,9 @@ pub struct TransitionPayload {
     pub to: String,
     pub reason: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fence_generation: Option<u64>,
+    pub fence_generation: Option<PositiveInteger>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub attempt_number: Option<u64>,
+    pub attempt_number: Option<PositiveInteger>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_adoption_key: Option<AdoptionKey>,
 }

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -1,0 +1,1232 @@
+//! Serde projections of every object published in Coven Automations v1.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+use super::error::ErrorEnvelope;
+
+pub type Timestamp = String;
+pub type AutomationId = String;
+pub type OccurrenceId = String;
+pub type RunId = String;
+pub type AttemptId = String;
+pub type ReceiptId = String;
+pub type AdoptionKey = String;
+pub type CorrelationId = String;
+pub type ExtensionBag = BTreeMap<String, Value>;
+pub type JsonObject = BTreeMap<String, Value>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SchemaVersion {
+    #[serde(rename = "coven.automations.v1")]
+    V1,
+}
+
+/// A wire-number that accepts and emits exactly `1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct VersionOne;
+
+impl Serialize for VersionOne {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(1)
+    }
+}
+
+impl<'de> Deserialize<'de> for VersionOne {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match u8::deserialize(deserializer)? {
+            1 => Ok(Self),
+            value => Err(serde::de::Error::custom(format!(
+                "expected version 1, got {value}"
+            ))),
+        }
+    }
+}
+
+/// The v1 conditions union has no variants, so only an empty array is valid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct EmptyConditions;
+
+impl Serialize for EmptyConditions {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Vec::<Value>::new().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for EmptyConditions {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let values = Vec::<Value>::deserialize(deserializer)?;
+        if values.is_empty() {
+            Ok(Self)
+        } else {
+            Err(serde::de::Error::custom(
+                "coven.automations.v1 defines no condition variants",
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DigestValue {
+    pub algorithm: DigestAlgorithm,
+    pub canonicalization: Canonicalization,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DigestAlgorithm {
+    #[serde(rename = "sha256")]
+    Sha256,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Canonicalization {
+    #[serde(rename = "jcs-rfc8785")]
+    JcsRfc8785,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PrincipalRef {
+    pub principal_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FamiliarRef {
+    pub familiar_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RuntimeDescriptor {
+    pub runtime_id: String,
+    pub capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ApprovalRef {
+    pub approval_policy_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_record_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrivacyClassification {
+    Public,
+    Operational,
+    Sensitive,
+    Restricted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RetentionClass {
+    pub classification: RetentionClassification,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delete_after: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetentionClassification {
+    Ephemeral,
+    Standard,
+    Extended,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProducerIdentity {
+    pub component: String,
+    pub instance_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implementation_version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Provenance {
+    pub created_by: PrincipalRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<PrincipalRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub imported_from: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ActivationWindow {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_from: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_until: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DefinitionLifecycleState {
+    Draft,
+    Paused,
+    Active,
+    Disabled,
+    Invalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AutomationDefinition {
+    pub schema_version: SchemaVersion,
+    pub automation_id: AutomationId,
+    pub revision: u64,
+    pub integrity: DigestValue,
+    pub lifecycle_state: DefinitionLifecycleState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletion: Option<DefinitionDeletion>,
+    pub display: DefinitionDisplay,
+    pub trigger: ScheduleTrigger,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<EmptyConditions>,
+    pub action: FamiliarInvocationAction,
+    pub binding: DefinitionBinding,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_requirements: Option<RuntimeDescriptor>,
+    pub policies: DefinitionPolicies,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<Provenance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activation: Option<ActivationWindow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<ExtensionBag>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionDeletion {
+    pub tombstoned: True,
+    pub requested_at: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_by: Option<PrincipalRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct True;
+
+impl Serialize for True {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bool(true)
+    }
+}
+
+impl<'de> Deserialize<'de> for True {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if bool::deserialize(deserializer)? {
+            Ok(Self)
+        } else {
+            Err(serde::de::Error::custom("expected true"))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionDisplay {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ScheduleTrigger {
+    pub variant: ScheduleVariant,
+    pub version: VersionOne,
+    pub schedule: Schedule,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScheduleVariant {
+    #[serde(rename = "schedule")]
+    Schedule,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Schedule {
+    pub rrule: String,
+    pub timezone: Timezone,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Timezone {
+    Local,
+    Utc,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FamiliarInvocationAction {
+    pub variant: FamiliarInvocationVariant,
+    pub version: VersionOne,
+    pub prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FamiliarInvocationVariant {
+    #[serde(rename = "familiarInvocation")]
+    FamiliarInvocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionBinding {
+    pub familiar_binding_policy: FamiliarBindingPolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub familiar_id: Option<String>,
+    pub authority: ApprovalRef,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FamiliarBindingPolicy {
+    Exact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionPolicies {
+    pub timeout: TimeoutPolicy,
+    pub retry: RetryPolicy,
+    pub concurrency: ConcurrencyPolicy,
+    pub misfire: MisfirePolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<DeliveryPolicy>,
+    pub retention: RetentionPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TimeoutPolicy {
+    pub per_run_minutes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RetryPolicy {
+    pub max_attempts: u64,
+    pub backoff_policy: BackoffPolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backoff_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable_classes: Option<Vec<RetryableClass>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackoffPolicy {
+    None,
+    Fixed,
+    Exponential,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryableClass {
+    TransientDispatch,
+    LeaseExpired,
+    RuntimeUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConcurrencyPolicy {
+    pub overlap: OverlapPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OverlapPolicy {
+    Forbid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MisfirePolicy {
+    pub disposition: MisfirePolicyDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MisfirePolicyDisposition {
+    Latest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DeliveryPolicy {
+    pub output_target: String,
+    pub mode: DeliveryMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryMode {
+    Atomic,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RetentionPolicy {
+    pub occurrence_history: RetentionClass,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_logs: Option<RetentionClass>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipts: Option<RetentionClass>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OccurrenceState {
+    Planned,
+    Eligible,
+    Claimed,
+    Dispatching,
+    Running,
+    Recovering,
+    RecoveryRequired,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Skipped,
+    Superseded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MisfireDisposition {
+    None,
+    CollapsedToLatest,
+    SkippedOverlap,
+    SkippedPaused,
+    SkippedInvalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AutomationOccurrence {
+    pub schema_version: SchemaVersion,
+    pub occurrence_id: OccurrenceId,
+    pub automation_id: AutomationId,
+    pub automation_revision: u64,
+    pub trigger_identity: TriggerIdentity,
+    pub occurrence_key: String,
+    pub scheduled_for: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eligible_at: Option<Timestamp>,
+    pub state: OccurrenceState,
+    pub state_reason: String,
+    pub fence: OccurrenceFence,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub misfire_disposition: Option<MisfireDisposition>,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claim_metadata: Option<ClaimMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_run_ref: Option<RunId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancellation: Option<Cancellation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<Recovery>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_window: Option<EventWindow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<ExtensionBag>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TriggerIdentity {
+    pub kind: TriggerIdentityKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rrule_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_by: Option<PrincipalRef>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TriggerIdentityKind {
+    #[serde(rename = "schedule.slot")]
+    ScheduleSlot,
+    #[serde(rename = "manual.request")]
+    ManualRequest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OccurrenceFence {
+    pub generation: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claimed_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lease_expires_at: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClaimMetadata {
+    pub claimed_at: Timestamp,
+    pub lease_minutes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Cancellation {
+    pub requested_at: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_by: Option<PrincipalRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acknowledged_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconciled_at: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Recovery {
+    pub entered_at: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<RecoveryEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_disposition: Option<RecoveryDisposition>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryEvidence {
+    LeaseExpired,
+    DispatchUnconfirmed,
+    RuntimeLost,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryDisposition {
+    FailedDeterministic,
+    FailedAmbiguous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EventWindow {
+    pub first_sequence: u64,
+    pub last_sequence: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunState {
+    Accepted,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Ambiguous,
+}
+
+pub type RunOutcome = RunState;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AutomationRun {
+    pub schema_version: SchemaVersion,
+    pub run_id: RunId,
+    pub occurrence_id: OccurrenceId,
+    pub automation_id: AutomationId,
+    pub automation_revision: u64,
+    pub binding: RunBinding,
+    pub state: RunState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_reason: Option<String>,
+    pub attempt_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_attempt_id: Option<AttemptId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_disposition: Option<TerminalDisposition>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<RunDelivery>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_digest: Option<DigestValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipt_ref: Option<ReceiptId>,
+    pub started_at: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<ExtensionBag>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RunBinding {
+    pub familiar: FamiliarRef,
+    pub authority: AuthorityBinding,
+    pub runtime: RuntimeDescriptor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AuthorityBinding {
+    pub principal: PrincipalRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval: Option<ApprovalRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication_class: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TerminalDisposition {
+    pub outcome: TerminalOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_class: Option<TerminalFailureClass>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalOutcome {
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalFailureClass {
+    LaunchRefused,
+    RuntimeError,
+    Timeout,
+    CancelledByRequest,
+    LeaseExpired,
+    AmbiguousEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RunDelivery {
+    pub status: RunDeliveryStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_refs: Option<Vec<ArtifactRef>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunDeliveryStatus {
+    None,
+    Pending,
+    Committed,
+    Refused,
+    RolledBack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArtifactRef {
+    pub r#ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub digest: Option<DigestValue>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttemptState {
+    Adopted,
+    Dispatching,
+    Started,
+    Observing,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AutomationAttempt {
+    pub schema_version: SchemaVersion,
+    pub attempt_id: AttemptId,
+    pub run_id: RunId,
+    pub occurrence_id: OccurrenceId,
+    pub attempt_number: u64,
+    pub adoption_key: AdoptionKey,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prior_disposition: Option<PriorDisposition>,
+    pub dispatch_fence: DispatchFence,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_correlation: Option<WorkerCorrelation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_classification: Option<RetryClassification>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lease_observations: Option<Vec<LeaseObservation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_cursors: Option<OutputCursors>,
+    pub state: AttemptState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opened_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settled_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<ExtensionBag>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PriorDisposition {
+    pub attempt_number: u64,
+    pub outcome: PriorAttemptOutcome,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PriorAttemptOutcome {
+    Failed,
+    TimedOut,
+    Ambiguous,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DispatchFence {
+    pub occurrence_fence_generation: u64,
+    pub dispatch_generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkerCorrelation {
+    pub worker_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adopted_at: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RetryClassification {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classification: Option<RetryClassificationKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eligible_classes: Option<Vec<RetryableClass>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryClassificationKind {
+    Initial,
+    AutomaticRetry,
+    OperatorRetry,
+    OperatorRecovery,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LeaseObservation {
+    pub observed_at: Timestamp,
+    pub heartbeat_ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OutputCursors {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_cursor: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_cursor: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SideEffectClass {
+    None,
+    LocalRead,
+    LocalWrite,
+    ExternalRead,
+    ExternalMutation,
+    IrreversibleExternalMutation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AutomationReceipt {
+    pub schema_version: SchemaVersion,
+    pub receipt_id: ReceiptId,
+    pub automation_id: AutomationId,
+    pub automation_revision: u64,
+    pub definition_digest: DigestValue,
+    pub occurrence_id: OccurrenceId,
+    pub occurrence_fence_generation: u64,
+    pub run_id: RunId,
+    pub attempt_id: AttemptId,
+    pub attempt_number: u64,
+    pub identity: FamiliarRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority: Option<ReceiptAuthority>,
+    pub runtime: RuntimeDescriptor,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_digest: Option<DigestValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_digest: Option<DigestValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exercised_capabilities: Option<Vec<String>>,
+    pub side_effect_class: SideEffectClass,
+    pub outcome: ReceiptOutcome,
+    pub produced_at: Timestamp,
+    pub producer: ProducerIdentity,
+    pub integrity: ReceiptIntegrity,
+    pub privacy: ReceiptPrivacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReceiptAuthority {
+    pub principal: PrincipalRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval: Option<ApprovalRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReceiptOutcome {
+    pub disposition: TerminalOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_failures: Option<Vec<PartialFailure>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_disposition: Option<ReceiptRecoveryDisposition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PartialFailure {
+    pub step: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovered: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiptRecoveryDisposition {
+    NotRequired,
+    RecoveredInline,
+    DeferredToOperator,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReceiptIntegrity {
+    pub algorithm: DigestAlgorithm,
+    pub canonicalization: Canonicalization,
+    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ReceiptAuthentication>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReceiptAuthentication {
+    None,
+    ProducerHmac,
+    Cosign,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReceiptPrivacy {
+    pub classification: PrivacyClassification,
+    pub retention: RetentionClass,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommandName {
+    #[serde(rename = "definition.create.v1")]
+    DefinitionCreate,
+    #[serde(rename = "definition.revise.v1")]
+    DefinitionRevise,
+    #[serde(rename = "definition.activate.v1")]
+    DefinitionActivate,
+    #[serde(rename = "definition.pause.v1")]
+    DefinitionPause,
+    #[serde(rename = "definition.disable.v1")]
+    DefinitionDisable,
+    #[serde(rename = "definition.tombstone.v1")]
+    DefinitionTombstone,
+    #[serde(rename = "occurrence.runNow.v1")]
+    OccurrenceRunNow,
+    #[serde(rename = "occurrence.cancel.v1")]
+    OccurrenceCancel,
+    #[serde(rename = "run.cancel.v1")]
+    RunCancel,
+    #[serde(rename = "attempt.cancel.v1")]
+    AttemptCancel,
+    #[serde(rename = "attempt.retry.v1")]
+    AttemptRetry,
+    #[serde(rename = "occurrence.recover.v1")]
+    OccurrenceRecover,
+    #[serde(rename = "definition.list.v1")]
+    DefinitionList,
+    #[serde(rename = "definition.get.v1")]
+    DefinitionGet,
+    #[serde(rename = "run.history.v1")]
+    RunHistory,
+    #[serde(rename = "definition.health.v1")]
+    DefinitionHealth,
+    #[serde(rename = "events.read.v1")]
+    EventsRead,
+    #[serde(rename = "events.subscribe.v1")]
+    EventsSubscribe,
+    #[serde(rename = "legacy.import.v1")]
+    LegacyImport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommandRequest {
+    pub schema_version: SchemaVersion,
+    pub command: CommandName,
+    pub adoption_key: AdoptionKey,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_revision: Option<u64>,
+    pub origin: CommandOrigin,
+    pub intent: CommandIntent,
+    /// Per-command payloads are a schema-defined object bag.
+    pub payload: JsonObject,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommandOrigin {
+    pub principal: PrincipalRef,
+    pub channel: CommandChannel,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<CorrelationId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommandChannel {
+    #[serde(rename = "daemon-ipc")]
+    DaemonIpc,
+    #[serde(rename = "http")]
+    Http,
+    #[serde(rename = "control-action")]
+    ControlAction,
+    #[serde(rename = "cli")]
+    Cli,
+    #[serde(rename = "sdk")]
+    Sdk,
+    #[serde(rename = "cave")]
+    Cave,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommandIntent {
+    pub statement: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandOutcome {
+    Committed,
+    Replayed,
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommandResponse {
+    pub schema_version: SchemaVersion,
+    pub command: CommandName,
+    pub adoption_key: AdoptionKey,
+    pub outcome: CommandOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay: Option<ReplayMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u64>,
+    /// Committed result bodies are explicitly open in the schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<JsonObject>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorEnvelope>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipt_ref: Option<ReceiptId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_ref: Option<EventRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReplayMetadata {
+    pub first_committed_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EventRef {
+    pub stream: String,
+    pub sequence: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EventKind {
+    #[serde(rename = "definition.created")]
+    DefinitionCreated,
+    #[serde(rename = "definition.revised")]
+    DefinitionRevised,
+    #[serde(rename = "definition.activated")]
+    DefinitionActivated,
+    #[serde(rename = "definition.paused")]
+    DefinitionPaused,
+    #[serde(rename = "definition.disabled")]
+    DefinitionDisabled,
+    #[serde(rename = "definition.invalidated")]
+    DefinitionInvalidated,
+    #[serde(rename = "definition.tombstoned")]
+    DefinitionTombstoned,
+    #[serde(rename = "definition.imported")]
+    DefinitionImported,
+    #[serde(rename = "occurrence.transitioned")]
+    OccurrenceTransitioned,
+    #[serde(rename = "occurrence.misfire_recorded")]
+    OccurrenceMisfireRecorded,
+    #[serde(rename = "run.transitioned")]
+    RunTransitioned,
+    #[serde(rename = "attempt.transitioned")]
+    AttemptTransitioned,
+    #[serde(rename = "receipt.recorded")]
+    ReceiptRecorded,
+    #[serde(rename = "feed.snapshot")]
+    FeedSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EventEnvelope {
+    pub schema_version: SchemaVersion,
+    pub event_id: String,
+    pub stream: StreamRef,
+    pub sequence: u64,
+    pub recorded_at: Timestamp,
+    pub observed_at: Timestamp,
+    pub producer: ProducerIdentity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub causation: Option<EventCausation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automation_id: Option<AutomationId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurrence_id: Option<OccurrenceId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<RunId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempt_id: Option<AttemptId>,
+    pub kind: EventKind,
+    pub summary: String,
+    pub payload: EventPayload,
+    pub privacy: EventPrivacy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<DigestValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StreamRef {
+    pub kind: StreamKind,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamKind {
+    Automation,
+    Occurrence,
+    Run,
+    Feed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EventCausation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adoption_key: Option<AdoptionKey>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cause_event_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<CorrelationId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EventPayload {
+    DefinitionLifecycle(DefinitionLifecyclePayload),
+    Transition(TransitionPayload),
+    Misfire(MisfirePayload),
+    Receipt(ReceiptPayload),
+    Snapshot(SnapshotPayload),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionLifecyclePayload {
+    pub revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition_digest: Option<DigestValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_state: Option<EventLifecycleState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub imported_from: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventLifecycleState {
+    Draft,
+    Paused,
+    Active,
+    Disabled,
+    Invalid,
+    Tombstoned,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TransitionPayload {
+    pub entity: TransitionEntity,
+    pub from: String,
+    pub to: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fence_generation: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempt_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_adoption_key: Option<AdoptionKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransitionEntity {
+    Occurrence,
+    Run,
+    Attempt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MisfirePayload {
+    pub disposition: MisfireDisposition,
+    pub collapsed_slots: Vec<Timestamp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReceiptPayload {
+    pub receipt_ref: ReceiptId,
+    pub outcome: TerminalOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub side_effect_class: Option<SideEffectClass>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SnapshotPayload {
+    pub through_sequence: u64,
+    /// Compacted state is explicitly an open, schema-defined JSON object.
+    pub state: JsonObject,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<SnapshotReason>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotReason {
+    RetentionCompaction,
+    ManualSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EventPrivacy {
+    pub classification: PrivacyClassification,
+    pub retention: RetentionClass,
+}
+
+impl fmt::Display for SchemaVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("coven.automations.v1")
+    }
+}

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -300,6 +300,82 @@ fn matches_artifact_reference(value: &str) -> bool {
     (1..=512).contains(&value.chars().count())
 }
 
+fn has_character_length(value: &str, minimum: usize, maximum: usize) -> bool {
+    (minimum..=maximum).contains(&value.chars().count())
+}
+
+fn matches_principal_display_name(value: &str) -> bool {
+    has_character_length(value, 0, 160)
+}
+
+fn matches_imported_from(value: &str) -> bool {
+    has_character_length(value, 0, 200)
+}
+
+fn matches_claimed_by(value: &str) -> bool {
+    has_character_length(value, 0, 128)
+}
+
+fn matches_authentication_class(value: &str) -> bool {
+    has_character_length(value, 0, 64)
+}
+
+fn matches_detail(value: &str) -> bool {
+    has_character_length(value, 0, 2_000)
+}
+
+fn matches_worker_id(value: &str) -> bool {
+    has_character_length(value, 1, 128)
+}
+
+fn matches_session_id(value: &str) -> bool {
+    has_character_length(value, 1, 128)
+}
+
+fn matches_note(value: &str) -> bool {
+    has_character_length(value, 0, 500)
+}
+
+fn matches_failure_class(value: &str) -> bool {
+    has_character_length(value, 0, 96)
+}
+
+fn matches_partial_failure_step(value: &str) -> bool {
+    has_character_length(value, 1, 128)
+}
+
+fn matches_partial_failure_reason(value: &str) -> bool {
+    has_character_length(value, 1, 1_000)
+}
+
+fn matches_privacy_notes(value: &str) -> bool {
+    has_character_length(value, 0, 500)
+}
+
+fn matches_operator_statement(value: &str) -> bool {
+    has_character_length(value, 1, 1_000)
+}
+
+fn matches_cursor(value: &str) -> bool {
+    has_character_length(value, 0, 256)
+}
+
+fn matches_checkpoint(value: &str) -> bool {
+    has_character_length(value, 0, 512)
+}
+
+fn matches_transition_state(value: &str) -> bool {
+    has_character_length(value, 1, 32)
+}
+
+fn matches_transition_reason(value: &str) -> bool {
+    has_character_length(value, 1, 500)
+}
+
+fn matches_error_message(value: &str) -> bool {
+    has_character_length(value, 1, 1_000)
+}
+
 validated_string!(Timestamp, matches_timestamp);
 validated_string!(AutomationId, matches_automation_id);
 validated_string!(OccurrenceId, matches_entity_id);
@@ -336,6 +412,24 @@ validated_string!(OccurrenceKey, matches_occurrence_key);
 validated_string!(StateReason, matches_state_reason);
 validated_string!(CommandReason, matches_reason);
 validated_string!(ArtifactReference, matches_artifact_reference);
+validated_string!(PrincipalDisplayName, matches_principal_display_name);
+validated_string!(ImportedFrom, matches_imported_from);
+validated_string!(ClaimedBy, matches_claimed_by);
+validated_string!(AuthenticationClass, matches_authentication_class);
+validated_string!(Detail, matches_detail);
+validated_string!(WorkerId, matches_worker_id);
+validated_string!(SessionId, matches_session_id);
+validated_string!(CommandNote, matches_note);
+validated_string!(FailureClass, matches_failure_class);
+validated_string!(PartialFailureStep, matches_partial_failure_step);
+validated_string!(PartialFailureReason, matches_partial_failure_reason);
+validated_string!(PrivacyNotes, matches_privacy_notes);
+validated_string!(OperatorStatement, matches_operator_statement);
+validated_string!(Cursor, matches_cursor);
+validated_string!(Checkpoint, matches_checkpoint);
+validated_string!(TransitionState, matches_transition_state);
+validated_string!(TransitionReason, matches_transition_reason);
+validated_string!(ErrorMessage, matches_error_message);
 
 macro_rules! validated_integer {
     ($name:ident, $minimum:expr, $maximum:expr) => {
@@ -437,9 +531,9 @@ fn matches_extension_key(key: &str) -> bool {
     !first.is_empty()
         && !middle.is_empty()
         && !last.is_empty()
-        && first
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'.')
+        && first.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'-')
+        })
         && middle
             .bytes()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
@@ -530,6 +624,69 @@ impl Serialize for DisplayTags {
 }
 
 impl<'de> Deserialize<'de> for DisplayTags {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(Vec::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedVec<T, const MAX: usize>(Vec<T>);
+
+impl<T, const MAX: usize> BoundedVec<T, MAX> {
+    pub fn new(values: Vec<T>) -> Result<Self, StringConstraintError> {
+        if values.len() <= MAX {
+            Ok(Self(values))
+        } else {
+            Err(StringConstraintError("collection exceeds schema maximum"))
+        }
+    }
+}
+
+impl<T: Serialize, const MAX: usize> Serialize for BoundedVec<T, MAX> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>, const MAX: usize> Deserialize<'de> for BoundedVec<T, MAX> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(Vec::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UniqueVec<T>(Vec<T>);
+
+impl<T: Ord> UniqueVec<T> {
+    pub fn new(values: Vec<T>) -> Result<Self, StringConstraintError> {
+        let mut seen = std::collections::BTreeSet::new();
+        if values.iter().all(|value| seen.insert(value)) {
+            Ok(Self(values))
+        } else {
+            Err(StringConstraintError("collection entries must be unique"))
+        }
+    }
+}
+
+impl<T: Serialize> Serialize for UniqueVec<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de> + Ord> Deserialize<'de> for UniqueVec<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -643,7 +800,7 @@ pub enum Canonicalization {
 pub struct PrincipalRef {
     pub principal_id: PrincipalId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
+    pub display_name: Option<PrincipalDisplayName>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -714,7 +871,7 @@ pub struct Provenance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub imported_from: Option<String>,
+    pub imported_from: Option<ImportedFrom>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -996,10 +1153,10 @@ pub struct RetryPolicy {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backoff_seconds: Option<BackoffSeconds>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retryable_classes: Option<Vec<RetryableClass>>,
+    pub retryable_classes: Option<UniqueVec<RetryableClass>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BackoffPolicy {
     None,
@@ -1007,7 +1164,7 @@ pub enum BackoffPolicy {
     Exponential,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RetryableClass {
     TransientDispatch,
@@ -1150,7 +1307,7 @@ pub enum TriggerIdentityKind {
 pub struct OccurrenceFence {
     pub generation: PositiveInteger,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub claimed_by: Option<String>,
+    pub claimed_by: Option<ClaimedBy>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease_expires_at: Option<Timestamp>,
 }
@@ -1356,7 +1513,7 @@ pub struct AuthorityBinding {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approval: Option<ApprovalRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub authentication_class: Option<String>,
+    pub authentication_class: Option<AuthenticationClass>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1366,7 +1523,7 @@ pub struct TerminalDisposition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_class: Option<TerminalFailureClass>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
+    pub detail: Option<Detail>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1397,7 +1554,7 @@ pub struct RunDelivery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<WorkingDirectory>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub artifact_refs: Option<Vec<ArtifactRef>>,
+    pub artifact_refs: Option<BoundedVec<ArtifactRef, 64>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1449,7 +1606,7 @@ pub struct AutomationAttempt {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_classification: Option<RetryClassification>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lease_observations: Option<Vec<LeaseObservation>>,
+    pub lease_observations: Option<BoundedVec<LeaseObservation, 1024>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_cursors: Option<OutputCursors>,
     pub state: AttemptState,
@@ -1480,6 +1637,11 @@ impl AutomationAttempt {
                 "attempts after the first require priorDisposition",
             ));
         }
+        if self.attempt_number.get() == 1 && self.prior_disposition.is_some() {
+            return Err(StringConstraintError(
+                "the first attempt must not contain priorDisposition",
+            ));
+        }
         Ok(())
     }
 }
@@ -1502,7 +1664,7 @@ impl<'de> Deserialize<'de> for AutomationAttempt {
             dispatch_fence: DispatchFence,
             worker_correlation: Option<WorkerCorrelation>,
             retry_classification: Option<RetryClassification>,
-            lease_observations: Option<Vec<LeaseObservation>>,
+            lease_observations: Option<BoundedVec<LeaseObservation, 1024>>,
             output_cursors: Option<OutputCursors>,
             state: AttemptState,
             state_reason: Option<StateReason>,
@@ -1562,9 +1724,9 @@ pub struct DispatchFence {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct WorkerCorrelation {
-    pub worker_id: String,
+    pub worker_id: WorkerId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
+    pub session_id: Option<SessionId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adopted_at: Option<Timestamp>,
 }
@@ -1575,6 +1737,7 @@ pub struct RetryClassification {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub classification: Option<RetryClassificationKind>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// This snapshot has no schema uniqueness or cardinality constraint.
     pub eligible_classes: Option<Vec<RetryableClass>>,
 }
 
@@ -1593,7 +1756,7 @@ pub struct LeaseObservation {
     pub observed_at: Timestamp,
     pub heartbeat_ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub note: Option<String>,
+    pub note: Option<CommandNote>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1664,11 +1827,11 @@ pub struct ReceiptAuthority {
 pub struct ReceiptOutcome {
     pub disposition: TerminalOutcome,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub failure_class: Option<String>,
+    pub failure_class: Option<FailureClass>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
+    pub detail: Option<Detail>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub partial_failures: Option<Vec<PartialFailure>>,
+    pub partial_failures: Option<BoundedVec<PartialFailure, 128>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_disposition: Option<ReceiptRecoveryDisposition>,
 }
@@ -1676,8 +1839,8 @@ pub struct ReceiptOutcome {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PartialFailure {
-    pub step: String,
-    pub reason: String,
+    pub step: PartialFailureStep,
+    pub reason: PartialFailureReason,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recovered: Option<bool>,
 }
@@ -1714,7 +1877,7 @@ pub struct ReceiptPrivacy {
     pub classification: PrivacyClassification,
     pub retention: RetentionClass,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub notes: Option<String>,
+    pub notes: Option<PrivacyNotes>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1993,7 +2156,7 @@ pub struct DefinitionTargetPayload {
 pub struct RunNowPayload {
     pub automation_id: AutomationId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub note: Option<String>,
+    pub note: Option<CommandNote>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bypass_eligibility: Option<bool>,
 }
@@ -2029,7 +2192,7 @@ pub struct AttemptRetryPayload {
     pub prior_attempt_number: PositiveInteger,
     pub prior_disposition: RetryPriorDisposition,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub note: Option<String>,
+    pub note: Option<CommandNote>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2046,7 +2209,7 @@ pub struct OccurrenceRecoverPayload {
     pub occurrence_id: OccurrenceId,
     pub evidence_determination: EvidenceDetermination,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement: Option<String>,
+    pub statement: Option<OperatorStatement>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2064,7 +2227,7 @@ pub struct DefinitionListPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<CommandListLimit>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cursor: Option<String>,
+    pub cursor: Option<Cursor>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2096,7 +2259,7 @@ pub struct RunHistoryPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<CommandListLimit>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cursor: Option<String>,
+    pub cursor: Option<Cursor>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2124,7 +2287,7 @@ pub struct EventsSubscribePayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub checkpoint: Option<String>,
+    pub checkpoint: Option<Checkpoint>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2147,7 +2310,7 @@ pub struct CommandOrigin {
     pub principal: PrincipalRef,
     pub channel: CommandChannel,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub authentication_class: Option<String>,
+    pub authentication_class: Option<AuthenticationClass>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2173,7 +2336,7 @@ pub enum CommandChannel {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CommandIntent {
-    pub statement: String,
+    pub statement: OperatorStatement,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2520,7 +2683,7 @@ pub struct DefinitionLifecyclePayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lifecycle_state: Option<EventLifecycleState>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub imported_from: Option<String>,
+    pub imported_from: Option<ImportedFrom>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2538,9 +2701,9 @@ pub enum EventLifecycleState {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TransitionPayload {
     pub entity: TransitionEntity,
-    pub from: String,
-    pub to: String,
-    pub reason: String,
+    pub from: TransitionState,
+    pub to: TransitionState,
+    pub reason: TransitionReason,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fence_generation: Option<PositiveInteger>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2561,7 +2724,7 @@ pub enum TransitionEntity {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct MisfirePayload {
     pub disposition: MisfireDisposition,
-    pub collapsed_slots: Vec<Timestamp>,
+    pub collapsed_slots: BoundedVec<Timestamp, 4096>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -7,9 +7,18 @@ use serde::ser::{SerializeMap, SerializeStruct, Serializer};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
+use super::canonical_json::{canonicalize_without_integrity, sha256_hex};
 use super::error::ErrorEnvelope;
 
 pub type JsonObject = BTreeMap<String, Value>;
+
+pub(super) fn deserialize_non_null_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringConstraintError(&'static str);
@@ -477,6 +486,7 @@ macro_rules! validated_integer {
 }
 
 validated_integer!(PositiveInteger, 1, 9_007_199_254_740_991);
+validated_integer!(SafeInteger, 0, 9_007_199_254_740_991);
 validated_integer!(TimeoutMinutes, 1, 44_640);
 validated_integer!(MaximumAttempts, 1, 10);
 validated_integer!(BackoffSeconds, 1, 86_400);
@@ -805,7 +815,11 @@ pub enum Canonicalization {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PrincipalRef {
     pub principal_id: PrincipalId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub display_name: Option<PrincipalDisplayName>,
 }
 
@@ -820,7 +834,11 @@ pub struct FamiliarRef {
 pub struct RuntimeDescriptor {
     pub runtime_id: RuntimeId,
     pub capabilities: RuntimeCapabilities,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub model: Option<RuntimeModel>,
 }
 
@@ -828,7 +846,11 @@ pub struct RuntimeDescriptor {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ApprovalRef {
     pub approval_policy_ref: ApprovalPolicyRef,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub approval_record_ref: Option<ApprovalRecordRef>,
 }
 
@@ -845,7 +867,11 @@ pub enum PrivacyClassification {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RetentionClass {
     pub classification: RetentionClassification,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub delete_after: Option<Timestamp>,
 }
 
@@ -862,7 +888,11 @@ pub enum RetentionClassification {
 pub struct ProducerIdentity {
     pub component: ComponentName,
     pub instance_id: InstanceId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub implementation_version: Option<ImplementationVersion>,
 }
 
@@ -870,22 +900,46 @@ pub struct ProducerIdentity {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Provenance {
     pub created_by: PrincipalRef,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub created_at: Option<Timestamp>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub updated_by: Option<PrincipalRef>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub updated_at: Option<Timestamp>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub imported_from: Option<ImportedFrom>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ActivationWindow {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub effective_from: Option<Timestamp>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub effective_until: Option<Timestamp>,
 }
 
@@ -927,6 +981,15 @@ pub struct AutomationDefinition {
 }
 
 impl AutomationDefinition {
+    pub fn verify_integrity(&self) -> anyhow::Result<()> {
+        let value = serde_json::to_value(self)?;
+        let actual = sha256_hex(&canonicalize_without_integrity(&value)?);
+        anyhow::ensure!(
+            actual == self.integrity.value.as_str(),
+            "definition integrity digest does not match its body"
+        );
+        Ok(())
+    }
     #[must_use]
     pub const fn lifecycle_state(&self) -> DefinitionLifecycleState {
         self.lifecycle_state
@@ -991,16 +1054,22 @@ impl<'de> Deserialize<'de> for AutomationDefinition {
             revision: PositiveInteger,
             integrity: DigestValue,
             lifecycle_state: DefinitionLifecycleState,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             deletion: Option<DefinitionDeletion>,
             display: DefinitionDisplay,
             trigger: ScheduleTrigger,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             conditions: Option<EmptyConditions>,
             action: FamiliarInvocationAction,
             binding: DefinitionBinding,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             runtime_requirements: Option<RuntimeDescriptor>,
             policies: DefinitionPolicies,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             provenance: Option<Provenance>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             activation: Option<ActivationWindow>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             extensions: Option<ExtensionBag>,
         }
 
@@ -1024,6 +1093,9 @@ impl<'de> Deserialize<'de> for AutomationDefinition {
             extensions: raw.extensions,
         };
         definition.validate().map_err(serde::de::Error::custom)?;
+        definition
+            .verify_integrity()
+            .map_err(serde::de::Error::custom)?;
         Ok(definition)
     }
 }
@@ -1033,9 +1105,17 @@ impl<'de> Deserialize<'de> for AutomationDefinition {
 pub struct DefinitionDeletion {
     pub tombstoned: True,
     pub requested_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub requested_by: Option<PrincipalRef>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub reason: Option<CommandReason>,
 }
 
@@ -1068,9 +1148,17 @@ impl<'de> Deserialize<'de> for True {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionDisplay {
     pub name: DisplayName,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub description: Option<DisplayDescription>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub tags: Option<DisplayTags>,
 }
 
@@ -1108,7 +1196,11 @@ pub struct FamiliarInvocationAction {
     pub variant: FamiliarInvocationVariant,
     pub version: VersionOne,
     pub prompt: InvocationPrompt,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cwd: Option<WorkingDirectory>,
 }
 
@@ -1122,7 +1214,11 @@ pub enum FamiliarInvocationVariant {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionBinding {
     pub familiar_binding_policy: FamiliarBindingPolicy,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub familiar_id: Option<FamiliarId>,
     pub authority: ApprovalRef,
 }
@@ -1140,7 +1236,11 @@ pub struct DefinitionPolicies {
     pub retry: RetryPolicy,
     pub concurrency: ConcurrencyPolicy,
     pub misfire: MisfirePolicy,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub delivery: Option<DeliveryPolicy>,
     pub retention: RetentionPolicy,
 }
@@ -1156,9 +1256,17 @@ pub struct TimeoutPolicy {
 pub struct RetryPolicy {
     pub max_attempts: MaximumAttempts,
     pub backoff_policy: BackoffPolicy,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub backoff_seconds: Option<BackoffSeconds>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub retryable_classes: Option<UniqueVec<RetryableClass>>,
 }
 
@@ -1205,9 +1313,17 @@ pub enum MisfirePolicyDisposition {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeliveryPolicy {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub output_target: Option<WorkingDirectory>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub mode: Option<DeliveryMode>,
 }
 
@@ -1221,9 +1337,17 @@ pub enum DeliveryMode {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RetentionPolicy {
     pub occurrence_history: RetentionClass,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub run_logs: Option<RetentionClass>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub receipts: Option<RetentionClass>,
 }
 
@@ -1265,28 +1389,64 @@ pub struct AutomationOccurrence {
     pub trigger_identity: TriggerIdentity,
     pub occurrence_key: OccurrenceKey,
     pub scheduled_for: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub observed_at: Option<Timestamp>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub eligible_at: Option<Timestamp>,
     pub state: OccurrenceState,
     pub state_reason: StateReason,
     pub fence: OccurrenceFence,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub misfire_disposition: Option<MisfireDisposition>,
     pub created_at: Timestamp,
     pub updated_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub claim_metadata: Option<ClaimMetadata>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub active_run_ref: Option<RunId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cancellation: Option<Cancellation>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub recovery: Option<Recovery>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub event_window: Option<EventWindow>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub extensions: Option<ExtensionBag>,
 }
 
@@ -1294,9 +1454,17 @@ pub struct AutomationOccurrence {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TriggerIdentity {
     pub kind: TriggerIdentityKind,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub rrule_ref: Option<RruleReference>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub requested_by: Option<PrincipalRef>,
 }
 
@@ -1312,9 +1480,17 @@ pub enum TriggerIdentityKind {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OccurrenceFence {
     pub generation: PositiveInteger,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub claimed_by: Option<ClaimedBy>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub lease_expires_at: Option<Timestamp>,
 }
 
@@ -1329,11 +1505,23 @@ pub struct ClaimMetadata {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Cancellation {
     pub requested_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub requested_by: Option<PrincipalRef>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub acknowledged_at: Option<Timestamp>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub reconciled_at: Option<Timestamp>,
 }
 
@@ -1341,9 +1529,17 @@ pub struct Cancellation {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Recovery {
     pub entered_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub evidence: Option<RecoveryEvidence>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub resolved_disposition: Option<RecoveryDisposition>,
 }
 
@@ -1365,8 +1561,8 @@ pub enum RecoveryDisposition {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventWindow {
-    pub first_sequence: u64,
-    pub last_sequence: u64,
+    pub first_sequence: SafeInteger,
+    pub last_sequence: SafeInteger,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1443,6 +1639,21 @@ impl AutomationRun {
                 "terminal runs require finishedAt and terminalDisposition",
             ));
         }
+        if let Some(disposition) = &self.terminal_disposition {
+            let matches_state = matches!(
+                (self.state, disposition.outcome),
+                (RunState::Succeeded, TerminalOutcome::Succeeded)
+                    | (RunState::Failed, TerminalOutcome::Failed)
+                    | (RunState::Cancelled, TerminalOutcome::Cancelled)
+                    | (RunState::TimedOut, TerminalOutcome::TimedOut)
+                    | (RunState::Ambiguous, TerminalOutcome::Ambiguous)
+            );
+            if terminal && !matches_state {
+                return Err(StringConstraintError(
+                    "terminalDisposition outcome must match the run state",
+                ));
+            }
+        }
         if !terminal && (self.finished_at.is_some() || self.terminal_disposition.is_some()) {
             return Err(StringConstraintError(
                 "nonterminal runs must not contain finishedAt or terminalDisposition",
@@ -1467,15 +1678,23 @@ impl<'de> Deserialize<'de> for AutomationRun {
             automation_revision: PositiveInteger,
             binding: RunBinding,
             state: RunState,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             state_reason: Option<StateReason>,
             attempt_count: RunAttemptCount,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             current_attempt_id: Option<AttemptId>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             terminal_disposition: Option<TerminalDisposition>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             delivery: Option<RunDelivery>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             result_digest: Option<DigestValue>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             receipt_ref: Option<ReceiptId>,
             started_at: Timestamp,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             finished_at: Option<Timestamp>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             extensions: Option<ExtensionBag>,
         }
 
@@ -1516,9 +1735,17 @@ pub struct RunBinding {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AuthorityBinding {
     pub principal: PrincipalRef,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub approval: Option<ApprovalRef>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub authentication_class: Option<AuthenticationClass>,
 }
 
@@ -1526,9 +1753,17 @@ pub struct AuthorityBinding {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TerminalDisposition {
     pub outcome: TerminalOutcome,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub failure_class: Option<TerminalFailureClass>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub detail: Option<Detail>,
 }
 
@@ -1557,9 +1792,17 @@ pub enum TerminalFailureClass {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RunDelivery {
     pub status: RunDeliveryStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub target: Option<WorkingDirectory>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub artifact_refs: Option<BoundedVec<ArtifactRef, 64>>,
 }
 
@@ -1577,7 +1820,11 @@ pub enum RunDeliveryStatus {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArtifactRef {
     pub r#ref: ArtifactReference,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub digest: Option<DigestValue>,
 }
 
@@ -1666,16 +1913,25 @@ impl<'de> Deserialize<'de> for AutomationAttempt {
             occurrence_id: OccurrenceId,
             attempt_number: PositiveInteger,
             adoption_key: AdoptionKey,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             prior_disposition: Option<PriorDisposition>,
             dispatch_fence: DispatchFence,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             worker_correlation: Option<WorkerCorrelation>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             retry_classification: Option<RetryClassification>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             lease_observations: Option<BoundedVec<LeaseObservation, 1024>>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             output_cursors: Option<OutputCursors>,
             state: AttemptState,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             state_reason: Option<StateReason>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             opened_at: Option<Timestamp>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             settled_at: Option<Timestamp>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             extensions: Option<ExtensionBag>,
         }
 
@@ -1731,18 +1987,34 @@ pub struct DispatchFence {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct WorkerCorrelation {
     pub worker_id: WorkerId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub session_id: Option<SessionId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub adopted_at: Option<Timestamp>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RetryClassification {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub classification: Option<RetryClassificationKind>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     /// This snapshot has no schema uniqueness or cardinality constraint.
     pub eligible_classes: Option<Vec<RetryableClass>>,
 }
@@ -1761,17 +2033,29 @@ pub enum RetryClassificationKind {
 pub struct LeaseObservation {
     pub observed_at: Timestamp,
     pub heartbeat_ok: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub note: Option<LeaseNote>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OutputCursors {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub event_cursor: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub log_cursor: Option<u64>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub event_cursor: Option<SafeInteger>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub log_cursor: Option<SafeInteger>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1785,7 +2069,7 @@ pub enum SideEffectClass {
     IrreversibleExternalMutation,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AutomationReceipt {
     pub schema_version: SchemaVersion,
@@ -1820,11 +2104,99 @@ pub struct AutomationReceipt {
     pub privacy: ReceiptPrivacy,
 }
 
+impl AutomationReceipt {
+    pub fn verify_integrity(&self) -> anyhow::Result<()> {
+        let value = serde_json::to_value(self)?;
+        let actual = sha256_hex(&canonicalize_without_integrity(&value)?);
+        anyhow::ensure!(
+            actual == self.integrity.value.as_str(),
+            "receipt integrity digest does not match its body"
+        );
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for AutomationReceipt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            schema_version: SchemaVersion,
+            receipt_id: ReceiptId,
+            automation_id: AutomationId,
+            automation_revision: PositiveInteger,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            definition_digest: Option<DigestValue>,
+            occurrence_id: OccurrenceId,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            occurrence_fence_generation: Option<PositiveInteger>,
+            run_id: RunId,
+            attempt_id: AttemptId,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            attempt_number: Option<PositiveInteger>,
+            identity: FamiliarRef,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            authority: Option<ReceiptAuthority>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            runtime: Option<RuntimeDescriptor>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            delivery_digest: Option<DigestValue>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            result_digest: Option<DigestValue>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            exercised_capabilities: Option<ExercisedCapabilities>,
+            side_effect_class: SideEffectClass,
+            outcome: ReceiptOutcome,
+            produced_at: Timestamp,
+            producer: ProducerIdentity,
+            integrity: ReceiptIntegrity,
+            privacy: ReceiptPrivacy,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let receipt = Self {
+            schema_version: raw.schema_version,
+            receipt_id: raw.receipt_id,
+            automation_id: raw.automation_id,
+            automation_revision: raw.automation_revision,
+            definition_digest: raw.definition_digest,
+            occurrence_id: raw.occurrence_id,
+            occurrence_fence_generation: raw.occurrence_fence_generation,
+            run_id: raw.run_id,
+            attempt_id: raw.attempt_id,
+            attempt_number: raw.attempt_number,
+            identity: raw.identity,
+            authority: raw.authority,
+            runtime: raw.runtime,
+            delivery_digest: raw.delivery_digest,
+            result_digest: raw.result_digest,
+            exercised_capabilities: raw.exercised_capabilities,
+            side_effect_class: raw.side_effect_class,
+            outcome: raw.outcome,
+            produced_at: raw.produced_at,
+            producer: raw.producer,
+            integrity: raw.integrity,
+            privacy: raw.privacy,
+        };
+        receipt
+            .verify_integrity()
+            .map_err(serde::de::Error::custom)?;
+        Ok(receipt)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ReceiptAuthority {
     pub principal: PrincipalRef,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub approval: Option<ApprovalRef>,
 }
 
@@ -1832,13 +2204,29 @@ pub struct ReceiptAuthority {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ReceiptOutcome {
     pub disposition: TerminalOutcome,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub failure_class: Option<FailureClass>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub detail: Option<Detail>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub partial_failures: Option<BoundedVec<PartialFailure, 128>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub recovery_disposition: Option<ReceiptRecoveryDisposition>,
 }
 
@@ -1847,7 +2235,11 @@ pub struct ReceiptOutcome {
 pub struct PartialFailure {
     pub step: PartialFailureStep,
     pub reason: PartialFailureReason,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub recovered: Option<bool>,
 }
 
@@ -1865,7 +2257,11 @@ pub struct ReceiptIntegrity {
     pub algorithm: DigestAlgorithm,
     pub canonicalization: Canonicalization,
     pub value: Sha256Digest,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub authentication: Option<ReceiptAuthentication>,
 }
 
@@ -1882,7 +2278,11 @@ pub enum ReceiptAuthentication {
 pub struct ReceiptPrivacy {
     pub classification: PrivacyClassification,
     pub retention: RetentionClass,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub notes: Option<PrivacyNotes>,
 }
 
@@ -2014,6 +2414,7 @@ impl<'de> Deserialize<'de> for CommandRequest {
             schema_version: SchemaVersion,
             command: CommandName,
             adoption_key: AdoptionKey,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             expected_revision: Option<PositiveInteger>,
             origin: CommandOrigin,
             intent: CommandIntent,
@@ -2153,7 +2554,11 @@ pub struct DefinitionMutationPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionTargetPayload {
     pub automation_id: AutomationId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub reason: Option<CommandReason>,
 }
 
@@ -2161,9 +2566,17 @@ pub struct DefinitionTargetPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RunNowPayload {
     pub automation_id: AutomationId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub note: Option<CommandNote>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub bypass_eligibility: Option<bool>,
 }
 
@@ -2171,7 +2584,11 @@ pub struct RunNowPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OccurrenceCancelPayload {
     pub occurrence_id: OccurrenceId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub reason: Option<CommandReason>,
 }
 
@@ -2179,7 +2596,11 @@ pub struct OccurrenceCancelPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RunCancelPayload {
     pub run_id: RunId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub reason: Option<CommandReason>,
 }
 
@@ -2187,7 +2608,11 @@ pub struct RunCancelPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AttemptCancelPayload {
     pub attempt_id: AttemptId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub reason: Option<CommandReason>,
 }
 
@@ -2197,7 +2622,11 @@ pub struct AttemptRetryPayload {
     pub run_id: RunId,
     pub prior_attempt_number: PositiveInteger,
     pub prior_disposition: RetryPriorDisposition,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub note: Option<CommandNote>,
 }
 
@@ -2214,7 +2643,11 @@ pub enum RetryPriorDisposition {
 pub struct OccurrenceRecoverPayload {
     pub occurrence_id: OccurrenceId,
     pub evidence_determination: EvidenceDetermination,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub statement: Option<OperatorStatement>,
 }
 
@@ -2228,11 +2661,23 @@ pub enum EvidenceDetermination {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionListPayload {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub lifecycle_state: Option<ListLifecycleState>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub limit: Option<CommandListLimit>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cursor: Option<Cursor>,
 }
 
@@ -2252,7 +2697,11 @@ pub enum ListLifecycleState {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionGetPayload {
     pub automation_id: AutomationId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub revision: Option<PositiveInteger>,
 }
 
@@ -2260,11 +2709,23 @@ pub struct DefinitionGetPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RunHistoryPayload {
     pub automation_id: AutomationId,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub occurrence_id: Option<OccurrenceId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub limit: Option<CommandListLimit>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cursor: Option<Cursor>,
 }
 
@@ -2278,11 +2739,23 @@ pub struct DefinitionHealthPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventsReadPayload {
     pub stream: CommandStreamRef,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub after: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub after: Option<SafeInteger>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub limit: Option<EventReadLimit>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub from: Option<Timestamp>,
 }
 
@@ -2290,9 +2763,17 @@ pub struct EventsReadPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventsSubscribePayload {
     pub stream: CommandStreamRef,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub after: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub after: Option<SafeInteger>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub checkpoint: Option<Checkpoint>,
 }
 
@@ -2300,7 +2781,11 @@ pub struct EventsSubscribePayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct LegacyImportPayload {
     pub source: LegacyImportSource,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub dry_run: Option<bool>,
 }
 
@@ -2315,11 +2800,23 @@ pub enum LegacyImportSource {
 pub struct CommandOrigin {
     pub principal: PrincipalRef,
     pub channel: CommandChannel,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub authentication_class: Option<AuthenticationClass>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub requested_at: Option<Timestamp>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub correlation_id: Option<CorrelationId>,
 }
 
@@ -2469,11 +2966,17 @@ impl<'de> Deserialize<'de> for CommandResponse {
             command: CommandName,
             adoption_key: AdoptionKey,
             outcome: CommandOutcome,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             replay: Option<ReplayMetadata>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             revision: Option<PositiveInteger>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             result: Option<JsonObject>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             error: Option<ErrorEnvelope>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             receipt_ref: Option<ReceiptId>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
             event_ref: Option<EventRef>,
         }
 
@@ -2573,7 +3076,7 @@ pub struct ReplayMetadata {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventRef {
     pub stream: EventRefStream,
-    pub sequence: u64,
+    pub sequence: SafeInteger,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2608,13 +3111,13 @@ pub enum EventKind {
     FeedSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventEnvelope {
     pub schema_version: SchemaVersion,
     pub event_id: EventId,
     pub stream: StreamRef,
-    pub sequence: u64,
+    pub sequence: SafeInteger,
     pub recorded_at: Timestamp,
     pub observed_at: Timestamp,
     pub producer: ProducerIdentity,
@@ -2634,6 +3137,79 @@ pub struct EventEnvelope {
     pub privacy: EventPrivacy,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub integrity: Option<DigestValue>,
+}
+
+impl EventEnvelope {
+    pub fn verify_integrity(&self) -> anyhow::Result<()> {
+        let Some(integrity) = &self.integrity else {
+            return Ok(());
+        };
+        let value = serde_json::to_value(self)?;
+        let actual = sha256_hex(&canonicalize_without_integrity(&value)?);
+        anyhow::ensure!(
+            actual == integrity.value.as_str(),
+            "event integrity digest does not match its body"
+        );
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for EventEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            schema_version: SchemaVersion,
+            event_id: EventId,
+            stream: StreamRef,
+            sequence: SafeInteger,
+            recorded_at: Timestamp,
+            observed_at: Timestamp,
+            producer: ProducerIdentity,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            causation: Option<EventCausation>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            automation_id: Option<AutomationId>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            occurrence_id: Option<OccurrenceId>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            run_id: Option<RunId>,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            attempt_id: Option<AttemptId>,
+            kind: EventKind,
+            summary: EventSummary,
+            payload: EventPayload,
+            privacy: EventPrivacy,
+            #[serde(default, deserialize_with = "deserialize_non_null_option")]
+            integrity: Option<DigestValue>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let event = Self {
+            schema_version: raw.schema_version,
+            event_id: raw.event_id,
+            stream: raw.stream,
+            sequence: raw.sequence,
+            recorded_at: raw.recorded_at,
+            observed_at: raw.observed_at,
+            producer: raw.producer,
+            causation: raw.causation,
+            automation_id: raw.automation_id,
+            occurrence_id: raw.occurrence_id,
+            run_id: raw.run_id,
+            attempt_id: raw.attempt_id,
+            kind: raw.kind,
+            summary: raw.summary,
+            payload: raw.payload,
+            privacy: raw.privacy,
+            integrity: raw.integrity,
+        };
+        event.verify_integrity().map_err(serde::de::Error::custom)?;
+        Ok(event)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2662,11 +3238,23 @@ pub enum StreamKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventCausation {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub adoption_key: Option<AdoptionKey>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cause_event_id: Option<CauseEventId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub correlation_id: Option<CorrelationId>,
 }
 
@@ -2684,11 +3272,23 @@ pub enum EventPayload {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionLifecyclePayload {
     pub revision: PositiveInteger,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub definition_digest: Option<DigestValue>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub lifecycle_state: Option<EventLifecycleState>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub imported_from: Option<ImportedFrom>,
 }
 
@@ -2710,11 +3310,23 @@ pub struct TransitionPayload {
     pub from: TransitionState,
     pub to: TransitionState,
     pub reason: TransitionReason,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub fence_generation: Option<PositiveInteger>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub attempt_number: Option<PositiveInteger>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub command_adoption_key: Option<AdoptionKey>,
 }
 
@@ -2738,17 +3350,25 @@ pub struct MisfirePayload {
 pub struct ReceiptPayload {
     pub receipt_ref: ReceiptId,
     pub outcome: TerminalOutcome,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub side_effect_class: Option<SideEffectClass>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SnapshotPayload {
-    pub through_sequence: u64,
+    pub through_sequence: SafeInteger,
     /// Compacted state is explicitly an open, schema-defined JSON object.
     pub state: JsonObject,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub reason: Option<SnapshotReason>,
 }
 

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -336,6 +336,10 @@ fn matches_note(value: &str) -> bool {
     has_character_length(value, 0, 500)
 }
 
+fn matches_lease_note(value: &str) -> bool {
+    has_character_length(value, 0, 200)
+}
+
 fn matches_failure_class(value: &str) -> bool {
     has_character_length(value, 0, 96)
 }
@@ -420,6 +424,7 @@ validated_string!(Detail, matches_detail);
 validated_string!(WorkerId, matches_worker_id);
 validated_string!(SessionId, matches_session_id);
 validated_string!(CommandNote, matches_note);
+validated_string!(LeaseNote, matches_lease_note);
 validated_string!(FailureClass, matches_failure_class);
 validated_string!(PartialFailureStep, matches_partial_failure_step);
 validated_string!(PartialFailureReason, matches_partial_failure_reason);
@@ -512,34 +517,35 @@ impl<'de> Deserialize<'de> for ExtensionBag {
 }
 
 fn matches_extension_key(key: &str) -> bool {
-    if let Some(suffix) = key.strip_prefix("x-") {
-        return !suffix.is_empty()
+    let vendor_local = key.strip_prefix("x-").is_some_and(|suffix| {
+        !suffix.is_empty()
             && suffix
                 .bytes()
-                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-');
-    }
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    });
     let mut parts = key.rsplitn(3, '.');
     let Some(last) = parts.next() else {
-        return false;
+        return vendor_local;
     };
     let Some(middle) = parts.next() else {
-        return false;
+        return vendor_local;
     };
     let Some(first) = parts.next() else {
-        return false;
+        return vendor_local;
     };
-    !first.is_empty()
-        && !middle.is_empty()
-        && !last.is_empty()
-        && first.bytes().all(|byte| {
-            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'-')
-        })
-        && middle
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
-        && last
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    vendor_local
+        || (!first.is_empty()
+            && !middle.is_empty()
+            && !last.is_empty()
+            && first.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'-')
+            })
+            && middle
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+            && last
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1756,7 +1762,7 @@ pub struct LeaseObservation {
     pub observed_at: Timestamp,
     pub heartbeat_ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub note: Option<CommandNote>,
+    pub note: Option<LeaseNote>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -3140,6 +3140,41 @@ pub struct EventEnvelope {
 }
 
 impl EventEnvelope {
+    fn validate(&self) -> Result<(), StringConstraintError> {
+        let payload_matches_kind = match (&self.kind, &self.payload) {
+            (
+                EventKind::DefinitionCreated
+                | EventKind::DefinitionRevised
+                | EventKind::DefinitionActivated
+                | EventKind::DefinitionPaused
+                | EventKind::DefinitionDisabled
+                | EventKind::DefinitionInvalidated
+                | EventKind::DefinitionTombstoned
+                | EventKind::DefinitionImported,
+                EventPayload::DefinitionLifecycle(_),
+            )
+            | (EventKind::OccurrenceMisfireRecorded, EventPayload::Misfire(_))
+            | (EventKind::ReceiptRecorded, EventPayload::Receipt(_))
+            | (EventKind::FeedSnapshot, EventPayload::Snapshot(_)) => true,
+            (EventKind::OccurrenceTransitioned, EventPayload::Transition(payload)) => {
+                payload.entity == TransitionEntity::Occurrence
+            }
+            (EventKind::RunTransitioned, EventPayload::Transition(payload)) => {
+                payload.entity == TransitionEntity::Run
+            }
+            (EventKind::AttemptTransitioned, EventPayload::Transition(payload)) => {
+                payload.entity == TransitionEntity::Attempt
+            }
+            _ => false,
+        };
+        if !payload_matches_kind {
+            return Err(StringConstraintError(
+                "event kind must match its payload variant and transition entity",
+            ));
+        }
+        Ok(())
+    }
+
     pub fn verify_integrity(&self) -> anyhow::Result<()> {
         let Some(integrity) = &self.integrity else {
             return Ok(());
@@ -3207,6 +3242,7 @@ impl<'de> Deserialize<'de> for EventEnvelope {
             privacy: raw.privacy,
             integrity: raw.integrity,
         };
+        event.validate().map_err(serde::de::Error::custom)?;
         event.verify_integrity().map_err(serde::de::Error::custom)?;
         Ok(event)
     }

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use serde::ser::{SerializeStruct, Serializer};
+use serde::ser::{SerializeMap, SerializeStruct, Serializer};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
@@ -214,6 +214,54 @@ fn matches_sha256_digest(value: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
+fn matches_event_id(value: &str) -> bool {
+    (20..=64).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
+}
+
+fn matches_event_stream_id(value: &str) -> bool {
+    value.chars().count() <= 320
+}
+
+fn matches_command_stream_id(value: &str) -> bool {
+    (1..=320).contains(&value.chars().count())
+}
+
+fn matches_event_summary(value: &str) -> bool {
+    (1..=300).contains(&value.chars().count())
+}
+
+fn matches_display_name(value: &str) -> bool {
+    (1..=160).contains(&value.chars().count())
+}
+
+fn matches_display_description(value: &str) -> bool {
+    value.chars().count() <= 2_000
+}
+
+fn matches_display_tag(value: &str) -> bool {
+    (1..=64).contains(&value.chars().count())
+}
+
+fn matches_cause_event_id(value: &str) -> bool {
+    value.chars().count() <= 64
+}
+
+fn matches_component_name(value: &str) -> bool {
+    (1..=96).contains(&value.chars().count())
+}
+
+fn matches_instance_id(value: &str) -> bool {
+    (1..=128).contains(&value.chars().count())
+}
+
+fn matches_implementation_version(value: &str) -> bool {
+    value.chars().count() <= 64
+}
+
+fn matches_event_ref_stream(value: &str) -> bool {
+    (1..=400).contains(&value.chars().count())
+}
+
 validated_string!(Timestamp, matches_timestamp);
 validated_string!(AutomationId, matches_automation_id);
 validated_string!(OccurrenceId, matches_entity_id);
@@ -230,6 +278,18 @@ validated_string!(Capability, matches_capability);
 validated_string!(Sha256Digest, matches_sha256_digest);
 validated_string!(ApprovalRecordRef, matches_approval_record_ref);
 validated_string!(RuntimeModel, matches_runtime_model);
+validated_string!(EventId, matches_event_id);
+validated_string!(EventStreamId, matches_event_stream_id);
+validated_string!(CommandStreamId, matches_command_stream_id);
+validated_string!(EventSummary, matches_event_summary);
+validated_string!(DisplayName, matches_display_name);
+validated_string!(DisplayDescription, matches_display_description);
+validated_string!(DisplayTag, matches_display_tag);
+validated_string!(CauseEventId, matches_cause_event_id);
+validated_string!(ComponentName, matches_component_name);
+validated_string!(InstanceId, matches_instance_id);
+validated_string!(ImplementationVersion, matches_implementation_version);
+validated_string!(EventRefStream, matches_event_ref_stream);
 
 macro_rules! validated_integer {
     ($name:ident, $minimum:expr, $maximum:expr) => {
@@ -271,7 +331,7 @@ macro_rules! validated_integer {
     };
 }
 
-validated_integer!(PositiveInteger, 1, u64::MAX);
+validated_integer!(PositiveInteger, 1, 9_007_199_254_740_991);
 validated_integer!(TimeoutMinutes, 1, 44_640);
 validated_integer!(MaximumAttempts, 1, 10);
 validated_integer!(BackoffSeconds, 1, 86_400);
@@ -392,6 +452,43 @@ impl ExercisedCapabilities {
                 "ExercisedCapabilities must be unique",
             ))
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisplayTags(Vec<DisplayTag>);
+
+impl DisplayTags {
+    fn new(values: Vec<DisplayTag>) -> Result<Self, StringConstraintError> {
+        if values.len() > 64 {
+            return Err(StringConstraintError(
+                "DisplayTags must contain at most 64 entries",
+            ));
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        if values.iter().all(|value| seen.insert(value.as_str())) {
+            Ok(Self(values))
+        } else {
+            Err(StringConstraintError("DisplayTags must be unique"))
+        }
+    }
+}
+
+impl Serialize for DisplayTags {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DisplayTags {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(Vec::deserialize(deserializer)?).map_err(serde::de::Error::custom)
     }
 }
 
@@ -554,10 +651,10 @@ pub enum RetentionClassification {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProducerIdentity {
-    pub component: String,
-    pub instance_id: String,
+    pub component: ComponentName,
+    pub instance_id: InstanceId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub implementation_version: Option<String>,
+    pub implementation_version: Option<ImplementationVersion>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -761,11 +858,11 @@ impl<'de> Deserialize<'de> for True {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DefinitionDisplay {
-    pub name: String,
+    pub name: DisplayName,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub description: Option<DisplayDescription>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<Vec<String>>,
+    pub tags: Option<DisplayTags>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1077,7 +1174,7 @@ pub enum RunState {
 
 pub type RunOutcome = RunState;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AutomationRun {
     pub schema_version: SchemaVersion,
@@ -1086,14 +1183,14 @@ pub struct AutomationRun {
     pub automation_id: AutomationId,
     pub automation_revision: PositiveInteger,
     pub binding: RunBinding,
-    pub state: RunState,
+    state: RunState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_reason: Option<String>,
     pub attempt_count: RunAttemptCount,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_attempt_id: Option<AttemptId>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminal_disposition: Option<TerminalDisposition>,
+    terminal_disposition: Option<TerminalDisposition>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delivery: Option<RunDelivery>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1102,9 +1199,95 @@ pub struct AutomationRun {
     pub receipt_ref: Option<ReceiptId>,
     pub started_at: Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub finished_at: Option<Timestamp>,
+    finished_at: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<ExtensionBag>,
+}
+
+impl AutomationRun {
+    #[must_use]
+    pub const fn state(&self) -> RunState {
+        self.state
+    }
+
+    #[must_use]
+    pub fn terminal_disposition(&self) -> Option<&TerminalDisposition> {
+        self.terminal_disposition.as_ref()
+    }
+
+    #[must_use]
+    pub fn finished_at(&self) -> Option<&Timestamp> {
+        self.finished_at.as_ref()
+    }
+
+    fn validate(&self) -> Result<(), StringConstraintError> {
+        if matches!(
+            self.state,
+            RunState::Succeeded
+                | RunState::Failed
+                | RunState::Cancelled
+                | RunState::TimedOut
+                | RunState::Ambiguous
+        ) && (self.finished_at.is_none() || self.terminal_disposition.is_none())
+        {
+            return Err(StringConstraintError(
+                "terminal runs require finishedAt and terminalDisposition",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for AutomationRun {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            schema_version: SchemaVersion,
+            run_id: RunId,
+            occurrence_id: OccurrenceId,
+            automation_id: AutomationId,
+            automation_revision: PositiveInteger,
+            binding: RunBinding,
+            state: RunState,
+            state_reason: Option<String>,
+            attempt_count: RunAttemptCount,
+            current_attempt_id: Option<AttemptId>,
+            terminal_disposition: Option<TerminalDisposition>,
+            delivery: Option<RunDelivery>,
+            result_digest: Option<DigestValue>,
+            receipt_ref: Option<ReceiptId>,
+            started_at: Timestamp,
+            finished_at: Option<Timestamp>,
+            extensions: Option<ExtensionBag>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let run = Self {
+            schema_version: raw.schema_version,
+            run_id: raw.run_id,
+            occurrence_id: raw.occurrence_id,
+            automation_id: raw.automation_id,
+            automation_revision: raw.automation_revision,
+            binding: raw.binding,
+            state: raw.state,
+            state_reason: raw.state_reason,
+            attempt_count: raw.attempt_count,
+            current_attempt_id: raw.current_attempt_id,
+            terminal_disposition: raw.terminal_disposition,
+            delivery: raw.delivery,
+            result_digest: raw.result_digest,
+            receipt_ref: raw.receipt_ref,
+            started_at: raw.started_at,
+            finished_at: raw.finished_at,
+            extensions: raw.extensions,
+        };
+        run.validate().map_err(serde::de::Error::custom)?;
+        Ok(run)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1801,7 +1984,7 @@ pub struct DefinitionHealthPayload {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventsReadPayload {
-    pub stream: StreamRef,
+    pub stream: CommandStreamRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1813,7 +1996,7 @@ pub struct EventsReadPayload {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventsSubscribePayload {
-    pub stream: StreamRef,
+    pub stream: CommandStreamRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1877,26 +2060,214 @@ pub enum CommandOutcome {
     Rejected,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CommandResponse {
-    pub schema_version: SchemaVersion,
-    pub command: CommandName,
-    pub adoption_key: AdoptionKey,
-    pub outcome: CommandOutcome,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub replay: Option<ReplayMetadata>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub revision: Option<PositiveInteger>,
-    /// Committed result bodies are explicitly open in the schema.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<JsonObject>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<ErrorEnvelope>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub receipt_ref: Option<ReceiptId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub event_ref: Option<EventRef>,
+    schema_version: SchemaVersion,
+    command: CommandName,
+    adoption_key: AdoptionKey,
+    body: CommandResponseBody,
+}
+
+impl CommandResponse {
+    #[must_use]
+    pub fn new(
+        schema_version: SchemaVersion,
+        command: CommandName,
+        adoption_key: AdoptionKey,
+        body: CommandResponseBody,
+    ) -> Self {
+        Self {
+            schema_version,
+            command,
+            adoption_key,
+            body,
+        }
+    }
+
+    #[must_use]
+    pub const fn outcome(&self) -> CommandOutcome {
+        self.body.outcome()
+    }
+
+    #[must_use]
+    pub fn body(&self) -> &CommandResponseBody {
+        &self.body
+    }
+}
+
+impl Serialize for CommandResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("schemaVersion", &self.schema_version)?;
+        map.serialize_entry("command", &self.command)?;
+        map.serialize_entry("adoptionKey", &self.adoption_key)?;
+        map.serialize_entry("outcome", &self.outcome())?;
+        match &self.body {
+            CommandResponseBody::Committed {
+                revision,
+                result,
+                receipt_ref,
+                event_ref,
+            } => {
+                if let Some(revision) = revision {
+                    map.serialize_entry("revision", revision)?;
+                }
+                map.serialize_entry("result", result)?;
+                if let Some(receipt_ref) = receipt_ref {
+                    map.serialize_entry("receiptRef", receipt_ref)?;
+                }
+                if let Some(event_ref) = event_ref {
+                    map.serialize_entry("eventRef", event_ref)?;
+                }
+            }
+            CommandResponseBody::Replayed {
+                replay,
+                revision,
+                result,
+                receipt_ref,
+                event_ref,
+            } => {
+                map.serialize_entry("replay", replay)?;
+                if let Some(revision) = revision {
+                    map.serialize_entry("revision", revision)?;
+                }
+                map.serialize_entry("result", result)?;
+                if let Some(receipt_ref) = receipt_ref {
+                    map.serialize_entry("receiptRef", receipt_ref)?;
+                }
+                if let Some(event_ref) = event_ref {
+                    map.serialize_entry("eventRef", event_ref)?;
+                }
+            }
+            CommandResponseBody::Rejected {
+                revision,
+                error,
+                receipt_ref,
+                event_ref,
+            } => {
+                if let Some(revision) = revision {
+                    map.serialize_entry("revision", revision)?;
+                }
+                map.serialize_entry("error", error)?;
+                if let Some(receipt_ref) = receipt_ref {
+                    map.serialize_entry("receiptRef", receipt_ref)?;
+                }
+                if let Some(event_ref) = event_ref {
+                    map.serialize_entry("eventRef", event_ref)?;
+                }
+            }
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CommandResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Raw {
+            schema_version: SchemaVersion,
+            command: CommandName,
+            adoption_key: AdoptionKey,
+            outcome: CommandOutcome,
+            replay: Option<ReplayMetadata>,
+            revision: Option<PositiveInteger>,
+            result: Option<JsonObject>,
+            error: Option<ErrorEnvelope>,
+            receipt_ref: Option<ReceiptId>,
+            event_ref: Option<EventRef>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let body = match raw.outcome {
+            CommandOutcome::Committed => match (raw.replay, raw.result, raw.error) {
+                (None, Some(result), None) => CommandResponseBody::Committed {
+                    revision: raw.revision,
+                    result,
+                    receipt_ref: raw.receipt_ref,
+                    event_ref: raw.event_ref,
+                },
+                _ => {
+                    return Err(serde::de::Error::custom(
+                        "committed responses require result and forbid error and replay",
+                    ));
+                }
+            },
+            CommandOutcome::Replayed => match (raw.replay, raw.result, raw.error) {
+                (Some(replay), Some(result), None) => CommandResponseBody::Replayed {
+                    replay,
+                    revision: raw.revision,
+                    result,
+                    receipt_ref: raw.receipt_ref,
+                    event_ref: raw.event_ref,
+                },
+                _ => {
+                    return Err(serde::de::Error::custom(
+                        "replayed responses require replay and result and forbid error",
+                    ));
+                }
+            },
+            CommandOutcome::Rejected => match (raw.replay, raw.result, raw.error) {
+                (None, None, Some(error)) => CommandResponseBody::Rejected {
+                    revision: raw.revision,
+                    error,
+                    receipt_ref: raw.receipt_ref,
+                    event_ref: raw.event_ref,
+                },
+                _ => {
+                    return Err(serde::de::Error::custom(
+                        "rejected responses require error and forbid result and replay",
+                    ));
+                }
+            },
+        };
+        Ok(Self::new(
+            raw.schema_version,
+            raw.command,
+            raw.adoption_key,
+            body,
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CommandResponseBody {
+    Committed {
+        revision: Option<PositiveInteger>,
+        result: JsonObject,
+        receipt_ref: Option<ReceiptId>,
+        event_ref: Option<EventRef>,
+    },
+    Replayed {
+        replay: ReplayMetadata,
+        revision: Option<PositiveInteger>,
+        result: JsonObject,
+        receipt_ref: Option<ReceiptId>,
+        event_ref: Option<EventRef>,
+    },
+    Rejected {
+        revision: Option<PositiveInteger>,
+        error: ErrorEnvelope,
+        receipt_ref: Option<ReceiptId>,
+        event_ref: Option<EventRef>,
+    },
+}
+
+impl CommandResponseBody {
+    #[must_use]
+    pub const fn outcome(&self) -> CommandOutcome {
+        match self {
+            Self::Committed { .. } => CommandOutcome::Committed,
+            Self::Replayed { .. } => CommandOutcome::Replayed,
+            Self::Rejected { .. } => CommandOutcome::Rejected,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1908,7 +2279,7 @@ pub struct ReplayMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventRef {
-    pub stream: String,
+    pub stream: EventRefStream,
     pub sequence: u64,
 }
 
@@ -1948,7 +2319,7 @@ pub enum EventKind {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EventEnvelope {
     pub schema_version: SchemaVersion,
-    pub event_id: String,
+    pub event_id: EventId,
     pub stream: StreamRef,
     pub sequence: u64,
     pub recorded_at: Timestamp,
@@ -1965,7 +2336,7 @@ pub struct EventEnvelope {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attempt_id: Option<AttemptId>,
     pub kind: EventKind,
-    pub summary: String,
+    pub summary: EventSummary,
     pub payload: EventPayload,
     pub privacy: EventPrivacy,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1976,7 +2347,14 @@ pub struct EventEnvelope {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StreamRef {
     pub kind: StreamKind,
-    pub id: String,
+    pub id: EventStreamId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommandStreamRef {
+    pub kind: StreamKind,
+    pub id: CommandStreamId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1994,7 +2372,7 @@ pub struct EventCausation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adoption_key: Option<AdoptionKey>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cause_event_id: Option<String>,
+    pub cause_event_id: Option<CauseEventId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub correlation_id: Option<CorrelationId>,
 }

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -6,6 +6,7 @@
 //! claim/lease, and run delivery land in follow-up modules on the same
 //! seams.
 
+pub mod contract;
 pub mod daemon_tick;
 pub mod definition;
 pub mod health;

--- a/docs/architecture/coven-automations-v1.md
+++ b/docs/architecture/coven-automations-v1.md
@@ -214,7 +214,7 @@ Control-action transport mapping: `POST /api/v1/actions` (`crates/coven-cli/src/
 
 Specified by `event-envelope.schema.json`.
 
-- **Envelope:** `schemaVersion`, `eventId` (globally unique), `stream {kind, id}`, gapless `sequence` per stream, `recordedAt`/`observedAt`, `producer`, optional `causation` (adoption key, cause event id, correlation id), object ids as applicable, `kind`, user-safe `summary` (no secrets, no prompts), typed `payload`, `privacy`, optional `integrity`.
+- **Envelope:** `schemaVersion`, `eventId` (globally unique), `stream {kind, id}`, gapless `sequence` per stream, `recordedAt`/`observedAt`, `producer`, optional `causation` (adoption key, cause event id, correlation id), object ids as applicable, `kind`, user-safe `summary` (no secrets, no prompts), typed `payload`, `privacy`, optional `integrity`. The event kind discriminates the payload: definition lifecycle kinds use definition payloads, each transition kind requires its matching entity, and misfire, receipt, and snapshot kinds use only their corresponding payload.
 - **Streams:** `automation/{id}`, `occurrence/{id}`, `run/{id}`, plus a global `feed`. Stream-local sequences are gapless and append via compare-and-set; out-of-order appends are refused (`STREAM_OUT_OF_ORDER`), never reordered.
 - **Delivery:** at-least-once. Consumers deduplicate on `eventId` and refuse regressions against their cursor (the golden vectors pin both).
 - **Read:** `events.read.v1` with `after` (exclusive sequence) or `from` (timestamp, resolved to a concrete cursor in the response); `events.subscribe.v1` with an opaque `checkpoint`. Expired checkpoints return `CURSOR_EXPIRED` (410) with the expiry instant — never a silent rewind.

--- a/spec/coven-automations/v1/coven.automations.v1.d.ts
+++ b/spec/coven-automations/v1/coven.automations.v1.d.ts
@@ -559,38 +559,48 @@ export type EventKind =
   | "receipt.recorded"
   | "feed.snapshot";
 
-export type EventPayload =
-  | {
-      revision: number;
-      definitionDigest?: Digest;
-      lifecycleState?: DefinitionLifecycleState | "tombstoned";
-      importedFrom?: string;
-    }
-  | {
-      entity: "occurrence" | "run" | "attempt";
-      from: string;
-      to: string;
-      reason: string;
-      fenceGeneration?: number;
-      attemptNumber?: number;
-      commandAdoptionKey?: AdoptionKey;
-    }
-  | {
-      disposition: MisfireDisposition;
-      collapsedSlots: Timestamp[];
-    }
-  | {
-      receiptRef: string;
-      outcome: RunOutcome;
-      sideEffectClass?: SideEffectClass;
-    }
-  | {
-      throughSequence: number;
-      state: Record<string, unknown>;
-      reason?: "retention_compaction" | "manual_snapshot";
-    };
+export interface DefinitionLifecycleEventPayload {
+  revision: number;
+  definitionDigest?: Digest;
+  lifecycleState?: DefinitionLifecycleState | "tombstoned";
+  importedFrom?: string;
+}
 
-export interface EventEnvelope {
+export interface TransitionEventPayload {
+  entity: "occurrence" | "run" | "attempt";
+  from: string;
+  to: string;
+  reason: string;
+  fenceGeneration?: number;
+  attemptNumber?: number;
+  commandAdoptionKey?: AdoptionKey;
+}
+
+export interface MisfireEventPayload {
+  disposition: MisfireDisposition;
+  collapsedSlots: Timestamp[];
+}
+
+export interface ReceiptEventPayload {
+  receiptRef: string;
+  outcome: RunOutcome;
+  sideEffectClass?: SideEffectClass;
+}
+
+export interface SnapshotEventPayload {
+  throughSequence: number;
+  state: Record<string, unknown>;
+  reason?: "retention_compaction" | "manual_snapshot";
+}
+
+export type EventPayload =
+  | DefinitionLifecycleEventPayload
+  | TransitionEventPayload
+  | MisfireEventPayload
+  | ReceiptEventPayload
+  | SnapshotEventPayload;
+
+export interface EventEnvelopeBase {
   schemaVersion: SchemaVersion;
   /** Globally unique; duplicates of a delivered eventId are redeliveries: ignore, never re-apply. */
   eventId: string;
@@ -609,12 +619,50 @@ export interface EventEnvelope {
   occurrenceId?: string;
   runId?: string;
   attemptId?: string;
-  kind: EventKind;
   summary: string;
-  payload: EventPayload;
   privacy: {
     classification: PrivacyClassification;
     retention: RetentionClass;
   };
   integrity?: Digest;
 }
+
+export type EventEnvelope = EventEnvelopeBase &
+  (
+    | {
+        kind:
+          | "definition.created"
+          | "definition.revised"
+          | "definition.activated"
+          | "definition.paused"
+          | "definition.disabled"
+          | "definition.invalidated"
+          | "definition.tombstoned"
+          | "definition.imported";
+        payload: DefinitionLifecycleEventPayload;
+      }
+    | {
+        kind: "occurrence.transitioned";
+        payload: TransitionEventPayload & { entity: "occurrence" };
+      }
+    | {
+        kind: "run.transitioned";
+        payload: TransitionEventPayload & { entity: "run" };
+      }
+    | {
+        kind: "attempt.transitioned";
+        payload: TransitionEventPayload & { entity: "attempt" };
+      }
+    | {
+        kind: "occurrence.misfire_recorded";
+        payload: MisfireEventPayload;
+      }
+    | {
+        kind: "receipt.recorded";
+        payload: ReceiptEventPayload;
+      }
+    | {
+        kind: "feed.snapshot";
+        payload: SnapshotEventPayload;
+      }
+  );

--- a/spec/coven-automations/v1/event-envelope.schema.json
+++ b/spec/coven-automations/v1/event-envelope.schema.json
@@ -102,6 +102,124 @@
       "description": "Required where the deployment requires tamper evidence (for example receipt.recorded events): digest over the canonical envelope with this member removed."
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "enum": [
+              "definition.created",
+              "definition.revised",
+              "definition.activated",
+              "definition.paused",
+              "definition.disabled",
+              "definition.invalidated",
+              "definition.tombstoned",
+              "definition.imported"
+            ]
+          }
+        },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/definitionLifecyclePayload" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "kind": { "const": "occurrence.transitioned" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "allOf": [
+              { "$ref": "#/$defs/transitionPayload" },
+              {
+                "properties": { "entity": { "const": "occurrence" } },
+                "required": ["entity"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "kind": { "const": "run.transitioned" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "allOf": [
+              { "$ref": "#/$defs/transitionPayload" },
+              {
+                "properties": { "entity": { "const": "run" } },
+                "required": ["entity"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "kind": { "const": "attempt.transitioned" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "allOf": [
+              { "$ref": "#/$defs/transitionPayload" },
+              {
+                "properties": { "entity": { "const": "attempt" } },
+                "required": ["entity"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": { "const": "occurrence.misfire_recorded" }
+        },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/misfirePayload" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "kind": { "const": "receipt.recorded" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/receiptPayload" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "kind": { "const": "feed.snapshot" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/snapshotPayload" }
+        }
+      }
+    }
+  ],
   "$defs": {
     "eventKind": {
       "enum": [

--- a/spec/coven-automations/v1/test-vectors.json
+++ b/spec/coven-automations/v1/test-vectors.json
@@ -2024,6 +2024,45 @@
       }
     },
     {
+      "name": "event-kind-payload-mismatch-rejected",
+      "kind": "schema",
+      "targetSchema": "event-envelope.schema.json",
+      "expected": "reject",
+      "object": {
+        "schemaVersion": "coven.automations.v1",
+        "eventId": "evtmis08b4d2f7a91c603",
+        "stream": {
+          "kind": "occurrence",
+          "id": "daily-notes-1756544400000"
+        },
+        "sequence": 6,
+        "recordedAt": "2026-08-30T09:00:06.000Z",
+        "observedAt": "2026-08-30T09:00:06.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a"
+        },
+        "automationId": "daily-notes",
+        "occurrenceId": "daily-notes-1756544400000",
+        "kind": "receipt.recorded",
+        "summary": "mismatched event kind and payload",
+        "payload": {
+          "entity": "occurrence",
+          "from": "running",
+          "to": "succeeded",
+          "reason": "run_settled",
+          "fenceGeneration": 1
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        }
+      },
+      "reason": "An event kind must select exactly its corresponding payload shape; consumers must not infer semantics from a contradictory pair."
+    },
+    {
       "name": "event-duplicate-delivery-is-ignored",
       "kind": "changefeed",
       "stream": {


### PR DESCRIPTION
## Context

- Summary: Adds the first independently reviewable #855 slice: schema-faithful Rust projections for the published `coven.automations.v1` objects, frozen errors, and canonical JCS/SHA-256 integrity behavior.
- Files changed: `crates/coven-cli/src/automations/contract/**`, module wiring, and the pinned `serde_jcs` dependency.
- Advances #855; does not close it. Transactional command adoption, migration, changefeed persistence/replay, TypeScript artifact reconciliation, bundle publication, and consumer canaries remain follow-up slices.

## Implementation

- Approach: Closed serde projections mirror the checked-in JSON Schemas and reject unknown fields, explicit null optionals, invalid bounds/cardinality, illegal lifecycle combinations, unsafe JCS integers, and command/payload mismatches.
- User-visible behavior: Establishes a stable Rust protocol boundary for definitions, occurrences, runs, attempts, receipts, command/error envelopes, and events before routing and storage adoption.
- Compatibility notes: Existing runtime behavior is unchanged. The known `coven.automations.v1.d.ts` drift is intentionally deferred to the artifact/bundle canary slice.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] 103 focused Automations tests passed, including 15 contract tests.
- [x] Independent specification review approved.
- [x] Independent code-quality review approved after null, integrity, terminal-outcome, and JCS-safe-counter fixes.

## Risk and Rollback

- Risk level: Low to moderate. This adds protocol types and tests but does not route production commands through them yet.
- Rollback plan: Revert this PR; existing internal Automations behavior remains intact.

## Agent Handoff

- Current state: Rust projection/JCS slice is complete and independently approved.
- Follow-ups: Implement transactional adoption/expected revisions, migration, durable event replay, generated TypeScript artifacts, deterministic bundle publication, and exact-artifact SDK/Cave canaries under #855.
- Known gaps: The checked-in TypeScript declaration currently diverges from schema optionality/conditionals and is explicitly not claimed complete by this PR.