### PR TITLE
feat(automations): package the v1 protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,48 @@ jobs:
       - run: python3 scripts/check-workflows-test.py
       - run: python3 scripts/check-ci-workflow-test.py
       - run: node --test scripts/package-github-release-test.mjs
+      - run: node --test scripts/package-automations-protocol.test.mjs
       - run: node --test scripts/release-stress-test.mjs
       - run: scripts/check-workflows.sh
+
+  automations-protocol-bundle:
+    name: Automations v1 protocol bundle
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
+        with:
+          node-version: 24
+      - name: Package exact-commit Automations protocol
+        env:
+          SOURCE_COMMIT: ${{ github.sha }}
+          AUTOMATIONS_ARTIFACT_DIR: ${{ runner.temp }}/coven-automations-v1-contract
+        run: |
+          set -euo pipefail
+          node --test scripts/package-automations-protocol.test.mjs
+          node scripts/package-automations-protocol.mjs \
+            --output "$AUTOMATIONS_ARTIFACT_DIR"
+          PROTOCOL_BUNDLE="$AUTOMATIONS_ARTIFACT_DIR/coven-automations-v1-contract-${SOURCE_COMMIT}.tar.gz"
+          PROTOCOL_SHA256="$(sha256sum "$PROTOCOL_BUNDLE" | awk '{print $1}')"
+          node scripts/package-automations-protocol.mjs verify \
+            --bundle "$PROTOCOL_BUNDLE" \
+            --source-commit "$SOURCE_COMMIT" \
+            --sha256 "$PROTOCOL_SHA256"
+          jq -e --arg sourceCommit "$SOURCE_COMMIT" \
+            '.sourceCommit == $sourceCommit and (.contractContentSha256 | test("^[0-9a-f]{64}$"))' \
+            "$AUTOMATIONS_ARTIFACT_DIR/manifest.json"
+      - name: Upload exact-commit Automations protocol
+        uses: actions/upload-artifact@v7
+        with:
+          name: coven-automations-v1-contract-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/coven-automations-v1-contract/coven-automations-v1-contract-${{ github.sha }}.tar.gz
+            ${{ runner.temp }}/coven-automations-v1-contract/manifest.json
+          if-no-files-found: error
 
   rust-lint-linux:
     name: Rust lint (Linux)
@@ -548,6 +588,7 @@ jobs:
     needs:
       - changes
       - policy-guard
+      - automations-protocol-bundle
       - rust-lint-linux
       - rust-test-linux
       - rust-test-windows
@@ -576,7 +617,7 @@ jobs:
               for name, data in jobs.items()
               if data["result"] not in {"success", "skipped"}
           }
-          for required in ("changes", "policy-guard"):
+          for required in ("changes", "policy-guard", "automations-protocol-bundle"):
               if jobs[required]["result"] != "success":
                   bad[required] = jobs[required]["result"]
           if bad:

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -91,6 +91,11 @@ jobs:
           node scripts/package-github-release.mjs verify-npm-signatures \
             --npm-version "$NPM_VERSION" \
             --audit-dir github-release-npm-audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.source.outputs.head_sha }}
+          path: github-release-protocol-source
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -136,13 +141,28 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.source.outputs.release_tag }}
           SOURCE_DATE_EPOCH: ${{ steps.source.outputs.source_date_epoch }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
         run: |
           set -euo pipefail
+          PROTOCOL_ARGS=()
+          if [[ -f github-release-protocol-source/scripts/package-automations-protocol.mjs ]]; then
+            SOURCE_COMMIT="$HEAD_SHA" \
+              node github-release-protocol-source/scripts/package-automations-protocol.mjs \
+                --output github-release-protocol
+            PROTOCOL_BUNDLE="$PWD/github-release-protocol/coven-automations-v1-contract-${HEAD_SHA}.tar.gz"
+            PROTOCOL_SHA256="$(sha256sum "$PROTOCOL_BUNDLE" | awk '{print $1}')"
+            node scripts/package-automations-protocol.mjs verify \
+              --bundle "$PROTOCOL_BUNDLE" \
+              --source-commit "$HEAD_SHA" \
+              --sha256 "$PROTOCOL_SHA256"
+            PROTOCOL_ARGS=(--source-commit "$HEAD_SHA" --protocol-bundle "$PROTOCOL_BUNDLE")
+          fi
           node scripts/package-github-release.mjs package \
             --release-tag "$RELEASE_TAG" \
             --artifacts-dir github-release-source \
             --output-dir github-release-assets \
-            --source-date-epoch "$SOURCE_DATE_EPOCH"
+            --source-date-epoch "$SOURCE_DATE_EPOCH" \
+            "${PROTOCOL_ARGS[@]}"
       - name: Synchronize canonical GitHub release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -1,6 +1,7 @@
 ---
 summary: "Release flow for @opencoven/cli and platform packages."
 description: "Operator runbook for releasing Coven to npm and GitHub Releases: OIDC setup, signed-tag publication, deterministic assets, provenance checks, and recovery."
+source_adjacent_reason: "Tracks release automation and artifact verification implemented in this repository."
 read_when:
   - Cutting a release
 title: "Releasing Coven to npm and GitHub Releases"

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -150,6 +150,7 @@ That single push is the entire release. The workflow takes over from there.
 3. **Build platform binaries** — matrix builds the release binary for `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, and `x86_64-pc-windows-msvc`, then uploads each as an artifact.
 4. **npm publish dry-run** — repacks the wrapper and native packages at the tag version and runs `npm publish --dry-run` for each. This is the same code path as the real publish minus the registry write, so a failure here means the real publish would also fail.
 5. **npm publish** — authenticates via GitHub Actions OIDC (`permissions: id-token: write`), then runs `npm publish --provenance --access public` for the four native packages and the wrapper. Each published tarball gets a provenance attestation linking it to this exact workflow run and commit SHA, visible on each package's npm page.
+6. **Automations protocol bundle** — starting with `v0.4.4`, rebuilds `spec/coven-automations/v1/` from the exact tagged commit into a deterministic source-bound bundle. The embedded manifest records every contract file digest and a commit-independent `contractContentSha256`. GitHub-only recovery of older tags preserves their original four-archive-plus-checksum asset contract.
 
 ### Postflight
 
@@ -171,9 +172,14 @@ The workflow creates or repairs one GitHub Release titled `Coven vX.Y.Z` using t
 - `coven-vX.Y.Z-macos-x64.tar.gz`
 - `coven-vX.Y.Z-linux-x64.tar.gz`
 - `coven-vX.Y.Z-windows-x64.zip`
+- `coven-automations-v1-contract-<tagged-commit>.tar.gz`
 - `SHA256SUMS`
 
-`SHA256SUMS` contains exactly four lexically ordered entries naming only those four archive filenames. The GitHub Release is the public binary/checksum surface; npm provenance remains the package-integrity surface.
+`SHA256SUMS` contains exactly four lexically ordered entries naming only the
+four native archive filenames. The Automations protocol bundle is verified
+separately through its embedded `manifest.json`; it must never be added to
+`SHA256SUMS`. The GitHub Release is the public binary/checksum surface; npm
+provenance remains the package-integrity surface.
 
 Download the published assets and verify the checksums actually match, rather
 than trusting that the file exists:
@@ -198,6 +204,33 @@ Get-Content SHA256SUMS | ForEach-Object {
 
 All four archives must report `OK`. This is the one checksum surface, so a
 single mismatch fails the release regardless of what npm reports.
+
+Verify the protocol asset is bound to the same commit as the immutable tag and
+that every archived file, recorded size/digest, and the aggregate content
+digest match. Use the protocol bundle SHA-256 recorded in the release workflow
+log and release evidence packet; do not derive the expected value from the
+download being verified:
+
+```sh
+TAG_COMMIT="$(git rev-list -n 1 vX.Y.Z)"
+PROTOCOL_BUNDLE="coven-automations-v1-contract-${TAG_COMMIT}.tar.gz"
+EXPECTED_PROTOCOL_SHA256="<64-character SHA-256 from the release evidence>"
+gh release download vX.Y.Z \
+  --repo OpenCoven/coven \
+  --pattern "$PROTOCOL_BUNDLE" \
+  --dir release-check
+node scripts/package-automations-protocol.mjs verify \
+  --bundle "release-check/$PROTOCOL_BUNDLE" \
+  --source-commit "$TAG_COMMIT" \
+  --sha256 "$EXPECTED_PROTOCOL_SHA256"
+```
+
+The verifier refuses malformed or non-normalized archives, unsafe or duplicate
+paths, missing or extra contract files, source-commit drift, and any bundle,
+file, size, or aggregate content-digest mismatch. The SDK and Cave release
+canaries must consume this downloaded archive and its recorded SHA-256. Reading
+`spec/coven-automations/v1/` from a source checkout does not certify the
+released artifact.
 
 ### Verify a fresh consumer install
 

--- a/scripts/package-automations-protocol.mjs
+++ b/scripts/package-automations-protocol.mjs
@@ -1,0 +1,528 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { gunzipSync, gzipSync } from 'node:zlib';
+
+const CONTRACT_PROFILE = 'coven.automations.v1';
+const BUNDLE_SCHEMA_VERSION = 'coven.automations.bundle.v1';
+const SPEC_RELATIVE_DIR = 'spec/coven-automations/v1';
+const ARCHIVE_ROOT = 'coven-automations-v1';
+
+function compareLexically(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function runGit(repoRoot, args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(' ')} failed: ${String(result.stderr || result.stdout).trim()}`
+    );
+  }
+  return result.stdout.trim();
+}
+
+function runGitBytes(repoRoot, args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: null
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(' ')} failed: ${String(result.stderr || result.stdout).trim()}`
+    );
+  }
+  return result.stdout;
+}
+
+function listContractFiles(specDir, relativeDir = '') {
+  const absoluteDir = path.join(specDir, relativeDir);
+  const files = [];
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const relativePath = path.posix.join(relativeDir.split(path.sep).join(path.posix.sep), entry.name);
+    const absolutePath = path.join(specDir, ...relativePath.split('/'));
+    const stat = lstatSync(absolutePath);
+    if (stat.isSymbolicLink() || (!stat.isDirectory() && !stat.isFile())) {
+      throw new Error(
+        `Automations protocol input tree must contain only regular files and directories: ${relativePath}`
+      );
+    }
+    if (stat.isDirectory()) {
+      files.push(...listContractFiles(specDir, relativePath));
+    } else {
+      files.push(relativePath);
+    }
+  }
+  return files.sort(compareLexically);
+}
+
+function writeString(buffer, offset, length, value) {
+  const bytes = Buffer.from(value);
+  if (bytes.length > length) {
+    throw new Error(`Tar header value exceeds ${length} bytes: ${value}`);
+  }
+  bytes.copy(buffer, offset);
+}
+
+function writeOctal(buffer, offset, length, value) {
+  const text = value.toString(8).padStart(length - 1, '0');
+  if (text.length > length - 1) {
+    throw new Error(`Tar header numeric value exceeds ${length} bytes: ${value}`);
+  }
+  writeString(buffer, offset, length, `${text}\0`);
+}
+
+function splitTarPath(name) {
+  if (Buffer.byteLength(name) <= 100) {
+    return { name, prefix: '' };
+  }
+  for (let index = name.lastIndexOf('/'); index > 0; index = name.lastIndexOf('/', index - 1)) {
+    const prefix = name.slice(0, index);
+    const basename = name.slice(index + 1);
+    if (Buffer.byteLength(prefix) <= 155 && Buffer.byteLength(basename) <= 100) {
+      return { name: basename, prefix };
+    }
+  }
+  throw new Error(`Tar entry path exceeds the ustar limit: ${name}`);
+}
+
+function createTarHeader(name, size) {
+  const header = Buffer.alloc(512, 0);
+  const split = splitTarPath(name);
+  writeString(header, 0, 100, split.name);
+  writeOctal(header, 100, 8, 0o644);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, size);
+  writeOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  writeString(header, 156, 1, '0');
+  writeString(header, 257, 6, 'ustar');
+  writeString(header, 263, 2, '00');
+  writeString(header, 345, 155, split.prefix);
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  writeString(header, 148, 8, `${checksum.toString(8).padStart(6, '0')}\0 `);
+  return header;
+}
+
+function createTarGz(entries) {
+  const parts = [];
+  for (const entry of entries) {
+    parts.push(createTarHeader(entry.name, entry.data.length));
+    parts.push(entry.data);
+    const remainder = entry.data.length % 512;
+    if (remainder !== 0) {
+      parts.push(Buffer.alloc(512 - remainder, 0));
+    }
+  }
+  parts.push(Buffer.alloc(1024, 0));
+  const gzip = gzipSync(Buffer.concat(parts), { level: 9, mtime: 0 });
+  gzip.writeUInt32LE(0, 4);
+  gzip[9] = 0xff;
+  return gzip;
+}
+
+function assertCleanSource(repoRoot, sourceCommit) {
+  if (!/^[0-9a-f]{40}$/.test(sourceCommit)) {
+    throw new Error(`Automations protocol source commit must be a lowercase 40-character Git SHA: ${sourceCommit}`);
+  }
+  const head = runGit(repoRoot, ['rev-parse', 'HEAD']);
+  if (head !== sourceCommit) {
+    throw new Error(`Automations protocol source commit ${sourceCommit} does not match HEAD ${head}`);
+  }
+  const status = runGit(repoRoot, ['status', '--porcelain=v1', '--untracked-files=all']);
+  if (status !== '') {
+    throw new Error(`Automations protocol input tree is dirty:\n${status}`);
+  }
+}
+
+function trackedContractFiles(repoRoot, sourceCommit) {
+  const tree = runGitBytes(repoRoot, [
+    'ls-tree',
+    '-r',
+    '-z',
+    '--full-tree',
+    sourceCommit,
+    '--',
+    SPEC_RELATIVE_DIR
+  ]).toString('utf8');
+  const prefix = `${SPEC_RELATIVE_DIR}/`;
+  return tree
+    .split('\0')
+    .filter(Boolean)
+    .map((record) => {
+      const separator = record.indexOf('\t');
+      if (separator === -1) {
+        throw new Error(`Invalid git ls-tree record for Automations protocol: ${record}`);
+      }
+      const [mode, type, object] = record.slice(0, separator).split(' ');
+      const sourcePath = record.slice(separator + 1);
+      if (
+        type !== 'blob' ||
+        !['100644', '100755'].includes(mode) ||
+        !sourcePath.startsWith(prefix)
+      ) {
+        throw new Error(
+          `Automations protocol input tree must contain only regular files: ${sourcePath}`
+        );
+      }
+      return {
+        path: sourcePath.slice(prefix.length),
+        object
+      };
+    })
+    .sort((left, right) => compareLexically(left.path, right.path));
+}
+
+export function packageAutomationsProtocol({ repoRoot, outputDir, sourceCommit }) {
+  const normalizedRepoRoot = path.resolve(String(repoRoot));
+  const normalizedOutputDir = path.resolve(String(outputDir));
+  const normalizedSourceCommit = String(sourceCommit).trim();
+  assertCleanSource(normalizedRepoRoot, normalizedSourceCommit);
+
+  const specDir = path.join(normalizedRepoRoot, ...SPEC_RELATIVE_DIR.split('/'));
+  const trackedFiles = trackedContractFiles(normalizedRepoRoot, normalizedSourceCommit);
+  const filesystemFiles = listContractFiles(specDir);
+  if (
+    filesystemFiles.join('\n') !== trackedFiles.map((file) => file.path).join('\n')
+  ) {
+    throw new Error(
+      'Automations protocol input tree does not exactly match tracked source files'
+    );
+  }
+  const files = trackedFiles.map(({ path: relativePath, object }) => {
+    const bytes = runGitBytes(normalizedRepoRoot, ['cat-file', 'blob', object]);
+    return {
+      path: relativePath,
+      sha256: sha256(bytes),
+      size: bytes.length,
+      bytes
+    };
+  });
+  if (files.length === 0) {
+    throw new Error(`Automations protocol input tree is empty: ${specDir}`);
+  }
+
+  const contractContentSha256 = sha256(
+    Buffer.from(files.map((file) => `${file.path}\0${file.sha256}\n`).join(''))
+  );
+  const manifest = {
+    schemaVersion: BUNDLE_SCHEMA_VERSION,
+    contractProfile: CONTRACT_PROFILE,
+    sourceCommit: normalizedSourceCommit,
+    contractContentSha256,
+    files: files.map(({ path: relativePath, sha256: digest, size }) => ({
+      path: relativePath,
+      sha256: digest,
+      size
+    }))
+  };
+  const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+  const archiveEntries = [
+    ...files.map((file) => ({
+      name: `${ARCHIVE_ROOT}/${file.path}`,
+      data: file.bytes
+    })),
+    {
+      name: 'manifest.json',
+      data: manifestBytes
+    }
+  ].sort((left, right) => compareLexically(left.name, right.name));
+  const bundleBytes = createTarGz(archiveEntries);
+
+  mkdirSync(normalizedOutputDir, { recursive: true });
+  const bundleName = `coven-automations-v1-contract-${normalizedSourceCommit}.tar.gz`;
+  const bundlePath = path.join(normalizedOutputDir, bundleName);
+  const manifestPath = path.join(normalizedOutputDir, 'manifest.json');
+  writeFileSync(bundlePath, bundleBytes);
+  writeFileSync(manifestPath, manifestBytes);
+
+  return {
+    bundlePath,
+    manifestPath,
+    bundleSha256: sha256(bundleBytes),
+    contractContentSha256
+  };
+}
+
+function tarString(header, offset, length) {
+  return header
+    .subarray(offset, offset + length)
+    .toString('utf8')
+    .replace(/\0.*$/s, '');
+}
+
+function tarOctal(header, offset, length) {
+  const value = tarString(header, offset, length).trim();
+  if (!/^[0-7]+$/.test(value)) {
+    throw new Error(`Invalid tar octal field: ${JSON.stringify(value)}`);
+  }
+  return Number.parseInt(value, 8);
+}
+
+function parseTarGz(bundleBytes) {
+  const canonicalGzipHeader = Buffer.from([
+    0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff
+  ]);
+  if (
+    bundleBytes.length < canonicalGzipHeader.length ||
+    !bundleBytes.subarray(0, canonicalGzipHeader.length).equals(canonicalGzipHeader)
+  ) {
+    throw new Error('Automations protocol bundle gzip header is not normalized');
+  }
+  let tar;
+  try {
+    tar = gunzipSync(bundleBytes);
+  } catch (error) {
+    throw new Error(`Automations protocol bundle gzip is invalid: ${error?.message ?? String(error)}`);
+  }
+  const entries = [];
+  let offset = 0;
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      if (
+        offset + 1024 !== tar.length ||
+        !tar.subarray(offset, offset + 1024).every((byte) => byte === 0)
+      ) {
+        throw new Error('Automations protocol tar has an invalid terminator');
+      }
+      return entries;
+    }
+    const expectedChecksum = tarOctal(header, 148, 8);
+    const checksumHeader = Buffer.from(header);
+    checksumHeader.fill(0x20, 148, 156);
+    const actualChecksum = checksumHeader.reduce((sum, byte) => sum + byte, 0);
+    if (actualChecksum !== expectedChecksum) {
+      throw new Error('Automations protocol tar header checksum mismatch');
+    }
+    const basename = tarString(header, 0, 100);
+    const prefix = tarString(header, 345, 155);
+    const name = prefix ? `${prefix}/${basename}` : basename;
+    const type = tarString(header, 156, 1);
+    const mode = tarOctal(header, 100, 8);
+    const uid = tarOctal(header, 108, 8);
+    const gid = tarOctal(header, 116, 8);
+    const size = tarOctal(header, 124, 12);
+    const mtime = tarOctal(header, 136, 12);
+    if (
+      type !== '0' ||
+      mode !== 0o644 ||
+      uid !== 0 ||
+      gid !== 0 ||
+      mtime !== 0 ||
+      !header.equals(createTarHeader(name, size))
+    ) {
+      throw new Error(`Automations protocol tar metadata is not normalized for ${name}`);
+    }
+    if (
+      name === '' ||
+      name.startsWith('/') ||
+      name.includes('\\') ||
+      name.split('/').some((component) => component === '' || component === '.' || component === '..')
+    ) {
+      throw new Error(`Automations protocol tar contains unsafe path ${JSON.stringify(name)}`);
+    }
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > tar.length) {
+      throw new Error(`Automations protocol tar entry exceeds archive bounds: ${name}`);
+    }
+    const paddedEnd = dataStart + Math.ceil(size / 512) * 512;
+    if (!tar.subarray(dataEnd, paddedEnd).every((byte) => byte === 0)) {
+      throw new Error(`Automations protocol tar padding is not normalized for ${name}`);
+    }
+    entries.push({ name, data: tar.subarray(dataStart, dataEnd) });
+    offset = paddedEnd;
+  }
+  throw new Error('Automations protocol tar is missing its terminator');
+}
+
+export function verifyAutomationsProtocolBundle({
+  bundlePath,
+  expectedSourceCommit,
+  expectedBundleSha256
+}) {
+  const normalizedSourceCommit = String(expectedSourceCommit).trim();
+  if (!/^[0-9a-f]{40}$/.test(normalizedSourceCommit)) {
+    throw new Error(`Expected source commit must be a lowercase 40-character Git SHA: ${normalizedSourceCommit}`);
+  }
+  const normalizedExpectedBundleSha256 = String(expectedBundleSha256).trim();
+  if (!/^[0-9a-f]{64}$/.test(normalizedExpectedBundleSha256)) {
+    throw new Error('Expected bundle SHA-256 must be 64 lowercase hexadecimal characters');
+  }
+  const bundleBytes = readFileSync(path.resolve(String(bundlePath)));
+  const actualBundleSha256 = sha256(bundleBytes);
+  if (actualBundleSha256 !== normalizedExpectedBundleSha256) {
+    throw new Error(
+      `Automations protocol bundle SHA-256 mismatch: expected ${normalizedExpectedBundleSha256}, got ${actualBundleSha256}`
+    );
+  }
+  const entries = parseTarGz(bundleBytes);
+  const names = entries.map((entry) => entry.name);
+  if (new Set(names).size !== names.length) {
+    throw new Error('Automations protocol bundle contains duplicate archive entries');
+  }
+  const sortedNames = [...names].sort(compareLexically);
+  if (names.join('\n') !== sortedNames.join('\n')) {
+    throw new Error('Automations protocol bundle entries are not lexically ordered');
+  }
+  const manifestEntry = entries.find((entry) => entry.name === 'manifest.json');
+  if (!manifestEntry) {
+    throw new Error('Automations protocol bundle is missing manifest.json');
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestEntry.data.toString('utf8'));
+  } catch (error) {
+    throw new Error(`Automations protocol manifest is invalid JSON: ${error?.message ?? String(error)}`);
+  }
+  if (
+    manifest.schemaVersion !== BUNDLE_SCHEMA_VERSION ||
+    manifest.contractProfile !== CONTRACT_PROFILE
+  ) {
+    throw new Error('Automations protocol manifest profile is invalid');
+  }
+  if (manifest.sourceCommit !== normalizedSourceCommit) {
+    throw new Error(
+      `Automations protocol source commit mismatch: expected ${normalizedSourceCommit}, got ${manifest.sourceCommit}`
+    );
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length === 0) {
+    throw new Error('Automations protocol manifest must list at least one contract file');
+  }
+  const contractEntries = new Map(
+    entries
+      .filter((entry) => entry.name !== 'manifest.json')
+      .map((entry) => {
+        const prefix = `${ARCHIVE_ROOT}/`;
+        if (!entry.name.startsWith(prefix)) {
+          throw new Error(`Unexpected Automations protocol archive entry: ${entry.name}`);
+        }
+        return [entry.name.slice(prefix.length), entry.data];
+      })
+  );
+  const manifestPaths = manifest.files.map((file) => file.path);
+  if (
+    new Set(manifestPaths).size !== manifestPaths.length ||
+    manifestPaths.join('\n') !== [...manifestPaths].sort(compareLexically).join('\n') ||
+    manifestPaths.join('\n') !== [...contractEntries.keys()].sort(compareLexically).join('\n')
+  ) {
+    throw new Error('Automations protocol manifest paths do not exactly match archive entries');
+  }
+  for (const file of manifest.files) {
+    if (
+      typeof file.path !== 'string' ||
+      !/^[0-9a-f]{64}$/.test(file.sha256) ||
+      !Number.isSafeInteger(file.size) ||
+      file.size < 0
+    ) {
+      throw new Error(`Automations protocol manifest file record is invalid: ${JSON.stringify(file)}`);
+    }
+    const bytes = contractEntries.get(file.path);
+    if (bytes.length !== file.size) {
+      throw new Error(`Automations protocol file size mismatch for ${file.path}`);
+    }
+    const actualFileSha256 = sha256(bytes);
+    if (actualFileSha256 !== file.sha256) {
+      throw new Error(`Automations protocol file SHA-256 mismatch for ${file.path}`);
+    }
+  }
+  const actualContentSha256 = sha256(
+    Buffer.from(manifest.files.map((file) => `${file.path}\0${file.sha256}\n`).join(''))
+  );
+  if (actualContentSha256 !== manifest.contractContentSha256) {
+    throw new Error(
+      `Automations protocol content SHA-256 mismatch: expected ${manifest.contractContentSha256}, got ${actualContentSha256}`
+    );
+  }
+  return {
+    sourceCommit: manifest.sourceCommit,
+    bundleSha256: actualBundleSha256,
+    contractContentSha256: actualContentSha256,
+    fileCount: manifest.files.length
+  };
+}
+
+function optionValue(args, name) {
+  const exactIndex = args.indexOf(name);
+  if (exactIndex !== -1) {
+    const value = args[exactIndex + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`${name} requires a value`);
+    }
+    return value;
+  }
+  const prefix = `${name}=`;
+  const inline = args.find((argument) => argument.startsWith(prefix));
+  return inline?.slice(prefix.length);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args[0] === 'verify') {
+    const verifyArgs = args.slice(1);
+    const result = verifyAutomationsProtocolBundle({
+      bundlePath: optionValue(verifyArgs, '--bundle'),
+      expectedSourceCommit: optionValue(verifyArgs, '--source-commit'),
+      expectedBundleSha256: optionValue(verifyArgs, '--sha256')
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  const packageArgs = args[0] === 'package' ? args.slice(1) : args;
+  const outputDir = optionValue(packageArgs, '--output');
+  if (!outputDir) {
+    throw new Error('Usage: package-automations-protocol.mjs --output <directory>');
+  }
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const sourceCommit = process.env.SOURCE_COMMIT;
+  if (!sourceCommit) {
+    throw new Error('SOURCE_COMMIT is required');
+  }
+  const result = packageAutomationsProtocol({
+    repoRoot,
+    outputDir,
+    sourceCommit
+  });
+  process.stdout.write(
+    `${JSON.stringify({
+      bundle: path.basename(result.bundlePath),
+      bundleSha256: result.bundleSha256,
+      contractContentSha256: result.contractContentSha256,
+      sourceCommit
+    })}\n`
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error?.message ?? String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/package-automations-protocol.mjs
+++ b/scripts/package-automations-protocol.mjs
@@ -485,10 +485,18 @@ function main() {
   const args = process.argv.slice(2);
   if (args[0] === 'verify') {
     const verifyArgs = args.slice(1);
+    const bundlePath = optionValue(verifyArgs, '--bundle');
+    const expectedSourceCommit = optionValue(verifyArgs, '--source-commit');
+    const expectedBundleSha256 = optionValue(verifyArgs, '--sha256');
+    if (!bundlePath || !expectedSourceCommit || !expectedBundleSha256) {
+      throw new Error(
+        'Usage: package-automations-protocol.mjs verify --bundle <archive> --source-commit <sha> --sha256 <digest>'
+      );
+    }
     const result = verifyAutomationsProtocolBundle({
-      bundlePath: optionValue(verifyArgs, '--bundle'),
-      expectedSourceCommit: optionValue(verifyArgs, '--source-commit'),
-      expectedBundleSha256: optionValue(verifyArgs, '--sha256')
+      bundlePath,
+      expectedSourceCommit,
+      expectedBundleSha256
     });
     process.stdout.write(`${JSON.stringify(result)}\n`);
     return;

--- a/scripts/package-automations-protocol.test.mjs
+++ b/scripts/package-automations-protocol.test.mjs
@@ -21,6 +21,7 @@ import {
 } from './package-automations-protocol.mjs';
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const scriptPath = path.join(repositoryRoot, 'scripts', 'package-automations-protocol.mjs');
 
 function runGit(cwd, args) {
   const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
@@ -373,4 +374,17 @@ test('pinned TypeScript declarations expose the implemented event page result', 
     declaration,
     /C extends "events\.read\.v1" \| "events\.subscribe\.v1" \? EventPage : Record<string, unknown>/
   );
+});
+
+test('verify CLI refuses missing required arguments with actionable usage', () => {
+  const result = spawnSync(process.execPath, [scriptPath, 'verify'], {
+    cwd: repositoryRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Usage: package-automations-protocol\.mjs verify --bundle <archive> --source-commit <sha> --sha256 <digest>/
+  );
+  assert.doesNotMatch(result.stderr, /undefined/);
 });

--- a/scripts/package-automations-protocol.test.mjs
+++ b/scripts/package-automations-protocol.test.mjs
@@ -1,0 +1,376 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { gunzipSync, gzipSync } from 'node:zlib';
+
+import {
+  packageAutomationsProtocol,
+  verifyAutomationsProtocolBundle
+} from './package-automations-protocol.mjs';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function runGit(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(
+    result.status,
+    0,
+    `git ${args.join(' ')} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+  );
+  return result.stdout.trim();
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function createFixtureRepository(scratchDir) {
+  const repoRoot = path.join(scratchDir, 'repo');
+  const specDir = path.join(repoRoot, 'spec', 'coven-automations', 'v1');
+  mkdirSync(path.join(specDir, 'nested'), { recursive: true });
+  writeFileSync(path.join(specDir, 'README.md'), '# Contract\n');
+  writeFileSync(path.join(specDir, 'b.json'), '{"b":2}\n');
+  writeFileSync(path.join(specDir, 'nested', 'a.json'), '{"a":1}\n');
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['config', 'user.name', 'Protocol Test']);
+  runGit(repoRoot, ['config', 'user.email', 'protocol@example.invalid']);
+  runGit(repoRoot, ['add', '.']);
+  runGit(repoRoot, ['commit', '-m', 'test: seed protocol']);
+  return {
+    repoRoot,
+    specDir,
+    sourceCommit: runGit(repoRoot, ['rev-parse', 'HEAD'])
+  };
+}
+
+function parseTarGz(bytes) {
+  const tar = gunzipSync(bytes);
+  const entries = [];
+  for (let offset = 0; offset + 512 <= tar.length; ) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+    const readString = (start, length) =>
+      header
+        .subarray(start, start + length)
+        .toString('utf8')
+        .replace(/\0.*$/s, '');
+    const readOctal = (start, length) => Number.parseInt(readString(start, length).trim() || '0', 8);
+    const name = readString(0, 100);
+    const size = readOctal(124, 12);
+    entries.push({
+      name,
+      mode: readOctal(100, 8),
+      uid: readOctal(108, 8),
+      gid: readOctal(116, 8),
+      size,
+      mtime: readOctal(136, 12),
+      type: readString(156, 1),
+      data: tar.subarray(offset + 512, offset + 512 + size)
+    });
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+function expectedContentDigest(files) {
+  return sha256(
+    Buffer.from(files.map(({ path: relativePath, sha256: digest }) => `${relativePath}\0${digest}\n`).join(''))
+  );
+}
+
+function withScratchDir(name, callback) {
+  const scratchDir = mkdtempSync(path.join(tmpdir(), `coven-${name}-`));
+  try {
+    return callback(scratchDir);
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+test('packages a deterministic source-bound protocol archive with normalized metadata', () => {
+  withScratchDir('automation-protocol-package', (scratchDir) => {
+    const fixture = createFixtureRepository(scratchDir);
+    const firstOutput = path.join(scratchDir, 'first');
+    const secondOutput = path.join(scratchDir, 'second');
+
+    const first = packageAutomationsProtocol({
+      repoRoot: fixture.repoRoot,
+      outputDir: firstOutput,
+      sourceCommit: fixture.sourceCommit
+    });
+    const second = packageAutomationsProtocol({
+      repoRoot: fixture.repoRoot,
+      outputDir: secondOutput,
+      sourceCommit: fixture.sourceCommit
+    });
+
+    assert.equal(
+      path.basename(first.bundlePath),
+      `coven-automations-v1-contract-${fixture.sourceCommit}.tar.gz`
+    );
+    assert.deepEqual(readFileSync(first.bundlePath), readFileSync(second.bundlePath));
+    assert.deepEqual(readFileSync(first.manifestPath), readFileSync(second.manifestPath));
+
+    const manifest = JSON.parse(readFileSync(first.manifestPath, 'utf8'));
+    assert.equal(manifest.schemaVersion, 'coven.automations.bundle.v1');
+    assert.equal(manifest.contractProfile, 'coven.automations.v1');
+    assert.equal(manifest.sourceCommit, fixture.sourceCommit);
+    assert.deepEqual(
+      manifest.files.map((file) => file.path),
+      ['README.md', 'b.json', 'nested/a.json']
+    );
+    assert.equal(manifest.contractContentSha256, expectedContentDigest(manifest.files));
+
+    const entries = parseTarGz(readFileSync(first.bundlePath));
+    assert.deepEqual(
+      entries.map((entry) => entry.name),
+      [
+        'coven-automations-v1/README.md',
+        'coven-automations-v1/b.json',
+        'coven-automations-v1/nested/a.json',
+        'manifest.json'
+      ]
+    );
+    for (const entry of entries) {
+      assert.equal(entry.mode, 0o644);
+      assert.equal(entry.uid, 0);
+      assert.equal(entry.gid, 0);
+      assert.equal(entry.mtime, 0);
+      assert.equal(entry.type, '0');
+    }
+    assert.deepEqual(
+      JSON.parse(entries.at(-1).data.toString('utf8')),
+      manifest
+    );
+    assert.equal(first.bundleSha256, sha256(readFileSync(first.bundlePath)));
+    assert.deepEqual(
+      [...readFileSync(first.bundlePath).subarray(0, 10)],
+      [0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff]
+    );
+  });
+});
+
+test('keeps the content digest stable while binding bundle bytes to the source commit', () => {
+  withScratchDir('automation-protocol-source-binding', (scratchDir) => {
+    const fixture = createFixtureRepository(scratchDir);
+    const first = packageAutomationsProtocol({
+      repoRoot: fixture.repoRoot,
+      outputDir: path.join(scratchDir, 'first'),
+      sourceCommit: fixture.sourceCommit
+    });
+    writeFileSync(path.join(fixture.repoRoot, 'unrelated.txt'), 'different source commit\n');
+    runGit(fixture.repoRoot, ['add', 'unrelated.txt']);
+    runGit(fixture.repoRoot, ['commit', '-m', 'test: advance source']);
+    const secondCommit = runGit(fixture.repoRoot, ['rev-parse', 'HEAD']);
+    const second = packageAutomationsProtocol({
+      repoRoot: fixture.repoRoot,
+      outputDir: path.join(scratchDir, 'second'),
+      sourceCommit: secondCommit
+    });
+
+    const firstManifest = JSON.parse(readFileSync(first.manifestPath, 'utf8'));
+    const secondManifest = JSON.parse(readFileSync(second.manifestPath, 'utf8'));
+    assert.equal(firstManifest.contractContentSha256, secondManifest.contractContentSha256);
+    assert.notEqual(first.bundleSha256, second.bundleSha256);
+  });
+});
+
+test('refuses dirty, mismatched, or non-regular protocol input trees', () => {
+  withScratchDir('automation-protocol-refusal', (scratchDir) => {
+    const fixture = createFixtureRepository(scratchDir);
+    assert.throws(
+      () =>
+        packageAutomationsProtocol({
+          repoRoot: fixture.repoRoot,
+          outputDir: path.join(scratchDir, 'mismatch'),
+          sourceCommit: '0'.repeat(40)
+        }),
+      /source commit .* does not match HEAD/i
+    );
+
+    writeFileSync(path.join(fixture.specDir, 'README.md'), '# Dirty contract\n');
+    assert.throws(
+      () =>
+        packageAutomationsProtocol({
+          repoRoot: fixture.repoRoot,
+          outputDir: path.join(scratchDir, 'dirty'),
+          sourceCommit: fixture.sourceCommit
+        }),
+      /protocol input tree is dirty/i
+    );
+    runGit(fixture.repoRoot, ['restore', 'spec/coven-automations/v1/README.md']);
+
+    writeFileSync(path.join(fixture.repoRoot, '.gitignore'), '*.log\n');
+    runGit(fixture.repoRoot, ['add', '.gitignore']);
+    runGit(fixture.repoRoot, ['commit', '-m', 'test: ignore logs']);
+    const ignoredCommit = runGit(fixture.repoRoot, ['rev-parse', 'HEAD']);
+    writeFileSync(path.join(fixture.specDir, 'ignored.log'), 'must not enter bundle\n');
+    assert.throws(
+      () =>
+        packageAutomationsProtocol({
+          repoRoot: fixture.repoRoot,
+          outputDir: path.join(scratchDir, 'ignored'),
+          sourceCommit: ignoredCommit
+        }),
+      /does not exactly match tracked source files/i
+    );
+    rmSync(path.join(fixture.specDir, 'ignored.log'));
+
+    symlinkSync('README.md', path.join(fixture.specDir, 'linked.md'));
+    runGit(fixture.repoRoot, ['add', 'spec/coven-automations/v1/linked.md']);
+    runGit(fixture.repoRoot, ['commit', '-m', 'test: add protocol symlink']);
+    const symlinkCommit = runGit(fixture.repoRoot, ['rev-parse', 'HEAD']);
+    assert.throws(
+      () =>
+        packageAutomationsProtocol({
+          repoRoot: fixture.repoRoot,
+          outputDir: path.join(scratchDir, 'symlink'),
+          sourceCommit: symlinkCommit
+        }),
+      /must contain only regular files/i
+    );
+  });
+});
+
+test('verifies every bundled file, content digest, source commit, and archive digest', () => {
+  withScratchDir('automation-protocol-verify', (scratchDir) => {
+    const fixture = createFixtureRepository(scratchDir);
+    const packaged = packageAutomationsProtocol({
+      repoRoot: fixture.repoRoot,
+      outputDir: path.join(scratchDir, 'out'),
+      sourceCommit: fixture.sourceCommit
+    });
+    const verified = verifyAutomationsProtocolBundle({
+      bundlePath: packaged.bundlePath,
+      expectedSourceCommit: fixture.sourceCommit,
+      expectedBundleSha256: packaged.bundleSha256
+    });
+    assert.equal(verified.contractContentSha256, packaged.contractContentSha256);
+    assert.equal(verified.fileCount, 3);
+
+    assert.throws(
+      () =>
+        verifyAutomationsProtocolBundle({
+          bundlePath: packaged.bundlePath,
+          expectedSourceCommit: 'f'.repeat(40),
+          expectedBundleSha256: packaged.bundleSha256
+        }),
+      /source commit mismatch/i
+    );
+    assert.throws(
+      () =>
+        verifyAutomationsProtocolBundle({
+          bundlePath: packaged.bundlePath,
+          expectedSourceCommit: fixture.sourceCommit,
+          expectedBundleSha256: 'f'.repeat(64)
+        }),
+      /bundle SHA-256 mismatch/i
+    );
+
+    const nonNormalizedGzip = Buffer.from(readFileSync(packaged.bundlePath));
+    nonNormalizedGzip[9] = 0x03;
+    const nonNormalizedGzipPath = path.join(scratchDir, 'non-normalized-gzip.tar.gz');
+    writeFileSync(nonNormalizedGzipPath, nonNormalizedGzip);
+    assert.throws(
+      () =>
+        verifyAutomationsProtocolBundle({
+          bundlePath: nonNormalizedGzipPath,
+          expectedSourceCommit: fixture.sourceCommit,
+          expectedBundleSha256: sha256(nonNormalizedGzip)
+        }),
+      /gzip header is not normalized/i
+    );
+
+    const nonNormalizedTar = gunzipSync(readFileSync(packaged.bundlePath));
+    const firstSize = Number.parseInt(
+      nonNormalizedTar.subarray(124, 136).toString('utf8').replace(/\0.*$/s, '').trim(),
+      8
+    );
+    nonNormalizedTar[512 + firstSize] = 1;
+    const nonNormalizedPadding = gzipSync(nonNormalizedTar, { level: 9, mtime: 0 });
+    nonNormalizedPadding.writeUInt32LE(0, 4);
+    nonNormalizedPadding[9] = 0xff;
+    const nonNormalizedPaddingPath = path.join(scratchDir, 'non-normalized-padding.tar.gz');
+    writeFileSync(nonNormalizedPaddingPath, nonNormalizedPadding);
+    assert.throws(
+      () =>
+        verifyAutomationsProtocolBundle({
+          bundlePath: nonNormalizedPaddingPath,
+          expectedSourceCommit: fixture.sourceCommit,
+          expectedBundleSha256: sha256(nonNormalizedPadding)
+        }),
+      /tar padding is not normalized/i
+    );
+
+    const extraTerminatorTar = Buffer.concat([
+      gunzipSync(readFileSync(packaged.bundlePath)),
+      Buffer.alloc(512, 0)
+    ]);
+    const extraTerminatorBundle = gzipSync(extraTerminatorTar, { level: 9, mtime: 0 });
+    extraTerminatorBundle.writeUInt32LE(0, 4);
+    extraTerminatorBundle[9] = 0xff;
+    const extraTerminatorPath = path.join(scratchDir, 'extra-terminator.tar.gz');
+    writeFileSync(extraTerminatorPath, extraTerminatorBundle);
+    assert.throws(
+      () =>
+        verifyAutomationsProtocolBundle({
+          bundlePath: extraTerminatorPath,
+          expectedSourceCommit: fixture.sourceCommit,
+          expectedBundleSha256: sha256(extraTerminatorBundle)
+        }),
+      /tar has an invalid terminator/i
+    );
+
+    const tamperedTar = gunzipSync(readFileSync(packaged.bundlePath));
+    const original = Buffer.from('{"b":2}\n');
+    const replacement = Buffer.from('{"b":3}\n');
+    const index = tamperedTar.indexOf(original);
+    assert.notEqual(index, -1);
+    replacement.copy(tamperedTar, index);
+    const tamperedBundle = gzipSync(tamperedTar, { level: 9, mtime: 0 });
+    tamperedBundle.writeUInt32LE(0, 4);
+    tamperedBundle[9] = 0xff;
+    const tamperedPath = path.join(scratchDir, 'tampered.tar.gz');
+    writeFileSync(tamperedPath, tamperedBundle);
+    assert.throws(
+      () =>
+        verifyAutomationsProtocolBundle({
+          bundlePath: tamperedPath,
+          expectedSourceCommit: fixture.sourceCommit,
+          expectedBundleSha256: sha256(tamperedBundle)
+        }),
+      /file SHA-256 mismatch for b\.json/i
+    );
+  });
+});
+
+test('pinned TypeScript declarations expose the implemented event page result', () => {
+  const declaration = readFileSync(
+    path.join(repositoryRoot, 'spec', 'coven-automations', 'v1', 'coven.automations.v1.d.ts'),
+    'utf8'
+  );
+  assert.match(declaration, /export interface EventRef \{/);
+  assert.match(declaration, /eventRef\?: EventRef;/);
+  assert.match(declaration, /export interface EventPage \{/);
+  assert.match(declaration, /events: EventEnvelope\[\];/);
+  assert.match(declaration, /nextAfter: number \| null;/);
+  assert.match(declaration, /checkpointExpiresAt: Timestamp;/);
+  assert.match(
+    declaration,
+    /C extends "events\.read\.v1" \| "events\.subscribe\.v1" \? EventPage : Record<string, unknown>/
+  );
+});

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -30,8 +30,8 @@ const releaseScriptText = readFileSync(path.join(repoRoot, 'scripts', 'package-g
 const fixtureRoot = path.join(repoRoot, 'scripts', 'fixtures', 'package-github-release', 'source-artifacts');
 const scratchRoot = path.join(repoRoot, 'npm', 'dist', '.package-github-release-tests');
 const SOURCE_DATE_EPOCH = 1_786_939_861;
-const RELEASE_TAG = 'v0.4.1';
-const NPM_VERSION = '0.4.1';
+const RELEASE_TAG = 'v0.4.4';
+const NPM_VERSION = '0.4.4';
 const HEAD_SHA = '0000000000000000000000000000000000000000';
 const SOURCE_RUN_ID = '31993572717';
 const SOURCE_RUN_ATTEMPT = 1;
@@ -46,12 +46,23 @@ const RELEASE_PACKAGES = [
   '@opencoven/cli-macos'
 ];
 const EXPECTED_ARCHIVES = [
-  'coven-v0.4.1-linux-x64.tar.gz',
-  'coven-v0.4.1-macos-aarch64.tar.gz',
-  'coven-v0.4.1-macos-x64.tar.gz',
-  'coven-v0.4.1-windows-x64.zip'
+  'coven-v0.4.4-linux-x64.tar.gz',
+  'coven-v0.4.4-macos-aarch64.tar.gz',
+  'coven-v0.4.4-macos-x64.tar.gz',
+  'coven-v0.4.4-windows-x64.zip'
 ].sort();
-const EXPECTED_ASSET_NAMES = [...EXPECTED_ARCHIVES, 'SHA256SUMS'].sort();
+const PROTOCOL_BUNDLE_NAME = `coven-automations-v1-contract-${HEAD_SHA}.tar.gz`;
+const EXPECTED_ASSET_NAMES = [...EXPECTED_ARCHIVES, PROTOCOL_BUNDLE_NAME, 'SHA256SUMS'].sort();
+
+function packageCanonicalRelease(options) {
+  const protocolBundlePath = path.join(path.dirname(options.outputDir), PROTOCOL_BUNDLE_NAME);
+  writeFileSync(protocolBundlePath, 'deterministic protocol bundle\n');
+  return packageGitHubRelease({
+    ...options,
+    sourceCommit: HEAD_SHA,
+    protocolBundlePath
+  });
+}
 
 function releasePackageVersionMap(version = NPM_VERSION) {
   return Object.fromEntries(RELEASE_PACKAGES.map((packageName) => [packageName, version]));
@@ -539,6 +550,14 @@ test('release-github workflow supports automatic and recovery triggers with pinn
   assert.match(workflowText, /node scripts\/package-github-release\.mjs package/);
   assert.match(
     workflowText,
+    /package-automations-protocol\.mjs[\s\S]*--protocol-bundle "\$PROTOCOL_BUNDLE"/
+  );
+  assert.match(
+    workflowText,
+    /if \[\[ -f github-release-protocol-source\/scripts\/package-automations-protocol\.mjs \]\]/
+  );
+  assert.match(
+    workflowText,
     /node scripts\/package-github-release\.mjs sync-release[\s\S]*--expected-tag-object-sha "\$TAG_OBJECT_SHA"[\s\S]*--expected-head-sha "\$HEAD_SHA"/
   );
   assert.match(workflowText, new RegExp(`actions/checkout@${CHECKOUT_ACTION_SHA}`));
@@ -563,16 +582,38 @@ test('release-github workflow uses least privilege, default-branch code, and nev
   assert.doesNotMatch(workflowText, /npm publish|publish-npm\.mjs --publish/);
   assert.match(ciWorkflowText, new RegExp(`actions/setup-node@${SETUP_NODE_ACTION_SHA}`));
   assert.match(ciWorkflowText, /node --test scripts\/package-github-release-test\.mjs/);
+  assert.match(ciWorkflowText, /automations-protocol-bundle:/);
+  assert.match(
+    ciWorkflowText,
+    /package-automations-protocol\.mjs[\s\S]*name: coven-automations-v1-contract-\$\{\{ github\.sha \}\}/
+  );
 });
 
 test('canonical release asset names and package definitions match the public contract', () => {
-  assert.deepEqual(canonicalReleaseAssetNames(RELEASE_TAG).sort(), EXPECTED_ASSET_NAMES);
+  assert.deepEqual(
+    canonicalReleaseAssetNames(RELEASE_TAG, HEAD_SHA).sort(),
+    EXPECTED_ASSET_NAMES
+  );
   assert.deepEqual(Object.keys(PACKAGE_DEFINITIONS).sort(), [
     'linux-x64',
     'macos',
     'macos-x64',
     'windows'
   ]);
+  assert.deepEqual(
+    canonicalReleaseAssetNames('v0.4.3', HEAD_SHA).sort(),
+    [
+      'coven-v0.4.3-linux-x64.tar.gz',
+      'coven-v0.4.3-macos-aarch64.tar.gz',
+      'coven-v0.4.3-macos-x64.tar.gz',
+      'coven-v0.4.3-windows-x64.zip',
+      'SHA256SUMS'
+    ].sort()
+  );
+  assert.ok(
+    canonicalReleaseAssetNames('v0.5.0', HEAD_SHA).includes(PROTOCOL_BUNDLE_NAME),
+    'later minor releases must retain the canonical protocol asset'
+  );
 });
 
 test('verifySourceRun accepts a successful release-npm run and derives the immutable version', () => {
@@ -666,7 +707,7 @@ test('verifyAnnotatedTag rejects lightweight, unsigned, or retargeted tags', () 
         releaseTag: RELEASE_TAG,
         expectedHeadSha: HEAD_SHA
       }),
-    /must name tag v0\.4\.1/
+    /must name tag v0\.4\.4/
   );
   assert.throws(
     () =>
@@ -1043,7 +1084,7 @@ test('verifyNpmRegistrySignatures rejects wrong-version package-lock entries bef
             }
           }
         }),
-      new RegExp(`${wrongPackage}.*0\\.4\\.1`)
+      new RegExp(`${wrongPackage}.*0\\.4\\.4`)
     );
     assert.deepEqual(calls, [
       {
@@ -1226,7 +1267,7 @@ test('verifyPackageProvenance rejects malformed or mismatched attestation payloa
         subjectDigest: goodDigest,
         workflowRef: 'refs/tags/v0.4.2'
       }),
-      error: /refs\/tags\/v0\.4\.1/
+      error: /refs\/tags\/v0\.4\.4/
     },
     {
       name: 'git commit mismatch',
@@ -1335,7 +1376,7 @@ test('packageGitHubRelease emits deterministic canonical assets with normalized 
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
 
-    const produced = packageGitHubRelease({
+    const produced = packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1349,19 +1390,19 @@ test('packageGitHubRelease emits deterministic canonical assets with normalized 
     assert.doesNotThrow(() => assertChecksumManifest(checksums, EXPECTED_ARCHIVES));
 
     const macosArm = parseTarGzEntries(
-      readFileSync(path.join(outputDir, 'coven-v0.4.1-macos-aarch64.tar.gz'))
+      readFileSync(path.join(outputDir, 'coven-v0.4.4-macos-aarch64.tar.gz'))
     );
     assert.equal(macosArm.gzipMtime, SOURCE_DATE_EPOCH);
     assertRootOnlyTarEntries(macosArm.entries, ['coven', 'coven-afs-serve']);
 
     const linux = parseTarGzEntries(
-      readFileSync(path.join(outputDir, 'coven-v0.4.1-linux-x64.tar.gz'))
+      readFileSync(path.join(outputDir, 'coven-v0.4.4-linux-x64.tar.gz'))
     );
     assert.equal(linux.gzipMtime, SOURCE_DATE_EPOCH);
     assertRootOnlyTarEntries(linux.entries, ['coven']);
 
     const windows = parseZipEntries(
-      readFileSync(path.join(outputDir, 'coven-v0.4.1-windows-x64.zip'))
+      readFileSync(path.join(outputDir, 'coven-v0.4.4-windows-x64.zip'))
     );
     const zipTimestamp = expectedZipTimestamp(SOURCE_DATE_EPOCH);
     assert.deepEqual(windows.map((entry) => entry.name), ['coven.exe']);
@@ -1378,7 +1419,7 @@ test('packageGitHubRelease is byte-identical across repeated runs with identical
       const artifactsDir = path.join(scratchDir, `${name}-artifacts`);
       const outputDir = path.join(scratchDir, `${name}-out`);
       cpSync(fixtureRoot, artifactsDir, { recursive: true });
-      packageGitHubRelease({
+      packageCanonicalRelease({
         releaseTag: RELEASE_TAG,
         artifactsDir,
         outputDir,
@@ -1416,7 +1457,7 @@ test('packageGitHubRelease rejects missing or extra source artifact files', () =
     rmSync(path.join(missingArtifactsDir, 'coven-macos', 'coven-afs-serve'));
     assert.throws(
       () =>
-        packageGitHubRelease({
+        packageCanonicalRelease({
           releaseTag: RELEASE_TAG,
           artifactsDir: missingArtifactsDir,
           outputDir: path.join(scratchDir, 'missing-out'),
@@ -1430,13 +1471,65 @@ test('packageGitHubRelease rejects missing or extra source artifact files', () =
     writeFileSync(path.join(extraArtifactsDir, 'coven-linux-x64', 'extra.txt'), 'unexpected\n');
     assert.throws(
       () =>
-        packageGitHubRelease({
+        packageCanonicalRelease({
           releaseTag: RELEASE_TAG,
           artifactsDir: extraArtifactsDir,
           outputDir: path.join(scratchDir, 'extra-out'),
           sourceDateEpoch: SOURCE_DATE_EPOCH
         }),
       /unexpected files/
+    );
+  });
+});
+
+test('packageGitHubRelease refuses missing or misnamed Automations protocol bundles', () => {
+  withScratchDir('invalid-protocol-bundle', (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    assert.throws(
+      () =>
+        packageGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          artifactsDir,
+          outputDir: path.join(scratchDir, 'missing-out'),
+          sourceDateEpoch: SOURCE_DATE_EPOCH,
+          sourceCommit: HEAD_SHA,
+          protocolBundlePath: path.join(scratchDir, PROTOCOL_BUNDLE_NAME)
+        }),
+      /protocol bundle must be a regular file/i
+    );
+
+    const wrongName = path.join(scratchDir, 'wrong-name.tar.gz');
+    writeFileSync(wrongName, 'protocol bundle\n');
+    assert.throws(
+      () =>
+        packageGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          artifactsDir,
+          outputDir: path.join(scratchDir, 'misnamed-out'),
+          sourceDateEpoch: SOURCE_DATE_EPOCH,
+          sourceCommit: HEAD_SHA,
+          protocolBundlePath: wrongName
+        }),
+      new RegExp(`protocol bundle must be a regular file named ${PROTOCOL_BUNDLE_NAME}`)
+    );
+  });
+});
+
+test('packageGitHubRelease preserves pre-v0.4.4 recovery without a protocol bundle', () => {
+  withScratchDir('legacy-release-package', (scratchDir) => {
+    const artifactsDir = path.join(scratchDir, 'artifacts');
+    const outputDir = path.join(scratchDir, 'out');
+    cpSync(fixtureRoot, artifactsDir, { recursive: true });
+    const produced = packageGitHubRelease({
+      releaseTag: 'v0.4.3',
+      artifactsDir,
+      outputDir,
+      sourceDateEpoch: SOURCE_DATE_EPOCH
+    });
+    assert.deepEqual(
+      produced.assetNames.sort(),
+      canonicalReleaseAssetNames('v0.4.3', HEAD_SHA).sort()
     );
   });
 });
@@ -1534,7 +1627,7 @@ test('syncGitHubRelease revalidates the verified remote tag before creating a mi
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1563,7 +1656,7 @@ test('syncGitHubRelease revalidates the verified remote tag before creating a mi
       }
     ]);
     assert.deepEqual(client.state.created, [
-      { releaseTag: RELEASE_TAG, title: 'Coven v0.4.1', notesFromTag: true, verifyTag: true }
+      { releaseTag: RELEASE_TAG, title: 'Coven v0.4.4', notesFromTag: true, verifyTag: true }
     ]);
     assert.deepEqual(result.uploaded.sort(), EXPECTED_ASSET_NAMES);
     assert.deepEqual(result.skipped, []);
@@ -1575,7 +1668,7 @@ test('syncGitHubRelease refuses release creation when the verified remote tag wa
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1585,7 +1678,7 @@ test('syncGitHubRelease refuses release creation when the verified remote tag wa
     const cases = [
       {
         name: 'deleted',
-        error: /no longer resolves to refs\/tags\/v0\.4\.1/i,
+        error: /no longer resolves to refs\/tags\/v0\.4\.4/i,
         revalidateTagState() {
           throw new Error(
             `Refusing GitHub release: ${RELEASE_TAG} no longer resolves to refs/tags/${RELEASE_TAG}.`
@@ -1636,7 +1729,7 @@ test('syncGitHubRelease skips a fully matching rerun, including >1 MiB assets, w
       Buffer.concat([readFileSync(windowsBinaryPath), Buffer.alloc(1_250_000, 0x61)])
     );
 
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1680,7 +1773,7 @@ test('syncGitHubRelease refuses a fully matching rerun when the verified remote 
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1724,7 +1817,7 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1759,6 +1852,8 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
         syncGitHubRelease({
           releaseTag: RELEASE_TAG,
           outputDir,
+          expectedTagObjectSha: baseTagRef().object.sha,
+          expectedHeadSha: HEAD_SHA,
           releaseClient: mismatchedClient
         }),
       /observed hash .* expected hash .* delete only the mismatched GitHub asset/i
@@ -1775,6 +1870,8 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
         syncGitHubRelease({
           releaseTag: RELEASE_TAG,
           outputDir,
+          expectedTagObjectSha: baseTagRef().object.sha,
+          expectedHeadSha: HEAD_SHA,
           releaseClient: extraClient
         }),
       /unexpected release assets/
@@ -1793,6 +1890,8 @@ test('syncGitHubRelease skips matching assets, uploads only missing ones, and fa
         syncGitHubRelease({
           releaseTag: RELEASE_TAG,
           outputDir,
+          expectedTagObjectSha: baseTagRef().object.sha,
+          expectedHeadSha: HEAD_SHA,
           releaseClient: duplicateClient
         }),
       /duplicate release assets/
@@ -1805,7 +1904,7 @@ test('syncGitHubRelease revalidates the verified remote tag before uploading mis
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1845,7 +1944,7 @@ test('syncGitHubRelease refuses to upload missing assets to an existing release 
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1855,7 +1954,7 @@ test('syncGitHubRelease refuses to upload missing assets to an existing release 
     const cases = [
       {
         name: 'deleted',
-        error: /no longer resolves to refs\/tags\/v0\.4\.1/i,
+        error: /no longer resolves to refs\/tags\/v0\.4\.4/i,
         revalidateTagState() {
           throw new Error(
             `Refusing GitHub release: ${RELEASE_TAG} no longer resolves to refs/tags/${RELEASE_TAG}.`
@@ -1905,7 +2004,7 @@ test('syncGitHubRelease rejects existing release metadata mismatches before acce
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
@@ -1931,7 +2030,7 @@ test('syncGitHubRelease rejects existing release metadata mismatches before acce
           title: 'Wrong title',
           assets: allAssets
         }),
-        error: /title .*Coven v0\.4\.1/i
+        error: /title .*Coven v0\.4\.4/i
       },
       {
         name: 'draft release',
@@ -1961,6 +2060,8 @@ test('syncGitHubRelease rejects existing release metadata mismatches before acce
           syncGitHubRelease({
             releaseTag: RELEASE_TAG,
             outputDir,
+            expectedTagObjectSha: baseTagRef().object.sha,
+            expectedHeadSha: HEAD_SHA,
             releaseClient: client
           }),
         error,
@@ -1977,13 +2078,13 @@ test('syncGitHubRelease preflights later mismatches before uploading earlier mis
     const artifactsDir = path.join(scratchDir, 'artifacts');
     const outputDir = path.join(scratchDir, 'out');
     cpSync(fixtureRoot, artifactsDir, { recursive: true });
-    packageGitHubRelease({
+    packageCanonicalRelease({
       releaseTag: RELEASE_TAG,
       artifactsDir,
       outputDir,
       sourceDateEpoch: SOURCE_DATE_EPOCH
     });
-    const windowsAssetName = 'coven-v0.4.1-windows-x64.zip';
+    const windowsAssetName = 'coven-v0.4.4-windows-x64.zip';
     const client = fakeReleaseClient({
       existingRelease: baseExistingRelease({
         assets: [{ id: 1, name: windowsAssetName }]
@@ -1998,6 +2099,8 @@ test('syncGitHubRelease preflights later mismatches before uploading earlier mis
         syncGitHubRelease({
           releaseTag: RELEASE_TAG,
           outputDir,
+          expectedTagObjectSha: baseTagRef().object.sha,
+          expectedHeadSha: HEAD_SHA,
           releaseClient: client
         }),
       /asset .*windows.* mismatch/i

--- a/scripts/package-github-release-test.mjs
+++ b/scripts/package-github-release-test.mjs
@@ -1491,6 +1491,16 @@ test('packageGitHubRelease refuses missing or misnamed Automations protocol bund
         packageGitHubRelease({
           releaseTag: RELEASE_TAG,
           artifactsDir,
+          outputDir: path.join(scratchDir, 'missing-inputs-out'),
+          sourceDateEpoch: SOURCE_DATE_EPOCH
+        }),
+      /v0\.4\.4 and later require sourceCommit and protocolBundlePath/i
+    );
+    assert.throws(
+      () =>
+        packageGitHubRelease({
+          releaseTag: RELEASE_TAG,
+          artifactsDir,
           outputDir: path.join(scratchDir, 'missing-out'),
           sourceDateEpoch: SOURCE_DATE_EPOCH,
           sourceCommit: HEAD_SHA,

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -949,6 +949,11 @@ export function packageGitHubRelease({
   writeFileSync(path.join(normalizedOutputDir, CHECKSUMS_NAME), checksumText);
   const protocolAssetNames = [];
   if (releaseIncludesAutomationsProtocol(releaseTag)) {
+    if (!sourceCommit || !protocolBundlePath) {
+      throw new Error(
+        'GitHub releases v0.4.4 and later require sourceCommit and protocolBundlePath for the Automations protocol asset.'
+      );
+    }
     const protocolBundleName = automationsProtocolBundleName(sourceCommit);
     const normalizedProtocolBundlePath = path.resolve(String(protocolBundlePath));
     if (

--- a/scripts/package-github-release.mjs
+++ b/scripts/package-github-release.mjs
@@ -2,7 +2,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { closeSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { closeSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -26,6 +26,7 @@ const ZIP_STORE_METHOD = 0;
 const TRUSTED_PUBLISHER_NAME = 'GitHub Actions';
 const TRUSTED_PUBLISHER_EMAIL = 'npm-oidc-no-reply@github.com';
 const TRUSTED_PUBLISHER_ID = 'github';
+const AUTOMATIONS_PROTOCOL_FIRST_RELEASE = [0, 4, 4];
 const RELEASE_PACKAGES = [
   '@opencoven/cli',
   '@opencoven/cli-linux-x64',
@@ -146,7 +147,9 @@ async function main() {
         releaseTag: requiredOption(options, 'release-tag'),
         artifactsDir: requiredOption(options, 'artifacts-dir'),
         outputDir: requiredOption(options, 'output-dir'),
-        sourceDateEpoch: requiredOption(options, 'source-date-epoch')
+        sourceDateEpoch: requiredOption(options, 'source-date-epoch'),
+        sourceCommit: options.get('source-commit'),
+        protocolBundlePath: options.get('protocol-bundle')
       });
       return;
     }
@@ -193,10 +196,35 @@ function requiredOption(options, key) {
   return value;
 }
 
-export function canonicalReleaseAssetNames(releaseTag) {
+export function automationsProtocolBundleName(sourceCommit) {
+  const normalized = String(sourceCommit).trim();
+  if (!/^[0-9a-f]{40}$/.test(normalized)) {
+    throw new Error(`Automations protocol source commit must be a lowercase 40-character Git SHA: ${normalized}`);
+  }
+  return `coven-automations-v1-contract-${normalized}.tar.gz`;
+}
+
+function releaseIncludesAutomationsProtocol(releaseTag) {
+  const { npmVersion } = parseReleaseTag(releaseTag);
+  const version = npmVersion.split('.').map(Number);
+  for (let index = 0; index < AUTOMATIONS_PROTOCOL_FIRST_RELEASE.length; index += 1) {
+    if (version[index] > AUTOMATIONS_PROTOCOL_FIRST_RELEASE[index]) {
+      return true;
+    }
+    if (version[index] < AUTOMATIONS_PROTOCOL_FIRST_RELEASE[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function canonicalReleaseAssetNames(releaseTag, sourceCommit) {
   const { npmVersion } = parseReleaseTag(releaseTag);
   return [
     ...Object.values(PACKAGE_DEFINITIONS).map((definition) => definition.assetName(npmVersion)),
+    ...(releaseIncludesAutomationsProtocol(releaseTag)
+      ? [automationsProtocolBundleName(sourceCommit)]
+      : []),
     CHECKSUMS_NAME
   ];
 }
@@ -887,7 +915,14 @@ function assertReleasePackagesResolvedInLockfile({ auditDir, npmVersion }) {
   return entries;
 }
 
-export function packageGitHubRelease({ releaseTag, artifactsDir, outputDir, sourceDateEpoch }) {
+export function packageGitHubRelease({
+  releaseTag,
+  artifactsDir,
+  outputDir,
+  sourceDateEpoch,
+  sourceCommit,
+  protocolBundlePath
+}) {
   const { npmVersion } = parseReleaseTag(releaseTag);
   const normalizedArtifactsDir = path.resolve(String(artifactsDir));
   const normalizedOutputDir = path.resolve(String(outputDir));
@@ -912,9 +947,32 @@ export function packageGitHubRelease({ releaseTag, artifactsDir, outputDir, sour
     checksumRecords.map((record) => record.assetName)
   );
   writeFileSync(path.join(normalizedOutputDir, CHECKSUMS_NAME), checksumText);
+  const protocolAssetNames = [];
+  if (releaseIncludesAutomationsProtocol(releaseTag)) {
+    const protocolBundleName = automationsProtocolBundleName(sourceCommit);
+    const normalizedProtocolBundlePath = path.resolve(String(protocolBundlePath));
+    if (
+      path.basename(normalizedProtocolBundlePath) !== protocolBundleName ||
+      !existsSync(normalizedProtocolBundlePath) ||
+      !statSync(normalizedProtocolBundlePath).isFile()
+    ) {
+      throw new Error(
+        `Refusing GitHub release: protocol bundle must be a regular file named ${protocolBundleName}.`
+      );
+    }
+    copyFileSync(
+      normalizedProtocolBundlePath,
+      path.join(normalizedOutputDir, protocolBundleName)
+    );
+    protocolAssetNames.push(protocolBundleName);
+  }
 
   return {
-    assetNames: [...checksumRecords.map((record) => record.assetName), CHECKSUMS_NAME].sort(),
+    assetNames: [
+      ...checksumRecords.map((record) => record.assetName),
+      ...protocolAssetNames,
+      CHECKSUMS_NAME
+    ].sort(),
     checksums: checksumRecords
   };
 }
@@ -1160,7 +1218,7 @@ export async function syncGitHubRelease({
   expectedHeadSha,
   releaseClient = createGhReleaseClient()
 }) {
-  const expectedAssetNames = canonicalReleaseAssetNames(releaseTag).sort();
+  const expectedAssetNames = canonicalReleaseAssetNames(releaseTag, expectedHeadSha).sort();
   const normalizedOutputDir = path.resolve(String(outputDir));
   const presentAssetNames = readdirSync(normalizedOutputDir).sort();
   if (presentAssetNames.join('\n') !== expectedAssetNames.join('\n')) {

--- a/spec/coven-automations/v1/README.md
+++ b/spec/coven-automations/v1/README.md
@@ -40,3 +40,18 @@ Cave, the SDK, Psyche adapters, runtimes, and future implementations consume the
 ## Conformance
 
 Required test suites and canary requirements (Coven, SDK, Cave — each against packed/released artifacts, not source-relative imports) are listed in `conformance-manifest.json`. Golden vectors are self-contained: any draft 2020-12 validator plus the digest recipe in `test-vectors.json` suffices to run them outside the Coven crate.
+
+## Immutable bundle
+
+CI packages this directory as
+`coven-automations-v1-contract-<source-commit>.tar.gz`. The archive contains
+these contract files under `coven-automations-v1/` plus `manifest.json`.
+The manifest binds the bundle to the exact source commit, records the SHA-256
+and byte size of every contract file, and publishes `contractContentSha256`
+over the lexically ordered `relative-path\0sha256\n` pairs. That content digest
+excludes the source commit and archive metadata, so consumers can distinguish
+unchanged contract bytes from a newly source-bound release bundle.
+
+SDK, Cave, and other canaries must download the exact-commit CI or release
+artifact and verify its digest and manifest. Importing this source directory
+directly is not a conformance result.

--- a/spec/coven-automations/v1/coven.automations.v1.d.ts
+++ b/spec/coven-automations/v1/coven.automations.v1.d.ts
@@ -526,6 +526,14 @@ export interface ErrorEnvelope {
   currentRevision?: number;
 }
 
+export interface EventRef {
+  stream: string;
+  sequence: number;
+}
+
+export type CommandResultByCommand<C extends CommandName> =
+  C extends "events.read.v1" | "events.subscribe.v1" ? EventPage : Record<string, unknown>;
+
 export interface CommandResponse<C extends CommandName = CommandName> {
   schemaVersion: SchemaVersion;
   command: C;
@@ -533,10 +541,10 @@ export interface CommandResponse<C extends CommandName = CommandName> {
   outcome: "committed" | "replayed" | "rejected";
   replay?: { firstCommittedAt: Timestamp };
   revision?: number;
-  result?: Record<string, unknown>;
+  result?: CommandResultByCommand<C>;
   error?: ErrorEnvelope;
   receiptRef?: string;
-  eventRef?: { stream: string; sequence: number };
+  eventRef?: EventRef;
 }
 
 // ---------------------------------------------------------------------------
@@ -558,6 +566,17 @@ export type EventKind =
   | "attempt.transitioned"
   | "receipt.recorded"
   | "feed.snapshot";
+
+export interface EventPage {
+  stream: StreamRef;
+  /** Concrete exclusive cursor used for this page; null means the stream beginning. */
+  after: number | null;
+  events: EventEnvelope[];
+  /** Last delivered sequence, or the concrete exclusive cursor when the page is empty. */
+  nextAfter: number | null;
+  checkpoint: string;
+  checkpointExpiresAt: Timestamp;
+}
 
 export interface DefinitionLifecycleEventPayload {
   revision: number;


### PR DESCRIPTION
## Summary
- package the exact regular Git blobs in `spec/coven-automations/v1/` into a deterministic source-bound archive with an embedded and standalone manifest
- verify externally recorded bundle SHA-256, normalized/safe archive structure, source commit, exact file set, every file size/hash, and aggregate contract-content digest
- upload an exact-commit CI artifact and require it in the PR gate
- publish the bundle as a canonical GitHub Release asset from v0.4.4 onward while preserving pre-v0.4.4 recovery and keeping `SHA256SUMS` scoped to four native archives
- reconcile the pinned TypeScript `EventRef` and `EventPage` result shape and document exact-artifact consumption

## Determinism and recovery
- ignored/untracked inputs cannot enter: filesystem paths must exactly match regular tracked blobs and bytes are read from the specified Git tree
- tar paths, ordering, modes, ownership, timestamps, padding, exact terminator, and gzip header are normalized
- unchanged contract bytes retain `contractContentSha256` across source commits while source-bound bundle bytes change
- old release tags without the bundler retain their original five canonical assets
- verifier and v0.4.4+ release packaging fail fast when required arguments are absent

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `node --test scripts/package-automations-protocol.test.mjs scripts/package-github-release-test.mjs scripts/release-stress-test.mjs`
- `python3 scripts/check-ci-workflow-test.py`
- `python3 scripts/check-workflows-test.py`
- `scripts/check-workflows.sh`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `python3 scripts/check-docs-ownership.py --range origin/main...HEAD`
- three independent release-integrity review rounds plus GitHub review fixes

## Exact artifact evidence
- source commit: `2a55b9d8cc036e317f3cdeb55fc4e53e5d45f193`
- bundle SHA-256: `b11de7d0f26500e1b0b240d21093d37260d3f7e512563dbc5e72e068a8e6e945`
- contract content SHA-256: `3c145eb92a93426ed64631f6487a8cd12903b0a49a6e752269f594ac50a779f5`
- manifest file count: 17

Advances #855. Exact CI-artifact SDK and Cave canaries remain the final #855 acceptance slice after this PR merges.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>