### PR TITLE
fix: keep npm smoke installs offline

### DIFF
--- a/scripts/test-cli-prepublish-test.mjs
+++ b/scripts/test-cli-prepublish-test.mjs
@@ -3,9 +3,26 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
+  buildLocalInstallArgs,
   DEFAULT_COMMAND_TIMEOUT_MS,
   synthesizeDryRunVersion
 } from './test-cli-prepublish.mjs';
+
+test('local tarball install is offline and disables registry extras', () => {
+  assert.deepEqual(
+    buildLocalInstallArgs('/tmp/native.tgz', '/tmp/wrapper.tgz'),
+    [
+      'install',
+      '--offline',
+      '--no-package-lock',
+      '--omit=optional',
+      '--no-audit',
+      '--no-fund',
+      '/tmp/native.tgz',
+      '/tmp/wrapper.tgz'
+    ]
+  );
+});
 
 test('synthesizeDryRunVersion honors COVEN_NPM_DRY_RUN_VERSION without calling npm view', () => {
   let called = false;

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -193,12 +193,8 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
     `${JSON.stringify({ name: 'coven-prepublish-test', private: true, version: '0.0.0' }, null, 2)}\n`
   );
 
-  // --omit=optional avoids npm trying to fetch the optional native package by
-  // version from the public registry; we install the local tarball directly.
-  const installArgs = ['install', '--no-package-lock', '--omit=optional', platformTgz, wrapperTgz];
-  if (dashboardTarball) {
-    installArgs.push(dashboardTarball);
-  }
+  // This is a local-package smoke test: fail instead of reaching the registry.
+  const installArgs = buildLocalInstallArgs(platformTgz, wrapperTgz, dashboardTarball);
   run('npm', installArgs, {
     cwd: tempDir
   });
@@ -255,6 +251,23 @@ export async function main() {
       console.log(`\nTemp project left at ${tempDir} (--keep-tempdir).`);
     }
   }
+}
+
+export function buildLocalInstallArgs(platformTgz, wrapperTgz, dashboardTarball) {
+  const installArgs = [
+    'install',
+    '--offline',
+    '--no-package-lock',
+    '--omit=optional',
+    '--no-audit',
+    '--no-fund',
+    platformTgz,
+    wrapperTgz
+  ];
+  if (dashboardTarball) {
+    installArgs.push(dashboardTarball);
+  }
+  return installArgs;
 }
 
 export function synthesizeDryRunVersion(


### PR DESCRIPTION
Closes #920.

## What changed

- installs the already-packed wrapper and native tarballs with npm offline mode;
- disables audit and funding registry work for this local-only smoke step;
- preserves the full packaged installed-user journey;
- pins the exact hermetic install arguments in a focused test.

## Evidence

- focused Node script suites: 147 passed, 1 platform-specific skip;
- full macOS prepublish smoke passed, including the packaged user journey;
- the same tarballs installed and launched successfully with `npm_config_registry=http://127.0.0.1:9`, proving the install no longer requires registry access;
- secret scan and staged privacy guard passed.

This does not weaken release dependency/signature auditing; it removes an accidental registry dependency from a local-tarball installation check.