### PR TITLE
fix: enforce security policy freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
       - run: python3 scripts/check-api-contract-docs-test.py
       - run: python3 scripts/check-api-contract-docs.py
       - run: python3 scripts/check-docs-ownership-test.py
+      - run: python3 scripts/check-security-policy-test.py
+      - run: python3 scripts/check-security-policy.py
       - run: python scripts/check-secrets.py
       - name: Documentation ownership guard (pull request changes)
         if: github.event_name == 'pull_request'

--- a/scripts/check-security-policy-test.py
+++ b/scripts/check-security-policy-test.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = pathlib.Path(__file__).with_name("check-security-policy.py")
+
+
+def load_checker():
+    if not SCRIPT.is_file():
+        return None
+    spec = importlib.util.spec_from_file_location("check_security_policy", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+module = load_checker()
+
+
+class SecurityPolicyTests(unittest.TestCase):
+    def checker(self):
+        self.assertIsNotNone(module, "check-security-policy.py is missing")
+        return module
+
+    def canonical_policy(self) -> str:
+        return (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+
+    def canonical_readme(self) -> str:
+        return (ROOT / "README.md").read_text(encoding="utf-8")
+
+    def validate(
+        self,
+        policy: str,
+        *,
+        readme: str | None = None,
+        root: pathlib.Path = ROOT,
+    ) -> list[str]:
+        checker = self.checker()
+        return checker.validate_policy(
+            policy,
+            self.canonical_readme() if readme is None else readme,
+            root,
+        )
+
+    def test_current_security_policy_is_valid(self) -> None:
+        self.assertEqual(self.validate(self.canonical_policy()), [])
+
+    def test_duplicate_security_policy_heading_fails(self) -> None:
+        policy = self.canonical_policy() + "\n## Security Policy\n"
+        errors = self.validate(policy)
+        self.assertTrue(
+            any("exactly one '# Security Policy' heading" in error for error in errors)
+        )
+
+    def test_retired_scope_and_personal_reporting_language_fail(self) -> None:
+        policy = self.canonical_policy().replace(
+            "## Policy maintenance",
+            "## OpenCoven Security Disclosure Addendum\n\n"
+            "- OpenTrust memory and session substrate\n"
+            "- Discord: https://discord.gg/example (DM @Example)\n\n"
+            "## Policy maintenance",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("retired scope language" in error for error in errors))
+        self.assertTrue(any("personal reporting channel" in error for error in errors))
+
+    def test_unsupported_response_deadline_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "Coven deliberately publishes **no acknowledgment or remediation deadline**.",
+            "We will acknowledge receipt within 48 hours.",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("response-time commitment" in error for error in errors))
+
+    def test_generic_response_deadline_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "Coven deliberately publishes **no acknowledgment or remediation deadline**.",
+            "We will respond within 48 hours.",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("response-time commitment" in error for error in errors))
+
+    def test_wrapped_response_deadline_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "Coven deliberately publishes **no acknowledgment or remediation deadline**.",
+            "We will respond\nwithin 48 hours.",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("response-time commitment" in error for error in errors))
+
+    def test_equivalent_addendum_scope_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "## Policy maintenance",
+            "This repository inherits the organization-wide OpenCoven security addendum.\n\n"
+            "## Policy maintenance",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("retired scope language" in error for error in errors))
+
+    def test_inherited_organization_wide_addendum_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "## Policy maintenance",
+            "This repository inherits the organization-wide security addendum.\n\n"
+            "## Policy maintenance",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("retired scope language" in error for error in errors))
+
+    def test_discord_user_dm_link_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "## Policy maintenance",
+            "Discord DM: https://discord.com/users/123456789012345678\n\n"
+            "## Policy maintenance",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("personal reporting channel" in error for error in errors))
+
+    def test_markdown_discord_user_link_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "## Policy maintenance",
+            "[Contact a maintainer](https://discord.com/users/123456789012345678)\n\n"
+            "## Policy maintenance",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("personal reporting channel" in error for error in errors))
+
+    def test_policy_cannot_broaden_to_all_opencoven_repositories(self) -> None:
+        policy = self.canonical_policy().replace(
+            "> Scope note: this policy covers Coven the runtime/daemon/CLI and the code in\n"
+            "> this repository.",
+            "> Scope note: this policy covers Coven and every OpenCoven repository.",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("must remain scoped to Coven" in error for error in errors))
+
+    def test_scope_note_cannot_add_the_rest_of_the_organization(self) -> None:
+        policy = self.canonical_policy().replace(
+            "> this repository.",
+            "> this repository, plus the rest of the OpenCoven organization.",
+            1,
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("must remain scoped to Coven" in error for error in errors))
+
+    def test_primary_advisory_intake_is_required(self) -> None:
+        policy = self.canonical_policy().replace(
+            "https://github.com/OpenCoven/coven/security/advisories/new",
+            "https://github.com/OpenCoven/coven/issues/new",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("private advisory intake" in error for error in errors))
+
+    def test_public_issues_cannot_become_the_primary_reporting_path(self) -> None:
+        policy = self.canonical_policy().replace(
+            "**Do not open a public GitHub issue for security vulnerabilities.**",
+            "**Open a public GitHub issue first for security vulnerabilities.**",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("must forbid public vulnerability reports" in error for error in errors))
+
+    def test_required_policy_sections_are_enforced(self) -> None:
+        policy = self.canonical_policy().replace(
+            "## 3. Residual risk and safe configuration",
+            "## 3. Operational notes",
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("required section" in error for error in errors))
+
+    def test_broken_relative_policy_link_fails(self) -> None:
+        policy = self.canonical_policy().replace(
+            "docs/API-CONTRACT.md",
+            "docs/DOES-NOT-EXIST.md",
+            1,
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("relative link does not resolve" in error for error in errors))
+
+    def test_readme_must_link_policy_and_private_advisories(self) -> None:
+        readme = self.canonical_readme().replace("(SECURITY.md)", "(README.md)")
+        readme = readme.replace(
+            "https://github.com/OpenCoven/coven/security/advisories",
+            "https://github.com/OpenCoven/coven/issues",
+        )
+        errors = self.validate(self.canonical_policy(), readme=readme)
+        self.assertTrue(any("README.md must link to SECURITY.md" in error for error in errors))
+        self.assertTrue(
+            any("README.md must link to private advisories" in error for error in errors)
+        )
+
+    def test_ci_runs_security_policy_test_and_checker(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn("python3 scripts/check-security-policy-test.py", workflow)
+        self.assertIn("python3 scripts/check-security-policy.py", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check-security-policy-test.py
+++ b/scripts/check-security-policy-test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import tempfile
 import unittest
 
 
@@ -181,6 +182,58 @@ class SecurityPolicyTests(unittest.TestCase):
         errors = self.validate(policy)
         self.assertTrue(any("relative link does not resolve" in error for error in errors))
 
+    def test_absolute_policy_link_fails_even_when_the_file_exists(self) -> None:
+        with tempfile.NamedTemporaryFile() as outside:
+            policy = self.canonical_policy().replace(
+                "docs/API-CONTRACT.md",
+                pathlib.Path(outside.name).as_posix(),
+                1,
+            )
+            errors = self.validate(policy)
+        self.assertTrue(any("must stay within the repository" in error for error in errors))
+
+    def test_policy_link_cannot_traverse_outside_the_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = pathlib.Path(directory)
+            root = parent / "repository"
+            root.mkdir()
+            (parent / "outside.md").write_text("outside", encoding="utf-8")
+            policy = self.canonical_policy().replace(
+                "docs/API-CONTRACT.md",
+                "../outside.md",
+                1,
+            )
+            errors = self.validate(policy, root=root)
+        self.assertTrue(any("must stay within the repository" in error for error in errors))
+
+    def test_windows_drive_policy_link_is_not_treated_as_external(self) -> None:
+        policy = self.canonical_policy().replace(
+            "docs/API-CONTRACT.md",
+            "C:\\Users\\example\\policy.md",
+            1,
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("must stay within the repository" in error for error in errors))
+
+    def test_unc_policy_link_cannot_escape_the_repository(self) -> None:
+        policy = self.canonical_policy().replace(
+            "docs/API-CONTRACT.md",
+            "\\\\server\\share\\policy.md",
+            1,
+        )
+        errors = self.validate(policy)
+        self.assertTrue(any("must stay within the repository" in error for error in errors))
+
+    def test_file_uri_policy_link_is_not_treated_as_external(self) -> None:
+        with tempfile.NamedTemporaryFile() as outside:
+            policy = self.canonical_policy().replace(
+                "docs/API-CONTRACT.md",
+                pathlib.Path(outside.name).as_uri(),
+                1,
+            )
+            errors = self.validate(policy)
+        self.assertTrue(any("must stay within the repository" in error for error in errors))
+
     def test_readme_must_link_policy_and_private_advisories(self) -> None:
         readme = self.canonical_readme().replace("(SECURITY.md)", "(README.md)")
         readme = readme.replace(
@@ -190,7 +243,10 @@ class SecurityPolicyTests(unittest.TestCase):
         errors = self.validate(self.canonical_policy(), readme=readme)
         self.assertTrue(any("README.md must link to SECURITY.md" in error for error in errors))
         self.assertTrue(
-            any("README.md must link to private advisories" in error for error in errors)
+            any(
+                "README.md must link to the public Security Advisories page" in error
+                for error in errors
+            )
         )
 
     def test_ci_runs_security_policy_test_and_checker(self) -> None:

--- a/scripts/check-security-policy.py
+++ b/scripts/check-security-policy.py
@@ -27,6 +27,7 @@ PRIVATE_ADVISORY_URL = (
     "https://github.com/OpenCoven/coven/security/advisories/new"
 )
 README_ADVISORY_URL = "https://github.com/OpenCoven/coven/security/advisories"
+WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
 RETIRED_SCOPE = re.compile(
     r"\b(?:OpenCoven Security Disclosure Addendum|"
     r"organization-wide OpenCoven security addendum|OpenTrust)\b|"
@@ -63,6 +64,12 @@ def relative_links(content: str) -> list[str]:
     for match in MARKDOWN_LINK.finditer(content):
         target = match.group(1).strip().strip("<>")
         if not target or target.startswith("#"):
+            continue
+        if WINDOWS_ABSOLUTE_PATH.match(target):
+            links.append(target)
+            continue
+        if target.lower().startswith("file:"):
+            links.append(target)
             continue
         if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", target):
             continue
@@ -108,7 +115,24 @@ def validate_policy(
         errors.append("SECURITY.md must keep private advisories as the primary path")
 
     for target in relative_links(policy):
-        if not (root / target).is_file():
+        if (
+            pathlib.PurePath(target).is_absolute()
+            or WINDOWS_ABSOLUTE_PATH.match(target)
+            or target.startswith("\\")
+            or target.lower().startswith("file:")
+        ):
+            errors.append(
+                f"SECURITY.md relative link must stay within the repository: {target}"
+            )
+            continue
+
+        resolved_root = root.resolve()
+        resolved_target = (root / target).resolve()
+        if not resolved_target.is_relative_to(resolved_root):
+            errors.append(
+                f"SECURITY.md relative link must stay within the repository: {target}"
+            )
+        elif not resolved_target.is_file():
             errors.append(
                 f"SECURITY.md relative link does not resolve: {target}"
             )
@@ -116,7 +140,7 @@ def validate_policy(
     if "(SECURITY.md)" not in readme:
         errors.append("README.md must link to SECURITY.md")
     if README_ADVISORY_URL not in readme:
-        errors.append("README.md must link to private advisories")
+        errors.append("README.md must link to the public Security Advisories page")
 
     return errors
 

--- a/scripts/check-security-policy.py
+++ b/scripts/check-security-policy.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from urllib.parse import unquote
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "SECURITY.md"
+README_PATH = ROOT / "README.md"
+
+POLICY_HEADING = re.compile(
+    r"^#{1,6}[ \t]+Security Policy[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+REQUIRED_SECTIONS = (
+    "## 1. Supported surfaces and security status",
+    "## 2. Enforced properties today",
+    "## 3. Residual risk and safe configuration",
+    "## 4. Reporting a vulnerability",
+    "## 5. Design goals vs guarantees",
+)
+PRIVATE_ADVISORY_URL = (
+    "https://github.com/OpenCoven/coven/security/advisories/new"
+)
+README_ADVISORY_URL = "https://github.com/OpenCoven/coven/security/advisories"
+RETIRED_SCOPE = re.compile(
+    r"\b(?:OpenCoven Security Disclosure Addendum|"
+    r"organization-wide OpenCoven security addendum|OpenTrust)\b|"
+    r"\b(?:inherits?|adopts?)[^.]{0,80}\borganization-wide\b"
+    r"[^.]{0,80}\bsecurity\b[^.]{0,30}\b(?:policy|addendum)\b",
+    re.IGNORECASE,
+)
+PERSONAL_REPORTING_CHANNEL = re.compile(
+    r"\bDiscord\b[^\n]{0,120}(?:\bDM\b|\bdirect message\b)|"
+    r"https?://(?:www\.)?discord(?:app)?\.com/users/",
+    re.IGNORECASE,
+)
+RESPONSE_TIME_COMMITMENT = re.compile(
+    r"\b(?:acknowledge|address|remediate|resolve|respond|reply|triage)"
+    r"[^.]{0,80}"
+    r"\bwithin\s+\d+\s+(?:hours?|days?|weeks?)\b",
+    re.IGNORECASE,
+)
+SCOPE_CONTRACT = (
+    "this policy covers Coven the runtime/daemon/CLI and the code in this repository."
+)
+BROAD_SCOPE = re.compile(
+    r"\b(?:all|every)\s+OpenCoven repositories?\b|"
+    r"\b(?:plus|and)\s+the\s+rest\s+of\s+the\s+OpenCoven\s+organization\b",
+    re.IGNORECASE,
+)
+PUBLIC_REPORT_WARNING = (
+    "**Do not open a public GitHub issue for security vulnerabilities.**"
+)
+
+
+def relative_links(content: str) -> list[str]:
+    links = []
+    for match in MARKDOWN_LINK.finditer(content):
+        target = match.group(1).strip().strip("<>")
+        if not target or target.startswith("#"):
+            continue
+        if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", target):
+            continue
+        links.append(unquote(target.split("#", 1)[0].split("?", 1)[0]))
+    return links
+
+
+def validate_policy(
+    policy: str,
+    readme: str,
+    root: pathlib.Path = ROOT,
+) -> list[str]:
+    errors = []
+    normalized_policy = re.sub(r"(?m)^>\s?", "", policy)
+    normalized_policy = re.sub(r"\s+", " ", normalized_policy)
+
+    headings = POLICY_HEADING.findall(policy)
+    if headings != ["# Security Policy"]:
+        errors.append(
+            "SECURITY.md must contain exactly one '# Security Policy' heading"
+        )
+
+    for section in REQUIRED_SECTIONS:
+        if section not in policy:
+            errors.append(f"SECURITY.md is missing required section: {section}")
+
+    if RETIRED_SCOPE.search(policy):
+        errors.append("SECURITY.md contains retired scope language")
+    if SCOPE_CONTRACT not in normalized_policy or BROAD_SCOPE.search(normalized_policy):
+        errors.append("SECURITY.md must remain scoped to Coven and this repository")
+    if PERSONAL_REPORTING_CHANNEL.search(policy):
+        errors.append("SECURITY.md contains a personal reporting channel")
+    if RESPONSE_TIME_COMMITMENT.search(normalized_policy):
+        errors.append("SECURITY.md contains an unsupported response-time commitment")
+    if PRIVATE_ADVISORY_URL not in policy:
+        errors.append("SECURITY.md must name the repository's private advisory intake")
+    if PUBLIC_REPORT_WARNING not in policy:
+        errors.append("SECURITY.md must forbid public vulnerability reports")
+    if not re.search(
+        rf"\*\*Primary path:\*\*[^.]{{0,300}}{re.escape(PRIVATE_ADVISORY_URL)}",
+        normalized_policy,
+    ):
+        errors.append("SECURITY.md must keep private advisories as the primary path")
+
+    for target in relative_links(policy):
+        if not (root / target).is_file():
+            errors.append(
+                f"SECURITY.md relative link does not resolve: {target}"
+            )
+
+    if "(SECURITY.md)" not in readme:
+        errors.append("README.md must link to SECURITY.md")
+    if README_ADVISORY_URL not in readme:
+        errors.append("README.md must link to private advisories")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_policy(
+        POLICY_PATH.read_text(encoding="utf-8"),
+        README_PATH.read_text(encoding="utf-8"),
+    )
+    if not errors:
+        return 0
+
+    print("Security policy check failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- complete the freshness/link validation deferred when #860 consolidated `SECURITY.md`
- fail CI on duplicate policy headings, missing contract sections, broadened organization scope, stale OpenTrust/addendum language, personal Discord reporting paths, unsupported response deadlines, or loss of private-advisory-first reporting
- verify repository-relative policy links and the canonical README security/advisory links

Closes #808

## Implementation

The checker pins the operational commitments that require deliberate review when changed while leaving external web availability to the broader documentation work in #778. It runs with a focused 18-case regression suite in the existing `Policy guard` job.

## Validation

- `python3 scripts/check-security-policy-test.py`
- `python3 scripts/check-security-policy.py`
- `python3 scripts/check-docs-ownership-test.py`
- `python3 scripts/check-api-contract-docs-test.py`
- `python3 scripts/check-api-contract-docs.py`
- `python3 scripts/check-workflows-test.py`
- `python3 scripts/check-ci-workflow-test.py`
- `python3 scripts/classify-ci-changes-test.py`
- `scripts/check-workflows.sh`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`

## Review

Independent bug-focused review completed after implementation. Concrete false negatives found in early passes were converted to regression tests and fixed; final review found no significant issues.

## Risk and rollback

Low operational risk: this changes CI policy enforcement, not runtime behavior. A false positive blocks a PR with a specific diagnostic and can be resolved by updating the policy and checker together. Rollback is a single commit revert.
