### PR TITLE
refactor: extract API response mapping

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -25,6 +25,9 @@ use crate::{
     privacy, project, session_launch, store, ward,
 };
 
+pub use crate::api_response::ApiResponse;
+pub(crate) use crate::api_response::{api_error, json_response};
+
 const MAX_EVENTS_LIMIT: i64 = 1_000;
 const EVENT_CANDIDATE_BATCH_LIMIT: usize = 16;
 const MAX_EVENT_CANDIDATE_BYTES: usize = coven_client::MAX_RESPONSE_BODY_BYTES;
@@ -547,13 +550,6 @@ pub struct EventsResponse {
 pub struct SessionPageResponse {
     pub sessions: Vec<store::SessionRecord>,
     pub next_cursor: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ApiResponse {
-    pub status: u16,
-    pub content_type: &'static str,
-    pub body: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5098,14 +5094,7 @@ where
     body.push_str(&events_json);
     body.push_str(&events_response_tail(last_seq, has_more));
     debug_assert!(body.len() < coven_client::MAX_RESPONSE_BODY_BYTES);
-    Ok((
-        ApiResponse {
-            status: 200,
-            content_type: "application/json",
-            body,
-        },
-        stats,
-    ))
+    Ok((ApiResponse::json_body(200, body), stats))
 }
 
 fn events_response_tail(last_seq: Option<i64>, has_more: bool) -> String {
@@ -12619,30 +12608,6 @@ fn reap_stale_created_sessions_throttled(conn: &rusqlite::Connection) {
     let cutoff = (Utc::now() - Duration::seconds(crate::daemon::STALE_CREATED_TTL_SECS))
         .to_rfc3339_opts(SecondsFormat::Nanos, true);
     let _ = store::mark_stale_created_sessions_failed(conn, &cutoff, &current_timestamp());
-}
-
-pub(crate) fn api_error(
-    status: u16,
-    code: &str,
-    message: &str,
-    details: Option<Value>,
-) -> Result<ApiResponse> {
-    let mut error = json!({
-        "code": code,
-        "message": message,
-    });
-    if let Some(d) = details {
-        error["details"] = d;
-    }
-    json_response(status, &json!({ "error": error }))
-}
-
-pub(crate) fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiResponse> {
-    Ok(ApiResponse {
-        status,
-        content_type: "application/json",
-        body: serde_json::to_string(body).context("failed to serialize API response")?,
-    })
 }
 
 #[cfg(test)]

--- a/crates/coven-cli/src/api_response.rs
+++ b/crates/coven-cli/src/api_response.rs
@@ -1,0 +1,152 @@
+//! Pure response and error-envelope mapping for the Coven daemon HTTP API.
+//!
+//! Route handlers decide status, error code, message, and details before
+//! entering this module. These constructors only serialize that decision into
+//! the stable [`ApiResponse`] transport shape; they perform no validation,
+//! policy, persistence, or I/O.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiResponse {
+    pub status: u16,
+    pub content_type: &'static str,
+    pub body: String,
+}
+
+impl ApiResponse {
+    pub(crate) fn json_body(status: u16, body: String) -> Self {
+        Self {
+            status,
+            content_type: "application/json",
+            body,
+        }
+    }
+}
+
+pub(crate) fn api_error(
+    status: u16,
+    code: &str,
+    message: &str,
+    details: Option<Value>,
+) -> Result<ApiResponse> {
+    let mut error = json!({
+        "code": code,
+        "message": message,
+    });
+    if let Some(details) = details {
+        error["details"] = details;
+    }
+    json_response(status, &json!({ "error": error }))
+}
+
+pub(crate) fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiResponse> {
+    Ok(ApiResponse {
+        status,
+        content_type: "application/json",
+        body: serde_json::to_string(body).context("failed to serialize API response")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_response_preserves_status_content_type_and_compact_body() -> Result<()> {
+        let response = json_response(202, &vec!["first", "second"])?;
+
+        assert_eq!(
+            response,
+            ApiResponse {
+                status: 202,
+                content_type: "application/json",
+                body: r#"["first","second"]"#.to_string(),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn json_body_preserves_a_pre_serialized_bounded_body() {
+        let body = r#"{"events":[],"nextCursor":null}"#.to_string();
+        let response = ApiResponse::json_body(200, body.clone());
+
+        assert_eq!(
+            response,
+            ApiResponse {
+                status: 200,
+                content_type: "application/json",
+                body,
+            }
+        );
+    }
+
+    #[test]
+    fn api_error_omits_details_when_absent() -> Result<()> {
+        let response = api_error(400, "invalid_request", "Invalid request.", None)?;
+
+        assert_eq!(response.status, 400);
+        assert_eq!(response.content_type, "application/json");
+        assert_eq!(
+            serde_json::from_str::<Value>(&response.body)?,
+            json!({
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Invalid request.",
+                }
+            })
+        );
+        assert!(!response.body.contains("details"));
+        Ok(())
+    }
+
+    #[test]
+    fn api_error_preserves_structured_details() -> Result<()> {
+        let details = json!({
+            "apiVersion": "v2",
+            "supportedApiVersions": ["v1"],
+        });
+        let response = api_error(
+            404,
+            "invalid_request",
+            "Unsupported API version.",
+            Some(details.clone()),
+        )?;
+
+        assert_eq!(
+            serde_json::from_str::<Value>(&response.body)?,
+            json!({
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Unsupported API version.",
+                    "details": details,
+                }
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn json_response_reports_serialization_context() {
+        struct SerializationFailure;
+
+        impl Serialize for SerializationFailure {
+            fn serialize<S>(&self, _serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                Err(serde::ser::Error::custom("fixture serialization failure"))
+            }
+        }
+
+        let error = json_response(200, &SerializationFailure).unwrap_err();
+        assert!(
+            format!("{error:#}")
+                .contains("failed to serialize API response: fixture serialization failure"),
+            "unexpected serialization error: {error:#}"
+        );
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 mod afs;
 mod afs_mount;
 mod api;
+mod api_response;
 mod api_routes;
 mod capabilities;
 mod cockpit_sources;

--- a/docs/authority-module-inventory.md
+++ b/docs/authority-module-inventory.md
@@ -44,9 +44,11 @@ characterization tests of each module.
    moved from `api.rs` to `api_routes.rs`. Pure parsing; rejection envelopes
    (`404 invalid_request` with `apiVersion`/`supportedApiVersions`,
    `404 not_found`) pinned by tests. No behavior change.
-2. **Response/error envelope mapping** (`api_error`, `json_response`,
-   `ApiResponse`, error-code precedence) — pure mapping, fan-in from every
-   handler; extract behind the same public envelopes.
+2. **Response/error envelope mapping — done (slice 2).** `ApiResponse`,
+   `api_error`, and `json_response` moved from `api.rs` to `api_response.rs`.
+   The seam is pure serialization: handlers still own status, code, message,
+   details, and precedence, while focused tests pin the transport shape,
+   optional-details behavior, and serialization error context.
 3. **Health/capability mapping and `RequestAuthority`** — the advertised
    capability surface is an authority decision (`sessionLaunchPolicy` depends
    on it); map it independently of session orchestration.
@@ -81,8 +83,9 @@ gates. Behavioral changes require a separate, separately approved PR.
   migration path. Policy decisions never move into the store layer.
 - **Executor/process lifecycle**: `pty_runner.rs` (and daemon supervision);
   never coupled to API formatting.
-- **Response/event mapping**: `api.rs` mapping helpers until slice 2 gives
-  them their own module; mapping stays pure (no I/O, no policy).
+- **Response/error envelope mapping**: `api_response.rs`; mapping stays pure
+  (no I/O, no policy). Route-specific response decisions remain with their
+  owning handler until a characterized domain extraction moves them.
 
 New cross-cutting responsibilities must justify staying inside a large module
 rather than joining the extracted contract.


### PR DESCRIPTION
## Summary
- extract `ApiResponse` and shared JSON/error-envelope constructors into a pure `api_response` module
- preserve route ownership of status, error code, message, details, precedence, and all authority decisions
- route the bounded pre-serialized event body through the same response transport seam without reparsing it
- record #806 authority-module slice 2 as complete

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- independent bug-focused review: no findings

Refs #806