### PR TITLE
chore: replace yanked der lock entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "pem-rfc7468 1.0.0",
  "zeroize",
@@ -5374,7 +5374,7 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der 0.8.0",
+ "der 0.8.2",
  "flate2",
  "log",
  "native-tls",


### PR DESCRIPTION
Closes #934.

Updates only the transitive `der` lock entry from yanked `0.8.0` to compatible `0.8.2`. This restores the dependency-audit gate without changing direct dependency manifests or policy.

Validation:
- `cargo deny check advisories licenses bans sources`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p coven-memory --locked`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`

`cargo test --workspace --locked` reached only the existing `parallel_protocol::maintenance_fence_blocks_claim_mutations_and_releases_cleanly` baseline failure; all preceding suites passed.