### PR TITLE
fix: retry silent Windows startup probes within the lifecycle deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
       - run: python3 scripts/check-reliability-scorecard.py
       - run: python3 scripts/check-workflows-test.py
       - run: python3 scripts/check-ci-workflow-test.py
+      - run: python3 scripts/install-native-link-dependencies-test.py
       - run: node --test scripts/package-github-release-test.mjs
       - run: node --test scripts/package-automations-protocol.test.mjs
       - run: node --test scripts/package-automations-authority-profile.test.mjs
@@ -216,7 +217,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-lint-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy
@@ -241,7 +242,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-test-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo test --workspace --locked
 
   rust-test-windows:
@@ -311,7 +312,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-afs-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Clippy (coven-afs mount feature)
         run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
       - name: Test (coven-afs mount feature)
@@ -375,7 +376,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-perf-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Build coven
         run: cargo build -p coven-cli --locked
       - name: Validate benchmark runner
@@ -525,7 +526,7 @@ jobs:
             ${{ runner.os }}-rust-npm-
       - name: Install native link dependencies (Linux only)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
       - run: node scripts/test-cli-prepublish.mjs --target=${{ matrix.npm-target }} --skip-build --skip-secrets-scan
         env:
@@ -572,7 +573,7 @@ jobs:
             ${{ runner.os }}-rust-npm-
       - name: Install native link dependencies (Linux only)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
       - name: Build the AFS mount export helper (macOS only)
         if: startsWith(matrix.npm-target, 'macos')
@@ -600,7 +601,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-engine-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Build coven
         run: cargo build -p coven-cli --locked
       - name: Install the pinned engine

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           components: clippy, rustfmt
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --locked
@@ -178,7 +178,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-release-perf-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Build coven
         run: cargo build -p coven-cli --locked
       - name: Validate benchmark runner
@@ -217,7 +217,7 @@ jobs:
           targets: ${{ matrix.rust-target }}
       - name: Install native link dependencies
         if: matrix.npm-target == 'linux-x64'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
         env:
           COVEN_BUILD_VERSION: v${{ needs.verify-tag.outputs.npm_version }}

--- a/.github/workflows/release-stress.yml
+++ b/.github/workflows/release-stress.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-release-stress-
       - name: Install native link dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       # Build the test binaries outside the timed loop. The stress harness
       # applies --command-timeout-ms per cargo invocation, so on a cold cache
       # the first surface spends its whole budget compiling and times out

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -144,6 +144,8 @@ struct DaemonHealthStatus {
 #[cfg(not(windows))]
 const MAX_DAEMON_STATUS_BYTES: usize = coven_client::MAX_DAEMON_STATUS_BYTES;
 const DAEMON_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(any(windows, test))]
+const WINDOWS_STARTUP_HEALTH_PROBE_SLICE: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DaemonSpawnSpec {
@@ -2659,13 +2661,43 @@ where
     P: FnMut(&str, LifecycleDeadline) -> Result<Option<DaemonStatus>>,
 {
     loop {
-        deadline.remaining("waiting for Coven daemon startup health")?;
-        if let Some(live) = probe(&status.socket, deadline)? {
-            return Ok(live);
+        let probe_started = Instant::now();
+        let probe_timeout = deadline
+            .remaining_at(probe_started, "waiting for Coven daemon startup health")?
+            .min(WINDOWS_STARTUP_HEALTH_PROBE_SLICE);
+        let probe_deadline = LifecycleDeadline {
+            instant: probe_started
+                .checked_add(probe_timeout)
+                .context("Windows daemon startup probe deadline overflowed")?,
+        };
+        // Windows binds the owner-only pipe before it enters the accept loop,
+        // so an authenticated client can hit a still-silent transport during
+        // daemon startup. Cap each probe so one such transient connection
+        // cannot consume the entire outer lifecycle deadline.
+        match probe(&status.socket, probe_deadline) {
+            Ok(Some(live)) => return Ok(live),
+            Ok(None) => {}
+            Err(error) if windows_startup_probe_is_pending(&error) => {}
+            Err(error) => return Err(error),
         }
         let remaining = deadline.remaining("waiting for Coven daemon startup health")?;
         std::thread::sleep(remaining.min(Duration::from_millis(50)));
     }
+}
+
+#[cfg(any(windows, test))]
+fn windows_startup_probe_is_pending(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<coven_client::ClientError>()
+            .is_some_and(|error| {
+                matches!(
+                    error,
+                    coven_client::ClientError::InvalidHttpResponse(message)
+                        if message == coven_client::EMPTY_RESPONSE_TIMEOUT_MESSAGE
+                )
+            })
+    })
 }
 
 impl DaemonStopController for SystemDaemonStopController {
@@ -5706,6 +5738,66 @@ mod tests {
                 .contains("timed out waiting for Coven daemon startup health"),
             "unexpected timeout phase: {error:#}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn windows_start_wait_caps_each_probe_to_preserve_retry_budget() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(None))?;
+        let observed = std::cell::RefCell::new(Vec::new());
+        let calls = std::cell::Cell::new(0);
+
+        let ready = wait_for_windows_running_daemon_with_probe(
+            &status,
+            Duration::from_secs(2),
+            |_, _, timeout| {
+                observed.borrow_mut().push(timeout);
+                let next = calls.get() + 1;
+                calls.set(next);
+                Ok(next >= 3)
+            },
+        )?;
+
+        assert!(ready);
+        assert_eq!(calls.get(), 3);
+        let observed = observed.into_inner();
+        assert_eq!(observed.len(), 3);
+        assert!(
+            observed
+                .iter()
+                .take(2)
+                .all(|timeout| *timeout > Duration::ZERO
+                    && *timeout <= WINDOWS_STARTUP_HEALTH_PROBE_SLICE),
+            "startup probes must stay capped so retries preserve the outer lifecycle budget: {observed:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn windows_start_wait_retries_response_pending_until_health_arrives() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(None))?;
+        let calls = std::cell::Cell::new(0);
+
+        let ready = wait_for_windows_running_daemon_with_identity_probe_until(
+            &status,
+            LifecycleDeadline::after(Duration::from_secs(1))?,
+            |_, _| {
+                let next = calls.get() + 1;
+                calls.set(next);
+                if next < 3 {
+                    Err(anyhow::Error::new(
+                        coven_client::ClientError::InvalidHttpResponse(
+                            coven_client::EMPTY_RESPONSE_TIMEOUT_MESSAGE.to_owned(),
+                        ),
+                    ))
+                } else {
+                    Ok(Some(status.clone()))
+                }
+            },
+        )?;
+
+        assert_eq!(ready, status);
+        assert_eq!(calls.get(), 3);
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2670,10 +2670,8 @@ where
                 .checked_add(probe_timeout)
                 .context("Windows daemon startup probe deadline overflowed")?,
         };
-        // Windows binds the owner-only pipe before it enters the accept loop,
-        // so an authenticated client can hit a still-silent transport during
-        // daemon startup. Cap each probe so one such transient connection
-        // cannot consume the entire outer lifecycle deadline.
+        // Startup may precede pipe creation or the accept loop. Bound both
+        // connect and silent-response probes within the outer lifecycle deadline.
         match probe(&status.socket, probe_deadline) {
             Ok(Some(live)) => return Ok(live),
             Ok(None) => {}
@@ -2685,6 +2683,7 @@ where
     }
 }
 
+/// Retry only known startup transport timeouts, never identity or protocol errors.
 #[cfg(any(windows, test))]
 fn windows_startup_probe_is_pending(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
@@ -2695,6 +2694,11 @@ fn windows_startup_probe_is_pending(error: &anyhow::Error) -> bool {
                     error,
                     coven_client::ClientError::InvalidHttpResponse(message)
                         if message == coven_client::EMPTY_RESPONSE_TIMEOUT_MESSAGE
+                ) || matches!(
+                    error,
+                    coven_client::ClientError::Io { operation, source }
+                        if *operation == coven_client::WINDOWS_CONNECT_OPERATION
+                            && source.kind() == std::io::ErrorKind::TimedOut
                 )
             })
     })
@@ -5798,6 +5802,61 @@ mod tests {
 
         assert_eq!(ready, status);
         assert_eq!(calls.get(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn windows_start_wait_retries_pre_connect_timeout_until_health_arrives() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(None))?;
+        let calls = std::cell::Cell::new(0);
+
+        let ready = wait_for_windows_running_daemon_with_identity_probe_until(
+            &status,
+            LifecycleDeadline::after(Duration::from_secs(1))?,
+            |_, _| {
+                let next = calls.get() + 1;
+                calls.set(next);
+                if next < 3 {
+                    Err(anyhow::Error::new(coven_client::ClientError::Io {
+                        operation: coven_client::WINDOWS_CONNECT_OPERATION,
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "timed out connecting to Coven daemon pipe",
+                        ),
+                    }))
+                } else {
+                    Ok(Some(status.clone()))
+                }
+            },
+        )?;
+
+        assert_eq!(ready, status);
+        assert_eq!(calls.get(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn windows_start_wait_does_not_retry_unrelated_io_errors() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(None))?;
+        let calls = std::cell::Cell::new(0);
+
+        let result = wait_for_windows_running_daemon_with_identity_probe_until(
+            &status,
+            LifecycleDeadline::after(Duration::from_secs(1))?,
+            |_, _| {
+                calls.set(calls.get() + 1);
+                Err(anyhow::Error::new(coven_client::ClientError::Io {
+                    operation: coven_client::WINDOWS_CONNECT_OPERATION,
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "access denied",
+                    ),
+                }))
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 1);
         Ok(())
     }
 

--- a/crates/coven-client/src/error.rs
+++ b/crates/coven-client/src/error.rs
@@ -9,6 +9,8 @@ pub(crate) const UNIX_CONFIGURE_WRITES_OPERATION: &str =
 pub(crate) const WINDOWS_CONNECT_OPERATION: &str = "failed to connect to Coven daemon pipe";
 pub(crate) const WINDOWS_CONFIGURE_WRITES_OPERATION: &str =
     "failed to configure nonblocking Coven daemon pipe writes";
+#[doc(hidden)]
+pub const EMPTY_RESPONSE_TIMEOUT_MESSAGE: &str = "no response bytes arrived before the deadline";
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct DaemonError {

--- a/crates/coven-client/src/error.rs
+++ b/crates/coven-client/src/error.rs
@@ -6,7 +6,8 @@ use thiserror::Error;
 pub(crate) const UNIX_CONNECT_OPERATION: &str = "failed to connect to Coven daemon socket";
 pub(crate) const UNIX_CONFIGURE_WRITES_OPERATION: &str =
     "failed to configure nonblocking Coven daemon socket writes";
-pub(crate) const WINDOWS_CONNECT_OPERATION: &str = "failed to connect to Coven daemon pipe";
+#[doc(hidden)]
+pub const WINDOWS_CONNECT_OPERATION: &str = "failed to connect to Coven daemon pipe";
 pub(crate) const WINDOWS_CONFIGURE_WRITES_OPERATION: &str =
     "failed to configure nonblocking Coven daemon pipe writes";
 #[doc(hidden)]

--- a/crates/coven-client/src/lib.rs
+++ b/crates/coven-client/src/lib.rs
@@ -18,7 +18,7 @@ pub use discovery::{
     read_windows_daemon_status_for_lifecycle, read_windows_daemon_status_for_lifecycle_until,
     supported_windows_pipe_names, validate_windows_daemon_pipe_name,
 };
-pub use error::{ClientError, DaemonError};
+pub use error::{ClientError, DaemonError, EMPTY_RESPONSE_TIMEOUT_MESSAGE};
 pub use http::DaemonClient;
 #[cfg(unix)]
 #[doc(hidden)]

--- a/crates/coven-client/src/lib.rs
+++ b/crates/coven-client/src/lib.rs
@@ -18,7 +18,9 @@ pub use discovery::{
     read_windows_daemon_status_for_lifecycle, read_windows_daemon_status_for_lifecycle_until,
     supported_windows_pipe_names, validate_windows_daemon_pipe_name,
 };
-pub use error::{ClientError, DaemonError, EMPTY_RESPONSE_TIMEOUT_MESSAGE};
+pub use error::{
+    ClientError, DaemonError, EMPTY_RESPONSE_TIMEOUT_MESSAGE, WINDOWS_CONNECT_OPERATION,
+};
 pub use http::DaemonClient;
 #[cfg(unix)]
 #[doc(hidden)]

--- a/crates/coven-client/src/transport/windows.rs
+++ b/crates/coven-client/src/transport/windows.rs
@@ -19,6 +19,7 @@ const TRAILING_RESPONSE_BYTES: &str =
     "daemon sent bytes beyond its declared response Content-Length";
 #[cfg(windows)]
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+const READ_RESPONSE_TIMEOUT_MESSAGE: &str = "timed out reading Coven daemon response";
 #[cfg(any(windows, test))]
 const fn windows_pipe_client_flags() -> u32 {
     // SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION. Passing zero asks
@@ -1001,9 +1002,7 @@ fn read_framed_response<R: Read>(
             )));
         }
         if Instant::now() >= deadline {
-            return Err(ClientError::InvalidHttpResponse(
-                "timed out reading Coven daemon response".to_owned(),
-            ));
+            return Err(read_response_timeout_error(response.is_empty()));
         }
         match reader.read(&mut chunk) {
             Ok(0) => {
@@ -1024,9 +1023,7 @@ fn read_framed_response<R: Read>(
                 if error.kind() != std::io::ErrorKind::Interrupted {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
-                        return Err(ClientError::InvalidHttpResponse(
-                            "timed out reading Coven daemon response".to_owned(),
-                        ));
+                        return Err(read_response_timeout_error(response.is_empty()));
                     }
                     std::thread::sleep(remaining.min(Duration::from_millis(10)));
                 }
@@ -1039,6 +1036,17 @@ fn read_framed_response<R: Read>(
             }
         }
     }
+}
+
+fn read_response_timeout_error(empty_response: bool) -> ClientError {
+    ClientError::InvalidHttpResponse(
+        if empty_response {
+            crate::EMPTY_RESPONSE_TIMEOUT_MESSAGE
+        } else {
+            READ_RESPONSE_TIMEOUT_MESSAGE
+        }
+        .to_owned(),
+    )
 }
 
 fn ensure_no_immediately_available_response_bytes<R: Read>(
@@ -1130,8 +1138,11 @@ mod tests {
         windows_pipe_client_flags, windows_pipe_connection_is_unavailable,
         windows_stop_identity_from_health, windows_stop_pipe_preflight,
         write_windows_pipe_with_deadline, MAX_RESPONSE_HEADERS_BYTES,
+        READ_RESPONSE_TIMEOUT_MESSAGE,
     };
-    use crate::{discovery::supported_windows_pipe_names, ClientError};
+    use crate::{
+        discovery::supported_windows_pipe_names, ClientError, EMPTY_RESPONSE_TIMEOUT_MESSAGE,
+    };
     use std::{
         collections::VecDeque,
         io::{Cursor, Read, Write},
@@ -1314,7 +1325,7 @@ mod tests {
     }
 
     #[test]
-    fn live_empty_pipe_polling_sleeps_and_obeys_the_absolute_deadline() {
+    fn live_empty_pipe_polling_reports_response_pending_at_the_absolute_deadline() {
         let mut reader = AlwaysNoDataReader { reads: 0 };
         let started = Instant::now();
         let error =
@@ -1323,17 +1334,59 @@ mod tests {
                 Err(error) => error,
             };
 
-        assert!(
-            error
-                .to_string()
-                .contains("timed out reading Coven daemon response"),
-            "unexpected error: {error}"
-        );
+        assert!(matches!(
+            error,
+            ClientError::InvalidHttpResponse(message)
+                if message == EMPTY_RESPONSE_TIMEOUT_MESSAGE
+        ));
         assert!(started.elapsed() < Duration::from_secs(1));
         assert!(
             reader.reads <= 5,
             "empty pipe polling spun {} times",
             reader.reads
+        );
+    }
+
+    struct BytesThenNoDataReader {
+        first_chunk: Option<&'static [u8]>,
+        reads_after_bytes: usize,
+    }
+
+    impl Read for BytesThenNoDataReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            if let Some(chunk) = self.first_chunk.take() {
+                buffer[..chunk.len()].copy_from_slice(chunk);
+                return Ok(chunk.len());
+            }
+            self.reads_after_bytes += 1;
+            Err(std::io::Error::from_raw_os_error(232))
+        }
+    }
+
+    #[test]
+    fn partial_response_timeout_stays_an_invalid_http_response() {
+        let mut reader = BytesThenNoDataReader {
+            first_chunk: Some(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbo"),
+            reads_after_bytes: 0,
+        };
+
+        let error = match read_framed_response(
+            &mut reader,
+            Instant::now() + Duration::from_millis(25),
+            1024,
+        ) {
+            Ok(_) => panic!("a stalled partial response must fail"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            ClientError::InvalidHttpResponse(message)
+                if message == READ_RESPONSE_TIMEOUT_MESSAGE
+        ));
+        assert!(
+            reader.reads_after_bytes > 0,
+            "the reader must continue polling after partial bytes arrive"
         );
     }
 

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -80,6 +80,24 @@ class CheckCiWorkflowTests(unittest.TestCase):
     def test_ci_sets_up_node_for_release_workflow_policy_tests(self) -> None:
         self.assertIn(f"actions/setup-node@{SETUP_NODE_SHA}", CI_TEXT)
 
+    def test_native_link_dependency_installs_use_scoped_apt_helper(self) -> None:
+        release_stress_text = RELEASE_STRESS_WORKFLOW.read_text(encoding='utf-8')
+        for workflow_text in [CI_TEXT, RELEASE_TEXT, release_stress_text]:
+            self.assertNotIn("sudo apt-get update && sudo apt-get install", workflow_text)
+            self.assertNotIn(
+                "apt-get install -y --no-install-recommends libopenblas-dev",
+                workflow_text,
+            )
+
+        expected_invocations = 7 + 3 + 1
+        actual_invocations = (
+            CI_TEXT.count("bash scripts/install-native-link-dependencies.sh")
+            + RELEASE_TEXT.count("bash scripts/install-native-link-dependencies.sh")
+            + release_stress_text.count("bash scripts/install-native-link-dependencies.sh")
+        )
+        self.assertEqual(actual_invocations, expected_invocations)
+        self.assertIn("python3 scripts/install-native-link-dependencies-test.py", CI_TEXT)
+
     def test_release_github_workflow_has_expected_trigger_and_permissions(self) -> None:
         self.assertIn("workflow_run:", RELEASE_GITHUB_TEXT)
         self.assertIn("Release npm packages", RELEASE_GITHUB_TEXT)

--- a/scripts/classify-ci-changes-test.py
+++ b/scripts/classify-ci-changes-test.py
@@ -109,6 +109,8 @@ class ClassifyTest(unittest.TestCase):
             'scripts/check-workflows.sh',
             'scripts/check-workflows-test.py',
             'scripts/check-ci-workflow-test.py',
+            'scripts/install-native-link-dependencies.sh',
+            'scripts/install-native-link-dependencies-test.py',
         ):
             with self.subTest(path=path):
                 result = self.classify(path)

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -77,6 +77,8 @@ def classify(paths: list[str]) -> dict[str, bool]:
             'scripts/check-workflows.sh',
             'scripts/check-workflows-test.py',
             'scripts/check-ci-workflow-test.py',
+            'scripts/install-native-link-dependencies.sh',
+            'scripts/install-native-link-dependencies-test.py',
         }
         categories['rust'] |= is_rust
         categories['afs'] |= is_afs

--- a/scripts/install-native-link-dependencies-test.py
+++ b/scripts/install-native-link-dependencies-test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("install-native-link-dependencies.sh")
+
+
+class NativeLinkDependencyInstallerTests(unittest.TestCase):
+    def run_installer(
+        self,
+        apt_etc_dir: pathlib.Path,
+        *,
+        fail_command: str | None = None,
+        packages: list[str] | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], list[list[str]], list[str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            tempdir = pathlib.Path(directory)
+            bin_dir = tempdir / "bin"
+            bin_dir.mkdir()
+            command_log = tempdir / "sudo-calls.jsonl"
+            source_log = tempdir / "sources.txt"
+            fake_sudo = bin_dir / "sudo"
+            fake_sudo.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env python3
+                    import json
+                    import os
+                    import pathlib
+                    import sys
+
+                    args = sys.argv[1:]
+                    with open(os.environ["COVEN_FAKE_SUDO_LOG"], "a", encoding="utf-8") as handle:
+                        handle.write(json.dumps(args) + "\\n")
+
+                    for arg in args:
+                        if arg.startswith("Dir::Etc::sourceparts="):
+                            sourceparts = pathlib.Path(arg.split("=", 1)[1])
+                            assert sourceparts.parent.stat().st_mode & 0o005 == 0o005, "apt sandbox cannot traverse metadata directory"
+                            with open(os.environ["COVEN_FAKE_SOURCE_LOG"], "a", encoding="utf-8") as handle:
+                                for path in sorted(sourceparts.iterdir()):
+                                    handle.write(f"--- {path.name} ---\\n")
+                                    handle.write(path.read_text(encoding="utf-8"))
+                                    handle.write("\\n")
+
+                    fail_command = os.environ.get("COVEN_FAKE_FAIL_COMMAND")
+                    if fail_command and fail_command in args:
+                        sys.exit(42 if fail_command == "update" else 43)
+                    sys.exit(0)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_sudo.chmod(0o755)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "COVEN_APT_ETC_DIR": str(apt_etc_dir),
+                    "COVEN_FAKE_SUDO_LOG": str(command_log),
+                    "COVEN_FAKE_SOURCE_LOG": str(source_log),
+                    "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                }
+            )
+            if fail_command is not None:
+                env["COVEN_FAKE_FAIL_COMMAND"] = fail_command
+            completed = subprocess.run(
+                ["bash", str(SCRIPT), *(packages or [])],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            calls = (
+                [
+                    json.loads(line)
+                    for line in command_log.read_text(encoding="utf-8").splitlines()
+                ]
+                if command_log.exists()
+                else []
+            )
+            sources = source_log.read_text(encoding="utf-8").splitlines() if source_log.exists() else []
+            return completed, calls, sources
+
+    def write_deb822_ubuntu_source(self, apt_etc_dir: pathlib.Path) -> None:
+        source_dir = apt_etc_dir / "sources.list.d"
+        source_dir.mkdir(parents=True)
+        (source_dir / "ubuntu.sources").write_text(
+            textwrap.dedent(
+                """\
+                Types: deb
+                URIs: http://azure.archive.ubuntu.com/ubuntu/
+                Suites: noble noble-updates noble-backports
+                Components: main restricted universe multiverse
+                Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+                Types: deb
+                URIs: http://security.ubuntu.com/ubuntu/
+                Suites: noble-security
+                Components: main restricted universe multiverse
+                Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+                """
+            ),
+            encoding="utf-8",
+        )
+
+    def test_update_and_install_are_scoped_to_ubuntu_sources_and_temp_lists(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0], "apt-get")
+        self.assertEqual(calls[1][0], "apt-get")
+        self.assertIn("update", calls[0])
+        self.assertIn("install", calls[1])
+        self.assertIn("-y", calls[1])
+        self.assertIn("--no-install-recommends", calls[1])
+        self.assertEqual(calls[1][-2:], ["--", "libopenblas-dev"])
+        self.assertIn("libopenblas-dev", calls[1])
+        for call in calls:
+            joined = "\n".join(call)
+            self.assertIn("Dir::Etc::sourcelist=/dev/null", call)
+            self.assertIn("APT::Get::List-Cleanup=0", call)
+            self.assertRegex(joined, r"Dir::Etc::sourceparts=.*sources\.list\.d")
+            self.assertRegex(joined, r"Dir::State::lists=.*/lists")
+            self.assertNotIn("/etc/apt/sources.list.d", joined)
+            self.assertNotIn("AllowUnauthenticated", joined)
+            self.assertNotIn("AllowInsecureRepositories", joined)
+        self.assertTrue(any("ubuntu.sources" in line for line in sources))
+        self.assertTrue(any("Signed-By:" in line for line in sources))
+
+    def test_deb822_mirror_file_source_used_by_hosted_ubuntu_runners_is_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            mirror_file = apt_etc_dir / "apt-mirrors.txt"
+            mirror_file.write_text(
+                "http://azure.archive.ubuntu.com/ubuntu/\n"
+                "http://security.ubuntu.com/ubuntu/\n",
+                encoding="utf-8",
+            )
+            source_dir = apt_etc_dir / "sources.list.d"
+            source_dir.mkdir(parents=True)
+            (source_dir / "ubuntu.sources").write_text(
+                textwrap.dedent(
+                    f"""\
+                    Types: deb
+                    URIs: mirror+file:{mirror_file}
+                    Suites: noble noble-updates noble-backports noble-security
+                    Components: main restricted universe multiverse
+                    Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(len(calls), 2)
+        source_text = "\n".join(sources)
+        self.assertIn("mirror+file:", source_text)
+        self.assertIn("Signed-By:", source_text)
+
+    def test_legacy_sources_list_filters_out_unrelated_repositories(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            (apt_etc_dir / "sources.list").write_text(
+                textwrap.dedent(
+                    """\
+                    deb http://archive.ubuntu.com/ubuntu noble main universe
+                    deb http://security.ubuntu.com/ubuntu noble-security main universe
+                    deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(len(calls), 2)
+        source_text = "\n".join(sources)
+        self.assertIn("archive.ubuntu.com/ubuntu", source_text)
+        self.assertIn("security.ubuntu.com/ubuntu", source_text)
+        self.assertNotIn("dl.google.com", source_text)
+
+    def test_update_failure_propagates_without_running_install(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+
+            completed, calls, _sources = self.run_installer(apt_etc_dir, fail_command="update")
+
+        self.assertEqual(completed.returncode, 42)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("update", calls[0])
+
+    def test_install_failure_propagates(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+
+            completed, calls, _sources = self.run_installer(apt_etc_dir, fail_command="install")
+
+        self.assertEqual(completed.returncode, 43)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("install", calls[1])
+
+    def test_missing_ubuntu_distribution_source_fails_before_sudo(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            completed, calls, _sources = self.run_installer(pathlib.Path(directory))
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(calls, [])
+        self.assertIn("Unable to find the Ubuntu apt distribution source", completed.stderr)
+
+    def test_deb822_source_without_signed_by_fails_before_sudo(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            source_dir = apt_etc_dir / "sources.list.d"
+            source_dir.mkdir(parents=True)
+            (source_dir / "ubuntu.sources").write_text(
+                textwrap.dedent(
+                    """\
+                    Types: deb
+                    URIs: http://archive.ubuntu.com/ubuntu/
+                    Suites: noble
+                    Components: main universe
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            completed, calls, _sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(calls, [])
+        self.assertIn("does not declare Signed-By key material", completed.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(unittest.main())

--- a/scripts/install-native-link-dependencies-test.py
+++ b/scripts/install-native-link-dependencies-test.py
@@ -34,11 +34,18 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                     import json
                     import os
                     import pathlib
+                    import shutil
                     import sys
 
                     args = sys.argv[1:]
                     with open(os.environ["COVEN_FAKE_SUDO_LOG"], "a", encoding="utf-8") as handle:
                         handle.write(json.dumps(args) + "\\n")
+
+                    if args[:3] == ["rm", "-rf", "--"]:
+                        cleanup_root = pathlib.Path(args[3])
+                        assert cleanup_root.parent == pathlib.Path(os.environ["TMPDIR"])
+                        shutil.rmtree(cleanup_root)
+                        sys.exit(0)
 
                     for arg in args:
                         if arg.startswith("Dir::Etc::sourceparts="):
@@ -66,6 +73,7 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                     "COVEN_FAKE_SUDO_LOG": str(command_log),
                     "COVEN_FAKE_SOURCE_LOG": str(source_log),
                     "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                    "TMPDIR": str(tempdir),
                 }
             )
             if fail_command is not None:
@@ -86,7 +94,18 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                 else []
             )
             sources = source_log.read_text(encoding="utf-8").splitlines() if source_log.exists() else []
-            return completed, calls, sources
+            apt_calls = [call for call in calls if call[0] == "apt-get"]
+            cleanup_calls = [call for call in calls if call[0] == "rm"]
+            if apt_calls:
+                source_arg = next(
+                    arg for arg in apt_calls[0] if arg.startswith("Dir::Etc::sourceparts=")
+                )
+                workdir = pathlib.Path(source_arg.split("=", 1)[1]).parent
+                self.assertEqual(cleanup_calls, [["rm", "-rf", "--", str(workdir)]])
+                self.assertFalse(workdir.exists(), "privileged apt metadata was not cleaned up")
+            else:
+                self.assertEqual(cleanup_calls, [])
+            return completed, apt_calls, sources
 
     def write_deb822_ubuntu_source(self, apt_etc_dir: pathlib.Path) -> None:
         source_dir = apt_etc_dir / "sources.list.d"

--- a/scripts/install-native-link-dependencies-test.py
+++ b/scripts/install-native-link-dependencies-test.py
@@ -197,8 +197,10 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                 textwrap.dedent(
                     """\
                     deb http://archive.ubuntu.com/ubuntu noble main universe
-                    deb http://security.ubuntu.com/ubuntu noble-security main universe
+                    deb [arch=amd64 signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] http://security.ubuntu.com/ubuntu noble-security main universe
                     deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main
+                    deb https://evilubuntu.com/ubuntu noble main
+                    deb https://third-party.example/packages stable main # ubuntu.com/ubuntu
                     """
                 ),
                 encoding="utf-8",
@@ -212,6 +214,9 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
         self.assertIn("archive.ubuntu.com/ubuntu", source_text)
         self.assertIn("security.ubuntu.com/ubuntu", source_text)
         self.assertNotIn("dl.google.com", source_text)
+        self.assertNotIn("evilubuntu.com", source_text)
+        self.assertNotIn("third-party.example", source_text)
+        self.assertIn("signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg", source_text)
 
     def test_update_failure_propagates_without_running_install(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -223,6 +228,85 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 42)
         self.assertEqual(len(calls), 1)
         self.assertIn("update", calls[0])
+
+    def test_lookalike_archive_hosts_are_never_installed(self) -> None:
+        for uri in [
+            "https://evilubuntu.com/ubuntu",
+            "https://ubuntu.com.attacker.example/ubuntu",
+            "https://attacker.example/ubuntu.com/ubuntu",
+        ]:
+            for deb822 in [False, True]:
+                with self.subTest(uri=uri, deb822=deb822), tempfile.TemporaryDirectory() as directory:
+                    apt_etc_dir = pathlib.Path(directory)
+                    if deb822:
+                        self.write_deb822_ubuntu_source(apt_etc_dir)
+                        source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+                        source.write_text(
+                            f"Types: deb\nURIs: {uri}\nSuites: noble\n"
+                            "Components: main\n"
+                            "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n",
+                            encoding="utf-8",
+                        )
+                    else:
+                        (apt_etc_dir / "sources.list").write_text(
+                            f"deb {uri} noble main\n", encoding="utf-8"
+                        )
+                    completed, calls, _sources = self.run_installer(apt_etc_dir)
+                    self.assertEqual(completed.returncode, 1, completed.stderr)
+                    self.assertEqual(calls, [])
+
+    def test_every_deb822_stanza_requires_ubuntu_uris_and_signing_metadata(self) -> None:
+        for extra in [
+            "Types: deb\nURIs: https://third-party.example/packages\nSuites: stable\n"
+            "Components: main\nSigned-By: /usr/share/keyrings/vendor.gpg\n",
+            "Types: deb\nURIs: http://archive.ubuntu.com/ubuntu/\nSuites: noble\n"
+            "Components: main\n",
+        ]:
+            with self.subTest(extra=extra), tempfile.TemporaryDirectory() as directory:
+                apt_etc_dir = pathlib.Path(directory)
+                self.write_deb822_ubuntu_source(apt_etc_dir)
+                source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+                source.write_text(source.read_text(encoding="utf-8") + "\n" + extra, encoding="utf-8")
+                completed, calls, _sources = self.run_installer(apt_etc_dir)
+                self.assertEqual(completed.returncode, 1, completed.stderr)
+                self.assertEqual(calls, [])
+
+    def test_every_uri_in_a_deb822_field_or_mirror_file_must_be_ubuntu(self) -> None:
+        for mirror in [False, True]:
+            with self.subTest(mirror=mirror), tempfile.TemporaryDirectory() as directory:
+                apt_etc_dir = pathlib.Path(directory)
+                self.write_deb822_ubuntu_source(apt_etc_dir)
+                uris = "http://archive.ubuntu.com/ubuntu/\n https://third-party.example/packages"
+                if mirror:
+                    mirror_file = apt_etc_dir / "apt-mirrors.txt"
+                    mirror_file.write_text(uris + "\n", encoding="utf-8")
+                    uris = f"mirror+file:{mirror_file}"
+                source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+                source.write_text(
+                    f"Types: deb\nURIs: {uris}\nSuites: noble\nComponents: main\n"
+                    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n",
+                    encoding="utf-8",
+                )
+                completed, calls, _sources = self.run_installer(apt_etc_dir)
+                self.assertEqual(completed.returncode, 1, completed.stderr)
+                self.assertEqual(calls, [])
+
+    def test_deb822_ubuntu_uri_continuations_preserve_the_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+            source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+            text = source.read_text(encoding="utf-8").replace(
+                "URIs: http://azure.archive.ubuntu.com/ubuntu/",
+                "URIs: http://azure.archive.ubuntu.com/ubuntu/\n"
+                " https://archive.ubuntu.com/ubuntu/",
+            )
+            source.write_text(text, encoding="utf-8")
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(len(calls), 2)
+            self.assertIn(text, "\n".join(sources))
+            self.assertEqual(source.read_text(encoding="utf-8"), text)
 
     def test_install_failure_propagates(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/install-native-link-dependencies.sh
+++ b/scripts/install-native-link-dependencies.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apt_etc_dir="${COVEN_APT_ETC_DIR:-/etc/apt}"
+source_file=""
+workdir="$(mktemp -d)"
+cleanup() { rm -rf "$workdir"; }
+trap cleanup EXIT
+# Apt's unprivileged downloader must be able to traverse the public metadata directory.
+chmod 755 "$workdir"
+
+ubuntu_archive_pattern='ubuntu\.com/ubuntu/?([[:space:]]|$)'
+
+deb822_source_points_to_ubuntu_archive() {
+  local file="$1"
+  if grep -Eq "^[[:space:]]*URIs:[[:space:]].*$ubuntu_archive_pattern" "$file"; then
+    return 0
+  fi
+
+  local uri mirror_file
+  while IFS= read -r uri; do
+    mirror_file="${uri#mirror+file:}"
+    if [[ -r "$mirror_file" ]] && grep -Eq "$ubuntu_archive_pattern" "$mirror_file"; then
+      return 0
+    fi
+  done < <(grep -Eho 'mirror\+file:[^[:space:]]+' "$file" || true)
+
+  return 1
+}
+
+sourceparts="$workdir/sources.list.d"
+lists="$workdir/lists"
+mkdir -p "$sourceparts" "$lists/partial"
+
+if [[ -r "$apt_etc_dir/sources.list.d/ubuntu.sources" ]]; then
+  source_file="$apt_etc_dir/sources.list.d/ubuntu.sources"
+  if ! grep -Eq '^[[:space:]]*Types:[[:space:]]*deb([[:space:]]|$)' "$source_file"; then
+    echo "::error::Ubuntu apt source $source_file does not declare deb package sources." >&2
+    exit 1
+  fi
+  if ! deb822_source_points_to_ubuntu_archive "$source_file"; then
+    echo "::error::Ubuntu apt source $source_file does not point at an Ubuntu distribution archive." >&2
+    exit 1
+  fi
+  if ! grep -Eq '^[[:space:]]*Signed-By:[[:space:]]*[^[:space:]]+' "$source_file"; then
+    echo "::error::Ubuntu apt source $source_file does not declare Signed-By key material." >&2
+    exit 1
+  fi
+  cp "$source_file" "$sourceparts/ubuntu.sources"
+elif [[ -r "$apt_etc_dir/sources.list" ]]; then
+  source_file="$apt_etc_dir/sources.list"
+  awk '
+    /^[[:space:]]*deb([[:space:]]|$)/ && /ubuntu\.com\/ubuntu\/?([[:space:]]|$)/ { print }
+  ' "$source_file" > "$sourceparts/ubuntu.list"
+  if [[ ! -s "$sourceparts/ubuntu.list" ]]; then
+    echo "::error::Ubuntu apt source $source_file does not contain deb entries for an Ubuntu distribution archive." >&2
+    exit 1
+  fi
+else
+  echo "::error::Unable to find the Ubuntu apt distribution source in $apt_etc_dir." >&2
+  exit 1
+fi
+
+apt_options=(
+  -o "Dir::Etc::sourcelist=/dev/null"
+  -o "Dir::Etc::sourceparts=$sourceparts"
+  -o "Dir::State::lists=$lists"
+  -o "APT::Get::List-Cleanup=0"
+)
+
+if (($#)); then
+  packages=("$@")
+else
+  packages=(libopenblas-dev)
+fi
+
+sudo apt-get "${apt_options[@]}" update
+sudo apt-get "${apt_options[@]}" install -y --no-install-recommends -- "${packages[@]}"

--- a/scripts/install-native-link-dependencies.sh
+++ b/scripts/install-native-link-dependencies.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 apt_etc_dir="${COVEN_APT_ETC_DIR:-/etc/apt}"
-source_file=""
 workdir="$(mktemp -d)"
 apt_started=0
 cleanup() {
@@ -16,57 +15,89 @@ trap cleanup EXIT
 # Apt's unprivileged downloader must be able to traverse the public metadata directory.
 chmod 755 "$workdir"
 
-ubuntu_archive_pattern='ubuntu\.com/ubuntu/?([[:space:]]|$)'
-
-deb822_source_points_to_ubuntu_archive() {
-  local file="$1"
-  if grep -Eq "^[[:space:]]*URIs:[[:space:]].*$ubuntu_archive_pattern" "$file"; then
-    return 0
-  fi
-
-  local uri mirror_file
-  while IFS= read -r uri; do
-    mirror_file="${uri#mirror+file:}"
-    if [[ -r "$mirror_file" ]] && grep -Eq "$ubuntu_archive_pattern" "$mirror_file"; then
-      return 0
-    fi
-  done < <(grep -Eho 'mirror\+file:[^[:space:]]+' "$file" || true)
-
-  return 1
-}
-
 sourceparts="$workdir/sources.list.d"
 lists="$workdir/lists"
 mkdir -p "$sourceparts" "$lists/partial"
 
-if [[ -r "$apt_etc_dir/sources.list.d/ubuntu.sources" ]]; then
-  source_file="$apt_etc_dir/sources.list.d/ubuntu.sources"
-  if ! grep -Eq '^[[:space:]]*Types:[[:space:]]*deb([[:space:]]|$)' "$source_file"; then
-    echo "::error::Ubuntu apt source $source_file does not declare deb package sources." >&2
-    exit 1
-  fi
-  if ! deb822_source_points_to_ubuntu_archive "$source_file"; then
-    echo "::error::Ubuntu apt source $source_file does not point at an Ubuntu distribution archive." >&2
-    exit 1
-  fi
-  if ! grep -Eq '^[[:space:]]*Signed-By:[[:space:]]*[^[:space:]]+' "$source_file"; then
-    echo "::error::Ubuntu apt source $source_file does not declare Signed-By key material." >&2
-    exit 1
-  fi
-  cp "$source_file" "$sourceparts/ubuntu.sources"
-elif [[ -r "$apt_etc_dir/sources.list" ]]; then
-  source_file="$apt_etc_dir/sources.list"
-  awk '
-    /^[[:space:]]*deb([[:space:]]|$)/ && /ubuntu\.com\/ubuntu\/?([[:space:]]|$)/ { print }
-  ' "$source_file" > "$sourceparts/ubuntu.list"
-  if [[ ! -s "$sourceparts/ubuntu.list" ]]; then
-    echo "::error::Ubuntu apt source $source_file does not contain deb entries for an Ubuntu distribution archive." >&2
-    exit 1
-  fi
-else
-  echo "::error::Unable to find the Ubuntu apt distribution source in $apt_etc_dir." >&2
-  exit 1
-fi
+python3 - "$apt_etc_dir" "$sourceparts" <<'PY'
+import pathlib
+import re
+import sys
+
+apt_etc_dir, sourceparts = map(pathlib.Path, sys.argv[1:])
+archive_uri = re.compile(r"https?://(?:[a-z0-9-]+\.)*ubuntu\.com/ubuntu/?", re.IGNORECASE)
+
+
+def ubuntu_uri(uri):
+    if uri.startswith("mirror+file:"):
+        mirror_file = pathlib.Path(uri.removeprefix("mirror+file:"))
+        if not mirror_file.is_absolute():
+            return False
+        mirrors = [
+            line.split("#", 1)[0].split()
+            for line in mirror_file.read_text(encoding="utf-8").splitlines()
+        ]
+        urls = [fields[0] for fields in mirrors if fields]
+        return bool(urls) and all(archive_uri.fullmatch(url) for url in urls)
+    return archive_uri.fullmatch(uri) is not None
+
+
+def validate_deb822(text):
+    # Validate each stanza and every URI, not merely one match in the whole file.
+    stanzas = []
+    fields = {}
+    current = None
+    for line in text.splitlines() + [""]:
+        if line.lstrip().startswith("#"):
+            continue
+        if not line.strip():
+            if fields:
+                stanzas.append(fields)
+            fields, current = {}, None
+        elif line[0].isspace():
+            if current is None:
+                raise ValueError("Ubuntu apt source has an orphan continuation line")
+            fields[current] += " " + line.strip()
+        else:
+            name, separator, value = line.partition(":")
+            name = name.lower()
+            if not separator or not re.fullmatch(r"[a-z][a-z-]*", name) or name in fields:
+                raise ValueError("Ubuntu apt source has malformed or duplicate fields")
+            fields[name], current = value.strip(), name
+    if not stanzas:
+        raise ValueError("Ubuntu apt source has no package stanzas")
+    for stanza in stanzas:
+        if "deb" not in stanza.get("types", "").split():
+            raise ValueError("Ubuntu apt source does not declare deb package sources")
+        uris = stanza.get("uris", "").split()
+        if not uris or not all(ubuntu_uri(uri) for uri in uris):
+            raise ValueError("Ubuntu apt source contains a non-Ubuntu distribution archive")
+        if not stanza.get("signed-by"):
+            raise ValueError("Ubuntu apt source does not declare Signed-By key material")
+
+
+try:
+    deb822 = apt_etc_dir / "sources.list.d/ubuntu.sources"
+    legacy = apt_etc_dir / "sources.list"
+    if deb822.exists():
+        text = deb822.read_text(encoding="utf-8")
+        validate_deb822(text)
+        (sourceparts / "ubuntu.sources").write_text(text, encoding="utf-8")
+    elif legacy.exists():
+        selected = []
+        for line in legacy.read_text(encoding="utf-8").splitlines():
+            match = re.match(r"^\s*deb\s+(?:\[[^\]\n]*\]\s+)?(\S+)\s+", line)
+            if match and archive_uri.fullmatch(match[1]):
+                selected.append(line)
+        if not selected:
+            raise ValueError("Ubuntu apt source has no deb entries for an Ubuntu distribution archive")
+        (sourceparts / "ubuntu.list").write_text("\n".join(selected) + "\n", encoding="utf-8")
+    else:
+        raise ValueError(f"Unable to find the Ubuntu apt distribution source in {apt_etc_dir}")
+except (OSError, ValueError) as error:
+    print(f"::error::{error}", file=sys.stderr)
+    sys.exit(1)
+PY
 
 apt_options=(
   -o "Dir::Etc::sourcelist=/dev/null"

--- a/scripts/install-native-link-dependencies.sh
+++ b/scripts/install-native-link-dependencies.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 apt_etc_dir="${COVEN_APT_ETC_DIR:-/etc/apt}"
 source_file=""
 workdir="$(mktemp -d)"
-cleanup() { rm -rf "$workdir"; }
+apt_started=0
+cleanup() {
+  if ((apt_started)); then
+    sudo rm -rf -- "$workdir"
+  else
+    rm -rf -- "$workdir"
+  fi
+}
 trap cleanup EXIT
 # Apt's unprivileged downloader must be able to traverse the public metadata directory.
 chmod 755 "$workdir"
@@ -74,5 +81,6 @@ else
   packages=(libopenblas-dev)
 fi
 
+apt_started=1
 sudo apt-get "${apt_options[@]}" update
 sudo apt-get "${apt_options[@]}" install -y --no-install-recommends -- "${packages[@]}"


### PR DESCRIPTION
## Context

Closes #967. Closes #971.

Completes the Windows daemon readiness follow-up observed after #962. Includes the exact authenticated native-dependency installer changes from #973, already required by the original readiness CI runs. #973 will be closed as superseded only after its changes are confirmed on main.

## Implementation

Windows startup probes receive at most 250 ms within the unchanged two-second lifecycle deadline. Only zero-response-byte timeouts and typed pre-connect timeouts retry. Partial HTTP responses, malformed framing, authentication failures, and process/pipe identity mismatches remain errors. Client timeout markers are additive; the public error enum is not expanded.

The CI prerequisite scopes apt update and install to authenticated Ubuntu distribution sources with isolated metadata. Signature/hash verification and error propagation remain enabled; unrelated runner repositories are not modified.

## Verification

- [x] Existing deterministic silent-pipe, partial-response, bounded-probe, and retry-until-health regressions.
- [x] Full local workspace tests, formatting, and clippy with warnings denied on refreshed head a85413ae.
- [x] Seven native-installer regressions and existing CI/workflow classifier guards.
- [x] Existing secret and range privacy guards.
- [x] Prior actual Windows lifecycle CI passed at cbd5626a: https://github.com/OpenCoven/coven/actions/runs/34393854040/job/102608645829
- Refreshed-head Linux/Windows CI must pass before protected merge. Local macOS tests are not substituted for Windows evidence.

## Risk and rollback

No change to the outer startup/stop budget, owner-local authentication, stale-record safety, or Windows lifetime Job requirements. No persistent-state migration. Reverting this PR restores the previous readiness behavior and native installer calls.

## Agent handoff

Kitty is completing this existing PR through protected merge, issue closure, and safe task-branch/worktree cleanup. No duplicate readiness implementation is being started.
