### PR TITLE
ci: isolate native dependency installation to authenticated Ubuntu sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
       - run: python3 scripts/check-reliability-scorecard.py
       - run: python3 scripts/check-workflows-test.py
       - run: python3 scripts/check-ci-workflow-test.py
+      - run: python3 scripts/install-native-link-dependencies-test.py
       - run: node --test scripts/package-github-release-test.mjs
       - run: node --test scripts/package-automations-protocol.test.mjs
       - run: node --test scripts/package-automations-authority-profile.test.mjs
@@ -216,7 +217,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-lint-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy
@@ -241,7 +242,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-test-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo test --workspace --locked
 
   rust-test-windows:
@@ -311,7 +312,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-afs-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Clippy (coven-afs mount feature)
         run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
       - name: Test (coven-afs mount feature)
@@ -375,7 +376,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-perf-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Build coven
         run: cargo build -p coven-cli --locked
       - name: Validate benchmark runner
@@ -525,7 +526,7 @@ jobs:
             ${{ runner.os }}-rust-npm-
       - name: Install native link dependencies (Linux only)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
       - run: node scripts/test-cli-prepublish.mjs --target=${{ matrix.npm-target }} --skip-build --skip-secrets-scan
         env:
@@ -572,7 +573,7 @@ jobs:
             ${{ runner.os }}-rust-npm-
       - name: Install native link dependencies (Linux only)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
       - name: Build the AFS mount export helper (macOS only)
         if: startsWith(matrix.npm-target, 'macos')
@@ -600,7 +601,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-engine-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Build coven
         run: cargo build -p coven-cli --locked
       - name: Install the pinned engine

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           components: clippy, rustfmt
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --locked
@@ -178,7 +178,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-release-perf-
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - name: Build coven
         run: cargo build -p coven-cli --locked
       - name: Validate benchmark runner
@@ -217,7 +217,7 @@ jobs:
           targets: ${{ matrix.rust-target }}
       - name: Install native link dependencies
         if: matrix.npm-target == 'linux-x64'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
         env:
           COVEN_BUILD_VERSION: v${{ needs.verify-tag.outputs.npm_version }}

--- a/.github/workflows/release-stress.yml
+++ b/.github/workflows/release-stress.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-release-stress-
       - name: Install native link dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+        run: bash scripts/install-native-link-dependencies.sh
       # Build the test binaries outside the timed loop. The stress harness
       # applies --command-timeout-ms per cargo invocation, so on a cold cache
       # the first surface spends its whole budget compiling and times out

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -80,6 +80,24 @@ class CheckCiWorkflowTests(unittest.TestCase):
     def test_ci_sets_up_node_for_release_workflow_policy_tests(self) -> None:
         self.assertIn(f"actions/setup-node@{SETUP_NODE_SHA}", CI_TEXT)
 
+    def test_native_link_dependency_installs_use_scoped_apt_helper(self) -> None:
+        release_stress_text = RELEASE_STRESS_WORKFLOW.read_text(encoding='utf-8')
+        for workflow_text in [CI_TEXT, RELEASE_TEXT, release_stress_text]:
+            self.assertNotIn("sudo apt-get update && sudo apt-get install", workflow_text)
+            self.assertNotIn(
+                "apt-get install -y --no-install-recommends libopenblas-dev",
+                workflow_text,
+            )
+
+        expected_invocations = 7 + 3 + 1
+        actual_invocations = (
+            CI_TEXT.count("bash scripts/install-native-link-dependencies.sh")
+            + RELEASE_TEXT.count("bash scripts/install-native-link-dependencies.sh")
+            + release_stress_text.count("bash scripts/install-native-link-dependencies.sh")
+        )
+        self.assertEqual(actual_invocations, expected_invocations)
+        self.assertIn("python3 scripts/install-native-link-dependencies-test.py", CI_TEXT)
+
     def test_release_github_workflow_has_expected_trigger_and_permissions(self) -> None:
         self.assertIn("workflow_run:", RELEASE_GITHUB_TEXT)
         self.assertIn("Release npm packages", RELEASE_GITHUB_TEXT)

--- a/scripts/classify-ci-changes-test.py
+++ b/scripts/classify-ci-changes-test.py
@@ -109,6 +109,8 @@ class ClassifyTest(unittest.TestCase):
             'scripts/check-workflows.sh',
             'scripts/check-workflows-test.py',
             'scripts/check-ci-workflow-test.py',
+            'scripts/install-native-link-dependencies.sh',
+            'scripts/install-native-link-dependencies-test.py',
         ):
             with self.subTest(path=path):
                 result = self.classify(path)

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -77,6 +77,8 @@ def classify(paths: list[str]) -> dict[str, bool]:
             'scripts/check-workflows.sh',
             'scripts/check-workflows-test.py',
             'scripts/check-ci-workflow-test.py',
+            'scripts/install-native-link-dependencies.sh',
+            'scripts/install-native-link-dependencies-test.py',
         }
         categories['rust'] |= is_rust
         categories['afs'] |= is_afs

--- a/scripts/install-native-link-dependencies-test.py
+++ b/scripts/install-native-link-dependencies-test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("install-native-link-dependencies.sh")
+
+
+class NativeLinkDependencyInstallerTests(unittest.TestCase):
+    def run_installer(
+        self,
+        apt_etc_dir: pathlib.Path,
+        *,
+        fail_command: str | None = None,
+        packages: list[str] | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], list[list[str]], list[str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            tempdir = pathlib.Path(directory)
+            bin_dir = tempdir / "bin"
+            bin_dir.mkdir()
+            command_log = tempdir / "sudo-calls.jsonl"
+            source_log = tempdir / "sources.txt"
+            fake_sudo = bin_dir / "sudo"
+            fake_sudo.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env python3
+                    import json
+                    import os
+                    import pathlib
+                    import sys
+
+                    args = sys.argv[1:]
+                    with open(os.environ["COVEN_FAKE_SUDO_LOG"], "a", encoding="utf-8") as handle:
+                        handle.write(json.dumps(args) + "\\n")
+
+                    for arg in args:
+                        if arg.startswith("Dir::Etc::sourceparts="):
+                            sourceparts = pathlib.Path(arg.split("=", 1)[1])
+                            assert sourceparts.parent.stat().st_mode & 0o005 == 0o005, "apt sandbox cannot traverse metadata directory"
+                            with open(os.environ["COVEN_FAKE_SOURCE_LOG"], "a", encoding="utf-8") as handle:
+                                for path in sorted(sourceparts.iterdir()):
+                                    handle.write(f"--- {path.name} ---\\n")
+                                    handle.write(path.read_text(encoding="utf-8"))
+                                    handle.write("\\n")
+
+                    fail_command = os.environ.get("COVEN_FAKE_FAIL_COMMAND")
+                    if fail_command and fail_command in args:
+                        sys.exit(42 if fail_command == "update" else 43)
+                    sys.exit(0)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_sudo.chmod(0o755)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "COVEN_APT_ETC_DIR": str(apt_etc_dir),
+                    "COVEN_FAKE_SUDO_LOG": str(command_log),
+                    "COVEN_FAKE_SOURCE_LOG": str(source_log),
+                    "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                }
+            )
+            if fail_command is not None:
+                env["COVEN_FAKE_FAIL_COMMAND"] = fail_command
+            completed = subprocess.run(
+                ["bash", str(SCRIPT), *(packages or [])],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            calls = (
+                [
+                    json.loads(line)
+                    for line in command_log.read_text(encoding="utf-8").splitlines()
+                ]
+                if command_log.exists()
+                else []
+            )
+            sources = source_log.read_text(encoding="utf-8").splitlines() if source_log.exists() else []
+            return completed, calls, sources
+
+    def write_deb822_ubuntu_source(self, apt_etc_dir: pathlib.Path) -> None:
+        source_dir = apt_etc_dir / "sources.list.d"
+        source_dir.mkdir(parents=True)
+        (source_dir / "ubuntu.sources").write_text(
+            textwrap.dedent(
+                """\
+                Types: deb
+                URIs: http://azure.archive.ubuntu.com/ubuntu/
+                Suites: noble noble-updates noble-backports
+                Components: main restricted universe multiverse
+                Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+                Types: deb
+                URIs: http://security.ubuntu.com/ubuntu/
+                Suites: noble-security
+                Components: main restricted universe multiverse
+                Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+                """
+            ),
+            encoding="utf-8",
+        )
+
+    def test_update_and_install_are_scoped_to_ubuntu_sources_and_temp_lists(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0], "apt-get")
+        self.assertEqual(calls[1][0], "apt-get")
+        self.assertIn("update", calls[0])
+        self.assertIn("install", calls[1])
+        self.assertIn("-y", calls[1])
+        self.assertIn("--no-install-recommends", calls[1])
+        self.assertEqual(calls[1][-2:], ["--", "libopenblas-dev"])
+        self.assertIn("libopenblas-dev", calls[1])
+        for call in calls:
+            joined = "\n".join(call)
+            self.assertIn("Dir::Etc::sourcelist=/dev/null", call)
+            self.assertIn("APT::Get::List-Cleanup=0", call)
+            self.assertRegex(joined, r"Dir::Etc::sourceparts=.*sources\.list\.d")
+            self.assertRegex(joined, r"Dir::State::lists=.*/lists")
+            self.assertNotIn("/etc/apt/sources.list.d", joined)
+            self.assertNotIn("AllowUnauthenticated", joined)
+            self.assertNotIn("AllowInsecureRepositories", joined)
+        self.assertTrue(any("ubuntu.sources" in line for line in sources))
+        self.assertTrue(any("Signed-By:" in line for line in sources))
+
+    def test_deb822_mirror_file_source_used_by_hosted_ubuntu_runners_is_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            mirror_file = apt_etc_dir / "apt-mirrors.txt"
+            mirror_file.write_text(
+                "http://azure.archive.ubuntu.com/ubuntu/\n"
+                "http://security.ubuntu.com/ubuntu/\n",
+                encoding="utf-8",
+            )
+            source_dir = apt_etc_dir / "sources.list.d"
+            source_dir.mkdir(parents=True)
+            (source_dir / "ubuntu.sources").write_text(
+                textwrap.dedent(
+                    f"""\
+                    Types: deb
+                    URIs: mirror+file:{mirror_file}
+                    Suites: noble noble-updates noble-backports noble-security
+                    Components: main restricted universe multiverse
+                    Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(len(calls), 2)
+        source_text = "\n".join(sources)
+        self.assertIn("mirror+file:", source_text)
+        self.assertIn("Signed-By:", source_text)
+
+    def test_legacy_sources_list_filters_out_unrelated_repositories(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            (apt_etc_dir / "sources.list").write_text(
+                textwrap.dedent(
+                    """\
+                    deb http://archive.ubuntu.com/ubuntu noble main universe
+                    deb http://security.ubuntu.com/ubuntu noble-security main universe
+                    deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(len(calls), 2)
+        source_text = "\n".join(sources)
+        self.assertIn("archive.ubuntu.com/ubuntu", source_text)
+        self.assertIn("security.ubuntu.com/ubuntu", source_text)
+        self.assertNotIn("dl.google.com", source_text)
+
+    def test_update_failure_propagates_without_running_install(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+
+            completed, calls, _sources = self.run_installer(apt_etc_dir, fail_command="update")
+
+        self.assertEqual(completed.returncode, 42)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("update", calls[0])
+
+    def test_install_failure_propagates(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+
+            completed, calls, _sources = self.run_installer(apt_etc_dir, fail_command="install")
+
+        self.assertEqual(completed.returncode, 43)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("install", calls[1])
+
+    def test_missing_ubuntu_distribution_source_fails_before_sudo(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            completed, calls, _sources = self.run_installer(pathlib.Path(directory))
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(calls, [])
+        self.assertIn("Unable to find the Ubuntu apt distribution source", completed.stderr)
+
+    def test_deb822_source_without_signed_by_fails_before_sudo(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            source_dir = apt_etc_dir / "sources.list.d"
+            source_dir.mkdir(parents=True)
+            (source_dir / "ubuntu.sources").write_text(
+                textwrap.dedent(
+                    """\
+                    Types: deb
+                    URIs: http://archive.ubuntu.com/ubuntu/
+                    Suites: noble
+                    Components: main universe
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            completed, calls, _sources = self.run_installer(apt_etc_dir)
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(calls, [])
+        self.assertIn("does not declare Signed-By key material", completed.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(unittest.main())

--- a/scripts/install-native-link-dependencies-test.py
+++ b/scripts/install-native-link-dependencies-test.py
@@ -34,11 +34,18 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                     import json
                     import os
                     import pathlib
+                    import shutil
                     import sys
 
                     args = sys.argv[1:]
                     with open(os.environ["COVEN_FAKE_SUDO_LOG"], "a", encoding="utf-8") as handle:
                         handle.write(json.dumps(args) + "\\n")
+
+                    if args[:3] == ["rm", "-rf", "--"]:
+                        cleanup_root = pathlib.Path(args[3])
+                        assert cleanup_root.parent == pathlib.Path(os.environ["TMPDIR"])
+                        shutil.rmtree(cleanup_root)
+                        sys.exit(0)
 
                     for arg in args:
                         if arg.startswith("Dir::Etc::sourceparts="):
@@ -66,6 +73,7 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                     "COVEN_FAKE_SUDO_LOG": str(command_log),
                     "COVEN_FAKE_SOURCE_LOG": str(source_log),
                     "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                    "TMPDIR": str(tempdir),
                 }
             )
             if fail_command is not None:
@@ -86,7 +94,18 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                 else []
             )
             sources = source_log.read_text(encoding="utf-8").splitlines() if source_log.exists() else []
-            return completed, calls, sources
+            apt_calls = [call for call in calls if call[0] == "apt-get"]
+            cleanup_calls = [call for call in calls if call[0] == "rm"]
+            if apt_calls:
+                source_arg = next(
+                    arg for arg in apt_calls[0] if arg.startswith("Dir::Etc::sourceparts=")
+                )
+                workdir = pathlib.Path(source_arg.split("=", 1)[1]).parent
+                self.assertEqual(cleanup_calls, [["rm", "-rf", "--", str(workdir)]])
+                self.assertFalse(workdir.exists(), "privileged apt metadata was not cleaned up")
+            else:
+                self.assertEqual(cleanup_calls, [])
+            return completed, apt_calls, sources
 
     def write_deb822_ubuntu_source(self, apt_etc_dir: pathlib.Path) -> None:
         source_dir = apt_etc_dir / "sources.list.d"

--- a/scripts/install-native-link-dependencies.sh
+++ b/scripts/install-native-link-dependencies.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apt_etc_dir="${COVEN_APT_ETC_DIR:-/etc/apt}"
+source_file=""
+workdir="$(mktemp -d)"
+cleanup() { rm -rf "$workdir"; }
+trap cleanup EXIT
+# Apt's unprivileged downloader must be able to traverse the public metadata directory.
+chmod 755 "$workdir"
+
+ubuntu_archive_pattern='ubuntu\.com/ubuntu/?([[:space:]]|$)'
+
+deb822_source_points_to_ubuntu_archive() {
+  local file="$1"
+  if grep -Eq "^[[:space:]]*URIs:[[:space:]].*$ubuntu_archive_pattern" "$file"; then
+    return 0
+  fi
+
+  local uri mirror_file
+  while IFS= read -r uri; do
+    mirror_file="${uri#mirror+file:}"
+    if [[ -r "$mirror_file" ]] && grep -Eq "$ubuntu_archive_pattern" "$mirror_file"; then
+      return 0
+    fi
+  done < <(grep -Eho 'mirror\+file:[^[:space:]]+' "$file" || true)
+
+  return 1
+}
+
+sourceparts="$workdir/sources.list.d"
+lists="$workdir/lists"
+mkdir -p "$sourceparts" "$lists/partial"
+
+if [[ -r "$apt_etc_dir/sources.list.d/ubuntu.sources" ]]; then
+  source_file="$apt_etc_dir/sources.list.d/ubuntu.sources"
+  if ! grep -Eq '^[[:space:]]*Types:[[:space:]]*deb([[:space:]]|$)' "$source_file"; then
+    echo "::error::Ubuntu apt source $source_file does not declare deb package sources." >&2
+    exit 1
+  fi
+  if ! deb822_source_points_to_ubuntu_archive "$source_file"; then
+    echo "::error::Ubuntu apt source $source_file does not point at an Ubuntu distribution archive." >&2
+    exit 1
+  fi
+  if ! grep -Eq '^[[:space:]]*Signed-By:[[:space:]]*[^[:space:]]+' "$source_file"; then
+    echo "::error::Ubuntu apt source $source_file does not declare Signed-By key material." >&2
+    exit 1
+  fi
+  cp "$source_file" "$sourceparts/ubuntu.sources"
+elif [[ -r "$apt_etc_dir/sources.list" ]]; then
+  source_file="$apt_etc_dir/sources.list"
+  awk '
+    /^[[:space:]]*deb([[:space:]]|$)/ && /ubuntu\.com\/ubuntu\/?([[:space:]]|$)/ { print }
+  ' "$source_file" > "$sourceparts/ubuntu.list"
+  if [[ ! -s "$sourceparts/ubuntu.list" ]]; then
+    echo "::error::Ubuntu apt source $source_file does not contain deb entries for an Ubuntu distribution archive." >&2
+    exit 1
+  fi
+else
+  echo "::error::Unable to find the Ubuntu apt distribution source in $apt_etc_dir." >&2
+  exit 1
+fi
+
+apt_options=(
+  -o "Dir::Etc::sourcelist=/dev/null"
+  -o "Dir::Etc::sourceparts=$sourceparts"
+  -o "Dir::State::lists=$lists"
+  -o "APT::Get::List-Cleanup=0"
+)
+
+if (($#)); then
+  packages=("$@")
+else
+  packages=(libopenblas-dev)
+fi
+
+sudo apt-get "${apt_options[@]}" update
+sudo apt-get "${apt_options[@]}" install -y --no-install-recommends -- "${packages[@]}"

--- a/scripts/install-native-link-dependencies.sh
+++ b/scripts/install-native-link-dependencies.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 apt_etc_dir="${COVEN_APT_ETC_DIR:-/etc/apt}"
 source_file=""
 workdir="$(mktemp -d)"
-cleanup() { rm -rf "$workdir"; }
+apt_started=0
+cleanup() {
+  if ((apt_started)); then
+    sudo rm -rf -- "$workdir"
+  else
+    rm -rf -- "$workdir"
+  fi
+}
 trap cleanup EXIT
 # Apt's unprivileged downloader must be able to traverse the public metadata directory.
 chmod 755 "$workdir"
@@ -74,5 +81,6 @@ else
   packages=(libopenblas-dev)
 fi
 
+apt_started=1
 sudo apt-get "${apt_options[@]}" update
 sudo apt-get "${apt_options[@]}" install -y --no-install-recommends -- "${packages[@]}"


### PR DESCRIPTION
## Objective

Fix the native-link dependency CI blocker tracked in #971. Two attempts each on
#970 and #933 failed before Rust compilation because the runner's unrelated
Google Chrome package index did not match its signed release hash.

## Change and acceptance

Use one helper for the existing eleven native dependency installs across CI,
npm release, and release-stress workflows. Both update and installation use
only the expected Ubuntu distribution source and isolated package lists.
Deb822 sources, hosted-runner mirror files, and legacy distribution lists are
supported. Existing signature/hash checks remain enabled; missing expected
source/signing information and apt failures remain hard errors. The helper
does not remove or modify the runner's global repositories. Its public metadata
directory remains traversable by apt's unprivileged downloader, and package
arguments cannot become apt flags.

## Evidence and impact

The no-sudo Python regression suite covers source scoping, hosted mirror
configuration, legacy filtering, missing signing metadata, and propagation of
update/install failures. Existing workflow, classifier, secret, and staged
privacy guards passed. Hosted Linux installation/build results remain pending
on this exact checkpoint; local macOS stubs are not represented as that proof.

No runtime authority, credential, database schema, or migration semantics
change. Release jobs keep their required gates. Reverting this helper/call-site
change restores the previous installer without changing runtime artifacts.
