### PR TITLE
test: extend shared Threads daemon journeys to Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,16 @@ jobs:
       - run: cargo test --workspace --locked
       - name: Exercise isolated Threads clock feature
         run: cargo test --locked -p coven-cli --bin coven --features threads-test-clock threads_
+      - name: Exercise real-daemon Threads journeys
+        run: cargo test --locked -p coven-cli --test threads_e2e --features threads-test-clock
+      - name: Upload Threads daemon evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: threads-daemon-windows-${{ github.sha }}
+          path: target/e2e-artifacts/
+          retention-days: 14
+          if-no-files-found: error
 
   # macOS runners bill at roughly ten times the Linux rate, so this follows the
   # npm-onboarding split: a cheap matrix on pull requests, the full one on main.

--- a/crates/coven-cli/tests/threads_e2e.rs
+++ b/crates/coven-cli/tests/threads_e2e.rs
@@ -1,17 +1,11 @@
-#![cfg(unix)]
-
 //! Real-daemon Threads boundary journeys with isolated state and provenance.
 //! Controlled replay coverage requires `threads-test-clock`. This suite does
 //! not certify the pending signed-authorization profile or human freeze gates.
 
 use std::ffi::OsString;
 use std::fs;
-use std::io::{Read, Write};
-use std::net::Shutdown;
-use std::os::unix::{
-    ffi::OsStrExt,
-    net::{UnixListener, UnixStream},
-};
+#[cfg(feature = "threads-test-clock")]
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::thread;
@@ -935,32 +929,6 @@ fn out_of_band_reviewed_drift_is_refused_without_execution() -> Result<()> {
 }
 
 #[test]
-fn http_client_rejects_truncated_response_body() -> Result<()> {
-    let temp = tempfile::tempdir()?;
-    let listener = UnixListener::bind(temp.path().join("coven.sock"))?;
-    let server = thread::spawn(move || -> std::io::Result<()> {
-        let (mut stream, _) = listener.accept()?;
-        let mut request = Vec::new();
-        stream.read_to_end(&mut request)?;
-        stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\n{}")?;
-        Ok(())
-    });
-
-    let error = unix_http_request(temp.path(), "GET", "/health", None)
-        .expect_err("truncated response must fail closed");
-    server
-        .join()
-        .map_err(|_| anyhow::anyhow!("HTTP fixture thread panicked"))??;
-    anyhow::ensure!(
-        error
-            .to_string()
-            .contains("before the declared 8-byte body"),
-        "unexpected truncated-response error: {error:#}"
-    );
-    Ok(())
-}
-
-#[test]
 fn same_home_daemon_lifecycle_helpers_survive_restart_and_crash() -> Result<()> {
     let evidence = EvidenceContext::new("same-home-daemon-lifecycle");
     let mut fixture = ThreadsFixture::start(&evidence)?;
@@ -1038,7 +1006,7 @@ fn same_home_daemon_lifecycle_helpers_survive_restart_and_crash() -> Result<()> 
             "success daemon log leaked unsanitized fixture paths:\n{daemon_log}"
         );
         anyhow::ensure!(
-            daemon_log.contains("socket <coven-home>/coven.sock")
+            daemon_log.contains(sanitized_daemon_endpoint())
                 && !daemon_log.contains("/private<coven-home>"),
             "success daemon log did not retain the sanitized socket placeholder:\n{daemon_log}"
         );
@@ -1046,7 +1014,7 @@ fn same_home_daemon_lifecycle_helpers_survive_restart_and_crash() -> Result<()> 
         let response: Value =
             serde_json::from_slice(&fs::read(fixture.artifact_dir.join("response.json"))?)?;
         anyhow::ensure!(
-            response["body"]["daemon"]["socket"] == "<coven-home>/coven.sock",
+            response["body"]["daemon"]["socket"] == sanitized_daemon_endpoint(),
             "success response provenance did not sanitize the socket path: {response}"
         );
         Ok(())
@@ -1095,23 +1063,28 @@ fn run_clocked_journey(
 
 #[cfg(feature = "threads-test-clock")]
 fn seed_clock(coven_home: &Path, capability: &str) -> Result<()> {
+    #[cfg(unix)]
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
     let root = coven_home.join("test-fixtures");
     let directory = root.join("threads-deterministic-clock");
     fs::create_dir_all(&directory)?;
-    for path in [&root, &directory] {
-        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    #[cfg(unix)]
+    {
+        for path in [&root, &directory] {
+            fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+        }
     }
     for (name, contents) in [
         ("enabled", "threads_test_clock_v1\n"),
         ("capability", capability),
         ("state.json", r#"{"now":"2099-01-01T00:00:00Z"}"#),
     ] {
-        fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        options
             .open(directory.join(name))?
             .write_all(contents.as_bytes())?;
     }
@@ -1566,6 +1539,8 @@ struct ThreadsFixture {
     coven: PathBuf,
     coven_home: PathBuf,
     workspace: PathBuf,
+    #[cfg(windows)]
+    pipe_names: [String; 3],
     path: OsString,
     run_id: String,
     scenario: String,
@@ -1620,6 +1595,8 @@ impl ThreadsFixture {
         fs::create_dir_all(&workspace)?;
         seed_familiar(&coven_home, &workspace)?;
         prepare(&coven_home, &workspace)?;
+        #[cfg(windows)]
+        let pipe_names = coven_client::supported_windows_pipe_names(&coven_home)?;
 
         let coven = PathBuf::from(env!("CARGO_BIN_EXE_coven"));
         let path = std::env::var_os("PATH").unwrap_or_default();
@@ -1628,6 +1605,8 @@ impl ThreadsFixture {
             coven,
             coven_home,
             workspace,
+            #[cfg(windows)]
+            pipe_names,
             path,
             run_id: evidence.run_id.clone(),
             scenario: evidence.scenario.clone(),
@@ -1648,7 +1627,12 @@ impl ThreadsFixture {
         Ok(fixture)
     }
 
-    fn request(&mut self, method: &str, path: &str, body: Option<&Value>) -> Result<HttpResponse> {
+    fn request(
+        &mut self,
+        method: &'static str,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<HttpResponse> {
         let mut request = body.cloned().unwrap_or(Value::Null);
         if let Some(capability) = request.get_mut("capability") {
             *capability = json!("<fixture-capability>");
@@ -1658,9 +1642,7 @@ impl ThreadsFixture {
             "path": path,
             "body": request,
         }));
-        let serialized = body.map(Value::to_string);
-        let (status, response) =
-            unix_http_request(&self.coven_home, method, path, serialized.as_deref())?;
+        let (status, response) = daemon_http_request(&self.coven_home, method, path, body)?;
         let parsed: Value = serde_json::from_str(&response)
             .with_context(|| format!("daemon returned non-JSON response: {response}"))?;
         self.last_response = Some(json!({
@@ -1783,19 +1765,12 @@ impl ThreadsFixture {
         let pid = self
             .current_daemon_pid()
             .context("daemon crash requires a running daemon")?;
-        let status = Command::new("kill")
-            .args(["-KILL", &pid.to_string()])
-            .status()
-            .context("sending SIGKILL to the daemon")?;
-        anyhow::ensure!(
-            status.success(),
-            "SIGKILL did not terminate daemon pid {pid}"
-        );
+        terminate_daemon_process(&self.coven_home, pid)?;
         wait_for_process_exit(pid, "crashed daemon", Duration::from_secs(3))?;
         self.daemon_events.push(DaemonLifecycleEvent::note(
             "daemon crash",
             Some(pid),
-            format!("sent SIGKILL to daemon pid {pid}"),
+            format!("forcibly terminated daemon pid {pid}"),
         ));
         self.daemon_pid = None;
         self.stopped = false;
@@ -1918,6 +1893,12 @@ impl ThreadsFixture {
     }
 
     fn sanitize_fixture_text(&self, value: &str) -> String {
+        #[cfg(windows)]
+        let value = self.pipe_names.iter().fold(value.to_owned(), |text, name| {
+            text.replace(name, sanitized_daemon_endpoint())
+        });
+        #[cfg(windows)]
+        let value = value.as_str();
         replace_sanitized_path(
             replace_sanitized_path(
                 sanitize_for_artifact(value),
@@ -1946,9 +1927,9 @@ impl Drop for ThreadsFixture {
                 "threads E2E fallback is terminating daemon pid {} after graceful stop success={stopped}",
                 pid,
             );
-            let _ = Command::new("kill")
-                .args(["-KILL", &pid.to_string()])
-                .status();
+            if let Err(error) = terminate_daemon_process(&self.coven_home, pid) {
+                eprintln!("failed terminating fixture daemon pid {pid}: {error:#}");
+            }
         }
     }
 }
@@ -2164,8 +2145,8 @@ fn wait_for_daemon_health(coven_home: &Path) -> Result<()> {
     let deadline = Instant::now() + Duration::from_secs(10);
     let mut last_error = None;
     while Instant::now() < deadline {
-        if coven_home.join("coven.sock").exists() {
-            match unix_http_request(coven_home, "GET", "/health", None) {
+        if coven_home.join("daemon.json").exists() {
+            match daemon_http_request(coven_home, "GET", "/health", None) {
                 Ok((200, body)) if body.contains(r#""ok":true"#) => return Ok(()),
                 Ok(_) => {}
                 Err(error) => last_error = Some(error),
@@ -2176,6 +2157,14 @@ fn wait_for_daemon_health(coven_home: &Path) -> Result<()> {
     match last_error {
         Some(error) => anyhow::bail!("daemon did not become ready: {error:#}"),
         None => anyhow::bail!("daemon did not become ready"),
+    }
+}
+
+fn sanitized_daemon_endpoint() -> &'static str {
+    if cfg!(windows) {
+        "<daemon-pipe>"
+    } else {
+        "<coven-home>/coven.sock"
     }
 }
 
@@ -2226,6 +2215,7 @@ fn wait_for_daemon_shutdown(coven_home: &Path, pid: Option<u32>) -> Result<()> {
     )
 }
 
+#[cfg(unix)]
 fn pid_is_alive(pid: u32) -> bool {
     Command::new("kill")
         .args(["-0", &pid.to_string()])
@@ -2235,89 +2225,90 @@ fn pid_is_alive(pid: u32) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn unix_http_request(
-    coven_home: &Path,
-    method: &str,
-    path: &str,
-    body: Option<&str>,
-) -> Result<(u16, String)> {
-    let body = body.unwrap_or_default();
-    let request = format!(
-        "{method} {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
-        body.len()
-    );
-    let mut stream = UnixStream::connect(coven_home.join("coven.sock"))?;
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
-    stream.write_all(request.as_bytes())?;
-    stream.shutdown(Shutdown::Write)?;
+#[cfg(windows)]
+fn pid_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::{
+        Foundation::{
+            CloseHandle, GetLastError, ERROR_INVALID_PARAMETER, WAIT_OBJECT_0, WAIT_TIMEOUT,
+        },
+        System::Threading::{OpenProcess, WaitForSingleObject},
+    };
 
-    let mut response = Vec::new();
-    let mut buffer = [0_u8; 8192];
-    let mut expected_len: Option<(usize, usize)> = None;
-    loop {
-        let read = stream.read(&mut buffer)?;
-        if read == 0 {
-            let (body_start, content_length) =
-                expected_len.context("daemon response ended before complete HTTP headers")?;
-            anyhow::ensure!(
-                response.len() >= body_start.saturating_add(content_length),
-                "daemon response ended after {} bytes, before the declared {}-byte body completed",
-                response.len().saturating_sub(body_start),
-                content_length
-            );
-            break;
-        }
-        response.extend_from_slice(&buffer[..read]);
-        anyhow::ensure!(
-            response.len() <= 5 * 1024 * 1024,
-            "daemon HTTP response exceeded the E2E response budget"
+    const SYNCHRONIZE_ACCESS: u32 = 0x0010_0000;
+    let handle = unsafe { OpenProcess(SYNCHRONIZE_ACCESS, 0, pid) };
+    if handle.is_null() {
+        let error = unsafe { GetLastError() };
+        assert_eq!(
+            error, ERROR_INVALID_PARAMETER,
+            "cannot establish fixture daemon pid {pid} liveness: Windows error {error}"
         );
-        if expected_len.is_none() {
-            if let Some(header_end) = find_bytes(&response, b"\r\n\r\n") {
-                let headers = std::str::from_utf8(&response[..header_end])?;
-                let content_length = headers
-                    .lines()
-                    .find_map(|line| {
-                        let (name, value) = line.split_once(':')?;
-                        name.eq_ignore_ascii_case("content-length")
-                            .then(|| value.trim().parse::<usize>())
-                    })
-                    .transpose()?
-                    .context("daemon response is missing Content-Length")?;
-                expected_len = Some((header_end + 4, content_length));
-            }
-        }
-        if expected_len.is_some_and(|(body_start, content_length)| {
-            response.len() >= body_start.saturating_add(content_length)
-        }) {
-            break;
-        }
+        return false;
     }
-    let (body_start, content_length) =
-        expected_len.context("daemon response is missing complete HTTP framing")?;
-    let body_end = body_start
-        .checked_add(content_length)
-        .context("daemon Content-Length overflowed the response budget")?;
-    anyhow::ensure!(
-        response.len() >= body_end,
-        "daemon response body is shorter than Content-Length"
-    );
-    let headers = std::str::from_utf8(&response[..body_start - 4])?;
-    let status = headers
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .and_then(|status| status.parse::<u16>().ok())
-        .with_context(|| format!("invalid HTTP response headers: {headers}"))?;
-    let body = String::from_utf8(response[body_start..body_end].to_vec())?;
-    Ok((status, body))
+    let result = unsafe { WaitForSingleObject(handle, 0) };
+    unsafe { CloseHandle(handle) };
+    match result {
+        WAIT_TIMEOUT => true,
+        WAIT_OBJECT_0 => false,
+        _ => panic!("cannot establish fixture daemon pid {pid} liveness: wait result {result}"),
+    }
 }
 
-fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
+#[cfg(unix)]
+fn terminate_daemon_process(_coven_home: &Path, pid: u32) -> Result<()> {
+    let status = Command::new("kill")
+        .args(["-KILL", &pid.to_string()])
+        .status()
+        .context("sending SIGKILL to the fixture daemon")?;
+    anyhow::ensure!(
+        status.success(),
+        "SIGKILL failed for fixture daemon pid {pid}"
+    );
+    Ok(())
+}
+
+#[cfg(windows)]
+fn terminate_daemon_process(coven_home: &Path, pid: u32) -> Result<()> {
+    let status: Value = serde_json::from_slice(&fs::read(coven_home.join("daemon.json"))?)?;
+    let pipe = status["socket"]
+        .as_str()
+        .context("daemon status has no pipe")?;
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let probe = coven_client::probe_windows_daemon_health_with_identity_until(pipe, deadline)?
+        .context("fixture daemon pipe disappeared before crash injection")?;
+    anyhow::ensure!(
+        probe.server_pid == pid,
+        "fixture daemon process changed before crash injection"
+    );
+    let process = coven_client::open_windows_daemon_process_for_stop_until(
+        pipe,
+        pid,
+        Some(probe.process_creation_time),
+        deadline,
+    )?
+    .context("fixture daemon identity could not be verified for crash injection")?;
+    anyhow::ensure!(
+        process.terminate_and_wait_until(deadline)?,
+        "verified fixture daemon pid {pid} did not exit after crash injection"
+    );
+    Ok(())
+}
+
+fn daemon_http_request(
+    coven_home: &Path,
+    method: &'static str,
+    path: &str,
+    body: Option<&Value>,
+) -> Result<(u16, String)> {
+    let endpoint = coven_client::DaemonEndpoint::discover(coven_home)
+        .context("discovering owner-local fixture daemon")?;
+    let mut client = coven_client::DaemonClient::new(endpoint);
+    let response = client
+        .request_json(method, path, body)
+        .with_context(|| format!("fixture daemon request {method} {path}"))?;
+    Ok((
+        response.status,
+        String::from_utf8(response.body).context("fixture daemon response is not UTF-8")?,
+    ))
 }
 
 fn ward_audit_jsonl(store: &Path) -> Result<String> {
@@ -2488,7 +2479,7 @@ fn git_state(path: &Path) -> Result<GitState> {
             let metadata = fs::symlink_metadata(&untracked)?;
             if metadata.file_type().is_symlink() {
                 fingerprint.update(relative.as_bytes());
-                fingerprint.update(fs::read_link(untracked)?.as_os_str().as_bytes());
+                fingerprint.update(fs::read_link(untracked)?.as_os_str().as_encoded_bytes());
             } else if metadata.is_file() {
                 fingerprint.update(relative.as_bytes());
                 fingerprint.update(fs::read(untracked)?);
@@ -2511,8 +2502,10 @@ fn file_sha256(path: &Path) -> Result<String> {
 
 fn sanitize_for_artifact(value: &str) -> String {
     let mut sanitized = value.replace(&workspace_root().display().to_string(), "<coven-workspace>");
-    if let Some(home) = std::env::var_os("HOME") {
-        sanitized = sanitized.replace(&PathBuf::from(home).display().to_string(), "<home>");
+    for key in ["HOME", "USERPROFILE"] {
+        if let Some(home) = std::env::var_os(key) {
+            sanitized = sanitized.replace(&PathBuf::from(home).display().to_string(), "<home>");
+        }
     }
     sanitized
 }

--- a/crates/coven-client/src/http.rs
+++ b/crates/coven-client/src/http.rs
@@ -12,6 +12,13 @@ const HEALTH_PATH: &str = "/api/v1/health";
 const RESERVED_SESSION_DETAIL_ROUTE_ERROR: &str =
     "ReadEndpoint::Session id collides with a reserved BASE v1 nested route";
 
+/// A complete, framed daemon response, including non-success HTTP statuses.
+#[derive(Debug)]
+pub struct DaemonHttpResponse {
+    pub status: u16,
+    pub body: Vec<u8>,
+}
+
 pub struct DaemonClient {
     endpoint: DaemonEndpoint,
     negotiated: Option<NegotiatedDaemon>,
@@ -55,6 +62,31 @@ impl DaemonClient {
             peer_identity: transport.peer_identity,
         });
         Ok(health)
+    }
+
+    /// Send JSON to a v1 route or exact `GET /health`, preserving response bytes.
+    ///
+    /// Negotiates health and binds the request to that authenticated peer. HTTP
+    /// rejections are returned unchanged; transport and identity failures remain
+    /// errors and requests are never automatically replayed. Unlike typed methods,
+    /// this does not infer route-specific capabilities or validate lifecycle fields.
+    pub fn request_json(
+        &mut self,
+        method: &'static str,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<DaemonHttpResponse, ClientError> {
+        validate_raw_request(method, path)?;
+        let body = body
+            .map(serde_json::to_vec)
+            .transpose()
+            .map_err(ClientError::InvalidJson)?;
+        self.ensure_health()?;
+        let response = self.send_bound(method, path, body.as_deref())?;
+        Ok(DaemonHttpResponse {
+            status: response.status,
+            body: response.body,
+        })
     }
 
     pub fn get_json<T: DeserializeOwned>(
@@ -193,6 +225,42 @@ impl DaemonClient {
         }
         serde_json::from_slice(&response.body).map_err(ClientError::InvalidJson)
     }
+}
+
+fn validate_raw_request(method: &str, path: &str) -> Result<(), ClientError> {
+    if method.is_empty()
+        || !method.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+    {
+        return Err(ClientError::InvalidRouteParameter("HTTP method"));
+    }
+    if !(path.starts_with("/api/v1/") || (method == "GET" && path == "/health"))
+        || !path.is_ascii()
+        || path
+            .bytes()
+            .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control() || byte == b'#')
+    {
+        return Err(ClientError::InvalidRouteParameter("HTTP request target"));
+    }
+    Ok(())
 }
 
 fn daemon_error(status: u16, body: Vec<u8>) -> Result<ClientError, ClientError> {

--- a/crates/coven-client/src/lib.rs
+++ b/crates/coven-client/src/lib.rs
@@ -21,7 +21,7 @@ pub use discovery::{
 pub use error::{
     ClientError, DaemonError, EMPTY_RESPONSE_TIMEOUT_MESSAGE, WINDOWS_CONNECT_OPERATION,
 };
-pub use http::DaemonClient;
+pub use http::{DaemonClient, DaemonHttpResponse};
 #[cfg(unix)]
 #[doc(hidden)]
 pub use lifecycle::{probe_unix_daemon_health, shutdown_unix_daemon};

--- a/crates/coven-client/src/transport/mod.rs
+++ b/crates/coven-client/src/transport/mod.rs
@@ -174,9 +174,9 @@ fn request_with_peer(
     body: Option<&[u8]>,
     expected_peer: Option<&PeerIdentity>,
 ) -> Result<TransportResponse, ClientError> {
-    if !path.starts_with("/api/v1/") {
+    if !(path.starts_with("/api/v1/") || (method == "GET" && path == "/health")) {
         return Err(ClientError::InvalidHttpResponse(
-            "attempted request outside /api/v1".to_owned(),
+            "attempted request outside /api/v1 or exact GET /health".to_owned(),
         ));
     }
     if let Some(body) = body {

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -355,6 +355,258 @@ fn negotiates_the_v1_health_contract_and_structured_errors() {
     server.join().expect("server thread");
 }
 
+#[test]
+fn raw_json_request_preserves_forbidden_response_bytes() {
+    let home = TestHome::new();
+    let body = " {\"error\":{\"code\":\"forbidden\",\"message\":\"denied\"}}\n";
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, HEALTH.to_owned()),
+            (
+                "/api/v1/familiars/sage/edits".to_owned(),
+                403,
+                body.to_owned(),
+            ),
+        ],
+    );
+    let mut client =
+        DaemonClient::new(DaemonEndpoint::discover(&home.path).expect("discover daemon"));
+    let response = client
+        .request_json(
+            "POST",
+            "/api/v1/familiars/sage/edits",
+            Some(&serde_json::json!({"edits": []})),
+        )
+        .expect("HTTP rejection is a completed response");
+    assert_eq!(response.status, 403);
+    assert_eq!(response.body, body.as_bytes());
+    server.join().expect("daemon thread");
+}
+
+#[test]
+fn raw_json_request_preserves_root_health_identity() {
+    let home = TestHome::new();
+    let body = lifecycle_health(&lifecycle_status(&home.path));
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, HEALTH.to_owned()),
+            ("/health".to_owned(), 200, body.clone()),
+        ],
+    );
+    let mut client =
+        DaemonClient::new(DaemonEndpoint::discover(&home.path).expect("discover daemon"));
+    let response = client
+        .request_json("GET", "/health", None)
+        .expect("read raw lifecycle health after negotiation");
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, body.as_bytes());
+    server.join().expect("daemon thread");
+}
+
+#[test]
+fn raw_json_request_rejects_truncated_response_framing() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    for truncated in [
+        "",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 4\r\n",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 4\r\n\r\n{}",
+    ] {
+        let home = TestHome::new();
+        let socket = home.path.join("coven.sock");
+        let listener = UnixListener::bind(&socket).expect("bind daemon");
+        fs::set_permissions(&socket, fs::Permissions::from_mode(0o600)).expect("protect socket");
+        let server = std::thread::spawn(move || {
+            for (path, response) in [
+                (
+                    "/api/v1/health",
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{HEALTH}",
+                        HEALTH.len()
+                    ),
+                ),
+                ("/api/v1/familiars/sage/edits", truncated.to_owned()),
+            ] {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let mut request = String::new();
+                stream.read_to_string(&mut request).expect("read request");
+                assert!(request.lines().next().unwrap().contains(path));
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+        let mut client =
+            DaemonClient::new(DaemonEndpoint::discover(&home.path).expect("discover daemon"));
+        let error = client
+            .request_json("POST", "/api/v1/familiars/sage/edits", None)
+            .expect_err("a truncated 403 must not become a completed raw response");
+        assert!(
+            matches!(
+                error,
+                ClientError::InvalidHttpResponse(ref message)
+                    if message == "connection closed before response completed"
+            ),
+            "unexpected error for {truncated:?}: {error}"
+        );
+        server.join().expect("daemon thread");
+    }
+}
+
+#[test]
+fn raw_json_request_sends_method_target_and_json_without_changing_typed_capabilities() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    let home = TestHome::new();
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind daemon");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600)).expect("protect socket");
+    let health = health_with_capabilities(serde_json::json!({
+        "sessions": false,
+        "structuredErrors": true
+    }));
+    let payload = serde_json::json!({"text": "quoted \" value", "edits": []});
+    let expected_body = serde_json::to_string(&payload).expect("serialize fixture");
+    let server = std::thread::spawn(move || {
+        for expected in [
+            "GET /api/v1/health HTTP/1.1\r\n",
+            "PATCH /api/v1/familiars/sage/edits?mode=review HTTP/1.1\r\n",
+            "",
+        ] {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = String::new();
+            stream.read_to_string(&mut request).expect("read request");
+            if expected.is_empty() {
+                assert!(
+                    request.is_empty(),
+                    "typed capability rejection leaked bytes"
+                );
+                continue;
+            }
+            assert!(
+                request.starts_with(expected),
+                "unexpected request: {request}"
+            );
+            let response = if expected.starts_with("GET") {
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{health}",
+                    health.len()
+                )
+            } else {
+                assert_eq!(request.split_once("\r\n\r\n").unwrap().1, expected_body);
+                assert!(
+                    request.contains(&format!("\r\nContent-Length: {}\r\n", expected_body.len()))
+                );
+                "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n".to_owned()
+            };
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        }
+    });
+    let mut client =
+        DaemonClient::new(DaemonEndpoint::discover(&home.path).expect("discover daemon"));
+    let response = client
+        .request_json(
+            "PATCH",
+            "/api/v1/familiars/sage/edits?mode=review",
+            Some(&payload),
+        )
+        .expect("send a raw route without assuming session capabilities");
+    assert_eq!(response.status, 204);
+    assert!(response.body.is_empty());
+    assert!(matches!(
+        client.get_json::<serde_json::Value>(unpaginated_sessions_read()),
+        Err(ClientError::CapabilityUnavailable {
+            capability: "sessions"
+        })
+    ));
+    server.join().expect("daemon thread");
+}
+
+#[test]
+fn raw_json_request_rejects_invalid_method_and_target_before_io() {
+    use std::os::unix::{fs::PermissionsExt, net::UnixListener};
+
+    let home = TestHome::new();
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind daemon");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600)).expect("protect socket");
+    listener.set_nonblocking(true).expect("nonblocking accept");
+    let mut client =
+        DaemonClient::new(DaemonEndpoint::discover(&home.path).expect("discover daemon"));
+    for (method, target) in [
+        ("", "/api/v1/health"),
+        ("GET\r\nX: injected", "/api/v1/health"),
+        ("GET POST", "/api/v1/health"),
+        ("GÉT", "/api/v1/health"),
+        ("GET", "/api/v1/health\r\nX: injected"),
+        ("GET", "/api/v1/health HTTP/1.1"),
+        ("GET", "/api/v1/health\0"),
+        ("GET", "/api/v1/health#fragment"),
+        ("GET", "http://coven/api/v1/health"),
+        ("GET", "//coven/api/v1/health"),
+        ("GET", "/api/v1"),
+        ("GET", "/other"),
+        ("POST", "/health"),
+        ("GET", "/health?extra=1"),
+        ("GET", "/health/"),
+    ] {
+        assert!(
+            matches!(
+                client.request_json(method, target, None),
+                Err(ClientError::InvalidRouteParameter(_))
+            ),
+            "invalid request was not rejected: {method:?} {target:?}"
+        );
+        assert!(
+            matches!(listener.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock),
+            "invalid request attempted transport I/O"
+        );
+    }
+}
+
+#[test]
+fn raw_json_request_binds_peer_and_renegotiates_only_on_next_call() {
+    let home = TestHome::new();
+    let original = serve_once(&home.path, 200, HEALTH.to_owned());
+    let mut client =
+        DaemonClient::new(DaemonEndpoint::discover(&home.path).expect("discover daemon"));
+    client.health().expect("negotiate original");
+    original.join().expect("original daemon");
+    let socket = home.path.join("coven.sock");
+    fs::rename(&socket, home.path.join(".retired")).expect("retire socket");
+    let replacement = serve_responses(
+        &home.path,
+        vec![
+            ("<peer-check>".to_owned(), 200, String::new()),
+            ("/api/v1/health".to_owned(), 200, HEALTH.to_owned()),
+            (
+                "/api/v1/familiars/sage/edits".to_owned(),
+                403,
+                ERROR.to_owned(),
+            ),
+        ],
+    );
+    let error = client
+        .request_json("POST", "/api/v1/familiars/sage/edits", None)
+        .expect_err("replacement must receive no request bytes");
+    assert!(matches!(error, ClientError::DaemonInstanceChanged));
+    let response = client
+        .request_json("POST", "/api/v1/familiars/sage/edits", None)
+        .expect("a separate call renegotiates");
+    assert_eq!(response.status, 403);
+    replacement.join().expect("replacement daemon");
+}
+
 #[cfg(unix)]
 #[test]
 fn missing_sessions_capability_blocks_sessions_but_not_events() {

--- a/docs/CLIENT-INTEGRATION.md
+++ b/docs/CLIENT-INTEGRATION.md
@@ -27,7 +27,7 @@ Recommended handshake:
 Rust integrations should use the owner-adjacent `coven-client` crate for this
 handshake and daemon framing. Discover `DaemonEndpoint` from the chosen Coven
 home, pass it to `DaemonClient::new`, and use its typed `/api/v1` operations.
-It does not accept URLs, arbitrary socket paths, or arbitrary request paths:
+It does not accept URLs or arbitrary socket paths:
 Unix discovery requires the current user's private `coven.sock`, and Windows
 discovery derives and validates only the daemon's owner-only named pipe. The
 client accepts a recorded legacy Windows pipe only from a validated private
@@ -38,6 +38,16 @@ The negotiated capabilities are tied to the connected daemon's peer
 fingerprint. Endpoint replacement invalidates the cache before request bytes
 are sent; callers must negotiate again, and mutations are never replayed
 automatically.
+
+For versioned routes without a typed wrapper, `DaemonClient::request_json`
+returns `DaemonHttpResponse` with the original HTTP status and body bytes,
+including non-success responses. It accepts confined `/api/v1/` targets and
+the exact `GET /health` probe, validates method/target syntax before I/O, and
+uses the same health negotiation, peer binding, framing limits, and deadlines
+as typed calls. Transport or identity failures remain errors. This does not
+grant request authority or imply that a returned HTTP error is safe to retry;
+the daemon remains responsible for route-specific authorization. Typed calls
+retain their capability checks and structured-error behavior.
 
 The `coven.daemon.v1` session routes use their historical raw-byte behavior,
 not URL-component decoding. `engine/42` is a valid raw path remainder and a

--- a/docs/reference/threads-e2e.md
+++ b/docs/reference/threads-e2e.md
@@ -13,9 +13,9 @@ source_adjacent_reason: "Tracks the real daemon test fixture and evidence contra
 The `threads_e2e` integration target exercises the Ward/Threads boundary
 through a real `coven daemon` process and its local IPC transport. Each test
 uses a unique temporary `COVEN_HOME`, familiar workspace, SQLite store, pending
-directory, and daemon socket.
+directory, and owner-local daemon endpoint.
 
-Run the complete available Unix daemon journeys from a Coven checkout:
+Run the complete available daemon journeys from a Coven checkout:
 
 ```sh
 cargo test --locked -p coven-cli --test threads_e2e --features threads-test-clock -- --nocapture
@@ -40,8 +40,17 @@ The clock feature is disabled in production builds. It uses a capability-gated
 fixture in each disposable home and explicit real-scheduler ticks, not sleeps
 or a mock scheduler. See [Threads test clock](../design/threads-test-clock.md).
 Without the feature, Cargo runs only the smaller smoke/lifecycle subset. CI
-executes the feature-enabled target on Linux and on the existing macOS push
-lane; this Unix-socket harness does not provide Windows daemon-journey proof.
+executes the feature-enabled target on Linux, Windows, and the existing macOS
+push lane. All platforms run the same 14 daemon journeys through `coven-client`
+discovery and authenticated transport; Windows uses the owner-only named pipe.
+HTTP framing regressions belong to the shared client's tests, not a separate
+harness parser. A cross-target compilation or Windows workspace run alone is
+not evidence that these journeys executed on Windows.
+
+Lifecycle commands still use the production CLI and its existing deadlines.
+Windows crash injection binds the process handle to the authenticated pipe
+server PID and creation time before termination. Requests are never retried
+automatically; a response timeout does not prove a mutation did not commit.
 
 ## Testing a local Threads checkout
 

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -80,18 +80,26 @@ class CheckCiWorkflowTests(unittest.TestCase):
     def test_ci_sets_up_node_for_release_workflow_policy_tests(self) -> None:
         self.assertIn(f"actions/setup-node@{SETUP_NODE_SHA}", CI_TEXT)
 
-    def test_unix_jobs_exercise_feature_enabled_threads_daemon_journeys(self) -> None:
+    def test_all_platforms_exercise_feature_enabled_threads_daemon_journeys(self) -> None:
         command = "cargo test --locked -p coven-cli --test threads_e2e --features threads-test-clock"
         for job, next_job in [
             ("rust-test-linux", "rust-test-windows"),
+            ("rust-test-windows", "rust-test-macos"),
             ("rust-test-macos", "afs-mount-linux"),
         ]:
             block = CI_TEXT.split(f"\n  {job}:\n", 1)[1].split(f"\n  {next_job}:\n", 1)[0]
             self.assertIn(command, block)
+        harness = CI_WORKFLOW.parents[2] / "crates/coven-cli/tests/threads_e2e.rs"
+        self.assertNotIn("#![cfg(unix)]", harness.read_text(encoding="utf-8"))
+
+    def test_windows_threads_journeys_retain_failure_evidence(self) -> None:
         windows = CI_TEXT.split("\n  rust-test-windows:\n", 1)[1].split(
             "\n  rust-test-macos:\n", 1
         )[0]
-        self.assertNotIn(command, windows)
+        self.assertIn("name: Upload Threads daemon evidence", windows)
+        self.assertIn("if: ${{ always() }}", windows)
+        self.assertIn("path: target/e2e-artifacts/", windows)
+        self.assertIn("retention-days: 14", windows)
 
     def test_native_link_dependency_installs_use_scoped_apt_helper(self) -> None:
         release_stress_text = RELEASE_STRESS_WORKFLOW.read_text(encoding='utf-8')

--- a/scripts/install-native-link-dependencies-test.py
+++ b/scripts/install-native-link-dependencies-test.py
@@ -197,8 +197,10 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
                 textwrap.dedent(
                     """\
                     deb http://archive.ubuntu.com/ubuntu noble main universe
-                    deb http://security.ubuntu.com/ubuntu noble-security main universe
+                    deb [arch=amd64 signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] http://security.ubuntu.com/ubuntu noble-security main universe
                     deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main
+                    deb https://evilubuntu.com/ubuntu noble main
+                    deb https://third-party.example/packages stable main # ubuntu.com/ubuntu
                     """
                 ),
                 encoding="utf-8",
@@ -212,6 +214,9 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
         self.assertIn("archive.ubuntu.com/ubuntu", source_text)
         self.assertIn("security.ubuntu.com/ubuntu", source_text)
         self.assertNotIn("dl.google.com", source_text)
+        self.assertNotIn("evilubuntu.com", source_text)
+        self.assertNotIn("third-party.example", source_text)
+        self.assertIn("signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg", source_text)
 
     def test_update_failure_propagates_without_running_install(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -223,6 +228,85 @@ class NativeLinkDependencyInstallerTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 42)
         self.assertEqual(len(calls), 1)
         self.assertIn("update", calls[0])
+
+    def test_lookalike_archive_hosts_are_never_installed(self) -> None:
+        for uri in [
+            "https://evilubuntu.com/ubuntu",
+            "https://ubuntu.com.attacker.example/ubuntu",
+            "https://attacker.example/ubuntu.com/ubuntu",
+        ]:
+            for deb822 in [False, True]:
+                with self.subTest(uri=uri, deb822=deb822), tempfile.TemporaryDirectory() as directory:
+                    apt_etc_dir = pathlib.Path(directory)
+                    if deb822:
+                        self.write_deb822_ubuntu_source(apt_etc_dir)
+                        source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+                        source.write_text(
+                            f"Types: deb\nURIs: {uri}\nSuites: noble\n"
+                            "Components: main\n"
+                            "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n",
+                            encoding="utf-8",
+                        )
+                    else:
+                        (apt_etc_dir / "sources.list").write_text(
+                            f"deb {uri} noble main\n", encoding="utf-8"
+                        )
+                    completed, calls, _sources = self.run_installer(apt_etc_dir)
+                    self.assertEqual(completed.returncode, 1, completed.stderr)
+                    self.assertEqual(calls, [])
+
+    def test_every_deb822_stanza_requires_ubuntu_uris_and_signing_metadata(self) -> None:
+        for extra in [
+            "Types: deb\nURIs: https://third-party.example/packages\nSuites: stable\n"
+            "Components: main\nSigned-By: /usr/share/keyrings/vendor.gpg\n",
+            "Types: deb\nURIs: http://archive.ubuntu.com/ubuntu/\nSuites: noble\n"
+            "Components: main\n",
+        ]:
+            with self.subTest(extra=extra), tempfile.TemporaryDirectory() as directory:
+                apt_etc_dir = pathlib.Path(directory)
+                self.write_deb822_ubuntu_source(apt_etc_dir)
+                source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+                source.write_text(source.read_text(encoding="utf-8") + "\n" + extra, encoding="utf-8")
+                completed, calls, _sources = self.run_installer(apt_etc_dir)
+                self.assertEqual(completed.returncode, 1, completed.stderr)
+                self.assertEqual(calls, [])
+
+    def test_every_uri_in_a_deb822_field_or_mirror_file_must_be_ubuntu(self) -> None:
+        for mirror in [False, True]:
+            with self.subTest(mirror=mirror), tempfile.TemporaryDirectory() as directory:
+                apt_etc_dir = pathlib.Path(directory)
+                self.write_deb822_ubuntu_source(apt_etc_dir)
+                uris = "http://archive.ubuntu.com/ubuntu/\n https://third-party.example/packages"
+                if mirror:
+                    mirror_file = apt_etc_dir / "apt-mirrors.txt"
+                    mirror_file.write_text(uris + "\n", encoding="utf-8")
+                    uris = f"mirror+file:{mirror_file}"
+                source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+                source.write_text(
+                    f"Types: deb\nURIs: {uris}\nSuites: noble\nComponents: main\n"
+                    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n",
+                    encoding="utf-8",
+                )
+                completed, calls, _sources = self.run_installer(apt_etc_dir)
+                self.assertEqual(completed.returncode, 1, completed.stderr)
+                self.assertEqual(calls, [])
+
+    def test_deb822_ubuntu_uri_continuations_preserve_the_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            apt_etc_dir = pathlib.Path(directory)
+            self.write_deb822_ubuntu_source(apt_etc_dir)
+            source = apt_etc_dir / "sources.list.d/ubuntu.sources"
+            text = source.read_text(encoding="utf-8").replace(
+                "URIs: http://azure.archive.ubuntu.com/ubuntu/",
+                "URIs: http://azure.archive.ubuntu.com/ubuntu/\n"
+                " https://archive.ubuntu.com/ubuntu/",
+            )
+            source.write_text(text, encoding="utf-8")
+            completed, calls, sources = self.run_installer(apt_etc_dir)
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(len(calls), 2)
+            self.assertIn(text, "\n".join(sources))
+            self.assertEqual(source.read_text(encoding="utf-8"), text)
 
     def test_install_failure_propagates(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/install-native-link-dependencies.sh
+++ b/scripts/install-native-link-dependencies.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 apt_etc_dir="${COVEN_APT_ETC_DIR:-/etc/apt}"
-source_file=""
 workdir="$(mktemp -d)"
 apt_started=0
 cleanup() {
@@ -16,57 +15,89 @@ trap cleanup EXIT
 # Apt's unprivileged downloader must be able to traverse the public metadata directory.
 chmod 755 "$workdir"
 
-ubuntu_archive_pattern='ubuntu\.com/ubuntu/?([[:space:]]|$)'
-
-deb822_source_points_to_ubuntu_archive() {
-  local file="$1"
-  if grep -Eq "^[[:space:]]*URIs:[[:space:]].*$ubuntu_archive_pattern" "$file"; then
-    return 0
-  fi
-
-  local uri mirror_file
-  while IFS= read -r uri; do
-    mirror_file="${uri#mirror+file:}"
-    if [[ -r "$mirror_file" ]] && grep -Eq "$ubuntu_archive_pattern" "$mirror_file"; then
-      return 0
-    fi
-  done < <(grep -Eho 'mirror\+file:[^[:space:]]+' "$file" || true)
-
-  return 1
-}
-
 sourceparts="$workdir/sources.list.d"
 lists="$workdir/lists"
 mkdir -p "$sourceparts" "$lists/partial"
 
-if [[ -r "$apt_etc_dir/sources.list.d/ubuntu.sources" ]]; then
-  source_file="$apt_etc_dir/sources.list.d/ubuntu.sources"
-  if ! grep -Eq '^[[:space:]]*Types:[[:space:]]*deb([[:space:]]|$)' "$source_file"; then
-    echo "::error::Ubuntu apt source $source_file does not declare deb package sources." >&2
-    exit 1
-  fi
-  if ! deb822_source_points_to_ubuntu_archive "$source_file"; then
-    echo "::error::Ubuntu apt source $source_file does not point at an Ubuntu distribution archive." >&2
-    exit 1
-  fi
-  if ! grep -Eq '^[[:space:]]*Signed-By:[[:space:]]*[^[:space:]]+' "$source_file"; then
-    echo "::error::Ubuntu apt source $source_file does not declare Signed-By key material." >&2
-    exit 1
-  fi
-  cp "$source_file" "$sourceparts/ubuntu.sources"
-elif [[ -r "$apt_etc_dir/sources.list" ]]; then
-  source_file="$apt_etc_dir/sources.list"
-  awk '
-    /^[[:space:]]*deb([[:space:]]|$)/ && /ubuntu\.com\/ubuntu\/?([[:space:]]|$)/ { print }
-  ' "$source_file" > "$sourceparts/ubuntu.list"
-  if [[ ! -s "$sourceparts/ubuntu.list" ]]; then
-    echo "::error::Ubuntu apt source $source_file does not contain deb entries for an Ubuntu distribution archive." >&2
-    exit 1
-  fi
-else
-  echo "::error::Unable to find the Ubuntu apt distribution source in $apt_etc_dir." >&2
-  exit 1
-fi
+python3 - "$apt_etc_dir" "$sourceparts" <<'PY'
+import pathlib
+import re
+import sys
+
+apt_etc_dir, sourceparts = map(pathlib.Path, sys.argv[1:])
+archive_uri = re.compile(r"https?://(?:[a-z0-9-]+\.)*ubuntu\.com/ubuntu/?", re.IGNORECASE)
+
+
+def ubuntu_uri(uri):
+    if uri.startswith("mirror+file:"):
+        mirror_file = pathlib.Path(uri.removeprefix("mirror+file:"))
+        if not mirror_file.is_absolute():
+            return False
+        mirrors = [
+            line.split("#", 1)[0].split()
+            for line in mirror_file.read_text(encoding="utf-8").splitlines()
+        ]
+        urls = [fields[0] for fields in mirrors if fields]
+        return bool(urls) and all(archive_uri.fullmatch(url) for url in urls)
+    return archive_uri.fullmatch(uri) is not None
+
+
+def validate_deb822(text):
+    # Validate each stanza and every URI, not merely one match in the whole file.
+    stanzas = []
+    fields = {}
+    current = None
+    for line in text.splitlines() + [""]:
+        if line.lstrip().startswith("#"):
+            continue
+        if not line.strip():
+            if fields:
+                stanzas.append(fields)
+            fields, current = {}, None
+        elif line[0].isspace():
+            if current is None:
+                raise ValueError("Ubuntu apt source has an orphan continuation line")
+            fields[current] += " " + line.strip()
+        else:
+            name, separator, value = line.partition(":")
+            name = name.lower()
+            if not separator or not re.fullmatch(r"[a-z][a-z-]*", name) or name in fields:
+                raise ValueError("Ubuntu apt source has malformed or duplicate fields")
+            fields[name], current = value.strip(), name
+    if not stanzas:
+        raise ValueError("Ubuntu apt source has no package stanzas")
+    for stanza in stanzas:
+        if "deb" not in stanza.get("types", "").split():
+            raise ValueError("Ubuntu apt source does not declare deb package sources")
+        uris = stanza.get("uris", "").split()
+        if not uris or not all(ubuntu_uri(uri) for uri in uris):
+            raise ValueError("Ubuntu apt source contains a non-Ubuntu distribution archive")
+        if not stanza.get("signed-by"):
+            raise ValueError("Ubuntu apt source does not declare Signed-By key material")
+
+
+try:
+    deb822 = apt_etc_dir / "sources.list.d/ubuntu.sources"
+    legacy = apt_etc_dir / "sources.list"
+    if deb822.exists():
+        text = deb822.read_text(encoding="utf-8")
+        validate_deb822(text)
+        (sourceparts / "ubuntu.sources").write_text(text, encoding="utf-8")
+    elif legacy.exists():
+        selected = []
+        for line in legacy.read_text(encoding="utf-8").splitlines():
+            match = re.match(r"^\s*deb\s+(?:\[[^\]\n]*\]\s+)?(\S+)\s+", line)
+            if match and archive_uri.fullmatch(match[1]):
+                selected.append(line)
+        if not selected:
+            raise ValueError("Ubuntu apt source has no deb entries for an Ubuntu distribution archive")
+        (sourceparts / "ubuntu.list").write_text("\n".join(selected) + "\n", encoding="utf-8")
+    else:
+        raise ValueError(f"Unable to find the Ubuntu apt distribution source in {apt_etc_dir}")
+except (OSError, ValueError) as error:
+    print(f"::error::{error}", file=sys.stderr)
+    sys.exit(1)
+PY
 
 apt_options=(
   -o "Dir::Etc::sourcelist=/dev/null"


### PR DESCRIPTION
## Objective and acceptance

Continue #976 by running the existing Threads daemon journeys on Windows,
not a second harness or a zero-test target. This is stacked on #931; it must
be reconciled with that integration before landing. Ref OpenCoven/coven-threads#31.

- [x] Preserve all 14 actual daemon journeys and their authority assertions.
- [x] Use supported owner-local client transport on Unix and Windows.
- [x] Preserve status/body for negative response assertions without replaying requests.
- [x] Keep production lifecycle commands and identity-bound Windows crash injection.
- [x] Enable feature-on Windows CI and retain sanitized failure evidence for 14 days.
- [x] Obtain actual nonzero hosted Windows daemon execution evidence (run 34424934851).

## Changes and canonical sources

The shared `crates/coven-cli/tests/threads_e2e.rs` fixture now uses
`DaemonEndpoint` and a small additive `DaemonClient::request_json` API.
The API accepts confined v1 targets and exact GET /health, validates syntax
before I/O, and preserves negotiated-peer binding, framing limits and the
existing five-second per-exchange deadline. HTTP rejection status/body are
returned unchanged; transport/identity errors remain errors. Typed methods
retain their capability checks. No mutation is automatically replayed.

Windows uses the supported owner-only pipe and existing authenticated
PID/creation-time-bound process handle helpers for crash injection. Clock
fixtures, liveness, provenance and path sanitization are platform-aware.
The custom Unix-only parser and its helper test were removed; equivalent
truncation coverage now exercises the production client. The suite therefore
has 14 actual daemon journeys rather than 14 journeys plus a custom-parser test.

Files: shared fixture; coven-client HTTP API/export/transport guard and
health regressions; CI and its regression guard; CLIENT-INTEGRATION and
source-adjacent Threads E2E documentation.

Consulted repository AGENTS/CONTRIBUTING, client discovery/transport/lifecycle,
Windows lifecycle regression patterns, and Threads E2E sections 4-9.
Current upstream startup recovery (#970) and installer hardening are preserved
through merge cfe8757, not reimplemented.

## Evidence

- Original restored 299afacf with the current Threads override: 15/15 passed,
  including the old parser helper. Historical macOS failures did not reproduce;
  no speculative retry or timeout increase was added.
- Test-first workflow guard failed for missing Windows journey execution;
  the artifact guard failed for absent evidence retention. All 12 guards now pass.
- 46 production-client health/transport regressions passed, including exact
  403 bytes, invalid request rejection before I/O, peer replacement without
  replay, root health identity fields and truncated framing.
- All 14 shared daemon journeys passed default-parallel with
  COVEN_THREADS_E2E_REQUIRE_LOCAL_OVERRIDE=1, including after cfe8757.
  Cargo metadata resolved coven-threads-core from current Threads checkout
  16ad832c44d7247823122af263c7e86aff880d01 with source=null.
- Native and Windows GNU cross-target Clippy passed for feature-on and
  feature-off fixture builds. Cross-compilation is not Windows execution.
- cargo fmt, staged privacy guard, repository secret guard, and all 11
  upstream native-link installer regressions passed.
- Independent read-only staged-change review reported no significant issues.

The local Cargo patch/lock delta is excluded from commits. Hosted CI uses
the committed Git-pinned Threads dependency; it is not the downstream
required current-Threads pin gate.

## Impact, rollback and remaining uncertainty

The client method/type are additive. No daemon route, authorization predicate,
schema, migration, audit store, credential profile or identity model changes.
Rollback is a normal source revert of the client/fixture/CI slice; persisted
daemon state has no new shape.

Hosted run 34424934851 succeeded, including all 14 actual Windows daemon journeys (zero ignored or filtered out) in 53.54 seconds. The tested synthetic merge cfd4bcaf2c8961a84b4dc93d9004d55a8f4fc7af combines base ad0153bf1b5cd3b7a9f10e8c2dbf3f06bc9ccdb0 and head cfe8757a88ff246d975ae61d44af2826d7e171e8. The retained Windows artifact contains 27 passed scenario manifests, all reporting platform windows and the committed Threads c3bd46b dependency with local override false. This is native Windows parity evidence, not the separate required current-Threads gate. Historical macOS parallel flakiness
is not declared repaired by these passing runs. Full J1-J8 acceptance,
trusted runtime binding, Cave acceptance and reviewed stable-pin enforcement
remain separate. #977's active snapshot-binding work was not modified.
No Nova coherence review, Val freeze or Phase-5 blocker closure is implied.
