### PR TITLE
fix: bind approved proposal commits to validated authority

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -10966,6 +10966,11 @@ fn decide_threads_proposal_inner(
                 }),
             );
         }
+        if let Err(error) = pause_threads_final_commit_fixture(coven_home) {
+            claim.preserve();
+            audit_reservation.preserve()?;
+            return Err(error);
+        }
         let (report, apply_cleanup_error) = match apply_after_review_approval(
             &ward,
             review_kind,
@@ -11282,6 +11287,11 @@ fn decide_threads_proposal_inner(
             audit_reservation.finish()?;
             return Err(error);
         }
+    }
+    if let Err(error) = pause_threads_final_commit_fixture(coven_home) {
+        claim.restore_pending(&document)?;
+        audit_reservation.finish()?;
+        return Err(error);
     }
     let expected_before = proposal_expected_before(&applying)?;
     let (report, apply_cleanup_error) = match apply_after_review_approval(
@@ -12460,6 +12470,16 @@ fn proposal_recovery_commitment(
         hasher.update(&identity_context.candidate_commitment);
     }
     Ok(hasher.finalize().as_bytes().to_vec())
+}
+
+#[cfg(feature = "threads-test-clock")]
+fn pause_threads_final_commit_fixture(coven_home: &Path) -> Result<()> {
+    crate::threads_clock::pause_final_commit_if_requested(coven_home)
+}
+
+#[cfg(not(feature = "threads-test-clock"))]
+fn pause_threads_final_commit_fixture(_coven_home: &Path) -> Result<()> {
+    Ok(())
 }
 
 fn proposal_before_images(
@@ -29985,6 +30005,54 @@ tier = 0
             std::fs::read_to_string(workspace.join("TOOLS.md"))?,
             "Synthetic tools before\n"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn identity_predicate_approve_refuses_identity_drift_at_final_commit() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let (pending, proposal_id, workspace) = stage_pending_identity_predicate_edit(home)?;
+        let decision_body = scheduled_decision_body(home, &proposal_id, None)?;
+        let identity_path = workspace.canonicalize()?.join("IDENTITY.md");
+        crate::ward::set_conditional_write_actions(
+            workspace.canonicalize()?.join("TOOLS.md"),
+            vec![(
+                identity_path,
+                b"# IDENTITY.md - Synthetic-other\n- **Name:** Synthetic-other\n- **Pronouns:** they/them\n"
+                    .to_vec(),
+            )],
+        );
+
+        let response = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/threads/proposals/{proposal_id}/approve"),
+            home,
+            None,
+            Some(&decision_body),
+        )?;
+
+        assert_eq!(response.status, 409, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["why"], "proposal-revalidation-failed");
+        assert!(pending.exists(), "failed approval must stay pending");
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("TOOLS.md"))?,
+            "Synthetic tools before\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("IDENTITY.md"))?,
+            "# IDENTITY.md - Synthetic-other\n- **Name:** Synthetic-other\n- **Pronouns:** they/them\n"
+        );
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        let terminal: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM ward_audit
+             WHERE proposal_id = ?1
+               AND event_type IN ('proposal_approved', 'proposal_rejected', 'proposal_vetoed')",
+            [&proposal_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(terminal, 0);
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -392,10 +392,17 @@ fn set_proposal_decision_failpoint(failpoint: Option<(ProposalDecisionFailpoint,
 }
 
 #[cfg(test)]
+struct ProposalBaselineCommitMutation {
+    familiar_id: String,
+    surface: String,
+    entry_hash: Vec<u8>,
+}
+
+#[cfg(test)]
 fn proposal_baseline_commit_mutations(
-) -> &'static Mutex<std::collections::HashMap<String, (String, String, Vec<u8>)>> {
+) -> &'static Mutex<std::collections::HashMap<String, ProposalBaselineCommitMutation>> {
     static MUTATIONS: OnceLock<
-        Mutex<std::collections::HashMap<String, (String, String, Vec<u8>)>>,
+        Mutex<std::collections::HashMap<String, ProposalBaselineCommitMutation>>,
     > = OnceLock::new();
     MUTATIONS.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
 }
@@ -410,7 +417,14 @@ fn set_proposal_baseline_commit_mutation(
     proposal_baseline_commit_mutations()
         .lock()
         .expect("proposal baseline mutation lock poisoned")
-        .insert(proposal_id, (familiar_id, surface, entry_hash));
+        .insert(
+            proposal_id,
+            ProposalBaselineCommitMutation {
+                familiar_id,
+                surface,
+                entry_hash,
+            },
+        );
 }
 
 fn maybe_mutate_proposal_baseline_before_commitment(
@@ -423,17 +437,17 @@ fn maybe_mutate_proposal_baseline_before_commitment(
             .lock()
             .expect("proposal baseline mutation lock poisoned")
             .remove(proposal_id);
-        if let Some((familiar_id, surface, entry_hash)) = mutation {
+        if let Some(mutation) = mutation {
             let changed = conn.execute(
                 "INSERT INTO ward_manifest (familiar_id, surface, manifest_id, entry_hash)
                  VALUES (?1, ?2, ?3, ?4)
                  ON CONFLICT(familiar_id, surface) DO UPDATE
                  SET entry_hash = excluded.entry_hash",
                 rusqlite::params![
-                    familiar_id,
-                    surface,
+                    mutation.familiar_id,
+                    mutation.surface,
                     uuid::Uuid::nil().to_string(),
-                    entry_hash
+                    mutation.entry_hash
                 ],
             )?;
             anyhow::ensure!(
@@ -12671,7 +12685,7 @@ fn proposal_recovery_commitment(
             Some(bytes) => {
                 hasher.update(&[1]);
                 hasher.update(&(bytes.len() as u64).to_be_bytes());
-                hasher.update(&bytes);
+                hasher.update(bytes);
             }
             None => {
                 hasher.update(&[0]);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -391,6 +391,62 @@ fn set_proposal_decision_failpoint(failpoint: Option<(ProposalDecisionFailpoint,
     }
 }
 
+#[cfg(test)]
+fn proposal_baseline_commit_mutations(
+) -> &'static Mutex<std::collections::HashMap<String, (String, String, Vec<u8>)>> {
+    static MUTATIONS: OnceLock<
+        Mutex<std::collections::HashMap<String, (String, String, Vec<u8>)>>,
+    > = OnceLock::new();
+    MUTATIONS.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_proposal_baseline_commit_mutation(
+    proposal_id: String,
+    familiar_id: String,
+    surface: String,
+    entry_hash: Vec<u8>,
+) {
+    proposal_baseline_commit_mutations()
+        .lock()
+        .expect("proposal baseline mutation lock poisoned")
+        .insert(proposal_id, (familiar_id, surface, entry_hash));
+}
+
+fn maybe_mutate_proposal_baseline_before_commitment(
+    conn: &rusqlite::Connection,
+    proposal_id: &str,
+) -> Result<()> {
+    #[cfg(test)]
+    {
+        let mutation = proposal_baseline_commit_mutations()
+            .lock()
+            .expect("proposal baseline mutation lock poisoned")
+            .remove(proposal_id);
+        if let Some((familiar_id, surface, entry_hash)) = mutation {
+            let changed = conn.execute(
+                "INSERT INTO ward_manifest (familiar_id, surface, manifest_id, entry_hash)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(familiar_id, surface) DO UPDATE
+                 SET entry_hash = excluded.entry_hash",
+                rusqlite::params![
+                    familiar_id,
+                    surface,
+                    uuid::Uuid::nil().to_string(),
+                    entry_hash
+                ],
+            )?;
+            anyhow::ensure!(
+                changed == 1,
+                "proposal baseline mutation did not match one manifest row"
+            );
+        }
+    }
+    #[cfg(not(test))]
+    let _ = (conn, proposal_id);
+    Ok(())
+}
+
 fn recovery_authorization(
     _proposal_id: &str,
     authorization: &ward::Authorization,
@@ -8146,6 +8202,8 @@ struct ProposalDecisionStatePreflight {
     #[serde(default)]
     recovery_commitment: Option<JsonByteArrayLen>,
     #[serde(default)]
+    baseline_snapshot: Option<serde::de::IgnoredAny>,
+    #[serde(default)]
     weave_hash: Option<JsonByteArrayLen>,
     #[serde(default)]
     rationale: Option<serde::de::IgnoredAny>,
@@ -9543,21 +9601,22 @@ fn proposal_recovery_is_proven_unapplied(
     {
         return false;
     }
-    let targets: Vec<String> = pending
-        .edits
-        .iter()
-        .map(|edit| edit.surface.as_str().to_string())
-        .collect();
+    let Some(expected_baselines) = applying.baseline_snapshot.as_ref() else {
+        return false;
+    };
+    let Ok(live_baselines) = reload_proposal_baselines(conn, &familiar_id, expected_baselines)
+    else {
+        return false;
+    };
     let Ok(commitment) = proposal_recovery_commitment(
-        conn,
         &config,
         document,
         ProposalRecoveryContext {
             coven_home,
             workspace: &workspace,
             familiar_id: &familiar_id,
-            targets: &targets,
             authorization: &authorization_from_writer(&pending.writer),
+            baseline_snapshot: &live_baselines,
             identity_context: None,
             require_bound_identity_context: false,
         },
@@ -10486,16 +10545,26 @@ fn decide_threads_proposal_inner(
                 }),
             );
         }
+        let Some(expected_baselines) = applying.baseline_snapshot.as_ref() else {
+            return json_response(
+                409,
+                &json!({
+                    "blocked": true,
+                    "why": "proposal-recovery-intent-unverifiable",
+                    "proposalId": proposal_id,
+                }),
+            );
+        };
+        let live_baselines = reload_proposal_baselines(&conn, &familiar_id, expected_baselines)?;
         let recovery_commitment = proposal_recovery_commitment(
-            &conn,
             &config,
             &document,
             ProposalRecoveryContext {
                 coven_home,
                 workspace: &workspace,
                 familiar_id: &familiar_id,
-                targets: &targets,
                 authorization: &authorization,
+                baseline_snapshot: &live_baselines,
                 identity_context: None,
                 require_bound_identity_context: false,
             },
@@ -10959,6 +11028,10 @@ fn decide_threads_proposal_inner(
             }
         };
         let expected_before = proposal_expected_before(&applying)?;
+        let expected_baselines = applying
+            .baseline_snapshot
+            .as_ref()
+            .context("verified recovery state lost its baseline snapshot")?;
         let recovery_authorization = recovery_authorization(proposal_id, &authorization);
         if !ward_config_is_unchanged(&workspace, &config)? {
             return json_response(
@@ -10985,8 +11058,8 @@ fn decide_threads_proposal_inner(
                         coven_home,
                         workspace: &workspace,
                         familiar_id: &familiar_id,
-                        targets: &targets,
                         authorization: &authorization,
+                        baseline_snapshot: expected_baselines,
                         identity_context: None,
                         require_bound_identity_context: false,
                     },
@@ -11015,10 +11088,9 @@ fn decide_threads_proposal_inner(
                         Some(ward::ApprovedApplyFailure::Applied(report)) => {
                             (report, Some(format!("{error:#}")))
                         }
-                        Some(
-                            ward::ApprovedApplyFailure::NoWrite
-                            | ward::ApprovedApplyFailure::RolledBack,
-                        ) if is_final_authority_drift(&error) => {
+                        Some(ward::ApprovedApplyFailure::NoWrite)
+                            if is_final_authority_drift(&error) =>
+                        {
                             claim.preserve();
                             audit_reservation.preserve()?;
                             return json_response(
@@ -11030,6 +11102,31 @@ fn decide_threads_proposal_inner(
                                     "terminal": false,
                                 }),
                             );
+                        }
+                        Some(
+                            failure @ (ward::ApprovedApplyFailure::RolledBack
+                            | ward::ApprovedApplyFailure::RolledBackCleanupFailed {
+                                ..
+                            }),
+                        ) if is_final_authority_drift(&error) => {
+                            if let Some(opened) = opened_window.as_ref() {
+                                claim.preserve();
+                                append_open_window_revalidation_failure(
+                                    &conn,
+                                    proposal_id,
+                                    pending,
+                                    opened,
+                                    &decision_semantics.approval_path_label,
+                                    note.as_deref(),
+                                    decision_now,
+                                )?;
+                                audit_reservation.finish()?;
+                                claim.consume()?;
+                                return final_authority_drift_response(proposal_id, true, &failure);
+                            }
+                            claim.restore_pending(&document)?;
+                            audit_reservation.finish()?;
+                            return final_authority_drift_response(proposal_id, false, &failure);
                         }
                         Some(
                             failure @ (ward::ApprovedApplyFailure::RolledBack
@@ -11278,16 +11375,16 @@ fn decide_threads_proposal_inner(
             );
         }
     }
+    maybe_mutate_proposal_baseline_before_commitment(&conn, proposal_id)?;
     let recovery_commitment = proposal_recovery_commitment(
-        &conn,
         &config,
         &document,
         ProposalRecoveryContext {
             coven_home,
             workspace: &workspace,
             familiar_id: &familiar_id,
-            targets: &targets,
             authorization: &authorization,
+            baseline_snapshot: &state.baseline_snapshot,
             identity_context: identity_context.as_ref(),
             require_bound_identity_context: true,
         },
@@ -11295,6 +11392,7 @@ fn decide_threads_proposal_inner(
     let applying = ProposalApplyingState {
         decision: "approve".to_string(),
         recovery_commitment,
+        baseline_snapshot: Some(state.baseline_snapshot.clone()),
         weave_hash: state.weave.weave_hash().to_vec(),
         before_images,
         rationale: note.clone(),
@@ -11360,8 +11458,11 @@ fn decide_threads_proposal_inner(
                     coven_home,
                     workspace: &workspace,
                     familiar_id: &familiar_id,
-                    targets: &targets,
                     authorization: &authorization,
+                    baseline_snapshot: applying
+                        .baseline_snapshot
+                        .as_ref()
+                        .expect("new applying state carries its validated baseline snapshot"),
                     identity_context: None,
                     require_bound_identity_context: false,
                 },
@@ -11393,8 +11494,9 @@ fn decide_threads_proposal_inner(
                         (report, Some(format!("{error:#}")))
                     }
                     Some(
-                        ward::ApprovedApplyFailure::NoWrite
-                        | ward::ApprovedApplyFailure::RolledBack,
+                        failure @ (ward::ApprovedApplyFailure::NoWrite
+                        | ward::ApprovedApplyFailure::RolledBack
+                        | ward::ApprovedApplyFailure::RolledBackCleanupFailed { .. }),
                     ) if is_final_authority_drift(&error) => {
                         if let Some(opened) = opened_window.as_ref() {
                             claim.preserve();
@@ -11409,15 +11511,7 @@ fn decide_threads_proposal_inner(
                             )?;
                             audit_reservation.finish()?;
                             claim.consume()?;
-                            return json_response(
-                                409,
-                                &json!({
-                                    "blocked": true,
-                                    "why": "proposal-revalidation-failed",
-                                    "proposalId": proposal_id,
-                                    "terminal": true,
-                                }),
-                            );
+                            return final_authority_drift_response(proposal_id, true, &failure);
                         }
                         append_proposal_refusal_audit(
                             &conn,
@@ -11431,15 +11525,7 @@ fn decide_threads_proposal_inner(
                         )?;
                         claim.restore_pending(&document)?;
                         audit_reservation.finish()?;
-                        return json_response(
-                            409,
-                            &json!({
-                                "blocked": true,
-                                "why": "proposal-revalidation-failed",
-                                "proposalId": proposal_id,
-                                "terminal": false,
-                            }),
-                        );
+                        return final_authority_drift_response(proposal_id, false, &failure);
                     }
                     Some(
                         failure @ (ward::ApprovedApplyFailure::NoWrite
@@ -12524,6 +12610,8 @@ fn proposal_decision_request(raw_value: &Value) -> Result<Option<ProposalDecisio
 struct ProposalApplyingState {
     decision: String,
     recovery_commitment: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    baseline_snapshot: Option<BTreeMap<String, Option<Vec<u8>>>>,
     weave_hash: Vec<u8>,
     before_images: Vec<ProposalBeforeImage>,
     rationale: Option<String>,
@@ -12548,14 +12636,13 @@ struct ProposalRecoveryContext<'a> {
     coven_home: &'a Path,
     workspace: &'a Path,
     familiar_id: &'a str,
-    targets: &'a [String],
     authorization: &'a ward::Authorization,
+    baseline_snapshot: &'a BTreeMap<String, Option<Vec<u8>>>,
     identity_context: Option<&'a coven_threads_core::CandidateIdentityContext>,
     require_bound_identity_context: bool,
 }
 
 fn proposal_recovery_commitment(
-    conn: &rusqlite::Connection,
     config: &ward::WardConfig,
     document: &ProposalEnvelopeDocument,
     context: ProposalRecoveryContext<'_>,
@@ -12564,25 +12651,22 @@ fn proposal_recovery_commitment(
         coven_home,
         workspace,
         familiar_id,
-        targets,
         authorization,
+        baseline_snapshot,
         identity_context,
         require_bound_identity_context,
     } = context;
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"coven:proposal-decision-recovery:v2");
+    hasher.update(b"coven:proposal-decision-recovery:v3");
     let config_bytes = serde_json::to_vec(config).context("serializing Ward config")?;
     hasher.update(&(config_bytes.len() as u64).to_be_bytes());
     hasher.update(&config_bytes);
     let authority_bytes = document.authority_bytes()?;
     hasher.update(&(authority_bytes.len() as u64).to_be_bytes());
     hasher.update(&authority_bytes);
-    let mut targets = targets.to_vec();
-    targets.sort();
-    for target in targets {
-        hasher.update(&(target.len() as u64).to_be_bytes());
-        hasher.update(target.as_bytes());
-        let baseline = crate::threads_gate::load_baseline(conn, familiar_id, &target)?;
+    for (surface, baseline) in baseline_snapshot {
+        hasher.update(&(surface.len() as u64).to_be_bytes());
+        hasher.update(surface.as_bytes());
         match baseline {
             Some(bytes) => {
                 hasher.update(&[1]);
@@ -12662,6 +12746,47 @@ fn is_final_authority_drift(error: &anyhow::Error) -> bool {
     })
 }
 
+fn final_authority_drift_response(
+    proposal_id: &str,
+    terminal: bool,
+    failure: &ward::ApprovedApplyFailure,
+) -> Result<ApiResponse> {
+    let mut body = json!({
+        "blocked": true,
+        "why": "proposal-revalidation-failed",
+        "proposalId": proposal_id,
+        "terminal": terminal,
+    });
+    if let ward::ApprovedApplyFailure::RolledBackCleanupFailed { targets } = failure {
+        body.as_object_mut()
+            .expect("proposal revalidation response is an object")
+            .insert(
+                "cleanupFailure".to_string(),
+                json!({
+                    "temporaryArtifactsRemain": true,
+                    "targets": targets,
+                }),
+            );
+    }
+    json_response(409, &body)
+}
+
+fn reload_proposal_baselines(
+    conn: &rusqlite::Connection,
+    familiar_id: &str,
+    expected: &BTreeMap<String, Option<Vec<u8>>>,
+) -> Result<BTreeMap<String, Option<Vec<u8>>>> {
+    expected
+        .keys()
+        .map(|surface| {
+            Ok((
+                surface.clone(),
+                crate::threads_gate::load_baseline(conn, familiar_id, surface)?,
+            ))
+        })
+        .collect()
+}
+
 fn ensure_proposal_final_authority_unchanged(
     conn: &rusqlite::Connection,
     config: &ward::WardConfig,
@@ -12674,8 +12799,23 @@ fn ensure_proposal_final_authority_unchanged(
     {
         return Err(final_authority_drift("ward-config-changed", None));
     }
-    let current = proposal_recovery_commitment(conn, config, document, context)
-        .map_err(|error| final_authority_drift("authority-evidence-unavailable", Some(error)))?;
+    let live_baselines =
+        reload_proposal_baselines(conn, context.familiar_id, context.baseline_snapshot)
+            .map_err(|error| final_authority_drift("baseline-evidence-unavailable", Some(error)))?;
+    let current = proposal_recovery_commitment(
+        config,
+        document,
+        ProposalRecoveryContext {
+            coven_home: context.coven_home,
+            workspace: context.workspace,
+            familiar_id: context.familiar_id,
+            authorization: context.authorization,
+            baseline_snapshot: &live_baselines,
+            identity_context: context.identity_context,
+            require_bound_identity_context: context.require_bound_identity_context,
+        },
+    )
+    .map_err(|error| final_authority_drift("authority-evidence-unavailable", Some(error)))?;
     if current != expected_recovery_commitment {
         return Err(final_authority_drift("authority-evidence-changed", None));
     }
@@ -30271,6 +30411,38 @@ tier = 0
     }
 
     #[test]
+    fn identity_predicate_approve_binds_the_validated_baseline_snapshot() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let (pending, proposal_id, workspace) = stage_pending_identity_predicate_edit(home)?;
+        let decision_body = scheduled_decision_body(home, &proposal_id, None)?;
+        set_proposal_baseline_commit_mutation(
+            proposal_id.clone(),
+            "sage".to_string(),
+            "TOOLS.md".to_string(),
+            vec![0x5a; 32],
+        );
+
+        let response = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/threads/proposals/{proposal_id}/approve"),
+            home,
+            None,
+            Some(&decision_body),
+        )?;
+
+        assert_eq!(response.status, 409, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["why"], "proposal-revalidation-failed");
+        assert!(pending.exists(), "failed approval must stay pending");
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("TOOLS.md"))?,
+            "Synthetic tools before\n"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn identity_predicate_recovery_preserves_claim_if_identity_evidence_diverged() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let home = temp.path();
@@ -30317,6 +30489,102 @@ tier = 0
         assert_eq!(
             std::fs::read_to_string(workspace.join("TOOLS.md"))?,
             "Synthetic tools after\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn identity_predicate_recovery_restores_pending_after_proven_drift_rollback() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let (pending, proposal_id, workspace) = stage_pending_identity_predicate_edit(home)?;
+        let decision_body = scheduled_decision_body(home, &proposal_id, None)?;
+        set_proposal_decision_failpoint(Some((
+            ProposalDecisionFailpoint::ApplyBeforeAudit,
+            proposal_id.clone(),
+        )));
+        let interrupted = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/threads/proposals/{proposal_id}/approve"),
+            home,
+            None,
+            Some(&decision_body),
+        );
+        assert!(interrupted.is_err());
+
+        let claim = find_pending_decision_claim(home, &proposal_id, "approve")
+            .expect("interrupted approval leaves a recovery claim");
+        std::fs::write(workspace.join("TOOLS.md"), "Synthetic tools before\n")?;
+        crate::ward::set_conditional_write_actions(
+            workspace.canonicalize()?.join("TOOLS.md"),
+            vec![(
+                workspace.canonicalize()?.join("IDENTITY.md"),
+                b"# IDENTITY.md - Synthetic-other\n- **Name:** Synthetic-other\n- **Pronouns:** they/them\n"
+                    .to_vec(),
+            )],
+        );
+
+        let retry = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/threads/proposals/{proposal_id}/approve"),
+            home,
+            None,
+            Some(&decision_body),
+        )?;
+
+        assert_eq!(retry.status, 409, "got {}", retry.body);
+        let body: Value = serde_json::from_str(&retry.body)?;
+        assert_eq!(body["why"], "proposal-revalidation-failed");
+        assert_eq!(body["terminal"], false);
+        assert!(
+            pending.exists(),
+            "proven rollback must restore the proposal"
+        );
+        assert!(!claim.exists(), "applying claim must not remain stranded");
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("TOOLS.md"))?,
+            "Synthetic tools before\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn identity_predicate_drift_reports_cleanup_failure_after_proven_rollback() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let (pending, proposal_id, workspace) = stage_pending_identity_predicate_edit(home)?;
+        let decision_body = scheduled_decision_body(home, &proposal_id, None)?;
+        let target = workspace.canonicalize()?.join("TOOLS.md");
+        crate::ward::set_conditional_write_actions(
+            target.clone(),
+            vec![(
+                workspace.canonicalize()?.join("IDENTITY.md"),
+                b"# IDENTITY.md - Synthetic-other\n- **Name:** Synthetic-other\n- **Pronouns:** they/them\n"
+                    .to_vec(),
+            )],
+        );
+        crate::ward::set_cleanup_artifact_replacement(
+            target,
+            b"concurrent staging replacement".to_vec(),
+        );
+
+        let response = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/threads/proposals/{proposal_id}/approve"),
+            home,
+            None,
+            Some(&decision_body),
+        )?;
+
+        assert_eq!(response.status, 409, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["why"], "proposal-revalidation-failed");
+        assert_eq!(body["cleanupFailure"]["temporaryArtifactsRemain"], true);
+        assert_eq!(body["cleanupFailure"]["targets"], json!(["TOOLS.md"]));
+        assert!(pending.exists(), "failed approval must stay pending");
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("TOOLS.md"))?,
+            "Synthetic tools before\n"
         );
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -9558,6 +9558,8 @@ fn proposal_recovery_is_proven_unapplied(
             familiar_id: &familiar_id,
             targets: &targets,
             authorization: &authorization_from_writer(&pending.writer),
+            identity_context: None,
+            require_bound_identity_context: false,
         },
     ) else {
         return false;
@@ -10494,6 +10496,8 @@ fn decide_threads_proposal_inner(
                 familiar_id: &familiar_id,
                 targets: &targets,
                 authorization: &authorization,
+                identity_context: None,
+                require_bound_identity_context: false,
             },
         )?;
         if applying.recovery_commitment != recovery_commitment {
@@ -10971,42 +10975,90 @@ fn decide_threads_proposal_inner(
             audit_reservation.preserve()?;
             return Err(error);
         }
-        let (report, apply_cleanup_error) = match apply_after_review_approval(
-            &ward,
-            review_kind,
-            &edits,
-            &recovery_authorization,
-            ApprovedApplyContext {
-                scheduled,
-                expected_before: &expected_before,
-                expected_resolved: &expected_resolved,
-            },
-            ward::ApprovedApplyMode::Recovery,
-        ) {
-            Ok(report) => (report, None),
-            Err(error) => {
-                if let Some(limit) = ward::ward_edit_budget_failure(&error) {
-                    return ward_apply_too_large_response(limit);
-                }
-                match ward::approved_apply_failure(&error).cloned() {
-                    Some(ward::ApprovedApplyFailure::Applied(report)) => {
-                        (report, Some(format!("{error:#}")))
+        let (report, apply_cleanup_error) = {
+            let mut final_authority_check = || {
+                ensure_proposal_final_authority_unchanged(
+                    &conn,
+                    &config,
+                    &document,
+                    ProposalRecoveryContext {
+                        coven_home,
+                        workspace: &workspace,
+                        familiar_id: &familiar_id,
+                        targets: &targets,
+                        authorization: &authorization,
+                        identity_context: None,
+                        require_bound_identity_context: false,
+                    },
+                    &applying.recovery_commitment,
+                )
+            };
+            match apply_after_review_approval(
+                &ward,
+                review_kind,
+                &edits,
+                &recovery_authorization,
+                ApprovedApplyContext {
+                    scheduled,
+                    expected_before: &expected_before,
+                    expected_resolved: &expected_resolved,
+                },
+                ward::ApprovedApplyMode::Recovery,
+                Some(&mut final_authority_check),
+            ) {
+                Ok(report) => (report, None),
+                Err(error) => {
+                    if let Some(limit) = ward::ward_edit_budget_failure(&error) {
+                        return ward_apply_too_large_response(limit);
                     }
-                    Some(
-                        failure @ (ward::ApprovedApplyFailure::RolledBack
-                        | ward::ApprovedApplyFailure::RolledBackCleanupFailed { .. }),
-                    ) => {
-                        claim.restore_pending(&document)?;
-                        audit_reservation.finish()?;
-                        return approved_apply_failed_response(proposal_id, &error, &failure, true);
+                    match ward::approved_apply_failure(&error).cloned() {
+                        Some(ward::ApprovedApplyFailure::Applied(report)) => {
+                            (report, Some(format!("{error:#}")))
+                        }
+                        Some(
+                            ward::ApprovedApplyFailure::NoWrite
+                            | ward::ApprovedApplyFailure::RolledBack,
+                        ) if is_final_authority_drift(&error) => {
+                            claim.preserve();
+                            audit_reservation.preserve()?;
+                            return json_response(
+                                409,
+                                &json!({
+                                    "blocked": true,
+                                    "why": "proposal-recovery-evidence-diverged",
+                                    "proposalId": proposal_id,
+                                    "terminal": false,
+                                }),
+                            );
+                        }
+                        Some(
+                            failure @ (ward::ApprovedApplyFailure::RolledBack
+                            | ward::ApprovedApplyFailure::RolledBackCleanupFailed {
+                                ..
+                            }),
+                        ) => {
+                            claim.restore_pending(&document)?;
+                            audit_reservation.finish()?;
+                            return approved_apply_failed_response(
+                                proposal_id,
+                                &error,
+                                &failure,
+                                true,
+                            );
+                        }
+                        Some(failure @ ward::ApprovedApplyFailure::NoWrite)
+                        | Some(failure @ ward::ApprovedApplyFailure::Ambiguous { .. }) => {
+                            claim.preserve();
+                            audit_reservation.preserve()?;
+                            return approved_apply_failed_response(
+                                proposal_id,
+                                &error,
+                                &failure,
+                                true,
+                            );
+                        }
+                        None => return Err(error),
                     }
-                    Some(failure @ ward::ApprovedApplyFailure::NoWrite)
-                    | Some(failure @ ward::ApprovedApplyFailure::Ambiguous { .. }) => {
-                        claim.preserve();
-                        audit_reservation.preserve()?;
-                        return approved_apply_failed_response(proposal_id, &error, &failure, true);
-                    }
-                    None => return Err(error),
                 }
             }
         };
@@ -11024,6 +11076,7 @@ fn decide_threads_proposal_inner(
                     expected_resolved: &expected_resolved,
                 },
                 ward::ApprovedApplyMode::Recovery,
+                None,
             )?;
             if rollback.is_refused() {
                 anyhow::bail!(
@@ -11225,20 +11278,23 @@ fn decide_threads_proposal_inner(
             );
         }
     }
+    let recovery_commitment = proposal_recovery_commitment(
+        &conn,
+        &config,
+        &document,
+        ProposalRecoveryContext {
+            coven_home,
+            workspace: &workspace,
+            familiar_id: &familiar_id,
+            targets: &targets,
+            authorization: &authorization,
+            identity_context: identity_context.as_ref(),
+            require_bound_identity_context: true,
+        },
+    )?;
     let applying = ProposalApplyingState {
         decision: "approve".to_string(),
-        recovery_commitment: proposal_recovery_commitment(
-            &conn,
-            &config,
-            &document,
-            ProposalRecoveryContext {
-                coven_home,
-                workspace: &workspace,
-                familiar_id: &familiar_id,
-                targets: &targets,
-                authorization: &authorization,
-            },
-        )?,
+        recovery_commitment,
         weave_hash: state.weave.weave_hash().to_vec(),
         before_images,
         rationale: note.clone(),
@@ -11294,44 +11350,123 @@ fn decide_threads_proposal_inner(
         return Err(error);
     }
     let expected_before = proposal_expected_before(&applying)?;
-    let (report, apply_cleanup_error) = match apply_after_review_approval(
-        &ward,
-        review_kind,
-        &edits,
-        &authorization,
-        ApprovedApplyContext {
-            scheduled,
-            expected_before: &expected_before,
-            expected_resolved: &expected_resolved,
-        },
-        ward::ApprovedApplyMode::Initial,
-    ) {
-        Ok(report) => (report, None),
-        Err(error) => {
-            if let Some(limit) = ward::ward_edit_budget_failure(&error) {
-                claim.restore_pending(&document)?;
-                audit_reservation.finish()?;
-                return ward_apply_too_large_response(limit);
-            }
-            match ward::approved_apply_failure(&error).cloned() {
-                Some(ward::ApprovedApplyFailure::Applied(report)) => {
-                    (report, Some(format!("{error:#}")))
-                }
-                Some(
-                    failure @ (ward::ApprovedApplyFailure::NoWrite
-                    | ward::ApprovedApplyFailure::RolledBack
-                    | ward::ApprovedApplyFailure::RolledBackCleanupFailed { .. }),
-                ) => {
+    let (report, apply_cleanup_error) = {
+        let mut final_authority_check = || {
+            ensure_proposal_final_authority_unchanged(
+                &conn,
+                &config,
+                &document,
+                ProposalRecoveryContext {
+                    coven_home,
+                    workspace: &workspace,
+                    familiar_id: &familiar_id,
+                    targets: &targets,
+                    authorization: &authorization,
+                    identity_context: None,
+                    require_bound_identity_context: false,
+                },
+                &applying.recovery_commitment,
+            )
+        };
+        match apply_after_review_approval(
+            &ward,
+            review_kind,
+            &edits,
+            &authorization,
+            ApprovedApplyContext {
+                scheduled,
+                expected_before: &expected_before,
+                expected_resolved: &expected_resolved,
+            },
+            ward::ApprovedApplyMode::Initial,
+            Some(&mut final_authority_check),
+        ) {
+            Ok(report) => (report, None),
+            Err(error) => {
+                if let Some(limit) = ward::ward_edit_budget_failure(&error) {
                     claim.restore_pending(&document)?;
                     audit_reservation.finish()?;
-                    return approved_apply_failed_response(proposal_id, &error, &failure, false);
+                    return ward_apply_too_large_response(limit);
                 }
-                Some(failure @ ward::ApprovedApplyFailure::Ambiguous { .. }) => {
-                    claim.preserve();
-                    audit_reservation.preserve()?;
-                    return approved_apply_failed_response(proposal_id, &error, &failure, false);
+                match ward::approved_apply_failure(&error).cloned() {
+                    Some(ward::ApprovedApplyFailure::Applied(report)) => {
+                        (report, Some(format!("{error:#}")))
+                    }
+                    Some(
+                        ward::ApprovedApplyFailure::NoWrite
+                        | ward::ApprovedApplyFailure::RolledBack,
+                    ) if is_final_authority_drift(&error) => {
+                        if let Some(opened) = opened_window.as_ref() {
+                            claim.preserve();
+                            append_open_window_revalidation_failure(
+                                &conn,
+                                proposal_id,
+                                pending,
+                                opened,
+                                &decision_semantics.approval_path_label,
+                                note.as_deref(),
+                                decision_now,
+                            )?;
+                            audit_reservation.finish()?;
+                            claim.consume()?;
+                            return json_response(
+                                409,
+                                &json!({
+                                    "blocked": true,
+                                    "why": "proposal-revalidation-failed",
+                                    "proposalId": proposal_id,
+                                    "terminal": true,
+                                }),
+                            );
+                        }
+                        append_proposal_refusal_audit(
+                            &conn,
+                            proposal_id,
+                            &familiar_id,
+                            state.weave.weave_hash(),
+                            &pending.writer,
+                            &targets,
+                            pending.channel,
+                            decision_now,
+                        )?;
+                        claim.restore_pending(&document)?;
+                        audit_reservation.finish()?;
+                        return json_response(
+                            409,
+                            &json!({
+                                "blocked": true,
+                                "why": "proposal-revalidation-failed",
+                                "proposalId": proposal_id,
+                                "terminal": false,
+                            }),
+                        );
+                    }
+                    Some(
+                        failure @ (ward::ApprovedApplyFailure::NoWrite
+                        | ward::ApprovedApplyFailure::RolledBack
+                        | ward::ApprovedApplyFailure::RolledBackCleanupFailed { .. }),
+                    ) => {
+                        claim.restore_pending(&document)?;
+                        audit_reservation.finish()?;
+                        return approved_apply_failed_response(
+                            proposal_id,
+                            &error,
+                            &failure,
+                            false,
+                        );
+                    }
+                    Some(failure @ ward::ApprovedApplyFailure::Ambiguous { .. }) => {
+                        claim.preserve();
+                        audit_reservation.preserve()?;
+                        return approved_apply_failed_response(
+                            proposal_id,
+                            &error,
+                            &failure,
+                            false,
+                        );
+                    }
+                    None => return Err(error),
                 }
-                None => return Err(error),
             }
         }
     };
@@ -12415,6 +12550,8 @@ struct ProposalRecoveryContext<'a> {
     familiar_id: &'a str,
     targets: &'a [String],
     authorization: &'a ward::Authorization,
+    identity_context: Option<&'a coven_threads_core::CandidateIdentityContext>,
+    require_bound_identity_context: bool,
 }
 
 fn proposal_recovery_commitment(
@@ -12429,6 +12566,8 @@ fn proposal_recovery_commitment(
         familiar_id,
         targets,
         authorization,
+        identity_context,
+        require_bound_identity_context,
     } = context;
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"coven:proposal-decision-recovery:v2");
@@ -12456,20 +12595,91 @@ fn proposal_recovery_commitment(
         };
     }
     if config.identity_invariant_set()?.is_some() {
-        let identity_context = crate::ward_identity::candidate_identity_context(
-            coven_home,
-            familiar_id,
-            workspace,
-            config,
-            &staged_edits_to_ward_edits(document.pending())?,
-            authorization,
-            None,
-        )
-        .expect("validated identity invariants always materialize a context");
+        let live_identity_context;
+        let identity_context = match identity_context {
+            Some(identity_context) => identity_context,
+            None if require_bound_identity_context => {
+                anyhow::bail!("validated candidate identity context is required")
+            }
+            None => {
+                live_identity_context = crate::ward_identity::candidate_identity_context(
+                    coven_home,
+                    familiar_id,
+                    workspace,
+                    config,
+                    &staged_edits_to_ward_edits(document.pending())?,
+                    authorization,
+                    None,
+                )
+                .context("candidate identity evidence is unavailable")?;
+                &live_identity_context
+            }
+        };
         hasher.update(b"identity-candidate-commitment");
         hasher.update(&identity_context.candidate_commitment);
     }
     Ok(hasher.finalize().as_bytes().to_vec())
+}
+
+#[derive(Debug)]
+struct ProposalFinalAuthorityDrift {
+    reason: &'static str,
+    source: Option<anyhow::Error>,
+}
+
+impl std::fmt::Display for ProposalFinalAuthorityDrift {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.source {
+            Some(source) => write!(
+                formatter,
+                "proposal final authority evidence changed before approved commit: {}: {source:#}",
+                self.reason
+            ),
+            None => write!(
+                formatter,
+                "proposal final authority evidence changed before approved commit: {}",
+                self.reason
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProposalFinalAuthorityDrift {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|source| source.as_ref())
+    }
+}
+
+fn final_authority_drift(reason: &'static str, source: Option<anyhow::Error>) -> anyhow::Error {
+    ProposalFinalAuthorityDrift { reason, source }.into()
+}
+
+fn is_final_authority_drift(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<ProposalFinalAuthorityDrift>()
+            .is_some()
+    })
+}
+
+fn ensure_proposal_final_authority_unchanged(
+    conn: &rusqlite::Connection,
+    config: &ward::WardConfig,
+    document: &ProposalEnvelopeDocument,
+    context: ProposalRecoveryContext<'_>,
+    expected_recovery_commitment: &[u8],
+) -> Result<()> {
+    if !ward_config_is_unchanged(context.workspace, config)
+        .map_err(|error| final_authority_drift("ward-config-unavailable", Some(error)))?
+    {
+        return Err(final_authority_drift("ward-config-changed", None));
+    }
+    let current = proposal_recovery_commitment(conn, config, document, context)
+        .map_err(|error| final_authority_drift("authority-evidence-unavailable", Some(error)))?;
+    if current != expected_recovery_commitment {
+        return Err(final_authority_drift("authority-evidence-changed", None));
+    }
+    Ok(())
 }
 
 #[cfg(feature = "threads-test-clock")]
@@ -12628,14 +12838,16 @@ fn apply_after_review_approval(
     authorization: &ward::Authorization,
     context: ApprovedApplyContext<'_>,
     mode: ward::ApprovedApplyMode,
+    final_authority_check: ward::ApprovedCommitCheck<'_>,
 ) -> Result<ward::ApplyReport> {
     if context.scheduled.is_some() {
-        return ward.apply_after_scheduled_approval(
+        return ward.apply_after_scheduled_approval_with_commit_check(
             edits,
             authorization,
             context.expected_before,
             context.expected_resolved,
             mode,
+            final_authority_check,
         );
     }
     match review_kind {
@@ -12652,20 +12864,22 @@ fn apply_after_review_approval(
                     ))
                 })
                 .collect::<Result<BTreeMap<_, _>>>()?;
-            ward.apply_after_threads_approval(
+            ward.apply_after_threads_approval_with_commit_check(
                 edits,
                 authorization,
                 &required,
                 context.expected_resolved,
                 mode,
+                final_authority_check,
             )
         }
-        PendingReviewKind::Coherence => ward.apply_after_coherence_approval(
+        PendingReviewKind::Coherence => ward.apply_after_coherence_approval_with_commit_check(
             edits,
             authorization,
             context.expected_before,
             context.expected_resolved,
             mode,
+            final_authority_check,
         ),
     }
 }

--- a/crates/coven-cli/src/threads_clock.rs
+++ b/crates/coven-cli/src/threads_clock.rs
@@ -23,6 +23,16 @@ const ACTIVATION_SENTINEL: &str = "threads_test_clock_v1";
 const CAPABILITY_FILE: &str = "capability";
 #[cfg(feature = "threads-test-clock")]
 const STATE_FILE: &str = "state.json";
+#[cfg(feature = "threads-test-clock")]
+const FINAL_COMMIT_PAUSE_FILE: &str = "pause-final-commit";
+#[cfg(feature = "threads-test-clock")]
+const FINAL_COMMIT_PAUSE_REACHED_FILE: &str = "pause-final-commit.reached";
+#[cfg(feature = "threads-test-clock")]
+const FINAL_COMMIT_PAUSE_REACHED_SENTINEL: &str = "threads_test_final_commit_pause_reached_v1";
+#[cfg(feature = "threads-test-clock")]
+const FINAL_COMMIT_PAUSE_RELEASE_FILE: &str = "pause-final-commit.release";
+#[cfg(feature = "threads-test-clock")]
+const FINAL_COMMIT_PAUSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ClockSource {
@@ -166,6 +176,76 @@ pub(crate) fn fixture_mode_enabled(_coven_home: &Path) -> Result<bool> {
 pub(crate) fn fixture_control_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(feature = "threads-test-clock")]
+pub(crate) fn pause_final_commit_if_requested(coven_home: &Path) -> Result<()> {
+    let Some(fixture) = ActiveFixture::load(coven_home)? else {
+        return Ok(());
+    };
+    let fixture_dir = fixture_directory(coven_home);
+    let pause_path = fixture_dir.join(FINAL_COMMIT_PAUSE_FILE);
+    match fs::symlink_metadata(&pause_path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "reading deterministic Threads final commit pause {}",
+                    pause_path.display()
+                )
+            });
+        }
+    }
+    crate::mobile_memory::config::validate_private_file(&pause_path)?;
+    let requested = read_capability(&pause_path)?;
+    if requested != fixture.capability {
+        return Err(InvalidFixtureCapability.into());
+    }
+
+    let reached_path = fixture_dir.join(FINAL_COMMIT_PAUSE_REACHED_FILE);
+    crate::mobile_memory::config::atomic_replace_private(
+        &reached_path,
+        format!("{FINAL_COMMIT_PAUSE_REACHED_SENTINEL}\n").as_bytes(),
+    )
+    .with_context(|| {
+        format!(
+            "recording deterministic Threads final commit pause {}",
+            reached_path.display()
+        )
+    })?;
+    let release_path = fixture_dir.join(FINAL_COMMIT_PAUSE_RELEASE_FILE);
+    let deadline = std::time::Instant::now() + FINAL_COMMIT_PAUSE_TIMEOUT;
+    loop {
+        match fs::symlink_metadata(&release_path) {
+            Ok(_) => {
+                crate::mobile_memory::config::validate_private_file(&release_path)?;
+                let release = read_capability(&release_path)?;
+                if release != fixture.capability {
+                    return Err(InvalidFixtureCapability.into());
+                }
+                let _ = fs::remove_file(&pause_path);
+                let _ = fs::remove_file(&release_path);
+                let _ = fs::remove_file(&reached_path);
+                return Ok(());
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                anyhow::ensure!(
+                    std::time::Instant::now() < deadline,
+                    "deterministic Threads final commit pause timed out"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "reading deterministic Threads final commit release {}",
+                        release_path.display()
+                    )
+                });
+            }
+        }
+    }
 }
 
 #[cfg(feature = "threads-test-clock")]
@@ -486,6 +566,45 @@ mod tests {
         assert_eq!(
             non_monotonic.requested,
             initial + time::Duration::minutes(4)
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "threads-test-clock")]
+    #[test]
+    fn final_commit_pause_requires_active_fixture_capability() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let initial = time::OffsetDateTime::parse(
+            "2026-09-09T10:00:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )?;
+        seed_fixture_for_tests(home, "cap-4", initial)?;
+        let fixture_dir = fixture_directory(home);
+        crate::mobile_memory::config::atomic_create_private(
+            &fixture_dir.join(FINAL_COMMIT_PAUSE_FILE),
+            b"cap-4",
+        )?;
+        crate::mobile_memory::config::atomic_create_private(
+            &fixture_dir.join(FINAL_COMMIT_PAUSE_RELEASE_FILE),
+            b"cap-4",
+        )?;
+
+        pause_final_commit_if_requested(home)?;
+
+        assert!(!fixture_dir.join(FINAL_COMMIT_PAUSE_FILE).exists());
+        assert!(!fixture_dir.join(FINAL_COMMIT_PAUSE_RELEASE_FILE).exists());
+        assert!(!fixture_dir.join(FINAL_COMMIT_PAUSE_REACHED_FILE).exists());
+
+        crate::mobile_memory::config::atomic_create_private(
+            &fixture_dir.join(FINAL_COMMIT_PAUSE_FILE),
+            b"wrong-cap",
+        )?;
+        let error = pause_final_commit_if_requested(home)
+            .expect_err("pause control must require the active fixture capability");
+        assert!(
+            error.downcast_ref::<InvalidFixtureCapability>().is_some(),
+            "got {error:#}"
         );
         Ok(())
     }

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -29,7 +29,7 @@
 //! layers fail closed; neither can be skipped on the daemon's only
 //! arbitrary-file write path into familiar homes (`POST /familiars/{id}/edits`).
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -232,6 +232,7 @@ pub struct GateRequest<'a> {
 pub(crate) struct WeaveState {
     pub familiar_uuid: threads::FamiliarId,
     pub weave: threads::Weave,
+    pub baseline_snapshot: BTreeMap<String, Option<Vec<u8>>>,
 }
 
 /// Gate a proposal's protected targets through the coven-threads weave.
@@ -488,12 +489,18 @@ pub(crate) fn build_weave_state_for_writer_at(
 
     let manifest_id = load_or_create_manifest_id(conn, familiar_id)?;
     let mut woven = Vec::with_capacity(surfaces.len());
+    let mut baseline_snapshot = BTreeMap::new();
     for surface in &surfaces {
         let surface_id = threads::SurfaceId::new(surface.clone());
         let disk = read_surface(workspace, surface)?;
         let current_hash = threads::manifest_entry_hash(&surface_id, &disk);
 
         let baseline = load_baseline(conn, familiar_id, surface)?;
+        let validated_baseline = match &baseline {
+            Some(recorded) => Some(recorded.clone()),
+            None if bootstrap_missing_baselines => Some(current_hash.to_vec()),
+            None => None,
+        };
         let (entry_hash, drifted) = match baseline {
             Some(recorded) => {
                 let drifted = recorded.as_slice() != current_hash.as_slice();
@@ -508,6 +515,7 @@ pub(crate) fn build_weave_state_for_writer_at(
             }
             None => (current_hash.to_vec(), false),
         };
+        baseline_snapshot.insert(surface.clone(), validated_baseline);
 
         let mut thread = threads::Thread {
             id: threads::ThreadId::new(),
@@ -577,6 +585,7 @@ pub(crate) fn build_weave_state_for_writer_at(
     Ok(WeaveState {
         familiar_uuid,
         weave,
+        baseline_snapshot,
     })
 }
 

--- a/crates/coven-cli/src/ward.rs
+++ b/crates/coven-cli/src/ward.rs
@@ -3155,10 +3155,9 @@ fn fail_after_conditional_rollback(
                 ApprovedApplyFailure::RolledBack,
             )),
             Err(cleanup_error) => Err(approved_apply_error(
-                anyhow!(
-                    "{error:#}; approved proposal was rolled back but cleanup failed: \
-                     {cleanup_error:#}"
-                ),
+                error.context(format!(
+                    "approved proposal was rolled back but cleanup failed: {cleanup_error:#}"
+                )),
                 ApprovedApplyFailure::RolledBackCleanupFailed {
                     targets: prepared
                         .iter()

--- a/crates/coven-cli/src/ward.rs
+++ b/crates/coven-cli/src/ward.rs
@@ -1015,6 +1015,15 @@ pub(crate) enum ApprovedApplyMode {
     Recovery,
 }
 
+pub(crate) type ApprovedCommitCheck<'a> = Option<&'a mut dyn FnMut() -> Result<()>>;
+
+fn run_approved_commit_check(check: &mut ApprovedCommitCheck<'_>) -> Result<()> {
+    if let Some(check) = check.as_deref_mut() {
+        check()?;
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct ApprovedApplyError {
     failure: ApprovedApplyFailure,
@@ -1649,6 +1658,25 @@ impl Ward {
         expected_resolved: &BTreeMap<String, String>,
         mode: ApprovedApplyMode,
     ) -> Result<ApplyReport> {
+        self.apply_after_threads_approval_with_commit_check(
+            edits,
+            authorization,
+            expected_before,
+            expected_resolved,
+            mode,
+            None,
+        )
+    }
+
+    pub(crate) fn apply_after_threads_approval_with_commit_check(
+        &self,
+        edits: &[FileEdit],
+        authorization: &Authorization,
+        expected_before: &BTreeMap<String, Vec<u8>>,
+        expected_resolved: &BTreeMap<String, String>,
+        mode: ApprovedApplyMode,
+        final_authority_check: ApprovedCommitCheck<'_>,
+    ) -> Result<ApplyReport> {
         (|| -> Result<()> {
             let mut budget = validate_file_edit_budget(edits)?;
             WardEditBudget::for_edit_count(expected_before.len())?;
@@ -1704,6 +1732,7 @@ impl Ward {
             outcome.decisions,
             &expected_before,
             mode,
+            final_authority_check,
         )?;
         Ok(ApplyReport { changes })
     }
@@ -1723,6 +1752,25 @@ impl Ward {
         expected_before: &BTreeMap<String, Option<Vec<u8>>>,
         expected_resolved: &BTreeMap<String, String>,
         mode: ApprovedApplyMode,
+    ) -> Result<ApplyReport> {
+        self.apply_after_coherence_approval_with_commit_check(
+            edits,
+            authorization,
+            expected_before,
+            expected_resolved,
+            mode,
+            None,
+        )
+    }
+
+    pub(crate) fn apply_after_coherence_approval_with_commit_check(
+        &self,
+        edits: &[FileEdit],
+        authorization: &Authorization,
+        expected_before: &BTreeMap<String, Option<Vec<u8>>>,
+        expected_resolved: &BTreeMap<String, String>,
+        mode: ApprovedApplyMode,
+        final_authority_check: ApprovedCommitCheck<'_>,
     ) -> Result<ApplyReport> {
         validate_approved_edit_budget(edits, expected_before)
             .map_err(|error| approved_apply_error(error, ApprovedApplyFailure::NoWrite))?;
@@ -1769,6 +1817,7 @@ impl Ward {
             outcome.decisions,
             expected_before,
             mode,
+            final_authority_check,
         )?;
         Ok(ApplyReport { changes })
     }
@@ -1785,6 +1834,25 @@ impl Ward {
         expected_before: &BTreeMap<String, Option<Vec<u8>>>,
         expected_resolved: &BTreeMap<String, String>,
         mode: ApprovedApplyMode,
+    ) -> Result<ApplyReport> {
+        self.apply_after_scheduled_approval_with_commit_check(
+            edits,
+            authorization,
+            expected_before,
+            expected_resolved,
+            mode,
+            None,
+        )
+    }
+
+    pub(crate) fn apply_after_scheduled_approval_with_commit_check(
+        &self,
+        edits: &[FileEdit],
+        authorization: &Authorization,
+        expected_before: &BTreeMap<String, Option<Vec<u8>>>,
+        expected_resolved: &BTreeMap<String, String>,
+        mode: ApprovedApplyMode,
+        final_authority_check: ApprovedCommitCheck<'_>,
     ) -> Result<ApplyReport> {
         validate_approved_edit_budget(edits, expected_before)
             .map_err(|error| approved_apply_error(error, ApprovedApplyFailure::NoWrite))?;
@@ -1826,6 +1894,7 @@ impl Ward {
             outcome.decisions,
             expected_before,
             mode,
+            final_authority_check,
         )?;
         Ok(ApplyReport { changes })
     }
@@ -2676,6 +2745,7 @@ fn write_atomically_if_unchanged(
     decisions: Vec<Decision>,
     expected_before: &BTreeMap<String, Option<Vec<u8>>>,
     mode: ApprovedApplyMode,
+    mut final_authority_check: ApprovedCommitCheck<'_>,
 ) -> Result<Vec<AppliedChange>> {
     validate_approved_edit_budget(edits, expected_before)
         .map_err(|error| approved_apply_error(error, ApprovedApplyFailure::NoWrite))?;
@@ -2763,6 +2833,9 @@ fn write_atomically_if_unchanged(
     }
 
     let mut swapped = Vec::new();
+    if let Err(error) = run_approved_commit_check(&mut final_authority_check) {
+        return fail_after_conditional_rollback(&prepared, &swapped, error);
+    }
     for index in 0..prepared.len() {
         if prepared[index].already_applied {
             continue;
@@ -2774,6 +2847,9 @@ fn write_atomically_if_unchanged(
                 .as_ref()
                 .context("prepared approved write has no staging paths")?;
             if let Err(error) = maybe_run_conditional_write_hook(&write.path) {
+                return fail_after_conditional_rollback(&prepared, &swapped, error);
+            }
+            if let Err(error) = run_approved_commit_check(&mut final_authority_check) {
                 return fail_after_conditional_rollback(&prepared, &swapped, error);
             }
             if write.expected_before.is_some() {
@@ -2871,6 +2947,9 @@ fn write_atomically_if_unchanged(
         if let Err(error) = verification {
             return fail_after_conditional_rollback(&prepared, &swapped, error);
         }
+        if let Err(error) = run_approved_commit_check(&mut final_authority_check) {
+            return fail_after_conditional_rollback(&prepared, &swapped, error);
+        }
     }
 
     let final_verification = (|| -> Result<()> {
@@ -2920,6 +2999,7 @@ fn write_atomically_if_unchanged(
                 &changed,
             )?;
         }
+        run_approved_commit_check(&mut final_authority_check)?;
         Ok(())
     })();
     if let Err(error) = final_verification {
@@ -8321,6 +8401,7 @@ tier = 1
             vec![decision],
             &BTreeMap::from([(edit.target.clone(), Some(b"before".to_vec()))]),
             ApprovedApplyMode::Initial,
+            None,
         );
 
         #[cfg(not(windows))]

--- a/crates/coven-cli/src/ward.rs
+++ b/crates/coven-cli/src/ward.rs
@@ -4582,7 +4582,7 @@ pub(crate) fn set_conditional_write_hook(path: PathBuf, replacement: Vec<u8>) {
 }
 
 #[cfg(test)]
-fn set_conditional_write_actions(trigger: PathBuf, actions: Vec<(PathBuf, Vec<u8>)>) {
+pub(crate) fn set_conditional_write_actions(trigger: PathBuf, actions: Vec<(PathBuf, Vec<u8>)>) {
     set_conditional_write_test_actions(
         trigger,
         actions

--- a/crates/coven-cli/tests/support/threads_final_commit_cases.rs
+++ b/crates/coven-cli/tests/support/threads_final_commit_cases.rs
@@ -1,0 +1,149 @@
+use super::*;
+
+#[test]
+#[cfg(feature = "threads-test-clock")]
+fn final_commit_identity_drift_closes_opened_window_without_applying() -> Result<()> {
+    let corpus = retired_ward_corpus()?;
+    let case = retired_review_case(&corpus)?;
+    let duration = case["approval"]["veto"]["duration_seconds"]
+        .as_i64()
+        .context("corpus veto duration")?;
+
+    run_clocked_journey(
+        "final-commit-identity-drift",
+        |home, workspace| seed_retired_review_case(home, workspace, case),
+        |fixture, capability| {
+            let staged = submit_retired_case(fixture, case)?;
+            let id = staged["proposalId"].as_str().context("proposal id")?;
+            tick_scheduler(fixture, capability)?;
+            advance_clock_to_offset(fixture, capability, duration + 1)?;
+            arm_final_commit_pause(fixture, capability)?;
+
+            let tick_home = fixture.coven_home.clone();
+            let tick_body = json!({ "capability": capability }).to_string();
+            let tick = thread::spawn(move || {
+                unix_http_request(
+                    &tick_home,
+                    "POST",
+                    "/api/v1/internal/threads/test-clock/tick",
+                    Some(&tick_body),
+                )
+            });
+
+            let wait_result = wait_for_final_commit_pause(fixture);
+            if wait_result.is_ok() {
+                fs::write(
+                    fixture.workspace.join("IDENTITY.md"),
+                    "# IDENTITY.md - Synthetic-other\n- **Pronouns:** they/them\n",
+                )?;
+            }
+            release_final_commit_pause(fixture, capability)?;
+            wait_result?;
+
+            let (status, body) = tick
+                .join()
+                .map_err(|_| anyhow::anyhow!("scheduler tick thread panicked"))??;
+            let body: Value = serde_json::from_str(&body)
+                .with_context(|| format!("scheduler tick returned non-JSON body: {body}"))?;
+            anyhow::ensure!(
+                status == 200 && body["processed"] == 1,
+                "scheduler did not terminalize the drifted proposal: HTTP {status} {body}"
+            );
+            assert_window_terminal(
+                fixture,
+                id,
+                "proposal_rejected",
+                "revalidation_failed",
+                json!(false),
+            )?;
+            assert_corpus_bytes(fixture, case, "before")?;
+            let applied: i64 = fixture.store()?.query_row(
+                "SELECT COUNT(*) FROM ward_audit
+                 WHERE event_type IN ('proposal_approved', 'apply_audit')",
+                [],
+                |row| row.get(0),
+            )?;
+            anyhow::ensure!(
+                applied == 0,
+                "final authority drift produced applied-write evidence"
+            );
+            let remaining = fixture.request("GET", "/api/v1/threads/proposals", None)?;
+            anyhow::ensure!(
+                remaining.status == 200 && remaining.body["proposals"] == json!([]),
+                "drifted opened window remained pending: {remaining:?}"
+            );
+            Ok(())
+        },
+    )
+}
+
+#[cfg(feature = "threads-test-clock")]
+fn final_commit_pause_dir(fixture: &ThreadsFixture) -> PathBuf {
+    fixture
+        .coven_home
+        .join("test-fixtures")
+        .join("threads-deterministic-clock")
+}
+
+#[cfg(feature = "threads-test-clock")]
+fn arm_final_commit_pause(fixture: &ThreadsFixture, capability: &str) -> Result<()> {
+    write_private_fixture_file(
+        &final_commit_pause_dir(fixture).join("pause-final-commit"),
+        capability,
+    )
+}
+
+#[cfg(feature = "threads-test-clock")]
+fn release_final_commit_pause(fixture: &ThreadsFixture, capability: &str) -> Result<()> {
+    write_private_fixture_file(
+        &final_commit_pause_dir(fixture).join("pause-final-commit.release"),
+        capability,
+    )
+}
+
+#[cfg(feature = "threads-test-clock")]
+fn wait_for_final_commit_pause(fixture: &ThreadsFixture) -> Result<()> {
+    let reached = final_commit_pause_dir(fixture).join("pause-final-commit.reached");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match fs::read_to_string(&reached) {
+            Ok(marker) => {
+                anyhow::ensure!(
+                    marker.trim_end_matches(['\r', '\n'])
+                        == "threads_test_final_commit_pause_reached_v1",
+                    "unexpected final commit pause marker: {marker:?}"
+                );
+                return Ok(());
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                anyhow::ensure!(
+                    Instant::now() < deadline,
+                    "timed out waiting for final commit pause"
+                );
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("reading final commit pause marker {}", reached.display())
+                });
+            }
+        }
+    }
+}
+
+#[cfg(feature = "threads-test-clock")]
+fn write_private_fixture_file(path: &Path, contents: &str) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("creating private fixture file {}", path.display()))?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("writing private fixture file {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("syncing private fixture file {}", path.display()))?;
+    Ok(())
+}

--- a/crates/coven-cli/tests/threads_e2e.rs
+++ b/crates/coven-cli/tests/threads_e2e.rs
@@ -27,6 +27,11 @@ const FAMILIAR_ID: &str = "sage";
 const PRINCIPAL_FINGERPRINT: &str = "fpr-e2e-synthetic";
 const REQUIRE_OVERRIDE_ENV: &str = "COVEN_THREADS_E2E_REQUIRE_LOCAL_OVERRIDE";
 
+#[cfg(feature = "threads-test-clock")]
+mod final_commit_cases {
+    include!("support/threads_final_commit_cases.rs");
+}
+
 #[test]
 fn smoke_bounded_ward_apply_over_real_daemon() -> Result<()> {
     run_journey("smoke-bounded-ward-apply", |fixture| {


### PR DESCRIPTION
## Context

Bind the final approved Threads commit to the exact authority evidence that was revalidated. Addresses #977 and stacks on #931; it does not introduce a new identity model, audit store, or cross-file transaction guarantee.

## Implementation

- Persist the exact Gate-2-resolved `ward_manifest` baseline snapshot used to build the validated weave, rather than rereading requested target keys while creating applying intent.
- Bind that snapshot, Ward config, proposal authority bytes, and validated candidate identity commitment into recovery commitment v3.
- Re-read the same resolved baseline keys immediately around conditional Ward writes; authority drift fails closed and rolls back owned target changes.
- Distinguish unknown recovery (`NoWrite`/`Ambiguous`) from proven rollback. Proven rollback restores ordinary proposals for fresh validation or terminally closes an already-opened window.
- Preserve typed authority-drift causes through rollback cleanup failures and report leftover temporary-artifact targets separately.
- Add deterministic unit coverage plus a feature-gated real-daemon pause journey.

## Acceptance and verification

- [x] 14 identity-predicate/commit-binding unit regressions pass.
- [x] All 16 `threads_e2e` journeys pass with `threads-test-clock`, including final-commit identity drift.
- [x] `cargo fmt --check`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] Secret and staged privacy guards.
- [x] Independent review findings repaired and re-review clean.
- [x] Full workspace reached 2,985 passing tests; one unrelated daemon lifecycle timeout failed, then passed three isolated retries. Two earlier full runs likewise reached unrelated smoke-daemon races that passed three isolated retries each.

## Risk and rollback

This is an authority-boundary and recovery-semantics change. Older applying records without the persisted baseline snapshot fail closed as unverifiable rather than reconstructing unvalidated evidence. Ambiguous writes remain durable; only proven rollback may restore or terminalize the proposal. Roll back the six commits in this stacked PR together if the dependency checkpoint changes.