### PR TITLE
feat: commit Runtime Authority receipt evidence

### DIFF
--- a/crates/coven-cli/src/automations/contract/authority.rs
+++ b/crates/coven-cli/src/automations/contract/authority.rs
@@ -270,6 +270,36 @@ pub fn validate_authority_profile(
     phase: AuthorityValidationPhase,
     verifier: Option<&dyn AuthorityEvidenceVerifier>,
 ) -> Result<AuthorityProfileDisposition, AuthorityProfileError> {
+    let disposition = validate_authority_profile_structure(
+        extensions,
+        consumer,
+        advertised_profiles,
+        advertised_capabilities,
+        phase,
+    )?;
+    let AuthorityProfileDisposition::Validated(extension) = &disposition else {
+        return Ok(disposition);
+    };
+    let verifier = verifier.ok_or_else(|| {
+        AuthorityProfileError::new(
+            AuthorityProfileErrorCode::AdapterMissing,
+            "Runtime Authority verification adapter is unavailable",
+        )
+    })?;
+    verifier.verify(extension, phase)?;
+    Ok(disposition)
+}
+
+/// Validates the signed profile shape and integrity without consulting live
+/// replay state. Callers must authenticate the exact binding through a
+/// verifier-backed terminal extension before trusting this projection.
+pub(crate) fn validate_authority_profile_structure(
+    extensions: &ExtensionBag,
+    consumer: AuthorityConsumerClass,
+    advertised_profiles: &[&str],
+    advertised_capabilities: &[&str],
+    phase: AuthorityValidationPhase,
+) -> Result<AuthorityProfileDisposition, AuthorityProfileError> {
     if consumer == AuthorityConsumerClass::GenericBaseV1 {
         return Ok(AuthorityProfileDisposition::PreservedOpaque(
             extensions.clone(),
@@ -332,13 +362,6 @@ pub fn validate_authority_profile(
             AuthorityProfileError::new(AuthorityProfileErrorCode::SchemaInvalid, error.to_string())
         })?;
     extension.validate_structure(phase)?;
-    let verifier = verifier.ok_or_else(|| {
-        AuthorityProfileError::new(
-            AuthorityProfileErrorCode::AdapterMissing,
-            "Runtime Authority verification adapter is unavailable",
-        )
-    })?;
-    verifier.verify(&extension, phase)?;
     Ok(AuthorityProfileDisposition::Validated(Box::new(extension)))
 }
 
@@ -1625,15 +1648,19 @@ fn schema_error(message: impl Into<String>) -> AuthorityProfileError {
 }
 
 #[cfg(test)]
-mod structural_tests {
+pub(crate) mod test_support {
     use serde_json::{json, Value};
 
-    use super::*;
+    use super::{
+        canonicalize, sha256_hex, AuthorityEvidenceVerifier, AuthorityProfileError,
+        AuthorityValidationPhase, AutomationAuthorityExtension, ExtensionBag,
+        AUTHORITY_EXTENSION_KEY, BINDING_DOMAIN, RECEIPT_DOMAIN,
+    };
 
     const VECTORS: &str =
         include_str!("../../../../../spec/coven-automations/authority/v1/test-vectors.json");
 
-    fn fixture(name: &str) -> Value {
+    pub(crate) fn fixture(name: &str) -> Value {
         serde_json::from_str::<Value>(VECTORS)
             .expect("authority vectors")
             .pointer(&format!("/fixtures/{name}"))
@@ -1656,6 +1683,59 @@ mod structural_tests {
         value["authentication"]["signedDigest"] = json!(digest);
         digest
     }
+
+    pub(crate) fn resign_binding(binding: &mut Value) -> String {
+        resign(binding, BINDING_DOMAIN)
+    }
+
+    pub(crate) fn resign_receipt(receipt: &mut Value) -> String {
+        resign(receipt, RECEIPT_DOMAIN)
+    }
+
+    pub(crate) fn authority_extensions_value() -> Value {
+        json!({
+            AUTHORITY_EXTENSION_KEY: {
+                "profile": "coven.automations.authority.v1",
+                "kind": "AutomationAuthorityExtension",
+                "executionBinding": fixture("binding"),
+                "receiptEvidence": fixture("receiptEvidence")
+            }
+        })
+    }
+
+    pub(crate) fn resign_authority_extensions(value: &mut Value) {
+        let extension = &mut value[AUTHORITY_EXTENSION_KEY];
+        let binding_digest = resign_binding(&mut extension["executionBinding"]);
+        if !extension["receiptEvidence"].is_null() {
+            extension["receiptEvidence"]["bindingDigest"]["value"] = json!(binding_digest);
+            resign_receipt(&mut extension["receiptEvidence"]);
+        }
+    }
+
+    pub(crate) fn extension_bag(value: Value) -> ExtensionBag {
+        serde_json::from_value(value).expect("authority extension bag")
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct AcceptingVerifier;
+
+    impl AuthorityEvidenceVerifier for AcceptingVerifier {
+        fn verify(
+            &self,
+            _extension: &AutomationAuthorityExtension,
+            _phase: AuthorityValidationPhase,
+        ) -> Result<(), AuthorityProfileError> {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod structural_tests {
+    use serde_json::{json, Value};
+
+    use super::test_support::{fixture, resign_binding, resign_receipt};
+    use super::*;
 
     fn extension(binding: Value, receipt: Value) -> AutomationAuthorityExtension {
         serde_json::from_value(json!({
@@ -1691,9 +1771,9 @@ mod structural_tests {
             *receipt
                 .pointer_mut(receipt_path)
                 .expect("receipt capability set") = json!(["artifact.write", "analysis.read"]);
-            let binding_digest = resign(&mut binding, BINDING_DOMAIN);
+            let binding_digest = resign_binding(&mut binding);
             receipt["bindingDigest"]["value"] = json!(binding_digest);
-            resign(&mut receipt, RECEIPT_DOMAIN);
+            resign_receipt(&mut receipt);
 
             extension(binding, receipt)
                 .validate_structure(AuthorityValidationPhase::Terminal)
@@ -1707,7 +1787,7 @@ mod structural_tests {
     fn binding_rejects_familiar_age_beyond_signed_bound() {
         let mut binding = fixture("binding");
         binding["familiar"]["verifiedAt"] = json!("2026-09-03T11:54:58.999Z");
-        resign(&mut binding, BINDING_DOMAIN);
+        resign_binding(&mut binding);
         let binding: AutomationExecutionBinding =
             serde_json::from_value(binding).expect("execution binding");
 
@@ -1721,7 +1801,7 @@ mod structural_tests {
     fn receipt_rejects_familiar_age_beyond_signed_bound() {
         let mut receipt = fixture("receiptEvidence");
         receipt["familiar"]["verifiedAt"] = json!("2026-09-03T11:54:58.999Z");
-        resign(&mut receipt, RECEIPT_DOMAIN);
+        resign_receipt(&mut receipt);
         let receipt: AutomationReceiptAuthorityEvidence =
             serde_json::from_value(receipt).expect("receipt authority evidence");
 
@@ -1735,7 +1815,7 @@ mod structural_tests {
     fn binding_accepts_familiar_age_equal_to_signed_bound() {
         let mut binding = fixture("binding");
         binding["familiar"]["verifiedAt"] = json!("2026-09-03T11:54:59.000Z");
-        resign(&mut binding, BINDING_DOMAIN);
+        resign_binding(&mut binding);
         let binding: AutomationExecutionBinding =
             serde_json::from_value(binding).expect("execution binding");
 
@@ -1767,7 +1847,7 @@ mod structural_tests {
             *binding
                 .pointer_mut(path)
                 .expect("approval consumption field") = replacement;
-            resign(&mut binding, BINDING_DOMAIN);
+            resign_binding(&mut binding);
             let binding: AutomationExecutionBinding =
                 serde_json::from_value(binding).expect("execution binding");
 
@@ -1806,7 +1886,7 @@ mod structural_tests {
             *receipt
                 .pointer_mut(path)
                 .expect("approval consumption field") = replacement;
-            resign(&mut receipt, RECEIPT_DOMAIN);
+            resign_receipt(&mut receipt);
             let receipt: AutomationReceiptAuthorityEvidence =
                 serde_json::from_value(receipt).expect("receipt authority evidence");
 
@@ -1827,7 +1907,7 @@ mod structural_tests {
         let mut binding = fixture("binding");
         binding["base"]["occurrenceId"] = json!("occurrence.other-20260903");
         binding["approval"]["consumption"]["occurrenceId"] = json!("occurrence.other-20260903");
-        resign(&mut binding, BINDING_DOMAIN);
+        resign_binding(&mut binding);
         let binding: AutomationExecutionBinding =
             serde_json::from_value(binding).expect("execution binding");
 
@@ -1845,7 +1925,7 @@ mod structural_tests {
         let mut receipt = fixture("receiptEvidence");
         receipt["occurrenceId"] = json!("occurrence.other-20260903");
         receipt["approval"]["consumption"]["occurrenceId"] = json!("occurrence.other-20260903");
-        resign(&mut receipt, RECEIPT_DOMAIN);
+        resign_receipt(&mut receipt);
         let receipt: AutomationReceiptAuthorityEvidence =
             serde_json::from_value(receipt).expect("receipt authority evidence");
 

--- a/crates/coven-cli/src/automations/contract/authority_tests.rs
+++ b/crates/coven-cli/src/automations/contract/authority_tests.rs
@@ -2,6 +2,9 @@ use std::collections::BTreeMap;
 
 use serde_json::{json, Value};
 
+use super::authority::test_support::{
+    authority_extensions_value, extension_bag, AcceptingVerifier,
+};
 use super::authority::{
     validate_authority_profile, AuthorityConsumerClass, AuthorityEvidenceVerifier,
     AuthorityProfileDisposition, AuthorityProfileError, AuthorityProfileErrorCode,
@@ -17,29 +20,7 @@ fn vectors() -> Value {
 }
 
 fn authority_extensions() -> ExtensionBag {
-    let vectors = vectors();
-    let value = json!({
-        AUTHORITY_EXTENSION_KEY: {
-            "profile": "coven.automations.authority.v1",
-            "kind": "AutomationAuthorityExtension",
-            "executionBinding": vectors["fixtures"]["binding"].clone(),
-            "receiptEvidence": vectors["fixtures"]["receiptEvidence"].clone()
-        }
-    });
-    serde_json::from_value(value).expect("authority extension bag")
-}
-
-#[derive(Debug)]
-struct AcceptingVerifier;
-
-impl AuthorityEvidenceVerifier for AcceptingVerifier {
-    fn verify(
-        &self,
-        _extension: &AutomationAuthorityExtension,
-        _phase: AuthorityValidationPhase,
-    ) -> Result<(), AuthorityProfileError> {
-        Ok(())
-    }
+    extension_bag(authority_extensions_value())
 }
 
 #[derive(Debug)]

--- a/crates/coven-cli/src/automations/receipts.rs
+++ b/crates/coven-cli/src/automations/receipts.rs
@@ -1,15 +1,26 @@
 //! Immutable Automations v1 receipt commitment.
 
-// The next #857 producer slice will call this seam once terminal side-effect
-// evidence exists; focused tests exercise the commitment invariants today.
+// These internal seams remain unwired until a producer can supply terminal
+// evidence without deriving side-effect, capability, result or delivery claims.
 #![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use serde::Serialize;
+use serde_json::Value;
 
+use super::contract::authority::{
+    validate_authority_profile, validate_authority_profile_structure, AuthorityApprovalBinding,
+    AuthorityConsumerClass, AuthorityEvidenceVerifier, AuthorityProfileDisposition,
+    AuthoritySideEffectClass, AuthorityValidationPhase, AutomationAuthorityExtension,
+    AUTHORITY_EXTENSION_KEY, AUTHORITY_PROFILE, BASE_PROFILE, RUNTIME_AUTHORITY_CAPABILITY,
+};
 use super::contract::events::append_event;
 use super::contract::types::{
-    AutomationReceipt, EventEnvelope, EventKind, EventPayload, StreamKind, TerminalOutcome,
+    AutomationReceipt, EventEnvelope, EventKind, EventPayload, ExtensionBag, SideEffectClass,
+    StreamKind, TerminalOutcome,
 };
 
 pub const AUTOMATION_RECEIPTS_SCHEMA_SQL: &str = "
@@ -68,10 +79,54 @@ pub const AUTOMATION_RECEIPTS_SCHEMA_SQL: &str = "
     END;
 ";
 
+pub const AUTOMATION_RECEIPT_AUTHORITY_EXTENSIONS_SCHEMA_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS automation_receipt_authority_extensions (
+        receipt_id TEXT PRIMARY KEY NOT NULL,
+        run_id TEXT UNIQUE NOT NULL,
+        attempt_id TEXT UNIQUE NOT NULL,
+        binding_id TEXT NOT NULL,
+        binding_digest TEXT NOT NULL CHECK (
+            length(binding_digest) = 64
+            AND binding_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        base_receipt_digest TEXT NOT NULL CHECK (
+            length(base_receipt_digest) = 64
+            AND base_receipt_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        terminal_evidence_digest TEXT NOT NULL CHECK (
+            length(terminal_evidence_digest) = 64
+            AND terminal_evidence_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        authority_json TEXT NOT NULL CHECK (json_valid(authority_json)),
+        produced_at TEXT NOT NULL,
+        FOREIGN KEY (receipt_id) REFERENCES automation_receipts(id) ON DELETE RESTRICT,
+        FOREIGN KEY (run_id) REFERENCES automation_runs(id) ON DELETE RESTRICT,
+        FOREIGN KEY (attempt_id) REFERENCES automation_attempts(id) ON DELETE RESTRICT
+    );
+
+    CREATE TRIGGER IF NOT EXISTS automation_receipt_authority_extensions_no_update
+    BEFORE UPDATE ON automation_receipt_authority_extensions
+    BEGIN
+        SELECT RAISE(ABORT, 'automation receipt authority extensions are immutable');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS automation_receipt_authority_extensions_no_delete
+    BEFORE DELETE ON automation_receipt_authority_extensions
+    BEGIN
+        SELECT RAISE(ABORT, 'automation receipt authority extensions are immutable');
+    END;
+";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReceiptCommitOutcome {
     Committed,
     Replayed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthorizedReceipt {
+    pub(crate) receipt: AutomationReceipt,
+    pub(crate) authority: AutomationAuthorityExtension,
 }
 
 struct StoredReceiptEvidence {
@@ -99,6 +154,18 @@ struct StoredEventEvidence {
     recorded_at_millis: i64,
     observed_at: String,
     event_json: String,
+}
+
+struct StoredAuthoritySidecar {
+    receipt_id: String,
+    run_id: String,
+    attempt_id: String,
+    binding_id: String,
+    binding_digest: String,
+    base_receipt_digest: String,
+    terminal_evidence_digest: String,
+    authority_json: String,
+    produced_at: String,
 }
 
 /// Read committed evidence in one snapshot, rechecking the body, terminal
@@ -190,6 +257,39 @@ fn read_receipt_in(conn: &Connection, receipt_id: &str) -> Result<Option<Automat
     Ok(Some(receipt))
 }
 
+pub(crate) fn read_authorized_receipt(
+    conn: &Connection,
+    receipt_id: &str,
+    verifier: &dyn AuthorityEvidenceVerifier,
+) -> Result<Option<AuthorizedReceipt>> {
+    if conn.is_autocommit() {
+        let transaction = conn.unchecked_transaction()?;
+        let receipt = read_authorized_receipt_in(&transaction, receipt_id, verifier)?;
+        transaction.commit()?;
+        return Ok(receipt);
+    }
+    read_authorized_receipt_in(conn, receipt_id, verifier)
+}
+
+fn read_authorized_receipt_in(
+    conn: &Connection,
+    receipt_id: &str,
+    verifier: &dyn AuthorityEvidenceVerifier,
+) -> Result<Option<AuthorizedReceipt>> {
+    let Some(receipt) = read_receipt_in(conn, receipt_id)? else {
+        return Ok(None);
+    };
+    let durable = durable_correlation(conn, &receipt)?;
+    let pinned = validated_pinned_authority(&durable)?;
+    let (stored, authority) =
+        validated_stored_authority(conn, receipt_id, &receipt, &durable, &pinned, verifier)?;
+    anyhow::ensure!(
+        stored.receipt_id == receipt_id,
+        "stored automation authority receipt key is invalid"
+    );
+    Ok(Some(AuthorizedReceipt { receipt, authority }))
+}
+
 fn validate_receipt_index(
     requested_receipt_id: &str,
     receipt: &AutomationReceipt,
@@ -246,11 +346,14 @@ struct DurableCorrelation {
     occurrence_id: String,
     familiar_id: Option<String>,
     runtime: String,
+    authority_profile: Option<String>,
     run_status: String,
     run_receipt_id: Option<String>,
     attempt_occurrence_id: String,
     attempt_number: i64,
+    adoption_key: String,
     occurrence_fence_generation: i64,
+    authority_extension_json: Option<String>,
     attempt_state: String,
     failure_class: Option<String>,
     state_reason: Option<String>,
@@ -276,24 +379,132 @@ pub fn commit_receipt(
     commit_receipt_in(conn, receipt, event)
 }
 
+pub(crate) fn commit_authorized_receipt(
+    conn: &Connection,
+    receipt: &AutomationReceipt,
+    event: &EventEnvelope,
+    terminal_extensions: &ExtensionBag,
+    verifier: &dyn AuthorityEvidenceVerifier,
+) -> Result<ReceiptCommitOutcome> {
+    if conn.is_autocommit() {
+        let transaction =
+            rusqlite::Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+                .context("failed to begin authorized automation receipt transaction")?;
+        let outcome = commit_authorized_receipt_in(
+            &transaction,
+            receipt,
+            event,
+            terminal_extensions,
+            verifier,
+        )?;
+        transaction
+            .commit()
+            .context("failed to commit authorized automation receipt transaction")?;
+        return Ok(outcome);
+    }
+    commit_authorized_receipt_in(conn, receipt, event, terminal_extensions, verifier)
+}
+
+fn commit_authorized_receipt_in(
+    conn: &Connection,
+    receipt: &AutomationReceipt,
+    event: &EventEnvelope,
+    terminal_extensions: &ExtensionBag,
+    verifier: &dyn AuthorityEvidenceVerifier,
+) -> Result<ReceiptCommitOutcome> {
+    let durable = validate_receipt_commit(conn, receipt, event)?;
+    let pinned = validated_pinned_authority(&durable)?;
+    let terminal = validated_authority_profile(
+        terminal_extensions,
+        AuthorityValidationPhase::Terminal,
+        verifier,
+        "terminal automation authority evidence is invalid",
+    )?;
+    validate_authorized_evidence(receipt, &durable, &pinned, &terminal)?;
+
+    let receipt_json =
+        serde_json::to_string(receipt).context("failed to serialize automation receipt")?;
+    let event_json =
+        serde_json::to_string(event).context("failed to serialize automation receipt event")?;
+    let authority_json = serde_json::to_string(&terminal)
+        .context("failed to serialize terminal automation authority evidence")?;
+    if let Some(outcome) = existing_commit(conn, receipt, event, &receipt_json, &event_json)? {
+        let (_, stored_authority) = validated_stored_authority(
+            conn,
+            receipt.receipt_id.as_str(),
+            receipt,
+            &durable,
+            &pinned,
+            verifier,
+        )?;
+        anyhow::ensure!(
+            stored_authority == terminal,
+            "authorized automation receipt replay conflicts with committed authority evidence"
+        );
+        return Ok(outcome);
+    }
+    anyhow::ensure!(
+        durable.run_receipt_id.is_none(),
+        "automation run already references a different receipt"
+    );
+
+    let receipt_evidence = terminal
+        .receipt_evidence
+        .0
+        .as_deref()
+        .context("terminal automation authority receipt evidence is unavailable")?;
+    conn.execute_batch("SAVEPOINT coven_authorized_automation_receipt_commit")
+        .context("failed to begin authorized automation receipt commitment")?;
+    let result = (|| {
+        insert_base_receipt_commit(conn, receipt, event, &receipt_json)?;
+        conn.execute(
+            "INSERT INTO automation_receipt_authority_extensions (
+                receipt_id, run_id, attempt_id, binding_id, binding_digest,
+                base_receipt_digest, terminal_evidence_digest,
+                authority_json, produced_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                receipt.receipt_id.as_str(),
+                receipt.run_id.as_str(),
+                receipt.attempt_id.as_str(),
+                terminal.execution_binding.binding_id.as_str(),
+                terminal.execution_binding.integrity.value.as_str(),
+                receipt_evidence.base_receipt_digest.value.as_str(),
+                receipt_evidence.integrity.value.as_str(),
+                authority_json,
+                receipt.produced_at.as_str(),
+            ],
+        )
+        .context("failed to insert automation receipt authority extension")?;
+        Ok(ReceiptCommitOutcome::Committed)
+    })();
+
+    match result {
+        Ok(outcome) => {
+            conn.execute_batch("RELEASE SAVEPOINT coven_authorized_automation_receipt_commit")
+                .context("failed to commit authorized automation receipt")?;
+            Ok(outcome)
+        }
+        Err(error) => {
+            let _ = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT coven_authorized_automation_receipt_commit;
+                 RELEASE SAVEPOINT coven_authorized_automation_receipt_commit;",
+            );
+            Err(error)
+        }
+    }
+}
+
 fn commit_receipt_in(
     conn: &Connection,
     receipt: &AutomationReceipt,
     event: &EventEnvelope,
 ) -> Result<ReceiptCommitOutcome> {
+    let durable = validate_receipt_commit(conn, receipt, event)?;
     anyhow::ensure!(
-        event.integrity.is_some(),
-        "automation receipt event integrity is required"
+        !is_runtime_authority_pinned(&durable),
+        "Runtime Authority-pinned runs require an authorized receipt commitment"
     );
-    receipt
-        .verify_integrity()
-        .context("automation receipt integrity is invalid")?;
-    event
-        .verify_integrity()
-        .context("automation receipt event integrity is invalid")?;
-    validate_receipt_event(receipt, event)?;
-    let durable = durable_correlation(conn, receipt)?;
-    validate_durable_correlation(receipt, &durable)?;
 
     let receipt_json =
         serde_json::to_string(receipt).context("failed to serialize automation receipt")?;
@@ -309,72 +520,13 @@ fn commit_receipt_in(
 
     conn.execute_batch("SAVEPOINT coven_automation_receipt_commit")
         .context("failed to begin automation receipt commitment")?;
-    let result = (|| {
-        conn.execute(
-            "INSERT INTO automation_receipts (
-                id, run_id, attempt_id, automation_id, automation_revision,
-                definition_digest, occurrence_id, occurrence_fence_generation,
-                attempt_number, outcome, receipt_digest, receipt_json, event_id, produced_at
-             ) VALUES (
-                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
-             )",
-            params![
-                receipt.receipt_id.as_str(),
-                receipt.run_id.as_str(),
-                receipt.attempt_id.as_str(),
-                receipt.automation_id.as_str(),
-                i64::try_from(receipt.automation_revision.get())
-                    .context("receipt automation revision exceeds SQLite range")?,
-                receipt
-                    .definition_digest
-                    .as_ref()
-                    .map(|digest| digest.value.as_str()),
-                receipt.occurrence_id.as_str(),
-                i64::try_from(
-                    receipt
-                        .occurrence_fence_generation
-                        .context("receipt occurrence fence generation is required")?
-                        .get()
-                )
-                .context("receipt occurrence fence generation exceeds SQLite range")?,
-                i64::try_from(
-                    receipt
-                        .attempt_number
-                        .context("receipt attempt number is required")?
-                        .get()
-                )
-                .context("receipt attempt number exceeds SQLite range")?,
-                terminal_outcome_name(receipt.outcome.disposition),
-                receipt.integrity.value.as_str(),
-                receipt_json,
-                event.event_id.as_str(),
-                receipt.produced_at.as_str(),
-            ],
-        )
-        .context("failed to insert automation receipt")?;
-        let linked = conn
-            .execute(
-                "UPDATE automation_runs
-                 SET receipt_id = ?2
-                 WHERE id = ?1 AND receipt_id IS NULL",
-                params![receipt.run_id.as_str(), receipt.receipt_id.as_str()],
-            )
-            .context("failed to link automation run receipt")?;
-        anyhow::ensure!(
-            linked == 1,
-            "automation run changed during receipt commitment"
-        );
-        append_event(conn, event, event.sequence.get())
-            .map_err(anyhow::Error::new)
-            .context("failed to append automation receipt event")?;
-        Ok(ReceiptCommitOutcome::Committed)
-    })();
+    let result = insert_base_receipt_commit(conn, receipt, event, &receipt_json);
 
     match result {
-        Ok(outcome) => {
+        Ok(()) => {
             conn.execute_batch("RELEASE SAVEPOINT coven_automation_receipt_commit")
                 .context("failed to commit automation receipt")?;
-            Ok(outcome)
+            Ok(ReceiptCommitOutcome::Committed)
         }
         Err(error) => {
             let _ = conn.execute_batch(
@@ -386,16 +538,109 @@ fn commit_receipt_in(
     }
 }
 
+fn validate_receipt_commit(
+    conn: &Connection,
+    receipt: &AutomationReceipt,
+    event: &EventEnvelope,
+) -> Result<DurableCorrelation> {
+    anyhow::ensure!(
+        event.integrity.is_some(),
+        "automation receipt event integrity is required"
+    );
+    receipt
+        .verify_integrity()
+        .context("automation receipt integrity is invalid")?;
+    event
+        .verify_integrity()
+        .context("automation receipt event integrity is invalid")?;
+    validate_receipt_event(receipt, event)?;
+    let durable = durable_correlation(conn, receipt)?;
+    validate_durable_correlation(receipt, &durable)?;
+    Ok(durable)
+}
+
+fn is_runtime_authority_pinned(durable: &DurableCorrelation) -> bool {
+    durable.authority_profile.as_deref() == Some(AUTHORITY_PROFILE)
+        || durable.authority_extension_json.is_some()
+}
+
+fn insert_base_receipt_commit(
+    conn: &Connection,
+    receipt: &AutomationReceipt,
+    event: &EventEnvelope,
+    receipt_json: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO automation_receipts (
+                id, run_id, attempt_id, automation_id, automation_revision,
+                definition_digest, occurrence_id, occurrence_fence_generation,
+                attempt_number, outcome, receipt_digest, receipt_json, event_id, produced_at
+             ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
+             )",
+        params![
+            receipt.receipt_id.as_str(),
+            receipt.run_id.as_str(),
+            receipt.attempt_id.as_str(),
+            receipt.automation_id.as_str(),
+            i64::try_from(receipt.automation_revision.get())
+                .context("receipt automation revision exceeds SQLite range")?,
+            receipt
+                .definition_digest
+                .as_ref()
+                .map(|digest| digest.value.as_str()),
+            receipt.occurrence_id.as_str(),
+            i64::try_from(
+                receipt
+                    .occurrence_fence_generation
+                    .context("receipt occurrence fence generation is required")?
+                    .get()
+            )
+            .context("receipt occurrence fence generation exceeds SQLite range")?,
+            i64::try_from(
+                receipt
+                    .attempt_number
+                    .context("receipt attempt number is required")?
+                    .get()
+            )
+            .context("receipt attempt number exceeds SQLite range")?,
+            terminal_outcome_name(receipt.outcome.disposition),
+            receipt.integrity.value.as_str(),
+            receipt_json,
+            event.event_id.as_str(),
+            receipt.produced_at.as_str(),
+        ],
+    )
+    .context("failed to insert automation receipt")?;
+    let linked = conn
+        .execute(
+            "UPDATE automation_runs
+                 SET receipt_id = ?2
+                 WHERE id = ?1 AND receipt_id IS NULL",
+            params![receipt.run_id.as_str(), receipt.receipt_id.as_str()],
+        )
+        .context("failed to link automation run receipt")?;
+    anyhow::ensure!(
+        linked == 1,
+        "automation run changed during receipt commitment"
+    );
+    append_event(conn, event, event.sequence.get())
+        .map_err(anyhow::Error::new)
+        .context("failed to append automation receipt event")?;
+    Ok(())
+}
+
 fn durable_correlation(
     conn: &Connection,
     receipt: &AutomationReceipt,
 ) -> Result<DurableCorrelation> {
     conn.query_row(
         "SELECT run.automation_id, run.automation_revision, run.definition_digest,
-                run.occurrence_id, run.familiar_id, run.runtime, run.status, run.receipt_id,
-                attempt.occurrence_id, attempt.attempt_number,
-                attempt.occurrence_fence_generation, attempt.state,
-                attempt.failure_class, attempt.state_reason, run.finished_at, attempt.settled_at
+                run.occurrence_id, run.familiar_id, run.runtime, run.authority_profile,
+                run.status, run.receipt_id, attempt.occurrence_id, attempt.attempt_number,
+                attempt.adoption_key, attempt.occurrence_fence_generation,
+                attempt.authority_extension_json, attempt.state, attempt.failure_class,
+                attempt.state_reason, run.finished_at, attempt.settled_at
          FROM automation_runs AS run
          JOIN automation_attempts AS attempt
            ON attempt.run_id = run.id
@@ -409,16 +654,19 @@ fn durable_correlation(
                 occurrence_id: row.get(3)?,
                 familiar_id: row.get(4)?,
                 runtime: row.get(5)?,
-                run_status: row.get(6)?,
-                run_receipt_id: row.get(7)?,
-                attempt_occurrence_id: row.get(8)?,
-                attempt_number: row.get(9)?,
-                occurrence_fence_generation: row.get(10)?,
-                attempt_state: row.get(11)?,
-                failure_class: row.get(12)?,
-                state_reason: row.get(13)?,
-                run_finished_at: row.get(14)?,
-                attempt_settled_at: row.get(15)?,
+                authority_profile: row.get(6)?,
+                run_status: row.get(7)?,
+                run_receipt_id: row.get(8)?,
+                attempt_occurrence_id: row.get(9)?,
+                attempt_number: row.get(10)?,
+                adoption_key: row.get(11)?,
+                occurrence_fence_generation: row.get(12)?,
+                authority_extension_json: row.get(13)?,
+                attempt_state: row.get(14)?,
+                failure_class: row.get(15)?,
+                state_reason: row.get(16)?,
+                run_finished_at: row.get(17)?,
+                attempt_settled_at: row.get(18)?,
             })
         },
     )
@@ -501,6 +749,301 @@ fn validate_durable_correlation(
         durable.run_finished_at.as_deref() == Some(receipt.produced_at.as_str())
             && durable.attempt_settled_at.as_deref() == Some(receipt.produced_at.as_str()),
         "automation receipt production time does not match terminal settlement"
+    );
+    Ok(())
+}
+
+fn validated_pinned_authority(
+    durable: &DurableCorrelation,
+) -> Result<AutomationAuthorityExtension> {
+    anyhow::ensure!(
+        durable.authority_profile.as_deref() == Some(AUTHORITY_PROFILE),
+        "automation run is not pinned to Runtime Authority"
+    );
+    let raw = durable
+        .authority_extension_json
+        .as_deref()
+        .context("stored pre-dispatch automation authority evidence is unavailable")?;
+    let extensions = stored_extension_bag(
+        raw,
+        "stored pre-dispatch automation authority evidence is invalid",
+    )?;
+    let disposition = validate_authority_profile_structure(
+        &extensions,
+        AuthorityConsumerClass::RuntimeAuthorityV1,
+        &[BASE_PROFILE, AUTHORITY_PROFILE],
+        &[RUNTIME_AUTHORITY_CAPABILITY],
+        AuthorityValidationPhase::PreDispatch,
+    )
+    .map_err(|error| {
+        anyhow::anyhow!(
+            "stored pre-dispatch automation authority evidence is invalid: {}",
+            error.code().as_str()
+        )
+    })?;
+    let AuthorityProfileDisposition::Validated(extension) = disposition else {
+        anyhow::bail!("stored pre-dispatch automation authority evidence is invalid");
+    };
+    Ok(*extension)
+}
+
+fn stored_extension_bag(raw: &str, error_message: &'static str) -> Result<ExtensionBag> {
+    let extension: Value = serde_json::from_str(raw).map_err(|_| anyhow::anyhow!(error_message))?;
+    ExtensionBag::new(BTreeMap::from([(
+        AUTHORITY_EXTENSION_KEY.to_owned(),
+        extension,
+    )]))
+    .map_err(|_| anyhow::anyhow!(error_message))
+}
+
+fn validated_authority_profile(
+    extensions: &ExtensionBag,
+    phase: AuthorityValidationPhase,
+    verifier: &dyn AuthorityEvidenceVerifier,
+    error_message: &'static str,
+) -> Result<AutomationAuthorityExtension> {
+    let disposition = validate_authority_profile(
+        extensions,
+        AuthorityConsumerClass::RuntimeAuthorityV1,
+        &[BASE_PROFILE, AUTHORITY_PROFILE],
+        &[RUNTIME_AUTHORITY_CAPABILITY],
+        phase,
+        Some(verifier),
+    )
+    .map_err(|error| anyhow::anyhow!("{error_message}: {}", error.code().as_str()))?;
+    let AuthorityProfileDisposition::Validated(extension) = disposition else {
+        anyhow::bail!("{error_message}");
+    };
+    Ok(*extension)
+}
+
+fn validate_authorized_evidence(
+    receipt: &AutomationReceipt,
+    durable: &DurableCorrelation,
+    pinned: &AutomationAuthorityExtension,
+    terminal: &AutomationAuthorityExtension,
+) -> Result<()> {
+    anyhow::ensure!(
+        terminal.execution_binding == pinned.execution_binding,
+        "terminal automation authority binding does not match the pinned dispatch binding"
+    );
+    validate_pinned_binding(receipt, durable, pinned)?;
+    let evidence = terminal
+        .receipt_evidence
+        .0
+        .as_deref()
+        .context("terminal automation authority receipt evidence is unavailable")?;
+    anyhow::ensure!(
+        evidence.receipt_id == receipt.receipt_id
+            && evidence.automation_id == receipt.automation_id
+            && evidence.automation_revision == receipt.automation_revision
+            && receipt.definition_digest.as_ref() == Some(&evidence.definition_digest)
+            && evidence.occurrence_id == receipt.occurrence_id
+            && receipt.occurrence_fence_generation == Some(evidence.occurrence_fence_generation)
+            && evidence.run_id == receipt.run_id
+            && evidence.attempt_id == receipt.attempt_id
+            && receipt.attempt_number == Some(evidence.attempt_number)
+            && evidence.base_receipt_digest.algorithm == receipt.integrity.algorithm
+            && evidence.base_receipt_digest.canonicalization == receipt.integrity.canonicalization
+            && evidence.base_receipt_digest.value == receipt.integrity.value,
+        "terminal automation authority evidence does not match the base receipt"
+    );
+    validate_overlapping_claims(receipt, terminal)
+}
+
+fn validate_pinned_binding(
+    receipt: &AutomationReceipt,
+    durable: &DurableCorrelation,
+    pinned: &AutomationAuthorityExtension,
+) -> Result<()> {
+    let base = &pinned.execution_binding.base;
+    anyhow::ensure!(
+        base.automation_id == receipt.automation_id
+            && base.automation_revision == receipt.automation_revision
+            && receipt.definition_digest.as_ref() == Some(&base.definition_digest)
+            && base.occurrence_id == receipt.occurrence_id
+            && receipt.occurrence_fence_generation == Some(base.occurrence_fence_generation)
+            && base.run_id == receipt.run_id
+            && base.attempt_id == receipt.attempt_id
+            && receipt.attempt_number == Some(base.attempt_number)
+            && base.adoption_key.as_str() == durable.adoption_key
+            && pinned.execution_binding.runtime.runtime_id.as_str() == durable.runtime,
+        "stored pre-dispatch automation authority binding is not correlated to the durable attempt"
+    );
+    Ok(())
+}
+
+fn validate_overlapping_claims(
+    receipt: &AutomationReceipt,
+    terminal: &AutomationAuthorityExtension,
+) -> Result<()> {
+    let evidence = terminal
+        .receipt_evidence
+        .0
+        .as_deref()
+        .context("terminal automation authority receipt evidence is unavailable")?;
+    let exercised = receipt
+        .exercised_capabilities
+        .as_ref()
+        .context("authorized automation receipts require explicit exercised capabilities")?;
+    anyhow::ensure!(
+        serialized_string_set(exercised)?
+            == serialized_string_set(&evidence.capabilities.exercised)?,
+        "base and authority exercised capabilities do not match"
+    );
+    anyhow::ensure!(
+        base_side_effect_rank(receipt.side_effect_class)
+            <= authority_side_effect_rank(evidence.risk.side_effect_class),
+        "base receipt side effect exceeds the authorized envelope"
+    );
+    if let Some(authority) = &receipt.authority {
+        anyhow::ensure!(
+            authority.principal.principal_id == evidence.principal_id,
+            "base and authority principal references do not match"
+        );
+        if let Some(record_ref) = authority
+            .approval
+            .as_ref()
+            .and_then(|approval| approval.approval_record_ref.as_ref())
+        {
+            anyhow::ensure!(
+                authority_approval_id(&evidence.approval) == Some(record_ref.as_str()),
+                "base and authority approval references do not match"
+            );
+        }
+    }
+    if let Some(runtime) = &receipt.runtime {
+        anyhow::ensure!(
+            runtime.runtime_id == evidence.runtime.runtime_id
+                && serialized_string_set(&runtime.capabilities)?
+                    == serialized_string_set(&evidence.runtime.capabilities)?,
+            "base and authority runtime descriptors do not match"
+        );
+    }
+    Ok(())
+}
+
+const fn base_side_effect_rank(side_effect: SideEffectClass) -> u8 {
+    match side_effect {
+        SideEffectClass::None => 0,
+        SideEffectClass::LocalRead => 1,
+        SideEffectClass::LocalWrite => 2,
+        SideEffectClass::ExternalRead => 3,
+        SideEffectClass::ExternalMutation => 4,
+        SideEffectClass::IrreversibleExternalMutation => 5,
+    }
+}
+
+const fn authority_side_effect_rank(side_effect: AuthoritySideEffectClass) -> u8 {
+    match side_effect {
+        AuthoritySideEffectClass::None => 0,
+        AuthoritySideEffectClass::LocalRead => 1,
+        AuthoritySideEffectClass::LocalWrite => 2,
+        AuthoritySideEffectClass::ExternalRead => 3,
+        AuthoritySideEffectClass::ExternalMutation => 4,
+        AuthoritySideEffectClass::IrreversibleExternalMutation => 5,
+    }
+}
+
+fn authority_approval_id(approval: &AuthorityApprovalBinding) -> Option<&str> {
+    match approval {
+        AuthorityApprovalBinding::NotRequired { .. } => None,
+        AuthorityApprovalBinding::HumanPerRun { evidence, .. }
+        | AuthorityApprovalBinding::ProtectedOwnerPerRun { evidence, .. }
+        | AuthorityApprovalBinding::BoundedRecurring { evidence, .. } => {
+            Some(evidence.approval_id.as_str())
+        }
+    }
+}
+
+fn serialized_string_set(value: &impl Serialize) -> Result<BTreeSet<String>> {
+    let Value::Array(values) = serde_json::to_value(value)
+        .map_err(|_| anyhow::anyhow!("automation authority claim encoding is invalid"))?
+    else {
+        anyhow::bail!("automation authority claim encoding is invalid");
+    };
+    values
+        .into_iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_owned)
+                .context("automation authority capability evidence is invalid")
+        })
+        .collect()
+}
+
+fn validated_stored_authority(
+    conn: &Connection,
+    requested_receipt_id: &str,
+    receipt: &AutomationReceipt,
+    durable: &DurableCorrelation,
+    pinned: &AutomationAuthorityExtension,
+    verifier: &dyn AuthorityEvidenceVerifier,
+) -> Result<(StoredAuthoritySidecar, AutomationAuthorityExtension)> {
+    let stored = conn
+        .query_row(
+            "SELECT receipt_id, run_id, attempt_id, binding_id, binding_digest,
+                    base_receipt_digest, terminal_evidence_digest,
+                    authority_json, produced_at
+             FROM automation_receipt_authority_extensions
+             WHERE receipt_id = ?1",
+            [requested_receipt_id],
+            |row| {
+                Ok(StoredAuthoritySidecar {
+                    receipt_id: row.get(0)?,
+                    run_id: row.get(1)?,
+                    attempt_id: row.get(2)?,
+                    binding_id: row.get(3)?,
+                    binding_digest: row.get(4)?,
+                    base_receipt_digest: row.get(5)?,
+                    terminal_evidence_digest: row.get(6)?,
+                    authority_json: row.get(7)?,
+                    produced_at: row.get(8)?,
+                })
+            },
+        )
+        .optional()
+        .context("failed to read automation receipt authority extension")?
+        .context("automation receipt authority extension is unavailable")?;
+    let extensions = stored_extension_bag(
+        &stored.authority_json,
+        "stored terminal automation authority evidence is invalid",
+    )?;
+    let authority = validated_authority_profile(
+        &extensions,
+        AuthorityValidationPhase::Terminal,
+        verifier,
+        "stored terminal automation authority evidence is invalid",
+    )?;
+    validate_authorized_evidence(receipt, durable, pinned, &authority)?;
+    validate_authority_sidecar_index(requested_receipt_id, receipt, &stored, &authority)?;
+    Ok((stored, authority))
+}
+
+fn validate_authority_sidecar_index(
+    requested_receipt_id: &str,
+    receipt: &AutomationReceipt,
+    stored: &StoredAuthoritySidecar,
+    authority: &AutomationAuthorityExtension,
+) -> Result<()> {
+    let evidence = authority
+        .receipt_evidence
+        .0
+        .as_deref()
+        .context("stored terminal automation authority receipt evidence is unavailable")?;
+    anyhow::ensure!(
+        stored.receipt_id == requested_receipt_id
+            && stored.receipt_id == receipt.receipt_id.as_str()
+            && stored.run_id == receipt.run_id.as_str()
+            && stored.attempt_id == receipt.attempt_id.as_str()
+            && stored.binding_id == authority.execution_binding.binding_id.as_str()
+            && stored.binding_digest == authority.execution_binding.integrity.value.as_str()
+            && stored.base_receipt_digest == receipt.integrity.value.as_str()
+            && stored.base_receipt_digest == evidence.base_receipt_digest.value.as_str()
+            && stored.terminal_evidence_digest == evidence.integrity.value.as_str()
+            && stored.produced_at == receipt.produced_at.as_str(),
+        "automation receipt authority index does not match committed evidence"
     );
     Ok(())
 }
@@ -636,15 +1179,26 @@ const fn terminal_states(outcome: TerminalOutcome) -> (&'static str, &'static st
 
 #[cfg(test)]
 mod tests {
-    use super::{commit_receipt, read_receipt, ReceiptCommitOutcome};
+    use super::{
+        commit_authorized_receipt, commit_receipt, read_authorized_receipt, read_receipt,
+        ReceiptCommitOutcome,
+    };
     use crate::api::{
         handle_request_with_runtime_and_authority, NoopSessionRuntime, RequestAuthority,
+    };
+    use crate::automations::contract::authority::test_support::{
+        authority_extensions_value, extension_bag, resign_authority_extensions, AcceptingVerifier,
+    };
+    use crate::automations::contract::authority::{
+        AuthorityEvidenceVerifier, AuthorityProfileError, AuthorityProfileErrorCode,
+        AuthorityValidationPhase, AutomationAuthorityExtension, AUTHORITY_EXTENSION_KEY,
+        AUTHORITY_PROFILE,
     };
     use crate::automations::contract::canonical_json::{
         canonicalize_without_integrity, sha256_hex,
     };
     use crate::automations::contract::events::stream_head;
-    use crate::automations::contract::types::{AutomationReceipt, EventEnvelope};
+    use crate::automations::contract::types::{AutomationReceipt, EventEnvelope, ExtensionBag};
     use crate::automations::definition::RoutineDefinition;
     use crate::automations::occurrences::insert_claimed_occurrence;
     use crate::automations::runs::{record_run_finish, record_run_start, RunFinish, RunStart};
@@ -654,7 +1208,7 @@ mod tests {
     use rusqlite::Connection;
     use serde_json::{json, Value};
     use std::path::PathBuf;
-    use std::sync::{Arc, Barrier};
+    use std::sync::{Arc, Barrier, Mutex};
 
     struct Fixture {
         _temp: tempfile::TempDir,
@@ -672,13 +1226,23 @@ mod tests {
         event_row_count: i64,
         event_table_count: i64,
         stream_head: Option<u64>,
+        sidecar_row_count: i64,
+        sidecar_table_count: i64,
     }
 
     fn fixture() -> Fixture {
-        fixture_with_attempt_occurrence("occurrence-daily-1")
+        fixture_with_options("occurrence-daily-1", false)
+    }
+
+    fn authorized_fixture() -> Fixture {
+        fixture_with_options("occurrence-daily-1", true)
     }
 
     fn fixture_with_attempt_occurrence(attempt_occurrence_id: &str) -> Fixture {
+        fixture_with_options(attempt_occurrence_id, false)
+    }
+
+    fn fixture_with_options(attempt_occurrence_id: &str, authorized: bool) -> Fixture {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("coven.sqlite3");
         initialize_store(&path).unwrap();
@@ -699,7 +1263,7 @@ mod tests {
         }))
         .unwrap();
         insert_definition(&conn, &definition).unwrap();
-        let definition_digest = conn
+        let definition_digest: String = conn
             .query_row(
                 "SELECT definition_digest
                  FROM automation_definitions
@@ -744,7 +1308,7 @@ mod tests {
             RunStart {
                 automation_id: "daily",
                 occurrence_id: Some("occurrence-daily-1"),
-                authority_profile: None,
+                authority_profile: authorized.then_some(AUTHORITY_PROFILE),
                 session_id: None,
                 familiar_id: Some("charm"),
                 runtime: "coven-code",
@@ -753,17 +1317,23 @@ mod tests {
             opened_at,
         )
         .unwrap();
+        let authority_extension_json = authorized.then(|| {
+            let value =
+                serde_json::to_value(authority_extensions_for(&definition_digest, None)).unwrap();
+            serde_json::to_string(&value[AUTHORITY_EXTENSION_KEY]).unwrap()
+        });
         conn.execute(
             "INSERT INTO automation_attempts (
                 id, run_id, occurrence_id, attempt_number, adoption_key,
                 occurrence_fence_generation, state, retry_classification,
-                not_before, opened_at, settled_at
-             ) VALUES (?1, ?2, ?3, 1, ?4, 1, 'succeeded', 'initial', ?5, ?5, ?6)",
+                authority_extension_json, not_before, opened_at, settled_at
+             ) VALUES (?1, ?2, ?3, 1, ?4, 1, 'succeeded', 'initial', ?5, ?6, ?6, ?7)",
             rusqlite::params![
                 "attempt-daily-1",
                 "run-daily-1",
                 attempt_occurrence_id,
                 "automation:run-daily-1:1",
+                authority_extension_json,
                 opened_at.to_rfc3339_opts(SecondsFormat::Millis, true),
                 (opened_at + chrono::Duration::seconds(5))
                     .to_rfc3339_opts(SecondsFormat::Millis, true),
@@ -836,6 +1406,139 @@ mod tests {
         serde_json::from_value(value).unwrap()
     }
 
+    fn make_authorized_receipt(fixture: &Fixture, receipt_id: &str) -> AutomationReceipt {
+        mutate_receipt(make_receipt(fixture, receipt_id), |value| {
+            value["authority"] = json!({
+                "principal": {"principalId": "principal:val"},
+                "approval": {
+                    "approvalPolicyRef": "policy://authority/familiars/charm",
+                    "approvalRecordRef": "approval:daily-notes-1"
+                }
+            });
+            value["runtime"] = json!({
+                "runtimeId": "coven-code",
+                "capabilities": ["analysis.read", "artifact.write"]
+            });
+            value["exercisedCapabilities"] = json!(["analysis.read", "artifact.write"]);
+            value["sideEffectClass"] = json!("none");
+        })
+    }
+
+    fn mutate_receipt(
+        receipt: AutomationReceipt,
+        mutate: impl FnOnce(&mut Value),
+    ) -> AutomationReceipt {
+        let mut value = serde_json::to_value(receipt).unwrap();
+        mutate(&mut value);
+        value["integrity"]["value"] =
+            json!(sha256_hex(&canonicalize_without_integrity(&value).unwrap()));
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn authority_extensions_for(
+        definition_digest: &str,
+        receipt: Option<&AutomationReceipt>,
+    ) -> ExtensionBag {
+        let mut value = authority_extensions_value();
+        let extension = &mut value[AUTHORITY_EXTENSION_KEY];
+        let binding = &mut extension["executionBinding"];
+        binding["base"]["automationId"] = json!("daily");
+        binding["base"]["automationRevision"] = json!(1);
+        binding["base"]["definitionDigest"]["value"] = json!(definition_digest);
+        binding["base"]["occurrenceId"] = json!("occurrence-daily-1");
+        binding["base"]["occurrenceFenceGeneration"] = json!(1);
+        binding["base"]["runId"] = json!("run-daily-1");
+        binding["base"]["attemptId"] = json!("attempt-daily-1");
+        binding["base"]["attemptNumber"] = json!(1);
+        binding["base"]["adoptionKey"] = json!("automation:run-daily-1:1");
+        binding["approval"]["use"]["occurrencePrefix"] = json!("occurrence-");
+        binding["approval"]["consumption"]["occurrenceId"] = json!("occurrence-daily-1");
+        binding["approval"]["consumption"]["runId"] = json!("run-daily-1");
+        binding["approval"]["consumption"]["attemptNumber"] = json!(1);
+        binding["approval"]["consumption"]["fenceGeneration"] = json!(1);
+        binding["risk"]["sideEffectClass"] = json!("external_mutation");
+        binding["runtime"]["runtimeId"] = json!("coven-code");
+
+        if let Some(receipt) = receipt {
+            let evidence = &mut extension["receiptEvidence"];
+            evidence["receiptId"] = json!(receipt.receipt_id.as_str());
+            evidence["automationId"] = json!(receipt.automation_id.as_str());
+            evidence["automationRevision"] = json!(receipt.automation_revision.get());
+            evidence["definitionDigest"] =
+                serde_json::to_value(receipt.definition_digest.as_ref().unwrap()).unwrap();
+            evidence["occurrenceId"] = json!(receipt.occurrence_id.as_str());
+            evidence["occurrenceFenceGeneration"] =
+                json!(receipt.occurrence_fence_generation.unwrap().get());
+            evidence["runId"] = json!(receipt.run_id.as_str());
+            evidence["attemptId"] = json!(receipt.attempt_id.as_str());
+            evidence["attemptNumber"] = json!(receipt.attempt_number.unwrap().get());
+            evidence["baseReceiptDigest"]["value"] = json!(receipt.integrity.value.as_str());
+            evidence["approval"]["use"]["occurrencePrefix"] = json!("occurrence-");
+            evidence["approval"]["consumption"]["occurrenceId"] =
+                json!(receipt.occurrence_id.as_str());
+            evidence["approval"]["consumption"]["runId"] = json!(receipt.run_id.as_str());
+            evidence["approval"]["consumption"]["attemptNumber"] =
+                json!(receipt.attempt_number.unwrap().get());
+            evidence["approval"]["consumption"]["fenceGeneration"] =
+                json!(receipt.occurrence_fence_generation.unwrap().get());
+            evidence["risk"]["sideEffectClass"] = json!("external_mutation");
+            evidence["runtime"]["runtimeId"] = json!("coven-code");
+        } else {
+            extension["receiptEvidence"] = Value::Null;
+        }
+        resign_authority_extensions(&mut value);
+        extension_bag(value)
+    }
+
+    fn terminal_authority(fixture: &Fixture, receipt: &AutomationReceipt) -> ExtensionBag {
+        authority_extensions_for(&fixture.definition_digest, Some(receipt))
+    }
+
+    fn mutate_authority(extensions: ExtensionBag, mutate: impl FnOnce(&mut Value)) -> ExtensionBag {
+        let mut value = serde_json::to_value(extensions).unwrap();
+        mutate(&mut value);
+        resign_authority_extensions(&mut value);
+        extension_bag(value)
+    }
+
+    #[derive(Debug)]
+    struct RefusingVerifier;
+
+    impl AuthorityEvidenceVerifier for RefusingVerifier {
+        fn verify(
+            &self,
+            _extension: &AutomationAuthorityExtension,
+            _phase: AuthorityValidationPhase,
+        ) -> Result<(), AuthorityProfileError> {
+            Err(AuthorityProfileError::new(
+                AuthorityProfileErrorCode::Stale,
+                "private verifier detail",
+            ))
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct TerminalOnlyVerifier {
+        phases: Mutex<Vec<AuthorityValidationPhase>>,
+    }
+
+    impl AuthorityEvidenceVerifier for TerminalOnlyVerifier {
+        fn verify(
+            &self,
+            _extension: &AutomationAuthorityExtension,
+            phase: AuthorityValidationPhase,
+        ) -> Result<(), AuthorityProfileError> {
+            self.phases.lock().unwrap().push(phase);
+            if phase == AuthorityValidationPhase::PreDispatch {
+                return Err(AuthorityProfileError::new(
+                    AuthorityProfileErrorCode::Replayed,
+                    "the dispatch evidence is already consumed",
+                ));
+            }
+            Ok(())
+        }
+    }
+
     fn receipt_event(receipt: &AutomationReceipt, sequence: u64) -> EventEnvelope {
         let mut value = json!({
             "schemaVersion": "coven.automations.v1",
@@ -858,7 +1561,7 @@ mod tests {
             "payload": {
                 "receiptRef": receipt.receipt_id.as_str(),
                 "outcome": "succeeded",
-                "sideEffectClass": "external_mutation"
+                "sideEffectClass": receipt.side_effect_class
             },
             "privacy": {
                 "classification": &receipt.privacy.classification,
@@ -916,7 +1619,198 @@ mod tests {
                 })
                 .unwrap(),
             stream_head: stream_head(&fixture.conn, "run", receipt.run_id.as_str()).unwrap(),
+            sidecar_row_count: fixture
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM automation_receipt_authority_extensions
+                     WHERE receipt_id = ?1",
+                    [receipt.receipt_id.as_str()],
+                    |row| row.get(0),
+                )
+                .unwrap(),
+            sidecar_table_count: fixture
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM automation_receipt_authority_extensions",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap(),
         }
+    }
+
+    fn assert_authorized_failure_is_atomic(
+        fixture: &Fixture,
+        receipt: &AutomationReceipt,
+        event: &EventEnvelope,
+        extensions: &ExtensionBag,
+        verifier: &dyn AuthorityEvidenceVerifier,
+    ) -> anyhow::Error {
+        let before = receipt_commit_state(fixture, receipt, event);
+        let error = commit_authorized_receipt(&fixture.conn, receipt, event, extensions, verifier)
+            .expect_err("invalid authorized commitment must fail closed");
+        let after = receipt_commit_state(fixture, receipt, event);
+        assert_eq!(after, before, "rejected commitment must be atomic");
+        error
+    }
+
+    fn corrupt_pinned_authority(fixture: &Fixture, mutate: impl FnOnce(&mut Value)) {
+        let pinned_json: String = fixture
+            .conn
+            .query_row(
+                "SELECT authority_extension_json
+                 FROM automation_attempts
+                 WHERE id = 'attempt-daily-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let mut pinned = json!({
+            AUTHORITY_EXTENSION_KEY: serde_json::from_str::<Value>(&pinned_json).unwrap()
+        });
+        mutate(&mut pinned);
+        fixture
+            .conn
+            .execute_batch(
+                "DROP TRIGGER automation_attempts_terminal_immutable;
+                 DROP TRIGGER automation_attempt_authority_immutable;",
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute(
+                "UPDATE automation_attempts
+                 SET authority_extension_json = ?2
+                 WHERE id = ?1",
+                rusqlite::params![
+                    "attempt-daily-1",
+                    serde_json::to_string(&pinned[AUTHORITY_EXTENSION_KEY]).unwrap()
+                ],
+            )
+            .unwrap();
+    }
+
+    fn mutate_reopened_authority_claim(fixture: &Fixture, claim: &str) {
+        let pinned_json: String = fixture
+            .conn
+            .query_row(
+                "SELECT authority_extension_json
+                 FROM automation_attempts
+                 WHERE id = 'attempt-daily-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let sidecar_json: String = fixture
+            .conn
+            .query_row(
+                "SELECT authority_json
+                 FROM automation_receipt_authority_extensions
+                 WHERE receipt_id = 'receipt-daily-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let mut pinned = json!({
+            AUTHORITY_EXTENSION_KEY: serde_json::from_str::<Value>(&pinned_json).unwrap()
+        });
+        let mut sidecar = json!({
+            AUTHORITY_EXTENSION_KEY: serde_json::from_str::<Value>(&sidecar_json).unwrap()
+        });
+        match claim {
+            "exercised" => {
+                sidecar[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["capabilities"]["exercised"] =
+                    json!(["analysis.read"]);
+            }
+            "principal" => {
+                pinned[AUTHORITY_EXTENSION_KEY]["executionBinding"]["principal"]["principalId"] =
+                    json!("principal:other");
+                sidecar[AUTHORITY_EXTENSION_KEY]["executionBinding"]["principal"]["principalId"] =
+                    json!("principal:other");
+                sidecar[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["principalId"] =
+                    json!("principal:other");
+            }
+            "approval" => {
+                pinned[AUTHORITY_EXTENSION_KEY]["executionBinding"]["approval"]["evidence"]
+                    ["approvalId"] = json!("approval:other");
+                sidecar[AUTHORITY_EXTENSION_KEY]["executionBinding"]["approval"]["evidence"]
+                    ["approvalId"] = json!("approval:other");
+                sidecar[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["approval"]["evidence"]
+                    ["approvalId"] = json!("approval:other");
+            }
+            "runtime-id" => {
+                pinned[AUTHORITY_EXTENSION_KEY]["executionBinding"]["runtime"]["runtimeId"] =
+                    json!("runtime:other");
+                sidecar[AUTHORITY_EXTENSION_KEY]["executionBinding"]["runtime"]["runtimeId"] =
+                    json!("runtime:other");
+                sidecar[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["runtime"]["runtimeId"] =
+                    json!("runtime:other");
+            }
+            "runtime-capabilities" => {
+                let expanded = json!(["analysis.read", "artifact.write", "network.publish"]);
+                pinned[AUTHORITY_EXTENSION_KEY]["executionBinding"]["runtime"]["capabilities"] =
+                    expanded.clone();
+                sidecar[AUTHORITY_EXTENSION_KEY]["executionBinding"]["runtime"]["capabilities"] =
+                    expanded.clone();
+                sidecar[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["runtime"]["capabilities"] =
+                    expanded;
+            }
+            "side-effect-envelope" => {
+                pinned[AUTHORITY_EXTENSION_KEY]["executionBinding"]["risk"]["sideEffectClass"] =
+                    json!("local_write");
+                sidecar[AUTHORITY_EXTENSION_KEY]["executionBinding"]["risk"]["sideEffectClass"] =
+                    json!("local_write");
+                sidecar[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["risk"]["sideEffectClass"] =
+                    json!("local_write");
+            }
+            _ => unreachable!(),
+        }
+        resign_authority_extensions(&mut pinned);
+        resign_authority_extensions(&mut sidecar);
+        let extension = &sidecar[AUTHORITY_EXTENSION_KEY];
+        let binding_digest = extension["executionBinding"]["integrity"]["value"]
+            .as_str()
+            .unwrap();
+        let terminal_digest = extension["receiptEvidence"]["integrity"]["value"]
+            .as_str()
+            .unwrap();
+
+        fixture
+            .conn
+            .execute_batch(
+                "DROP TRIGGER automation_attempts_terminal_immutable;
+                 DROP TRIGGER automation_attempt_authority_immutable;
+                 DROP TRIGGER automation_receipt_authority_extensions_no_update;",
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute(
+                "UPDATE automation_attempts
+                 SET authority_extension_json = ?2
+                 WHERE id = ?1",
+                rusqlite::params![
+                    "attempt-daily-1",
+                    serde_json::to_string(&pinned[AUTHORITY_EXTENSION_KEY]).unwrap()
+                ],
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute(
+                "UPDATE automation_receipt_authority_extensions
+                 SET binding_digest = ?2,
+                     terminal_evidence_digest = ?3,
+                     authority_json = ?4
+                 WHERE receipt_id = ?1",
+                rusqlite::params![
+                    "receipt-daily-1",
+                    binding_digest,
+                    terminal_digest,
+                    serde_json::to_string(extension).unwrap(),
+                ],
+            )
+            .unwrap();
     }
 
     #[test]
@@ -981,6 +1875,707 @@ mod tests {
                 [],
             )
             .is_err());
+    }
+
+    #[test]
+    fn authorized_receipt_commit_reopens_with_validated_terminal_sidecar() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+        let pinned_before: String = fixture
+            .conn
+            .query_row(
+                "SELECT authority_extension_json
+                 FROM automation_attempts
+                 WHERE id = 'attempt-daily-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(
+            commit_authorized_receipt(
+                &fixture.conn,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            )
+            .unwrap(),
+            ReceiptCommitOutcome::Committed
+        );
+        assert_eq!(
+            receipt_commit_state(&fixture, &receipt, &event).sidecar_row_count,
+            1
+        );
+
+        let reopened = crate::store::open_store(&fixture.store_path).unwrap();
+        let authorized =
+            read_authorized_receipt(&reopened, receipt.receipt_id.as_str(), &AcceptingVerifier)
+                .unwrap()
+                .expect("authorized receipt");
+        assert_eq!(authorized.receipt, receipt);
+        assert_eq!(
+            serde_json::to_value(authorized.authority).unwrap(),
+            serde_json::to_value(&terminal).unwrap()[AUTHORITY_EXTENSION_KEY]
+        );
+        let pinned_after: String = reopened
+            .query_row(
+                "SELECT authority_extension_json
+                 FROM automation_attempts
+                 WHERE id = 'attempt-daily-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(pinned_after, pinned_before);
+    }
+
+    #[test]
+    fn authorized_commit_and_read_only_apply_live_terminal_verification() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+        let commit_verifier = TerminalOnlyVerifier::default();
+        commit_authorized_receipt(&fixture.conn, &receipt, &event, &terminal, &commit_verifier)
+            .unwrap();
+        assert_eq!(
+            *commit_verifier.phases.lock().unwrap(),
+            vec![AuthorityValidationPhase::Terminal]
+        );
+
+        let read_verifier = TerminalOnlyVerifier::default();
+        read_authorized_receipt(&fixture.conn, receipt.receipt_id.as_str(), &read_verifier)
+            .unwrap();
+        assert_eq!(
+            *read_verifier.phases.lock().unwrap(),
+            vec![AuthorityValidationPhase::Terminal]
+        );
+    }
+
+    #[test]
+    fn authority_sidecar_is_immutable_and_unique_per_receipt_run_and_attempt() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+        commit_authorized_receipt(
+            &fixture.conn,
+            &receipt,
+            &event,
+            &terminal,
+            &AcceptingVerifier,
+        )
+        .unwrap();
+
+        assert!(fixture
+            .conn
+            .execute(
+                "UPDATE automation_receipt_authority_extensions
+                 SET produced_at = produced_at || 'x'
+                 WHERE receipt_id = ?1",
+                [receipt.receipt_id.as_str()],
+            )
+            .is_err());
+        assert!(fixture
+            .conn
+            .execute(
+                "DELETE FROM automation_receipt_authority_extensions
+                 WHERE receipt_id = ?1",
+                [receipt.receipt_id.as_str()],
+            )
+            .is_err());
+        assert!(fixture
+            .conn
+            .execute(
+                "INSERT INTO automation_receipt_authority_extensions (
+                    receipt_id, run_id, attempt_id, binding_id, binding_digest,
+                    base_receipt_digest, terminal_evidence_digest,
+                    authority_json, produced_at
+                 )
+                 SELECT receipt_id, run_id, attempt_id, binding_id, binding_digest,
+                        base_receipt_digest, terminal_evidence_digest,
+                        authority_json, produced_at
+                 FROM automation_receipt_authority_extensions
+                 WHERE receipt_id = ?1",
+                [receipt.receipt_id.as_str()],
+            )
+            .is_err());
+        assert_eq!(
+            fixture
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM automation_receipt_authority_extensions",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        for column in ["receipt_id", "run_id", "attempt_id"] {
+            let unique_index_count: i64 = fixture
+                .conn
+                .query_row(
+                    "SELECT COUNT(*)
+                     FROM pragma_index_list('automation_receipt_authority_extensions') AS indexes
+                     WHERE indexes.\"unique\" = 1
+                       AND (
+                           SELECT group_concat(name, ',')
+                           FROM pragma_index_info(indexes.name)
+                       ) = ?1",
+                    [column],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(unique_index_count, 1, "missing UNIQUE({column})");
+        }
+    }
+
+    #[test]
+    fn authorized_receipt_requires_exact_base_digest_correlation() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = mutate_authority(terminal_authority(&fixture, &receipt), |value| {
+            value[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["baseReceiptDigest"]["value"] =
+                json!("0".repeat(64));
+        });
+
+        assert_authorized_failure_is_atomic(
+            &fixture,
+            &receipt,
+            &event,
+            &terminal,
+            &AcceptingVerifier,
+        );
+    }
+
+    #[test]
+    fn authorized_receipt_accepts_lower_or_equal_actual_side_effects() {
+        for actual in ["none", "external_mutation"] {
+            let fixture = authorized_fixture();
+            let receipt = mutate_receipt(
+                make_authorized_receipt(&fixture, "receipt-daily-1"),
+                |value| value["sideEffectClass"] = json!(actual),
+            );
+            let event = receipt_event(&receipt, 0);
+            let terminal = terminal_authority(&fixture, &receipt);
+
+            assert_eq!(
+                commit_authorized_receipt(
+                    &fixture.conn,
+                    &receipt,
+                    &event,
+                    &terminal,
+                    &AcceptingVerifier,
+                )
+                .unwrap(),
+                ReceiptCommitOutcome::Committed,
+                "{actual}"
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_receipt_rejects_initial_side_effect_escalation_atomically() {
+        let fixture = authorized_fixture();
+        let receipt = mutate_receipt(
+            make_authorized_receipt(&fixture, "receipt-daily-1"),
+            |value| value["sideEffectClass"] = json!("irreversible_external_mutation"),
+        );
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+
+        assert_authorized_failure_is_atomic(
+            &fixture,
+            &receipt,
+            &event,
+            &terminal,
+            &AcceptingVerifier,
+        );
+    }
+
+    #[test]
+    fn authorized_receipt_rejects_a_spliced_execution_binding() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = mutate_authority(terminal_authority(&fixture, &receipt), |value| {
+            value[AUTHORITY_EXTENSION_KEY]["executionBinding"]["bindingId"] =
+                json!("binding:spliced");
+            value[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["bindingId"] =
+                json!("binding:spliced");
+        });
+
+        assert_authorized_failure_is_atomic(
+            &fixture,
+            &receipt,
+            &event,
+            &terminal,
+            &AcceptingVerifier,
+        );
+    }
+
+    #[test]
+    fn authorized_receipt_rejects_missing_or_malformed_terminal_evidence() {
+        for malformed in [
+            Value::Null,
+            json!("private malformed terminal evidence"),
+            json!({"kind": "AutomationReceiptAuthorityEvidence"}),
+        ] {
+            let fixture = authorized_fixture();
+            let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+            let event = receipt_event(&receipt, 0);
+            let mut value = serde_json::to_value(terminal_authority(&fixture, &receipt)).unwrap();
+            value[AUTHORITY_EXTENSION_KEY]["receiptEvidence"] = malformed;
+            let terminal = extension_bag(value);
+
+            let error = assert_authorized_failure_is_atomic(
+                &fixture,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            );
+            assert!(
+                !format!("{error:#}").contains("private malformed terminal evidence"),
+                "{error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_receipt_requires_verifier_acceptance() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+
+        let error = assert_authorized_failure_is_atomic(
+            &fixture,
+            &receipt,
+            &event,
+            &terminal,
+            &RefusingVerifier,
+        );
+        assert!(!format!("{error:#}").contains("private verifier detail"));
+    }
+
+    #[test]
+    fn authorized_receipt_replay_is_exact_and_conflicts_fail_closed() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+
+        assert_eq!(
+            commit_authorized_receipt(
+                &fixture.conn,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            )
+            .unwrap(),
+            ReceiptCommitOutcome::Committed
+        );
+        assert_eq!(
+            commit_authorized_receipt(
+                &fixture.conn,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            )
+            .unwrap(),
+            ReceiptCommitOutcome::Replayed
+        );
+
+        let conflicting = mutate_authority(terminal.clone(), |value| {
+            value[AUTHORITY_EXTENSION_KEY]["executionBinding"]["principal"]["principalId"] =
+                json!("principal:other");
+            value[AUTHORITY_EXTENSION_KEY]["receiptEvidence"]["principalId"] =
+                json!("principal:other");
+        });
+        assert_authorized_failure_is_atomic(
+            &fixture,
+            &receipt,
+            &event,
+            &conflicting,
+            &AcceptingVerifier,
+        );
+        assert_eq!(
+            receipt_commit_state(&fixture, &receipt, &event).sidecar_row_count,
+            1
+        );
+    }
+
+    #[test]
+    fn base_only_commit_rejects_authority_pinned_runs_before_fresh_or_replay_acceptance() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let before = receipt_commit_state(&fixture, &receipt, &event);
+        assert!(commit_receipt(&fixture.conn, &receipt, &event).is_err());
+        assert_eq!(receipt_commit_state(&fixture, &receipt, &event), before);
+
+        let terminal = terminal_authority(&fixture, &receipt);
+        commit_authorized_receipt(
+            &fixture.conn,
+            &receipt,
+            &event,
+            &terminal,
+            &AcceptingVerifier,
+        )
+        .unwrap();
+        assert!(commit_receipt(&fixture.conn, &receipt, &event).is_err());
+        assert_eq!(
+            receipt_commit_state(&fixture, &receipt, &event).sidecar_row_count,
+            1
+        );
+    }
+
+    #[test]
+    fn structural_v1_base_receipt_commit_remains_available() {
+        let fixture = fixture();
+        let receipt = make_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+
+        assert_eq!(
+            commit_receipt(&fixture.conn, &receipt, &event).unwrap(),
+            ReceiptCommitOutcome::Committed
+        );
+        assert_eq!(
+            receipt_commit_state(&fixture, &receipt, &event).sidecar_table_count,
+            0
+        );
+    }
+
+    #[test]
+    fn authorized_receipt_rolls_back_base_event_head_and_sidecar_when_sidecar_insert_fails() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+        fixture
+            .conn
+            .execute_batch(
+                "CREATE TRIGGER fail_authority_sidecar_insert
+                 BEFORE INSERT ON automation_receipt_authority_extensions
+                 BEGIN
+                     SELECT RAISE(ABORT, 'injected sidecar failure');
+                 END;",
+            )
+            .unwrap();
+
+        assert_authorized_failure_is_atomic(
+            &fixture,
+            &receipt,
+            &event,
+            &terminal,
+            &AcceptingVerifier,
+        );
+    }
+
+    #[test]
+    fn authorized_receipt_base_validation_and_event_append_failures_are_atomic() {
+        for failure in ["missing-integrity", "out-of-order"] {
+            let fixture = authorized_fixture();
+            let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+            let mut event = receipt_event(&receipt, u64::from(failure == "out-of-order"));
+            if failure == "missing-integrity" {
+                event.integrity = None;
+            }
+            let terminal = terminal_authority(&fixture, &receipt);
+
+            assert_authorized_failure_is_atomic(
+                &fixture,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_receipt_initial_claim_contradictions_fail_atomically() {
+        for claim in [
+            "missing-exercised",
+            "exercised",
+            "principal",
+            "approval",
+            "runtime-id",
+            "runtime-capabilities",
+        ] {
+            let fixture = authorized_fixture();
+            let receipt = mutate_receipt(
+                make_authorized_receipt(&fixture, "receipt-daily-1"),
+                |value| match claim {
+                    "missing-exercised" => {
+                        value
+                            .as_object_mut()
+                            .unwrap()
+                            .remove("exercisedCapabilities");
+                    }
+                    "exercised" => {
+                        value["exercisedCapabilities"] = json!(["analysis.read"]);
+                    }
+                    "principal" => {
+                        value["authority"]["principal"]["principalId"] = json!("principal:other");
+                    }
+                    "approval" => {
+                        value["authority"]["approval"]["approvalRecordRef"] =
+                            json!("approval:other");
+                    }
+                    "runtime-id" => {
+                        value["runtime"]["runtimeId"] = json!("runtime:other");
+                    }
+                    "runtime-capabilities" => {
+                        value["runtime"]["capabilities"] =
+                            json!(["analysis.read", "artifact.write", "network.publish"]);
+                    }
+                    _ => unreachable!(),
+                },
+            );
+            let event = receipt_event(&receipt, 0);
+            let terminal = terminal_authority(&fixture, &receipt);
+
+            assert_authorized_failure_is_atomic(
+                &fixture,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_receipt_reopen_rejects_contradictory_overlapping_claims() {
+        for claim in [
+            "exercised",
+            "principal",
+            "approval",
+            "runtime-id",
+            "runtime-capabilities",
+            "side-effect-envelope",
+        ] {
+            let fixture = authorized_fixture();
+            let receipt = if claim == "side-effect-envelope" {
+                mutate_receipt(
+                    make_authorized_receipt(&fixture, "receipt-daily-1"),
+                    |value| value["sideEffectClass"] = json!("external_mutation"),
+                )
+            } else {
+                make_authorized_receipt(&fixture, "receipt-daily-1")
+            };
+            let event = receipt_event(&receipt, 0);
+            let terminal = terminal_authority(&fixture, &receipt);
+            commit_authorized_receipt(
+                &fixture.conn,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            )
+            .unwrap();
+            mutate_reopened_authority_claim(&fixture, claim);
+
+            let error = read_authorized_receipt(
+                &fixture.conn,
+                receipt.receipt_id.as_str(),
+                &AcceptingVerifier,
+            )
+            .expect_err("contradictory reopened claims must fail closed");
+            let expected_error = if claim == "side-effect-envelope" {
+                "side effect"
+            } else {
+                "authority"
+            };
+            assert!(
+                format!("{error:#}").contains(expected_error),
+                "{claim}: {error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_receipt_read_and_replay_reject_tampered_sidecar_json_and_indexes() {
+        for corrupt_sql in [
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET authority_json = json_set(
+                 authority_json,
+                 '$.receiptEvidence.principalId',
+                 'principal:tampered'
+             );
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET binding_id = 'binding:tampered';
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET binding_digest = printf('%064d', 0);
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET base_receipt_digest = printf('%064d', 0);
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET terminal_evidence_digest = printf('%064d', 0);
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET run_id = 'run-moved';
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET attempt_id = 'attempt-moved';
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET produced_at = produced_at || 'x';
+             PRAGMA foreign_keys = ON;",
+            "PRAGMA foreign_keys = OFF;
+             DROP TRIGGER automation_receipt_authority_extensions_no_update;
+             UPDATE automation_receipt_authority_extensions
+             SET receipt_id = 'receipt-moved';
+             PRAGMA foreign_keys = ON;",
+        ] {
+            let fixture = authorized_fixture();
+            let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+            let event = receipt_event(&receipt, 0);
+            let terminal = terminal_authority(&fixture, &receipt);
+            commit_authorized_receipt(
+                &fixture.conn,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            )
+            .unwrap();
+            fixture.conn.execute_batch(corrupt_sql).unwrap();
+
+            assert!(
+                read_authorized_receipt(
+                    &fixture.conn,
+                    receipt.receipt_id.as_str(),
+                    &AcceptingVerifier,
+                )
+                .is_err(),
+                "{corrupt_sql}"
+            );
+            assert!(
+                commit_authorized_receipt(
+                    &fixture.conn,
+                    &receipt,
+                    &event,
+                    &terminal,
+                    &AcceptingVerifier,
+                )
+                .is_err(),
+                "{corrupt_sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_receipt_read_rejects_malformed_sidecar_without_disclosure() {
+        let fixture = authorized_fixture();
+        let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+        let event = receipt_event(&receipt, 0);
+        let terminal = terminal_authority(&fixture, &receipt);
+        commit_authorized_receipt(
+            &fixture.conn,
+            &receipt,
+            &event,
+            &terminal,
+            &AcceptingVerifier,
+        )
+        .unwrap();
+        fixture
+            .conn
+            .execute_batch(
+                "DROP TRIGGER automation_receipt_authority_extensions_no_update;
+                 PRAGMA ignore_check_constraints = ON;
+                 UPDATE automation_receipt_authority_extensions
+                 SET authority_json = '{private malformed authority sidecar';
+                 PRAGMA ignore_check_constraints = OFF;",
+            )
+            .unwrap();
+
+        let error = read_authorized_receipt(
+            &fixture.conn,
+            receipt.receipt_id.as_str(),
+            &AcceptingVerifier,
+        )
+        .expect_err("malformed sidecar must fail closed");
+        assert!(
+            !format!("{error:#}").contains("private malformed authority sidecar"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn corrupt_pinned_authority_profile_and_enum_are_privacy_safe() {
+        for corruption in ["profile", "enum", "malformed"] {
+            let fixture = authorized_fixture();
+            let receipt = make_authorized_receipt(&fixture, "receipt-daily-1");
+            let event = receipt_event(&receipt, 0);
+            let terminal = terminal_authority(&fixture, &receipt);
+            let sentinel = format!("private-{corruption}-sentinel");
+            if corruption == "malformed" {
+                fixture
+                    .conn
+                    .execute_batch(
+                        "DROP TRIGGER automation_attempts_terminal_immutable;
+                         DROP TRIGGER automation_attempt_authority_immutable;",
+                    )
+                    .unwrap();
+                fixture
+                    .conn
+                    .execute(
+                        "UPDATE automation_attempts
+                         SET authority_extension_json = ?2
+                         WHERE id = ?1",
+                        rusqlite::params!["attempt-daily-1", format!("{{{sentinel}")],
+                    )
+                    .unwrap();
+            } else {
+                corrupt_pinned_authority(&fixture, |value| match corruption {
+                    "profile" => {
+                        value[AUTHORITY_EXTENSION_KEY]["profile"] = json!(sentinel);
+                    }
+                    "enum" => {
+                        value[AUTHORITY_EXTENSION_KEY]["executionBinding"]["kind"] =
+                            json!(sentinel);
+                    }
+                    _ => unreachable!(),
+                });
+            }
+
+            let error = assert_authorized_failure_is_atomic(
+                &fixture,
+                &receipt,
+                &event,
+                &terminal,
+                &AcceptingVerifier,
+            );
+            assert!(!format!("{error:#}").contains(&sentinel), "{error:#}");
+        }
     }
 
     fn read_response(fixture: &Fixture, authority: RequestAuthority) -> crate::api::ApiResponse {

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1026,6 +1026,10 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
         .context("failed to initialize automation events schema")?;
     conn.execute_batch(crate::automations::receipts::AUTOMATION_RECEIPTS_SCHEMA_SQL)
         .context("failed to initialize automation receipts schema")?;
+    conn.execute_batch(
+        crate::automations::receipts::AUTOMATION_RECEIPT_AUTHORITY_EXTENSIONS_SCHEMA_SQL,
+    )
+    .context("failed to initialize automation receipt authority extensions schema")?;
     crate::automations::contract::events::backfill_definition_event_baselines(conn)
         .context("failed to backfill automation definition event baselines")?;
     crate::automations::store::migrate_durable_local_timezones(conn)?;


### PR DESCRIPTION
## Context

Refs #857.

#975 made immutable base Automation receipts readable without overclaiming authority. This slice adds the separate terminal Runtime Authority evidence store and atomic commitment seam required before any runtime path can truthfully produce an authority-verified receipt.

## Implementation

- add an immutable one-per-receipt/run/attempt terminal authority sidecar, separate from the pinned pre-dispatch binding
- atomically commit the base receipt, run link, integrity-bearing event, stream head, and terminal authority sidecar
- validate the terminal companion profile with the authoritative verifier and consumed-state semantics
- exact-match the terminal execution binding to the immutable pinned dispatch binding
- exact-match receipt correlation and the base receipt digest
- require consistent principal/approval/runtime/exercised-capability claims across the base receipt and sidecar
- permit actual side effects below the signed authority envelope but reject escalation beyond it
- preserve Structural v1 `commit_receipt`, while rejecting base-only commitment for authority-pinned runs
- add verifier-backed reopen/revalidation with privacy-safe malformed/tampered evidence failures
- preserve idempotent replay and full rollback on any conflict

## Security invariants

- pinned pre-dispatch authority is never rewritten
- terminal verification does not reapply live pre-dispatch replay rules to consumed authority
- no side effects, exercised capabilities, results, deliveries, authentication, or authority are derived by storage
- Runtime Authority-pinned runs cannot bypass mandatory terminal evidence with the base-only API
- malformed stored authority never leaks attacker-controlled values through error chains

## Verification

- receipt tests: 35 passed
- authority tests: 24 passed before main integration; focused post-merge authority tests passed
- store tests: 179 passed
- `cargo check -p coven-cli`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`
- staged privacy and repository secret guards
- independent spec and correctness reviews approved

## Follow-up boundary

This PR intentionally does not wire a runtime producer. The next #857 slice will use this seam only for deterministic pre-runtime launch refusals, where Coven can prove `sideEffectClass: none`, explicit empty exercised capabilities, and absent result/delivery digests. Launched-session receipts remain fail closed until the runtime provides durable authenticated terminal evidence.