### PR TITLE
fix: preserve early Windows status replacement results

### DIFF
--- a/crates/coven-client/src/discovery.rs
+++ b/crates/coven-client/src/discovery.rs
@@ -2042,9 +2042,18 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn status_file_reader_allows_an_atomic_status_replacement() {
-        use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr, sync::mpsc, time::Duration};
+        use std::{
+            ffi::OsStr,
+            os::windows::{
+                ffi::OsStrExt,
+                io::{FromRawHandle, OwnedHandle},
+            },
+            ptr,
+            sync::mpsc,
+            time::Duration,
+        };
         use windows_sys::Win32::{
-            Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE},
+            Foundation::{GENERIC_READ, INVALID_HANDLE_VALUE},
             Storage::FileSystem::{CreateFileW, FILE_ATTRIBUTE_NORMAL, OPEN_EXISTING},
         };
 
@@ -2071,6 +2080,8 @@ mod tests {
             )
         };
         assert_ne!(reader, INVALID_HANDLE_VALUE, "open status reader");
+        // Keep the reader owned so failure paths also close the Windows handle.
+        let reader = unsafe { OwnedHandle::from_raw_handle(reader) };
         let home_path = home.clone();
         let (result_tx, result_rx) = mpsc::channel();
         let writer = std::thread::spawn(move || {
@@ -2081,18 +2092,19 @@ mod tests {
                 ))
                 .expect("report status replacement");
         });
-        assert!(
-            result_rx.recv_timeout(Duration::from_millis(20)).is_err(),
-            "status replacement should wait for the active reader"
-        );
-        unsafe {
-            CloseHandle(reader);
-        }
-        result_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("status replacement result")
-            .expect("replace status after reader closes");
-        writer.join().expect("status replacement thread");
+        // Replacement may complete while a delete-sharing reader is open. Preserve
+        // an early success or error instead of requiring a minimum writer duration.
+        let early_result = result_rx.recv_timeout(Duration::from_millis(20));
+        drop(reader);
+        let result = match early_result {
+            Ok(result) => Ok(result),
+            Err(mpsc::RecvTimeoutError::Timeout) => result_rx.recv_timeout(Duration::from_secs(2)),
+            Err(error) => Err(error),
+        };
+        let result = result.expect("status replacement result");
+        let joined = writer.join();
+        result.expect("replace status after reader closes");
+        joined.expect("status replacement thread");
         assert_eq!(
             std::fs::read_to_string(&status_path).expect("read replaced status"),
             "{\"pid\":2}\n"


### PR DESCRIPTION
## Context

Closes #981. Protected Chat run 34425192604 identified the test's 20 ms no-result assertion as the failure. That assertion rejects both early successful replacement and an early writer error without preserving the result.

## Implementation

Preserve the first receive result and wait again only after a timeout. Own the Windows reader handle so failure paths close it. Check receive timeout before joining the writer, then retain writer-error and exact replacement-content assertions. Only `crates/coven-client/src/discovery.rs` test code changes; production sharing, ACLs, retries, and limits are unchanged.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy -p coven-client --all-targets -- -D warnings`
- [x] `cargo test -p coven-client --locked` — 115 tests passed on macOS
- [x] `cargo check -p coven-client --tests --target x86_64-pc-windows-gnu --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] Independent review, including correction of the timeout-before-join ordering

This single-crate test-only change uses the routed local validation allowed by CONTRIBUTING.md. Full workspace and native Windows execution remain CI checks; cross-compilation is not native Windows proof.

## Risk and Rollback

Test-only change; revert this commit if necessary. Early writer errors remain failures. The previous protected result does not establish whether the writer succeeded.

## Agent Handoff

Native Windows CI must verify the test. Any adoption into the protected frozen source requires a separately verified source/validator binding and fresh protected run; this PR alone does not establish release acceptance. Chat and active worktrees are preserved.
