### PR TITLE
feat: record verified authority launch refusals

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -524,6 +524,9 @@ impl std::fmt::Display for RuntimeLaunchAdmissionClosedError {
 
 impl std::error::Error for RuntimeLaunchAdmissionClosedError {}
 
+pub(crate) const RUNTIME_AUTHORITY_PROJECTION_UNSUPPORTED: &str =
+    "runtime does not accept automation authority projections; no process started";
+
 pub trait SessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()>;
     fn launch_session_with_writer(
@@ -573,6 +576,11 @@ pub trait SessionRuntime {
     ) -> Result<()> {
         self.launch_adopted_session(launch, writer, ownership_established)
     }
+    /// Reports whether this runtime accepts the bounded Runtime Authority
+    /// projection supplied to automation launches.
+    fn accepts_automation_authority_projection(&self) -> bool {
+        false
+    }
     /// Launches an automation session with the bounded authority evidence that
     /// the execution consumer is permitted to observe.
     ///
@@ -589,7 +597,7 @@ pub trait SessionRuntime {
         ownership_established: &mut dyn FnMut() -> Result<()>,
     ) -> Result<()> {
         if authority.is_some() {
-            anyhow::bail!("runtime does not accept automation authority projections");
+            anyhow::bail!(RUNTIME_AUTHORITY_PROJECTION_UNSUPPORTED);
         }
         self.launch_contained_adopted_session(launch, writer, ownership_established)
     }
@@ -12489,6 +12497,86 @@ fn reap_stale_created_sessions_throttled(conn: &rusqlite::Connection) {
 pub(crate) mod tests {
     use super::*;
     use crate::api_routes::{COVEN_API_ROUTE_VERSION, SUPPORTED_API_ROUTE_VERSIONS};
+
+    #[test]
+    fn default_authorized_launch_refuses_before_launch_or_ownership() {
+        struct CountingRuntime {
+            launches: std::sync::atomic::AtomicUsize,
+        }
+
+        impl SessionRuntime for CountingRuntime {
+            fn launch_session(&self, _launch: &SessionLaunch) -> Result<()> {
+                self.launches
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            }
+
+            fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+                Ok(())
+            }
+
+            fn kill_session(&self, _session_id: &str) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let extension: crate::automations::contract::authority::AutomationAuthorityExtension =
+            serde_json::from_value(
+                crate::automations::contract::authority::test_support::authority_extensions_value()
+                    [crate::automations::contract::authority::AUTHORITY_EXTENSION_KEY]
+                    .clone(),
+            )
+            .unwrap();
+        let authority =
+            crate::automations::authority_projection::AutomationAuthorityConsumerProjection::from_validated(
+                &extension,
+            );
+        let launch = SessionLaunch {
+            id: "session-authority-refusal".to_string(),
+            project_root: "/work/project".to_string(),
+            cwd: "/work/project".to_string(),
+            harness: "coven-code".to_string(),
+            model: None,
+            launch_mode: HarnessLaunchMode::NonInteractive,
+            launch_policy: None,
+            prompt: "Do the thing.".to_string(),
+            title: "authority refusal".to_string(),
+            conversation: None,
+            conversation_id: None,
+            familiar_id: Some("charm".to_string()),
+            caller_familiar_id: None,
+        };
+        let runtime = CountingRuntime {
+            launches: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let ownership_callbacks = std::sync::atomic::AtomicUsize::new(0);
+        let mut ownership_established = || {
+            ownership_callbacks.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        };
+
+        let error = runtime
+            .launch_authorized_contained_adopted_session(
+                &launch,
+                Some(&authority),
+                None,
+                &mut ownership_established,
+            )
+            .expect_err("the default runtime must reject authority projections");
+
+        assert_eq!(
+            error.to_string(),
+            "runtime does not accept automation authority projections; no process started"
+        );
+        assert_eq!(
+            runtime.launches.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            ownership_callbacks.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
 
     struct TestWorker<T> {
         completion: std::sync::mpsc::Receiver<T>,

--- a/crates/coven-cli/src/automations/contract/authority.rs
+++ b/crates/coven-cli/src/automations/contract/authority.rs
@@ -501,6 +501,11 @@ impl Serialize for AuthorityCapabilitySet {
 
 impl AuthorityCapabilitySet {
     #[must_use]
+    pub(crate) const fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    #[must_use]
     pub fn as_slice(&self) -> &[AuthorityCapability] {
         &self.0
     }

--- a/crates/coven-cli/src/automations/contract/types.rs
+++ b/crates/coven-cli/src/automations/contract/types.rs
@@ -604,6 +604,11 @@ impl<'de> Deserialize<'de> for RuntimeCapabilities {
 pub struct ExercisedCapabilities(Vec<Capability>);
 
 impl ExercisedCapabilities {
+    #[must_use]
+    pub(crate) const fn empty() -> Self {
+        Self(Vec::new())
+    }
+
     fn new(values: Vec<Capability>) -> Result<Self, StringConstraintError> {
         if values.len() > 128 {
             return Err(StringConstraintError(

--- a/crates/coven-cli/src/automations/receipts.rs
+++ b/crates/coven-cli/src/automations/receipts.rs
@@ -1,27 +1,164 @@
 //! Immutable Automations v1 receipt commitment.
 
-// These internal seams remain unwired until a producer can supply terminal
-// evidence without deriving side-effect, capability, result or delivery claims.
+// Broader receipt paths remain unwired until producers can supply terminal
+// evidence without deriving unsupported result or delivery claims.
 #![allow(dead_code)]
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde::Serialize;
 use serde_json::Value;
 
+use super::contract::authority::AutomationExecutionBinding;
 use super::contract::authority::{
     validate_authority_profile, validate_authority_profile_structure, AuthorityApprovalBinding,
     AuthorityConsumerClass, AuthorityEvidenceVerifier, AuthorityProfileDisposition,
     AuthoritySideEffectClass, AuthorityValidationPhase, AutomationAuthorityExtension,
     AUTHORITY_EXTENSION_KEY, AUTHORITY_PROFILE, BASE_PROFILE, RUNTIME_AUTHORITY_CAPABILITY,
 };
+use super::contract::canonical_json::{canonicalize_without_integrity, sha256_hex};
 use super::contract::events::append_event;
 use super::contract::types::{
-    AutomationReceipt, EventEnvelope, EventKind, EventPayload, ExtensionBag, SideEffectClass,
-    StreamKind, TerminalOutcome,
+    AutomationReceipt, Canonicalization, ComponentName, Detail, DigestAlgorithm, DigestValue,
+    EventEnvelope, EventId, EventKind, EventPayload, EventPrivacy, EventStreamId, EventSummary,
+    ExercisedCapabilities, ExtensionBag, FailureClass, FamiliarId, FamiliarRef,
+    ImplementationVersion, InstanceId, PrivacyClassification, ProducerIdentity,
+    ReceiptAuthentication, ReceiptAuthority, ReceiptId, ReceiptIntegrity, ReceiptOutcome,
+    ReceiptPayload, ReceiptPrivacy, ReceiptRecoveryDisposition, RetentionClass,
+    RetentionClassification, SafeInteger, SchemaVersion, Sha256Digest, SideEffectClass, StreamKind,
+    StreamRef, TerminalOutcome, Timestamp,
 };
+
+pub(crate) const NO_LAUNCH_AUTHORITY_UNSUPPORTED_DETAIL: &str =
+    crate::api::RUNTIME_AUTHORITY_PROJECTION_UNSUPPORTED;
+
+fn receipt_producer() -> Result<ProducerIdentity> {
+    Ok(ProducerIdentity {
+        component: ComponentName::new("coven-daemon".to_string())?,
+        instance_id: InstanceId::new("local-authority".to_string())?,
+        implementation_version: Some(ImplementationVersion::new(
+            env!("CARGO_PKG_VERSION").to_string(),
+        )?),
+    })
+}
+
+pub(crate) fn build_no_launch_receipt(
+    receipt_id: &str,
+    binding: &AutomationExecutionBinding,
+    familiar_id: &str,
+    produced_at: DateTime<Utc>,
+) -> Result<AutomationReceipt> {
+    let produced_at =
+        Timestamp::new(produced_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))?;
+    let mut receipt = AutomationReceipt {
+        schema_version: SchemaVersion::V1,
+        receipt_id: ReceiptId::new(receipt_id.to_string())?,
+        automation_id: binding.base.automation_id.clone(),
+        automation_revision: binding.base.automation_revision,
+        definition_digest: Some(binding.base.definition_digest.clone()),
+        occurrence_id: binding.base.occurrence_id.clone(),
+        occurrence_fence_generation: Some(binding.base.occurrence_fence_generation),
+        run_id: binding.base.run_id.clone(),
+        attempt_id: binding.base.attempt_id.clone(),
+        attempt_number: Some(binding.base.attempt_number),
+        identity: FamiliarRef {
+            familiar_id: FamiliarId::new(familiar_id.to_string())?,
+        },
+        authority: Some(ReceiptAuthority {
+            principal: super::contract::types::PrincipalRef {
+                principal_id: binding.principal.principal_id.clone(),
+                display_name: None,
+            },
+            // Runtime Authority does not carry the base contract's policy ref,
+            // so no approval reference can be copied losslessly.
+            approval: None,
+        }),
+        runtime: None,
+        delivery_digest: None,
+        result_digest: None,
+        exercised_capabilities: Some(ExercisedCapabilities::empty()),
+        side_effect_class: SideEffectClass::None,
+        outcome: ReceiptOutcome {
+            disposition: TerminalOutcome::Failed,
+            failure_class: Some(FailureClass::new(
+                "runtime_authority_unsupported".to_string(),
+            )?),
+            detail: Some(Detail::new(
+                NO_LAUNCH_AUTHORITY_UNSUPPORTED_DETAIL.to_string(),
+            )?),
+            partial_failures: None,
+            recovery_disposition: Some(ReceiptRecoveryDisposition::NotRequired),
+        },
+        produced_at,
+        producer: receipt_producer()?,
+        integrity: ReceiptIntegrity {
+            algorithm: DigestAlgorithm::Sha256,
+            canonicalization: Canonicalization::JcsRfc8785,
+            value: Sha256Digest::new("0".repeat(64))?,
+            authentication: Some(ReceiptAuthentication::None),
+        },
+        privacy: ReceiptPrivacy {
+            classification: PrivacyClassification::Operational,
+            retention: RetentionClass {
+                classification: RetentionClassification::Standard,
+                delete_after: None,
+            },
+            notes: None,
+        },
+    };
+    let value = serde_json::to_value(&receipt)?;
+    receipt.integrity.value =
+        Sha256Digest::new(sha256_hex(&canonicalize_without_integrity(&value)?))?;
+    receipt.verify_integrity()?;
+    Ok(receipt)
+}
+
+pub(crate) fn build_receipt_recorded_event(
+    event_id: &str,
+    receipt: &AutomationReceipt,
+    sequence: u64,
+) -> Result<EventEnvelope> {
+    let mut event = EventEnvelope {
+        schema_version: SchemaVersion::V1,
+        event_id: EventId::new(event_id.to_string())?,
+        stream: StreamRef {
+            kind: StreamKind::Run,
+            id: EventStreamId::new(receipt.run_id.as_str().to_string())?,
+        },
+        sequence: SafeInteger::new(sequence)?,
+        recorded_at: receipt.produced_at.clone(),
+        observed_at: receipt.produced_at.clone(),
+        producer: receipt.producer.clone(),
+        causation: None,
+        automation_id: Some(receipt.automation_id.clone()),
+        occurrence_id: Some(receipt.occurrence_id.clone()),
+        run_id: Some(receipt.run_id.clone()),
+        attempt_id: Some(receipt.attempt_id.clone()),
+        kind: EventKind::ReceiptRecorded,
+        summary: EventSummary::new("automation run receipt recorded".to_string())?,
+        payload: EventPayload::Receipt(ReceiptPayload {
+            receipt_ref: receipt.receipt_id.clone(),
+            outcome: receipt.outcome.disposition,
+            side_effect_class: Some(receipt.side_effect_class),
+        }),
+        privacy: EventPrivacy {
+            classification: receipt.privacy.classification,
+            retention: receipt.privacy.retention.clone(),
+        },
+        integrity: None,
+    };
+    let value = serde_json::to_value(&event)?;
+    event.integrity = Some(DigestValue {
+        algorithm: DigestAlgorithm::Sha256,
+        canonicalization: Canonicalization::JcsRfc8785,
+        value: Sha256Digest::new(sha256_hex(&canonicalize_without_integrity(&value)?))?,
+    });
+    event.verify_integrity()?;
+    Ok(event)
+}
 
 pub const AUTOMATION_RECEIPTS_SCHEMA_SQL: &str = "
     CREATE TABLE IF NOT EXISTS automation_receipts (
@@ -1180,8 +1317,8 @@ const fn terminal_states(outcome: TerminalOutcome) -> (&'static str, &'static st
 #[cfg(test)]
 mod tests {
     use super::{
-        commit_authorized_receipt, commit_receipt, read_authorized_receipt, read_receipt,
-        ReceiptCommitOutcome,
+        build_no_launch_receipt, build_receipt_recorded_event, commit_authorized_receipt,
+        commit_receipt, read_authorized_receipt, read_receipt, ReceiptCommitOutcome,
     };
     use crate::api::{
         handle_request_with_runtime_and_authority, NoopSessionRuntime, RequestAuthority,
@@ -1492,6 +1629,100 @@ mod tests {
 
     fn terminal_authority(fixture: &Fixture, receipt: &AutomationReceipt) -> ExtensionBag {
         authority_extensions_for(&fixture.definition_digest, Some(receipt))
+    }
+
+    #[test]
+    fn no_launch_builders_emit_minimal_correlated_terminal_evidence() {
+        let fixture = authorized_fixture();
+        let extension = authority_extensions_for(&fixture.definition_digest, None);
+        let extension: AutomationAuthorityExtension = serde_json::from_value(
+            serde_json::to_value(extension).unwrap()[AUTHORITY_EXTENSION_KEY].clone(),
+        )
+        .unwrap();
+        let receipt = build_no_launch_receipt(
+            "receipt-no-launch-1",
+            &extension.execution_binding,
+            "charm",
+            fixture.produced_at,
+        )
+        .unwrap();
+        let event =
+            build_receipt_recorded_event("evt00000000000000000000000000042", &receipt, 4).unwrap();
+
+        receipt.verify_integrity().unwrap();
+        event.verify_integrity().unwrap();
+        let receipt_value = serde_json::to_value(&receipt).unwrap();
+        assert_eq!(receipt_value["automationId"], json!("daily"));
+        assert_eq!(receipt_value["automationRevision"], json!(1));
+        assert_eq!(
+            receipt_value["definitionDigest"]["value"],
+            json!(fixture.definition_digest)
+        );
+        assert_eq!(receipt_value["occurrenceId"], json!("occurrence-daily-1"));
+        assert_eq!(receipt_value["occurrenceFenceGeneration"], json!(1));
+        assert_eq!(receipt_value["runId"], json!("run-daily-1"));
+        assert_eq!(receipt_value["attemptId"], json!("attempt-daily-1"));
+        assert_eq!(receipt_value["attemptNumber"], json!(1));
+        assert_eq!(receipt_value["identity"]["familiarId"], json!("charm"));
+        assert_eq!(
+            receipt_value["authority"]["principal"]["principalId"],
+            json!("principal:val")
+        );
+        assert!(receipt_value["authority"].get("approval").is_none());
+        assert!(receipt_value.get("runtime").is_none());
+        assert!(receipt_value.get("deliveryDigest").is_none());
+        assert!(receipt_value.get("resultDigest").is_none());
+        assert_eq!(receipt_value["exercisedCapabilities"], json!([]));
+        assert_eq!(receipt_value["sideEffectClass"], json!("none"));
+        assert_eq!(receipt_value["outcome"]["disposition"], json!("failed"));
+        assert_eq!(
+            receipt_value["outcome"]["failureClass"],
+            json!("runtime_authority_unsupported")
+        );
+        assert_eq!(
+            receipt_value["outcome"]["detail"],
+            json!("runtime does not accept automation authority projections; no process started")
+        );
+        assert_eq!(
+            receipt_value["outcome"]["recoveryDisposition"],
+            json!("not_required")
+        );
+        assert_eq!(
+            receipt_value["producedAt"],
+            json!(fixture
+                .produced_at
+                .to_rfc3339_opts(SecondsFormat::Millis, true))
+        );
+        assert_eq!(receipt_value["integrity"]["authentication"], json!("none"));
+        assert_eq!(
+            receipt_value["privacy"]["classification"],
+            json!("operational")
+        );
+
+        let event_value = serde_json::to_value(event).unwrap();
+        assert_eq!(
+            event_value["stream"],
+            json!({"kind": "run", "id": "run-daily-1"})
+        );
+        assert_eq!(event_value["sequence"], json!(4));
+        assert_eq!(event_value["recordedAt"], receipt_value["producedAt"]);
+        assert_eq!(event_value["observedAt"], receipt_value["producedAt"]);
+        assert_eq!(event_value["automationId"], receipt_value["automationId"]);
+        assert_eq!(event_value["occurrenceId"], receipt_value["occurrenceId"]);
+        assert_eq!(event_value["runId"], receipt_value["runId"]);
+        assert_eq!(event_value["attemptId"], receipt_value["attemptId"]);
+        assert_eq!(
+            event_value["payload"]["receiptRef"],
+            receipt_value["receiptId"]
+        );
+        assert_eq!(
+            event_value["payload"]["outcome"],
+            receipt_value["outcome"]["disposition"]
+        );
+        assert_eq!(
+            event_value["payload"]["sideEffectClass"],
+            receipt_value["sideEffectClass"]
+        );
     }
 
     fn mutate_authority(extensions: ExtensionBag, mutate: impl FnOnce(&mut Value)) -> ExtensionBag {

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -18,14 +18,19 @@ use super::authority_projection::AutomationAuthorityConsumerProjection;
 use super::contract::authority::{
     validate_authority_profile, AuthorityConsumerClass, AuthorityEvidenceVerifier,
     AuthorityProfileDisposition, AuthorityProfileError, AuthorityProfileErrorCode,
-    AuthorityValidationPhase, AutomationAuthorityExtension, AUTHORITY_PROFILE,
-    RUNTIME_AUTHORITY_CAPABILITY,
+    AuthorityValidationPhase, AutomationAuthorityExtension, AutomationExecutionBinding,
+    AUTHORITY_PROFILE, RUNTIME_AUTHORITY_CAPABILITY,
 };
-use super::contract::types::{BackoffPolicy, ExtensionBag, RetryableClass};
+use super::contract::events::stream_head;
+use super::contract::types::{AutomationReceipt, BackoffPolicy, ExtensionBag, RetryableClass};
 use super::definition::{RoutineDefinition, RoutineRetryPolicy};
 use super::occurrences::{
     insert_claimed_occurrence, mark_occurrence_running, recover_expired_leases,
     recover_expired_leases_with_scheduler_fence, settle_occurrence,
+};
+use super::receipts::{
+    build_no_launch_receipt, build_receipt_recorded_event, commit_authorized_receipt, read_receipt,
+    ReceiptCommitOutcome, NO_LAUNCH_AUTHORITY_UNSUPPORTED_DETAIL,
 };
 use super::runs::{
     is_retry_quarantined, record_retry_exhaustion, record_run_finish, record_run_start, RunFinish,
@@ -218,10 +223,22 @@ pub(crate) struct AutomationAuthorityRequest {
     pub runtime_id: String,
 }
 
+// Production construction remains blocked until the trusted-state adapter lands.
+#[allow(dead_code)]
+pub(crate) struct AutomationTerminalAuthorityRequest<'a> {
+    pub execution_binding: &'a AutomationExecutionBinding,
+    pub receipt: &'a AutomationReceipt,
+}
+
 pub(crate) trait AutomationDispatchAuthority: AuthorityEvidenceVerifier {
     fn resolve(
         &self,
         request: &AutomationAuthorityRequest,
+    ) -> Result<ExtensionBag, AuthorityProfileError>;
+
+    fn produce_terminal_evidence(
+        &self,
+        request: &AutomationTerminalAuthorityRequest<'_>,
     ) -> Result<ExtensionBag, AuthorityProfileError>;
 }
 
@@ -274,8 +291,10 @@ fn authority_binding_matches_request(
         && extension.execution_binding.runtime.runtime_id.as_str() == request.runtime_id
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ResolvedAuthority {
     extension_json: String,
+    execution_binding: AutomationExecutionBinding,
     consumer_projection: AutomationAuthorityConsumerProjection,
 }
 
@@ -316,6 +335,7 @@ fn resolve_authority_extension(
         .map_err(|_| "failed to serialize validated automation authority binding".to_string())?;
     Ok(Some(ResolvedAuthority {
         extension_json,
+        execution_binding: extension.execution_binding.clone(),
         consumer_projection,
     }))
 }
@@ -646,7 +666,7 @@ fn persist_launch_with_clock(
     Ok(PersistLaunch::Ready(AttemptDispatch {
         run_id: run_id.to_string(),
         attempt_number,
-        authority: authority.map(|authority| Box::new(authority.consumer_projection)),
+        authority: authority.map(Box::new),
     }))
 }
 
@@ -745,6 +765,172 @@ struct RejectedLaunch<'a> {
     scheduler_fence: Option<&'a super::leadership::SchedulerFence>,
 }
 
+struct UnsupportedAuthorityLaunch<'a> {
+    occurrence_id: &'a str,
+    run_id: &'a str,
+    attempt_number: u8,
+    session_id: &'a str,
+    familiar_id: &'a str,
+    resolved: &'a ResolvedAuthority,
+    authority: &'a dyn AutomationDispatchAuthority,
+    scheduler_fence: Option<&'a super::leadership::SchedulerFence>,
+}
+
+fn no_launch_receipt_id(binding: &AutomationExecutionBinding) -> String {
+    let digest = blake3::hash(
+        format!(
+            "runtime-authority-unsupported:{}",
+            binding.base.attempt_id.as_str()
+        )
+        .as_bytes(),
+    );
+    format!("receipt-{}", digest.to_hex())
+}
+
+fn no_launch_receipt_event_id(receipt_id: &str) -> String {
+    let digest = blake3::hash(receipt_id.as_bytes()).to_hex().to_string();
+    format!("evt{}", &digest[..32])
+}
+
+fn settle_runtime_authority_unsupported(
+    conn: &Connection,
+    rejected: UnsupportedAuthorityLaunch<'_>,
+    now: DateTime<Utc>,
+) -> Result<ReceiptCommitOutcome, String> {
+    let UnsupportedAuthorityLaunch {
+        occurrence_id,
+        run_id,
+        attempt_number,
+        session_id,
+        familiar_id,
+        resolved,
+        authority,
+        scheduler_fence,
+    } = rejected;
+    let receipt_id = no_launch_receipt_id(&resolved.execution_binding);
+    let receipt = read_receipt(conn, &receipt_id)
+        .map_err(|error| format!("failed to inspect no-launch receipt replay: {error:#}"))?
+        .map_or_else(
+            || build_no_launch_receipt(&receipt_id, &resolved.execution_binding, familiar_id, now),
+            Ok,
+        )
+        .map_err(|error| format!("failed to build no-launch receipt: {error:#}"))?;
+    let terminal_extensions = authority
+        .produce_terminal_evidence(&AutomationTerminalAuthorityRequest {
+            execution_binding: &resolved.execution_binding,
+            receipt: &receipt,
+        })
+        .map_err(|error| {
+            format!(
+                "automation authority refused terminal evidence: {}",
+                error.code().as_str()
+            )
+        })?;
+
+    let transaction = rusqlite::Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|error| format!("failed to begin no-launch receipt settlement: {error}"))?;
+    if let Some(fence) = scheduler_fence {
+        require_current_scheduler_fence(&transaction, occurrence_id, fence)?;
+    }
+    let event_id = no_launch_receipt_event_id(receipt.receipt_id.as_str());
+    let existing_sequence = transaction
+        .query_row(
+            "SELECT sequence FROM automation_events WHERE event_id = ?1",
+            [&event_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()
+        .map_err(|error| format!("failed to inspect no-launch receipt event replay: {error}"))?;
+    let event_sequence = match existing_sequence {
+        Some(sequence) => u64::try_from(sequence)
+            .map_err(|_| "stored no-launch receipt event sequence is negative".to_string())?,
+        None => stream_head(&transaction, "run", run_id)
+            .map_err(|error| format!("failed to read no-launch receipt event sequence: {error}"))?
+            .map_or(Ok(0), |head| {
+                head.checked_add(1)
+                    .ok_or_else(|| "no-launch receipt event sequence overflowed".to_string())
+            })?,
+    };
+    let event = build_receipt_recorded_event(&event_id, &receipt, event_sequence)
+        .map_err(|error| format!("failed to build no-launch receipt event: {error:#}"))?;
+
+    if existing_sequence.is_none() {
+        let now_iso = receipt.produced_at.as_str();
+        let settled_session = crate::store::update_session_terminal_if_active(
+            &transaction,
+            session_id,
+            "failed",
+            None,
+            now_iso,
+        )
+        .map_err(|error| format!("failed to settle unsupported authority session: {error:#}"))?;
+        if !settled_session {
+            return Err("unsupported authority session changed before settlement".to_string());
+        }
+        let failure = PreownershipFailure::RuntimeAuthorityUnsupported;
+        let settled_attempt = transaction
+            .execute(
+                "UPDATE automation_attempts
+                 SET state = 'failed',
+                     failure_class = ?3,
+                     state_reason = ?4,
+                     settled_at = ?5
+                 WHERE run_id = ?1
+                   AND attempt_number = ?2
+                   AND state = 'dispatching'",
+                rusqlite::params![
+                    run_id,
+                    i64::from(attempt_number),
+                    failure_class_name(failure),
+                    NO_LAUNCH_AUTHORITY_UNSUPPORTED_DETAIL,
+                    now_iso,
+                ],
+            )
+            .map_err(|error| format!("failed to settle unsupported authority attempt: {error}"))?;
+        if settled_attempt != 1 {
+            return Err("unsupported authority attempt changed before settlement".to_string());
+        }
+        if !settle_occurrence(
+            &transaction,
+            occurrence_id,
+            "failed",
+            Some(NO_LAUNCH_AUTHORITY_UNSUPPORTED_DETAIL),
+            now,
+        )? {
+            return Err("unsupported authority occurrence changed before settlement".to_string());
+        }
+        if !record_run_finish(
+            &transaction,
+            run_id,
+            RunFinish {
+                status: "failed",
+                exit_code: None,
+                session_id: Some(session_id.to_string()),
+                log_json: None,
+                output_commit: None,
+            },
+            now,
+        )
+        .map_err(|error| format!("failed to settle unsupported authority run: {error:#}"))?
+        {
+            return Err("unsupported authority run changed before settlement".to_string());
+        }
+    }
+
+    let outcome = commit_authorized_receipt(
+        &transaction,
+        &receipt,
+        &event,
+        &terminal_extensions,
+        authority,
+    )
+    .map_err(|error| format!("failed to commit no-launch authority receipt: {error:#}"))?;
+    transaction
+        .commit()
+        .map_err(|error| format!("failed to commit no-launch receipt settlement: {error}"))?;
+    Ok(outcome)
+}
+
 fn settle_rejected_launch(
     conn: &Connection,
     rejected: RejectedLaunch<'_>,
@@ -799,7 +985,9 @@ fn settle_rejected_launch(
     }
     let retryable = match failure {
         PreownershipFailure::Retryable(failure_class) => definition.retry.retries(failure_class),
-        PreownershipFailure::LaunchRefused => false,
+        PreownershipFailure::LaunchRefused | PreownershipFailure::RuntimeAuthorityUnsupported => {
+            false
+        }
     };
     let retry_deadline_open: bool = transaction
         .query_row(
@@ -955,7 +1143,7 @@ enum PersistLaunch {
 struct AttemptDispatch {
     run_id: String,
     attempt_number: u8,
-    authority: Option<Box<AutomationAuthorityConsumerProjection>>,
+    authority: Option<Box<ResolvedAuthority>>,
 }
 
 struct DispatchControl<'a> {
@@ -1002,6 +1190,41 @@ fn dispatch_occurrence_with_clock(
         }
     };
 
+    if let Some(resolved) = attempt.authority.as_deref() {
+        if !runtime.accepts_automation_authority_projection() {
+            let AutomationAuthorityMode::RuntimeAuthority(authority) = control.authority else {
+                return Err(
+                    "unsupported Runtime Authority dispatch is missing its authority producer"
+                        .to_string(),
+                );
+            };
+            let failure_at = (control.clock)().max(now);
+            settle_runtime_authority_unsupported(
+                conn,
+                UnsupportedAuthorityLaunch {
+                    occurrence_id,
+                    run_id: &attempt.run_id,
+                    attempt_number: attempt.attempt_number,
+                    session_id: &launch.id,
+                    familiar_id: definition.familiar_id.as_deref().ok_or_else(|| {
+                        "Runtime Authority no-launch receipt requires a durable familiar ID"
+                            .to_string()
+                    })?,
+                    resolved,
+                    authority,
+                    scheduler_fence: control.scheduler_fence,
+                },
+                failure_at,
+            )?;
+            return Ok(DispatchAttempt::Completed(RunOutcome {
+                run_id,
+                status: "failed".to_string(),
+                session_id: None,
+                error: Some(NO_LAUNCH_AUTHORITY_UNSUPPORTED_DETAIL.to_string()),
+            }));
+        }
+    }
+
     let ownership_published = Cell::new(false);
     let ownership_publication_error = RefCell::new(None);
     let mut ownership_established = || match publish_runtime_ownership(
@@ -1026,7 +1249,10 @@ fn dispatch_occurrence_with_clock(
     };
     let launch_result = runtime.launch_authorized_contained_adopted_session(
         &launch,
-        attempt.authority.as_deref(),
+        attempt
+            .authority
+            .as_deref()
+            .map(|authority| &authority.consumer_projection),
         None,
         &mut ownership_established,
     );
@@ -1214,6 +1440,7 @@ fn current_run_id_for_occurrence(
 enum PreownershipFailure {
     Retryable(RetryableClass),
     LaunchRefused,
+    RuntimeAuthorityUnsupported,
 }
 
 fn classify_preownership_failure(error: &anyhow::Error) -> PreownershipFailure {
@@ -1242,13 +1469,14 @@ fn classify_preownership_failure(error: &anyhow::Error) -> PreownershipFailure {
 }
 
 fn failure_class_name(failure: PreownershipFailure) -> &'static str {
-    let PreownershipFailure::Retryable(failure_class) = failure else {
-        return "launch_refused";
-    };
-    match failure_class {
-        RetryableClass::TransientDispatch => "transient_dispatch",
-        RetryableClass::LeaseExpired => "lease_expired",
-        RetryableClass::RuntimeUnavailable => "runtime_unavailable",
+    match failure {
+        PreownershipFailure::Retryable(failure_class) => match failure_class {
+            RetryableClass::TransientDispatch => "transient_dispatch",
+            RetryableClass::LeaseExpired => "lease_expired",
+            RetryableClass::RuntimeUnavailable => "runtime_unavailable",
+        },
+        PreownershipFailure::LaunchRefused => "launch_refused",
+        PreownershipFailure::RuntimeAuthorityUnsupported => "runtime_authority_unsupported",
     }
 }
 
@@ -3485,6 +3713,9 @@ fn load_definition_for_occurrence_dispatch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::automations::contract::authority::test_support::{
+        authority_extensions_value, extension_bag, resign_authority_extensions,
+    };
     use crate::automations::contract::authority::{
         AuthorityEvidenceVerifier, AuthorityProfileError, AuthorityProfileErrorCode,
         AuthorityValidationPhase, AutomationAuthorityExtension, AUTHORITY_EXTENSION_KEY,
@@ -3607,6 +3838,10 @@ mod tests {
             ))
         }
 
+        fn accepts_automation_authority_projection(&self) -> bool {
+            true
+        }
+
         fn launch_authorized_contained_adopted_session(
             &self,
             _launch: &SessionLaunch,
@@ -3696,6 +3931,160 @@ mod tests {
         }
     }
 
+    struct BaseV1CapabilityProbeRuntime {
+        capability_queries: Cell<usize>,
+        launches: Cell<usize>,
+    }
+
+    impl SessionRuntime for BaseV1CapabilityProbeRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("automation dispatch must use strict containment")
+        }
+
+        fn launch_contained_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            self.launches.set(self.launches.get() + 1);
+            ownership_established()
+        }
+
+        fn accepts_automation_authority_projection(&self) -> bool {
+            self.capability_queries
+                .set(self.capability_queries.get() + 1);
+            false
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct ForgingAuthorityUnsupportedRuntime {
+        launches: Cell<usize>,
+    }
+
+    impl SessionRuntime for ForgingAuthorityUnsupportedRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            self.launches.set(self.launches.get() + 1);
+            Ok(())
+        }
+
+        fn launch_authorized_contained_adopted_session(
+            &self,
+            launch: &SessionLaunch,
+            authority: Option<&AutomationAuthorityConsumerProjection>,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            _ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            self.launch_session(launch)?;
+            let mut ignored_ownership = || Ok(());
+            SessionRuntime::launch_authorized_contained_adopted_session(
+                &ContainedRuntime,
+                launch,
+                authority,
+                None,
+                &mut ignored_ownership,
+            )
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct GenericAuthorityRejectingRuntime;
+
+    impl SessionRuntime for GenericAuthorityRejectingRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("automation dispatch must use the authority-aware entrypoint")
+        }
+
+        fn accepts_automation_authority_projection(&self) -> bool {
+            true
+        }
+
+        fn launch_authorized_contained_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            authority: Option<&AutomationAuthorityConsumerProjection>,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            _ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            assert!(authority.is_some());
+            anyhow::bail!("synthetic generic authority-aware launch refusal")
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct IoAuthorityRejectingRuntime;
+
+    impl SessionRuntime for IoAuthorityRejectingRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
+            unreachable!("automation dispatch must use the authority-aware entrypoint")
+        }
+
+        fn accepts_automation_authority_projection(&self) -> bool {
+            true
+        }
+
+        fn launch_authorized_contained_adopted_session(
+            &self,
+            _launch: &SessionLaunch,
+            authority: Option<&AutomationAuthorityConsumerProjection>,
+            _writer: Option<crate::maintenance_gate::WriterLease>,
+            _ownership_established: &mut dyn FnMut() -> anyhow::Result<()>,
+        ) -> anyhow::Result<()> {
+            assert!(authority.is_some());
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "synthetic authority runtime unavailable",
+            )
+            .into())
+        }
+
+        fn send_input(
+            &self,
+            _session_id: &str,
+            _payload: &serde_json::Value,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     struct AuthorityObservingRuntime<'a> {
         conn: &'a Connection,
     }
@@ -3703,6 +4092,10 @@ mod tests {
     impl SessionRuntime for AuthorityObservingRuntime<'_> {
         fn launch_session(&self, _launch: &SessionLaunch) -> anyhow::Result<()> {
             unreachable!("automation dispatch must use strict containment")
+        }
+
+        fn accepts_automation_authority_projection(&self) -> bool {
+            true
         }
 
         fn launch_authorized_contained_adopted_session(
@@ -3890,6 +4283,7 @@ mod tests {
             binding["approval"]["consumption"]["attemptNumber"] = json!(request.attempt_number);
             binding["approval"]["consumption"]["fenceGeneration"] =
                 json!(request.occurrence_fence_generation);
+            binding["risk"]["sideEffectClass"] = json!("external_mutation");
 
             let mut body = binding.clone();
             let object = body.as_object_mut().expect("binding object");
@@ -3923,16 +4317,256 @@ mod tests {
                 )
             })
         }
+
+        fn produce_terminal_evidence(
+            &self,
+            request: &AutomationTerminalAuthorityRequest<'_>,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            let mut value = authority_extensions_value();
+            let extension = &mut value[AUTHORITY_EXTENSION_KEY];
+            extension["executionBinding"] = serde_json::to_value(request.execution_binding)
+                .map_err(|error| {
+                    AuthorityProfileError::new(
+                        AuthorityProfileErrorCode::SchemaInvalid,
+                        error.to_string(),
+                    )
+                })?;
+            let binding = extension["executionBinding"].clone();
+            let receipt = request.receipt;
+            let evidence = &mut extension["receiptEvidence"];
+            evidence["receiptId"] = json!(receipt.receipt_id.as_str());
+            evidence["automationId"] = json!(receipt.automation_id.as_str());
+            evidence["automationRevision"] = json!(receipt.automation_revision.get());
+            evidence["definitionDigest"] =
+                serde_json::to_value(receipt.definition_digest.as_ref().unwrap()).unwrap();
+            evidence["occurrenceId"] = json!(receipt.occurrence_id.as_str());
+            evidence["occurrenceFenceGeneration"] =
+                json!(receipt.occurrence_fence_generation.unwrap().get());
+            evidence["runId"] = json!(receipt.run_id.as_str());
+            evidence["attemptId"] = json!(receipt.attempt_id.as_str());
+            evidence["attemptNumber"] = json!(receipt.attempt_number.unwrap().get());
+            evidence["baseReceiptDigest"] = json!({
+                "algorithm": "sha256",
+                "canonicalization": "jcs-rfc8785",
+                "value": receipt.integrity.value.as_str()
+            });
+            evidence["bindingId"] = binding["bindingId"].clone();
+            evidence["bindingDigest"] = binding["integrity"].clone();
+            evidence["principalId"] = binding["principal"]["principalId"].clone();
+            evidence["familiar"] = json!({
+                "familiarRootId": binding["familiar"]["familiarRootId"],
+                "identityRevisionId": binding["familiar"]["identityRevisionId"],
+                "declarationDigest": binding["familiar"]["declarationDigest"],
+                "statusAtDecision": binding["familiar"]["statusAtDecision"],
+                "verifiedAt": binding["familiar"]["verifiedAt"],
+                "freshnessPolicyVersion": binding["familiar"]["freshnessPolicyVersion"],
+                "freshnessBoundSeconds": binding["familiar"]["freshnessBoundSeconds"],
+                "validTime": binding["familiar"]["validTime"],
+                "revocation": binding["familiar"]["revocation"],
+                "retirement": binding["familiar"]["retirement"]
+            });
+            evidence["authorization"] = json!({
+                "operation": binding["authorization"]["operation"],
+                "requestId": binding["authorization"]["requestId"],
+                "requestDigest": binding["authorization"]["requestDigest"],
+                "decisionId": binding["authorization"]["decisionId"],
+                "decisionDigest": binding["authorization"]["decisionDigest"],
+                "consumptionSnapshotDigest":
+                    binding["authorization"]["consumptionSnapshotDigest"],
+                "outcome": binding["authorization"]["outcome"]
+            });
+            evidence["capabilities"] = json!({
+                "requested": binding["capabilities"]["requested"],
+                "granted": binding["capabilities"]["granted"],
+                "denied": binding["capabilities"]["denied"],
+                "degraded": binding["capabilities"]["degraded"],
+                "exercised": []
+            });
+            evidence["approval"] = binding["approval"].clone();
+            evidence["risk"] = binding["risk"].clone();
+            evidence["runtime"] = json!({
+                "runtimeId": binding["runtime"]["runtimeId"],
+                "descriptorVersion": binding["runtime"]["descriptorVersion"],
+                "descriptorDigest": binding["runtime"]["descriptorDigest"],
+                "capabilities": binding["runtime"]["capabilities"]
+            });
+            evidence["decisionTimestamp"] = binding["decisionTimestamp"].clone();
+            evidence["producer"] = binding["producer"].clone();
+            evidence["privacy"] = binding["privacy"].clone();
+            resign_authority_extensions(&mut value);
+            Ok(extension_bag(value))
+        }
     }
 
     impl AuthorityEvidenceVerifier for VectorAuthority {
         fn verify(
             &self,
-            _extension: &AutomationAuthorityExtension,
+            extension: &AutomationAuthorityExtension,
+            _phase: AuthorityValidationPhase,
+        ) -> Result<(), AuthorityProfileError> {
+            if let Some(evidence) = extension.receipt_evidence.0.as_deref() {
+                assert_ne!(
+                    evidence.authentication.signature,
+                    extension.execution_binding.authentication.signature
+                );
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct CountingAuthority {
+        resolve_calls: Cell<usize>,
+        terminal_calls: Cell<usize>,
+    }
+
+    impl AutomationDispatchAuthority for CountingAuthority {
+        fn resolve(
+            &self,
+            request: &AutomationAuthorityRequest,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            self.resolve_calls.set(self.resolve_calls.get() + 1);
+            VectorAuthority.resolve(request)
+        }
+
+        fn produce_terminal_evidence(
+            &self,
+            request: &AutomationTerminalAuthorityRequest<'_>,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            self.terminal_calls.set(self.terminal_calls.get() + 1);
+            VectorAuthority.produce_terminal_evidence(request)
+        }
+    }
+
+    impl AuthorityEvidenceVerifier for CountingAuthority {
+        fn verify(
+            &self,
+            extension: &AutomationAuthorityExtension,
             phase: AuthorityValidationPhase,
         ) -> Result<(), AuthorityProfileError> {
-            assert_eq!(phase, AuthorityValidationPhase::PreDispatch);
-            Ok(())
+            VectorAuthority.verify(extension, phase)
+        }
+    }
+
+    #[derive(Debug)]
+    struct RefusingTerminalAuthority;
+
+    impl AutomationDispatchAuthority for RefusingTerminalAuthority {
+        fn resolve(
+            &self,
+            request: &AutomationAuthorityRequest,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            VectorAuthority.resolve(request)
+        }
+
+        fn produce_terminal_evidence(
+            &self,
+            _request: &AutomationTerminalAuthorityRequest<'_>,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            Err(AuthorityProfileError::new(
+                AuthorityProfileErrorCode::Stale,
+                "private terminal signer detail",
+            ))
+        }
+    }
+
+    impl AuthorityEvidenceVerifier for RefusingTerminalAuthority {
+        fn verify(
+            &self,
+            extension: &AutomationAuthorityExtension,
+            phase: AuthorityValidationPhase,
+        ) -> Result<(), AuthorityProfileError> {
+            VectorAuthority.verify(extension, phase)
+        }
+    }
+
+    #[derive(Debug)]
+    struct RefusingTerminalVerifierAuthority;
+
+    impl AutomationDispatchAuthority for RefusingTerminalVerifierAuthority {
+        fn resolve(
+            &self,
+            request: &AutomationAuthorityRequest,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            VectorAuthority.resolve(request)
+        }
+
+        fn produce_terminal_evidence(
+            &self,
+            request: &AutomationTerminalAuthorityRequest<'_>,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            VectorAuthority.produce_terminal_evidence(request)
+        }
+    }
+
+    impl AuthorityEvidenceVerifier for RefusingTerminalVerifierAuthority {
+        fn verify(
+            &self,
+            extension: &AutomationAuthorityExtension,
+            phase: AuthorityValidationPhase,
+        ) -> Result<(), AuthorityProfileError> {
+            if phase == AuthorityValidationPhase::Terminal {
+                return Err(AuthorityProfileError::new(
+                    AuthorityProfileErrorCode::Stale,
+                    "private terminal verifier detail",
+                ));
+            }
+            VectorAuthority.verify(extension, phase)
+        }
+    }
+
+    struct SupersedingTerminalAuthority<'a> {
+        conn: &'a Connection,
+        terminal_calls: Cell<usize>,
+    }
+
+    impl AutomationDispatchAuthority for SupersedingTerminalAuthority<'_> {
+        fn resolve(
+            &self,
+            request: &AutomationAuthorityRequest,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            VectorAuthority.resolve(request)
+        }
+
+        fn produce_terminal_evidence(
+            &self,
+            request: &AutomationTerminalAuthorityRequest<'_>,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            self.terminal_calls.set(self.terminal_calls.get() + 1);
+            self.conn
+                .execute(
+                    "UPDATE automation_scheduler_authority
+                     SET owner_id = 'replacement-scheduler',
+                         generation = generation + 1
+                     WHERE id = 1",
+                    [],
+                )
+                .map_err(|error| {
+                    AuthorityProfileError::new(
+                        AuthorityProfileErrorCode::TrustedStateUnavailable,
+                        error.to_string(),
+                    )
+                })?;
+            VectorAuthority.produce_terminal_evidence(request)
+        }
+    }
+
+    impl AuthorityEvidenceVerifier for SupersedingTerminalAuthority<'_> {
+        fn verify(
+            &self,
+            extension: &AutomationAuthorityExtension,
+            phase: AuthorityValidationPhase,
+        ) -> Result<(), AuthorityProfileError> {
+            VectorAuthority.verify(extension, phase)
         }
     }
 
@@ -3949,6 +4583,14 @@ mod tests {
                 AuthorityProfileErrorCode::Stale,
                 "synthetic trusted-state detail that must not escape",
             ))
+        }
+
+        fn produce_terminal_evidence(
+            &self,
+            _request: &AutomationTerminalAuthorityRequest<'_>,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            unreachable!("stale authority resolution must refuse before terminal evidence")
         }
     }
 
@@ -3974,6 +4616,14 @@ mod tests {
             let mut mismatched = request.clone();
             mismatched.runtime_id = "different-runtime".to_string();
             VectorAuthority.resolve(&mismatched)
+        }
+
+        fn produce_terminal_evidence(
+            &self,
+            _request: &AutomationTerminalAuthorityRequest<'_>,
+        ) -> Result<crate::automations::contract::types::ExtensionBag, AuthorityProfileError>
+        {
+            unreachable!("mismatched authority must refuse before terminal evidence")
         }
     }
 
@@ -4196,6 +4846,125 @@ mod tests {
         initialize_store(&path).unwrap();
         let conn = crate::store::open_store(&path).unwrap();
         (temp, conn)
+    }
+
+    fn receipt_artifact_counts(conn: &Connection, run_id: &str) -> (i64, i64, i64) {
+        conn.query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM automation_receipts WHERE run_id = ?1),
+                (SELECT COUNT(*) FROM automation_receipt_authority_extensions
+                 WHERE run_id = ?1),
+                (SELECT COUNT(*) FROM automation_events
+                 WHERE stream_kind = 'run' AND stream_id = ?1
+                   AND json_extract(event_json, '$.kind') = 'receipt.recorded')",
+            [run_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap()
+    }
+
+    struct NoLaunchTerminalState {
+        occurrence_state: String,
+        occurrence_reason: Option<String>,
+        occurrence_updated_at: String,
+        run_status: String,
+        run_finished_at: Option<String>,
+        receipt_id: Option<String>,
+        attempt_state: String,
+        attempt_failure_class: Option<String>,
+        attempt_reason: Option<String>,
+        attempt_settled_at: Option<String>,
+        session_status: String,
+        session_updated_at: String,
+    }
+
+    fn persist_authority_attempt(
+        conn: &Connection,
+        routine: &RoutineDefinition,
+        occurrence_id: &str,
+        run_id: &str,
+        now: DateTime<Utc>,
+        authority: &dyn AutomationDispatchAuthority,
+        scheduler_fence: Option<&super::super::leadership::SchedulerFence>,
+    ) -> (SessionLaunch, AttemptDispatch) {
+        let launch = build_session_launch(routine, routine.cwd.as_deref().unwrap()).unwrap();
+        let attempt = persist_launch_with_clock(
+            conn,
+            run_id,
+            occurrence_id,
+            routine,
+            &launch,
+            PersistLaunchContext {
+                not_before: now,
+                authority: AutomationAuthorityMode::RuntimeAuthority(authority),
+                scheduler_fence,
+            },
+            || now,
+        )
+        .unwrap();
+        let PersistLaunch::Ready(attempt) = attempt else {
+            panic!("authority attempt must be ready for dispatch");
+        };
+        (launch, attempt)
+    }
+
+    fn assert_dispatching_without_receipt(
+        conn: &Connection,
+        run_id: &str,
+        occurrence_id: &str,
+        session_id: &str,
+    ) {
+        let state: (
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "SELECT o.state, r.status, a.state, o.failure_reason, a.failure_class, r.receipt_id
+                 FROM automation_occurrences AS o
+                 JOIN automation_runs AS r ON r.occurrence_id = o.id
+                 JOIN automation_attempts AS a ON a.run_id = r.id
+                 WHERE o.id = ?1 AND r.id = ?2 AND r.session_id = ?3",
+                rusqlite::params![occurrence_id, run_id, session_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            state,
+            (
+                "claimed".to_string(),
+                "running".to_string(),
+                "dispatching".to_string(),
+                None,
+                None,
+                None,
+            )
+        );
+        let session_status: String = conn
+            .query_row(
+                "SELECT status FROM sessions WHERE id = ?1",
+                [session_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(session_status, "created");
+        assert_eq!(receipt_artifact_counts(conn, run_id), (0, 0, 0));
+        assert_eq!(
+            super::super::contract::events::stream_head(conn, "run", run_id).unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -4545,11 +5314,12 @@ mod tests {
             .unwrap();
         assert_eq!(profile.as_deref(), Some("coven.automations.authority.v1"));
         assert!(extension.is_some());
+        assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
     }
 
     #[test]
-    fn runtime_authority_refuses_a_consumer_that_does_not_accept_the_projection() {
-        let (_temp, conn) = temp_store();
+    fn runtime_authority_capability_refusal_never_invokes_a_forgeable_launch_entrypoint() {
+        let (temp, conn) = temp_store();
         let routine = definition("daily-notes");
         insert_definition(&conn, &routine).unwrap();
         let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
@@ -4560,16 +5330,20 @@ mod tests {
         );
         let mut clock = || now;
         let cancelled = || false;
+        let authority = CountingAuthority::default();
+        let runtime = ForgingAuthorityUnsupportedRuntime {
+            launches: Cell::new(0),
+        };
         let mut control = DispatchControl {
             clock: &mut clock,
             cancelled: &cancelled,
-            authority: AutomationAuthorityMode::RuntimeAuthority(&VectorAuthority),
+            authority: AutomationAuthorityMode::RuntimeAuthority(&authority),
             scheduler_fence: None,
         };
 
         let dispatch = dispatch_occurrence_with_clock(
             &conn,
-            &ContainedRuntime,
+            &runtime,
             &routine,
             occurrence_id,
             routine.cwd.as_deref().unwrap(),
@@ -4583,23 +5357,542 @@ mod tests {
 
         assert_eq!(outcome.status, "failed");
         assert_eq!(outcome.session_id, None);
+        assert_eq!(authority.resolve_calls.get(), 1);
+        assert_eq!(authority.terminal_calls.get(), 1);
+        assert_eq!(
+            runtime.launches.get(),
+            0,
+            "dispatcher-controlled refusal must not invoke any runtime launch method"
+        );
         assert_eq!(
             outcome.error.as_deref(),
-            Some("runtime does not accept automation authority projections")
+            Some("runtime does not accept automation authority projections; no process started")
         );
-        let (attempt_state, session_status): (String, String) = conn
+        let state = conn
             .query_row(
-                "SELECT a.state, s.status
+                "SELECT o.state, o.failure_reason, o.updated_at,
+                        r.status, r.finished_at, r.receipt_id,
+                        a.state, a.failure_class, a.state_reason, a.settled_at,
+                        s.status, s.updated_at
                  FROM automation_attempts AS a
                  JOIN automation_runs AS r ON r.id = a.run_id
+                 JOIN automation_occurrences AS o ON o.id = r.occurrence_id
                  JOIN sessions AS s ON s.id = r.session_id
                  WHERE r.id = ?1",
                 [&outcome.run_id],
+                |row| {
+                    Ok(NoLaunchTerminalState {
+                        occurrence_state: row.get(0)?,
+                        occurrence_reason: row.get(1)?,
+                        occurrence_updated_at: row.get(2)?,
+                        run_status: row.get(3)?,
+                        run_finished_at: row.get(4)?,
+                        receipt_id: row.get(5)?,
+                        attempt_state: row.get(6)?,
+                        attempt_failure_class: row.get(7)?,
+                        attempt_reason: row.get(8)?,
+                        attempt_settled_at: row.get(9)?,
+                        session_status: row.get(10)?,
+                        session_updated_at: row.get(11)?,
+                    })
+                },
+            )
+            .unwrap();
+        let receipt_id = state
+            .receipt_id
+            .expect("terminal Runtime Authority receipt");
+        let terminal_time = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        assert_eq!(state.occurrence_state, "failed");
+        assert_eq!(
+            state.occurrence_reason.as_deref(),
+            Some("runtime does not accept automation authority projections; no process started")
+        );
+        assert_eq!(state.occurrence_updated_at, terminal_time);
+        assert_eq!(state.run_status, "failed");
+        assert_eq!(
+            state.run_finished_at.as_deref(),
+            Some(terminal_time.as_str())
+        );
+        assert_eq!(state.attempt_state, "failed");
+        assert_eq!(
+            state.attempt_failure_class.as_deref(),
+            Some("runtime_authority_unsupported")
+        );
+        assert_eq!(
+            state.attempt_reason.as_deref(),
+            Some("runtime does not accept automation authority projections; no process started")
+        );
+        assert_eq!(
+            state.attempt_settled_at.as_deref(),
+            Some(terminal_time.as_str())
+        );
+        assert_eq!(state.session_status, "failed");
+        assert_eq!(state.session_updated_at, terminal_time);
+        let counts: (i64, i64, i64) = conn
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM automation_receipts WHERE run_id = ?1),
+                    (SELECT COUNT(*) FROM automation_receipt_authority_extensions
+                     WHERE run_id = ?1),
+                    (SELECT COUNT(*) FROM automation_events
+                     WHERE stream_kind = 'run' AND stream_id = ?1
+                       AND json_extract(event_json, '$.kind') = 'receipt.recorded')",
+                [&outcome.run_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(counts, (1, 1, 1));
+        assert_eq!(
+            super::super::contract::events::stream_head(&conn, "run", &outcome.run_id).unwrap(),
+            Some(0)
+        );
+        drop(conn);
+
+        let reopened =
+            crate::store::open_store(&temp.path().join("store.sqlite")).expect("reopened store");
+        let authorized = super::super::receipts::read_authorized_receipt(
+            &reopened,
+            &receipt_id,
+            &VectorAuthority,
+        )
+        .unwrap()
+        .expect("authorized no-launch receipt");
+        let receipt = serde_json::to_value(&authorized.receipt).unwrap();
+        assert_eq!(receipt["identity"]["familiarId"], json!("charm"));
+        assert_eq!(
+            receipt["authority"]["principal"]["principalId"],
+            json!("principal:val")
+        );
+        assert_eq!(receipt["exercisedCapabilities"], json!([]));
+        assert_eq!(receipt["sideEffectClass"], json!("none"));
+        assert!(receipt.get("runtime").is_none());
+        assert!(receipt.get("resultDigest").is_none());
+        assert!(receipt.get("deliveryDigest").is_none());
+        let authority = serde_json::to_value(&authorized.authority).unwrap();
+        assert_eq!(
+            authority["receiptEvidence"]["baseReceiptDigest"]["value"],
+            receipt["integrity"]["value"]
+        );
+        assert_eq!(
+            authority["receiptEvidence"]["bindingDigest"],
+            authority["executionBinding"]["integrity"]
+        );
+        assert_eq!(
+            authority["receiptEvidence"]["capabilities"]["exercised"],
+            json!([])
+        );
+        assert_eq!(
+            authority["receiptEvidence"]["risk"]["sideEffectClass"],
+            json!("external_mutation")
+        );
+        assert_ne!(
+            authority["receiptEvidence"]["authentication"]["signature"],
+            authority["executionBinding"]["authentication"]["signature"]
+        );
+    }
+
+    #[test]
+    fn terminal_authority_producer_refusal_preserves_dispatching_state() {
+        let (_temp, conn) = temp_store();
+        let routine = definition("terminal-producer-refusal");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let occurrence_id = "occurrence.terminal-producer-refusal";
+        assert!(
+            insert_claimed_occurrence(&conn, occurrence_id, &routine.id, "daemon", 60, now)
+                .unwrap()
+        );
+        let mut clock = || now;
+        let cancelled = || false;
+        let mut control = DispatchControl {
+            clock: &mut clock,
+            cancelled: &cancelled,
+            authority: AutomationAuthorityMode::RuntimeAuthority(&RefusingTerminalAuthority),
+            scheduler_fence: None,
+        };
+
+        let error = match dispatch_occurrence_with_clock(
+            &conn,
+            &ContainedRuntime,
+            &routine,
+            occurrence_id,
+            routine.cwd.as_deref().unwrap(),
+            now,
+            &mut control,
+        ) {
+            Ok(_) => panic!("terminal producer refusal must fail closed"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("AUTHORITY_STALE"), "{error}");
+        assert!(!error.contains("private terminal signer detail"), "{error}");
+        let (run_id, session_id): (String, String) = conn
+            .query_row(
+                "SELECT id, session_id FROM automation_runs WHERE occurrence_id = ?1",
+                [occurrence_id],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .unwrap();
-        assert_eq!(attempt_state, "failed");
-        assert_eq!(session_status, "failed");
+        assert_dispatching_without_receipt(&conn, &run_id, occurrence_id, &session_id);
+    }
+
+    #[test]
+    fn generic_and_io_authority_launch_failures_do_not_produce_receipts() {
+        for (runtime, expected_failure) in [
+            (
+                &GenericAuthorityRejectingRuntime as &dyn SessionRuntime,
+                "launch_refused",
+            ),
+            (
+                &IoAuthorityRejectingRuntime as &dyn SessionRuntime,
+                "runtime_unavailable",
+            ),
+        ] {
+            let (_temp, conn) = temp_store();
+            let routine = definition("non-terminal-authority-error");
+            insert_definition(&conn, &routine).unwrap();
+            let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+            let occurrence_id = "occurrence.non-terminal-authority-error";
+            assert!(insert_claimed_occurrence(
+                &conn,
+                occurrence_id,
+                &routine.id,
+                "daemon",
+                60,
+                now
+            )
+            .unwrap());
+            let mut clock = || now;
+            let cancelled = || false;
+            let mut control = DispatchControl {
+                clock: &mut clock,
+                cancelled: &cancelled,
+                authority: AutomationAuthorityMode::RuntimeAuthority(&VectorAuthority),
+                scheduler_fence: None,
+            };
+
+            let dispatch = dispatch_occurrence_with_clock(
+                &conn,
+                runtime,
+                &routine,
+                occurrence_id,
+                routine.cwd.as_deref().unwrap(),
+                now,
+                &mut control,
+            )
+            .unwrap();
+            let DispatchAttempt::Completed(outcome) = dispatch else {
+                panic!("generic authority-aware failure must settle");
+            };
+
+            assert_eq!(outcome.status, "failed");
+            let failure_class: Option<String> = conn
+                .query_row(
+                    "SELECT failure_class FROM automation_attempts WHERE run_id = ?1",
+                    [&outcome.run_id],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(failure_class.as_deref(), Some(expected_failure));
+            assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
+        }
+    }
+
+    #[test]
+    fn terminal_authority_verifier_refusal_rolls_back_lifecycle_and_evidence() {
+        let (_temp, conn) = temp_store();
+        let routine = definition("terminal-verifier-refusal");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let occurrence_id = "occurrence.terminal-verifier-refusal";
+        assert!(
+            insert_claimed_occurrence(&conn, occurrence_id, &routine.id, "daemon", 60, now)
+                .unwrap()
+        );
+        let mut clock = || now;
+        let cancelled = || false;
+        let mut control = DispatchControl {
+            clock: &mut clock,
+            cancelled: &cancelled,
+            authority: AutomationAuthorityMode::RuntimeAuthority(
+                &RefusingTerminalVerifierAuthority,
+            ),
+            scheduler_fence: None,
+        };
+
+        let error = match dispatch_occurrence_with_clock(
+            &conn,
+            &ContainedRuntime,
+            &routine,
+            occurrence_id,
+            routine.cwd.as_deref().unwrap(),
+            now,
+            &mut control,
+        ) {
+            Ok(_) => panic!("terminal verification refusal must roll back"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.contains("terminal automation authority evidence is invalid"),
+            "{error}"
+        );
+        assert!(
+            !error.contains("private terminal verifier detail"),
+            "{error}"
+        );
+        let (run_id, session_id): (String, String) = conn
+            .query_row(
+                "SELECT id, session_id FROM automation_runs WHERE occurrence_id = ?1",
+                [occurrence_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_dispatching_without_receipt(&conn, &run_id, occurrence_id, &session_id);
+    }
+
+    #[test]
+    fn terminal_authority_sidecar_failure_rolls_back_lifecycle_event_and_link() {
+        let (_temp, conn) = temp_store();
+        let routine = definition("terminal-sidecar-failure");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let occurrence_id = "occurrence.terminal-sidecar-failure";
+        assert!(
+            insert_claimed_occurrence(&conn, occurrence_id, &routine.id, "daemon", 60, now)
+                .unwrap()
+        );
+        conn.execute_batch(
+            "CREATE TRIGGER reject_terminal_authority_sidecar
+             BEFORE INSERT ON automation_receipt_authority_extensions
+             BEGIN
+                 SELECT RAISE(ABORT, 'synthetic sidecar failure');
+             END;",
+        )
+        .unwrap();
+        let mut clock = || now;
+        let cancelled = || false;
+        let mut control = DispatchControl {
+            clock: &mut clock,
+            cancelled: &cancelled,
+            authority: AutomationAuthorityMode::RuntimeAuthority(&VectorAuthority),
+            scheduler_fence: None,
+        };
+
+        let error = match dispatch_occurrence_with_clock(
+            &conn,
+            &ContainedRuntime,
+            &routine,
+            occurrence_id,
+            routine.cwd.as_deref().unwrap(),
+            now,
+            &mut control,
+        ) {
+            Ok(_) => panic!("sidecar failure must roll back the full settlement"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("synthetic sidecar failure"), "{error}");
+        let (run_id, session_id): (String, String) = conn
+            .query_row(
+                "SELECT id, session_id FROM automation_runs WHERE occurrence_id = ?1",
+                [occurrence_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_dispatching_without_receipt(&conn, &run_id, occurrence_id, &session_id);
+    }
+
+    #[test]
+    fn stale_scheduler_after_terminal_signing_rolls_back_every_settlement_write() {
+        let (temp, conn) = temp_store();
+        let routine = definition("stale-terminal-authority");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let leadership =
+            super::super::leadership::SchedulerLeadership::acquire(temp.path(), &conn, now)
+                .unwrap();
+        let occurrence_id = "occurrence.stale-terminal-authority";
+        assert!(
+            insert_claimed_occurrence(&conn, occurrence_id, &routine.id, "daemon", 60, now)
+                .unwrap()
+        );
+        conn.execute(
+            "UPDATE automation_occurrences
+             SET scheduler_generation = ?2
+             WHERE id = ?1",
+            rusqlite::params![occurrence_id, leadership.fence().generation()],
+        )
+        .unwrap();
+        let authority = SupersedingTerminalAuthority {
+            conn: &conn,
+            terminal_calls: Cell::new(0),
+        };
+        let (launch, attempt) = persist_authority_attempt(
+            &conn,
+            &routine,
+            occurrence_id,
+            "run-stale-terminal-authority",
+            now,
+            &authority,
+            Some(&leadership.fence()),
+        );
+        let resolved = attempt.authority.as_deref().unwrap();
+
+        let error = settle_runtime_authority_unsupported(
+            &conn,
+            UnsupportedAuthorityLaunch {
+                occurrence_id,
+                run_id: &attempt.run_id,
+                attempt_number: attempt.attempt_number,
+                session_id: &launch.id,
+                familiar_id: routine.familiar_id.as_deref().unwrap(),
+                resolved,
+                authority: &authority,
+                scheduler_fence: Some(&leadership.fence()),
+            },
+            now,
+        )
+        .expect_err("stale scheduler must refuse terminal commitment");
+
+        assert_eq!(authority.terminal_calls.get(), 1);
+        assert!(error.contains("scheduler fence is stale"), "{error}");
+        assert_dispatching_without_receipt(&conn, &attempt.run_id, occurrence_id, &launch.id);
+    }
+
+    #[test]
+    fn no_launch_receipt_uses_the_exact_next_run_event_sequence() {
+        let (_temp, conn) = temp_store();
+        let routine = definition("no-launch-event-sequence");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let occurrence_id = "occurrence.no-launch-event-sequence";
+        assert!(
+            insert_claimed_occurrence(&conn, occurrence_id, &routine.id, "daemon", 60, now)
+                .unwrap()
+        );
+        let (launch, attempt) = persist_authority_attempt(
+            &conn,
+            &routine,
+            occurrence_id,
+            "run-no-launch-event-sequence",
+            now,
+            &VectorAuthority,
+            None,
+        );
+        let existing: crate::automations::contract::types::EventEnvelope =
+            serde_json::from_value(json!({
+                "schemaVersion": "coven.automations.v1",
+                "eventId": "evtruntransition00000001",
+                "stream": {"kind": "run", "id": attempt.run_id},
+                "sequence": 0,
+                "recordedAt": "2026-09-03T12:00:00.000Z",
+                "observedAt": "2026-09-03T12:00:00.000Z",
+                "producer": {"component": "coven-daemon", "instanceId": "daemon@test"},
+                "automationId": routine.id,
+                "occurrenceId": occurrence_id,
+                "runId": attempt.run_id,
+                "kind": "run.transitioned",
+                "summary": "run accepted for dispatch",
+                "payload": {
+                    "entity": "run",
+                    "from": "accepted",
+                    "to": "running",
+                    "reason": "dispatch"
+                },
+                "privacy": {
+                    "classification": "operational",
+                    "retention": {"classification": "standard"}
+                }
+            }))
+            .unwrap();
+        super::super::contract::events::append_event(&conn, &existing, 0).unwrap();
+        let resolved = attempt.authority.as_deref().unwrap();
+
+        assert_eq!(
+            settle_runtime_authority_unsupported(
+                &conn,
+                UnsupportedAuthorityLaunch {
+                    occurrence_id,
+                    run_id: &attempt.run_id,
+                    attempt_number: attempt.attempt_number,
+                    session_id: &launch.id,
+                    familiar_id: routine.familiar_id.as_deref().unwrap(),
+                    resolved,
+                    authority: &VectorAuthority,
+                    scheduler_fence: None,
+                },
+                now,
+            )
+            .unwrap(),
+            ReceiptCommitOutcome::Committed
+        );
+        let receipt_sequence: i64 = conn
+            .query_row(
+                "SELECT sequence FROM automation_events
+                 WHERE stream_kind = 'run' AND stream_id = ?1
+                   AND json_extract(event_json, '$.kind') = 'receipt.recorded'",
+                [&attempt.run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(receipt_sequence, 1);
+        assert_eq!(
+            super::super::contract::events::stream_head(&conn, "run", &attempt.run_id).unwrap(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn no_launch_receipt_settlement_replays_without_a_duplicate_event() {
+        let (_temp, conn) = temp_store();
+        let routine = definition("no-launch-replay");
+        insert_definition(&conn, &routine).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let occurrence_id = "occurrence.no-launch-replay";
+        assert!(
+            insert_claimed_occurrence(&conn, occurrence_id, &routine.id, "daemon", 60, now)
+                .unwrap()
+        );
+        let (launch, attempt) = persist_authority_attempt(
+            &conn,
+            &routine,
+            occurrence_id,
+            "run-no-launch-replay",
+            now,
+            &VectorAuthority,
+            None,
+        );
+        let resolved = attempt.authority.as_deref().unwrap();
+        let rejected = || UnsupportedAuthorityLaunch {
+            occurrence_id,
+            run_id: &attempt.run_id,
+            attempt_number: attempt.attempt_number,
+            session_id: &launch.id,
+            familiar_id: routine.familiar_id.as_deref().unwrap(),
+            resolved,
+            authority: &VectorAuthority,
+            scheduler_fence: None,
+        };
+
+        assert_eq!(
+            settle_runtime_authority_unsupported(&conn, rejected(), now).unwrap(),
+            ReceiptCommitOutcome::Committed
+        );
+        assert_eq!(
+            settle_runtime_authority_unsupported(
+                &conn,
+                rejected(),
+                now + chrono::Duration::seconds(30),
+            )
+            .unwrap(),
+            ReceiptCommitOutcome::Replayed
+        );
+        assert_eq!(receipt_artifact_counts(&conn, &attempt.run_id), (1, 1, 1));
+        assert_eq!(
+            super::super::contract::events::stream_head(&conn, "run", &attempt.run_id).unwrap(),
+            Some(0)
+        );
     }
 
     #[test]
@@ -4787,6 +6080,10 @@ mod tests {
         assert_eq!(attempt_state, "failed");
         assert!(authority.is_some());
         assert_eq!(occurrence_state, "failed");
+        assert_eq!(
+            receipt_artifact_counts(&conn, "run.daily-notes-no-process"),
+            (0, 0, 0)
+        );
     }
 
     #[test]
@@ -4844,6 +6141,7 @@ mod tests {
         assert_eq!(attempt_state, "failed");
         assert!(authority.is_some());
         assert_eq!(occurrence_state, "failed");
+        assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
     }
 
     #[test]
@@ -4909,6 +6207,7 @@ mod tests {
         assert_ne!(attempts[0].1, attempts[1].1);
         assert_eq!(attempts[1].2, "adopted");
         assert!(attempts[1].3.is_none());
+        assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
     }
 
     #[test]
@@ -5370,10 +6669,15 @@ mod tests {
         let (_temp, conn) = temp_store();
         insert_definition(&conn, &definition("daily")).unwrap();
         let launched_at = Utc::now();
-        let outcome =
-            run_routine_now(&conn, &ContainedRuntime, &definition("daily"), launched_at).unwrap();
+        let runtime = BaseV1CapabilityProbeRuntime {
+            capability_queries: Cell::new(0),
+            launches: Cell::new(0),
+        };
+        let outcome = run_routine_now(&conn, &runtime, &definition("daily"), launched_at).unwrap();
         assert_eq!(outcome.status, "running");
         assert!(outcome.session_id.is_some());
+        assert_eq!(runtime.capability_queries.get(), 0);
+        assert_eq!(runtime.launches.get(), 1);
 
         let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs.len(), 1);
@@ -6059,6 +7363,7 @@ mod tests {
 
         let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs[0].status, "failed");
+        assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
         assert_eq!(runs[0].exit_code, Some(17));
 
         let state: String = conn
@@ -6236,6 +7541,7 @@ mod tests {
 
         let runs = super::super::runs::list_runs(&conn, "daily", 10).unwrap();
         assert_eq!(runs[0].status, "failed");
+        assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
 
         let state: String = conn
             .query_row(

--- a/crates/coven-cli/src/automations/runs.rs
+++ b/crates/coven-cli/src/automations/runs.rs
@@ -60,7 +60,7 @@ pub const AUTOMATION_ATTEMPTS_SCHEMA_SQL: &str = "
             failure_class IS NULL OR failure_class IN (
                 'transient_dispatch', 'lease_expired', 'runtime_unavailable',
                 'launch_refused', 'runtime_error', 'timeout', 'cancelled',
-                'ambiguous_evidence'
+                'ambiguous_evidence', 'runtime_authority_unsupported'
             )
         ),
         prior_attempt_number INTEGER CHECK (
@@ -647,6 +647,176 @@ pub fn ensure_authority_columns(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn ensure_runtime_authority_unsupported_failure_class(conn: &Connection) -> Result<()> {
+    let table_sql: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'table' AND name = 'automation_attempts'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .context("failed to inspect automation_attempts schema")?;
+    let Some(table_sql) = table_sql else {
+        return Ok(());
+    };
+    if !table_sql.contains("failure_class") || table_sql.contains("'runtime_authority_unsupported'")
+    {
+        return Ok(());
+    }
+    anyhow::ensure!(
+        conn.is_autocommit(),
+        "automation attempt failure-class migration requires autocommit"
+    );
+    let attempt_columns = conn
+        .prepare("PRAGMA table_info(automation_attempts)")
+        .context("failed to inspect automation_attempt columns before failure-class migration")?
+        .query_map([], |row| row.get::<_, String>(1))
+        .context("failed to query automation_attempt columns before failure-class migration")?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read automation_attempt columns before failure-class migration")?;
+    let authority_extension_source = if attempt_columns
+        .iter()
+        .any(|column| column == "authority_extension_json")
+    {
+        "authority_extension_json"
+    } else {
+        "NULL"
+    };
+    let schema_objects = conn
+        .prepare(
+            "SELECT type, name, sql
+             FROM sqlite_master
+             WHERE tbl_name = 'automation_attempts'
+               AND type IN ('index', 'trigger')
+               AND sql IS NOT NULL
+             ORDER BY type, name",
+        )
+        .context("failed to inspect automation_attempt indexes and triggers")?
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .context("failed to query automation_attempt indexes and triggers")?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read automation_attempt indexes and triggers")?;
+    let foreign_keys_enabled: bool = conn
+        .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+        .context("failed to inspect SQLite foreign-key mode")?;
+    let legacy_alter_table_enabled: bool = conn
+        .query_row("PRAGMA legacy_alter_table", [], |row| row.get(0))
+        .context("failed to inspect SQLite alter-table mode")?;
+    let migration = (|| -> Result<()> {
+        conn.execute_batch(
+            "PRAGMA foreign_keys = OFF;
+             PRAGMA legacy_alter_table = ON;
+             BEGIN IMMEDIATE;",
+        )
+        .context("failed to begin automation attempt failure-class migration")?;
+        let current_table_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table' AND name = 'automation_attempts'",
+                [],
+                |row| row.get(0),
+            )
+            .context("failed to recheck automation_attempts schema during migration")?;
+        if current_table_sql.contains("'runtime_authority_unsupported'") {
+            conn.execute_batch("COMMIT")
+                .context("failed to finish concurrent automation attempt migration")?;
+            return Ok(());
+        }
+        for (object_type, name, _) in &schema_objects {
+            let quoted_name = name.replace('"', "\"\"");
+            conn.execute_batch(&format!("DROP {object_type} IF EXISTS \"{quoted_name}\";"))
+                .with_context(|| {
+                    format!("failed to drop automation_attempt schema object {name} for migration")
+                })?;
+        }
+        conn.execute_batch(
+            "ALTER TABLE automation_attempts
+                 RENAME TO automation_attempts_legacy_failure_class;",
+        )
+        .context("failed to rename legacy automation_attempts table")?;
+        conn.execute_batch(AUTOMATION_ATTEMPTS_SCHEMA_SQL)
+            .context("failed to recreate automation_attempts schema")?;
+        conn.execute_batch(&format!(
+            "INSERT INTO automation_attempts (
+                id, run_id, occurrence_id, attempt_number, adoption_key,
+                occurrence_fence_generation, dispatch_generation, state,
+                failure_class, prior_attempt_number, prior_disposition,
+                retry_classification, authority_extension_json, not_before,
+                session_id, state_reason, opened_at, settled_at
+             )
+             SELECT id, run_id, occurrence_id, attempt_number, adoption_key,
+                    occurrence_fence_generation, dispatch_generation, state,
+                    failure_class, prior_attempt_number, prior_disposition,
+                    retry_classification, {authority_extension_source}, not_before,
+                    session_id, state_reason, opened_at, settled_at
+             FROM automation_attempts_legacy_failure_class;
+             DROP TABLE automation_attempts_legacy_failure_class;"
+        ))
+        .context("failed to copy automation attempts into the widened schema")?;
+        for (_, name, sql) in &schema_objects {
+            if matches!(
+                name.as_str(),
+                "idx_automation_attempts_dispatch"
+                    | "automation_attempts_terminal_immutable"
+                    | "automation_attempts_delete_terminal_refused"
+            ) {
+                continue;
+            }
+            conn.execute_batch(sql).with_context(|| {
+                format!("failed to restore automation_attempt schema object {name}")
+            })?;
+        }
+        let foreign_key_errors: i64 = conn
+            .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+                row.get(0)
+            })
+            .context("failed to verify foreign keys after automation attempt migration")?;
+        anyhow::ensure!(
+            foreign_key_errors == 0,
+            "automation attempt failure-class migration produced {foreign_key_errors} foreign-key violation(s)"
+        );
+        conn.execute_batch("COMMIT")
+            .context("failed to commit automation attempt failure-class migration")
+    })();
+    let mut failure = migration.err();
+    if failure.is_some() && !conn.is_autocommit() {
+        if let Err(rollback_error) = conn.execute_batch("ROLLBACK;") {
+            let migration_error = failure.take().expect("migration failure is present");
+            failure = Some(migration_error.context(format!(
+                "failed to roll back automation attempt failure-class migration: {rollback_error}"
+            )));
+        }
+    }
+    if !legacy_alter_table_enabled {
+        if let Err(restore_error) = conn.execute_batch("PRAGMA legacy_alter_table = OFF;") {
+            failure = Some(match failure.take() {
+                Some(migration_error) => migration_error.context(format!(
+                    "also failed to restore SQLite alter-table mode: {restore_error}"
+                )),
+                None => restore_error.into(),
+            });
+        }
+    }
+    if foreign_keys_enabled {
+        if let Err(restore_error) = conn.execute_batch("PRAGMA foreign_keys = ON;") {
+            failure = Some(match failure.take() {
+                Some(migration_error) => migration_error.context(format!(
+                    "also failed to restore SQLite foreign-key mode: {restore_error}"
+                )),
+                None => restore_error.into(),
+            });
+        }
+    }
+    failure.map_or(Ok(()), Err)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -760,6 +930,289 @@ mod tests {
         assert!(conn
             .execute("DELETE FROM automation_attempts WHERE id = 'attempt-1'", [],)
             .is_err());
+    }
+
+    #[test]
+    fn initialize_store_migrates_the_no_launch_failure_class_without_losing_attempt_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_initialized_store(&path).unwrap();
+        let legacy_attempt_schema =
+            AUTOMATION_ATTEMPTS_SCHEMA_SQL.replace(", 'runtime_authority_unsupported'", "");
+        conn.execute(
+            "INSERT INTO automation_occurrences (
+                id, automation_id, scheduled_for, state, attempt, created_at, updated_at
+             ) VALUES (
+                'occurrence-existing', 'automation-existing',
+                '2026-09-03T12:00:00.000Z', 'running', 1,
+                '2026-09-03T12:00:00.000Z', '2026-09-03T12:00:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (
+                id, project_root, harness, title, status, created_at, updated_at
+             ) VALUES (
+                'session-existing', '/work/project', 'coven-code', 'existing',
+                'created', '2026-09-03T12:00:00.000Z', '2026-09-03T12:00:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO automation_runs (
+                id, automation_id, occurrence_id, session_id, runtime, status, started_at
+             ) VALUES (
+                'run-existing', 'automation-existing', 'occurrence-existing',
+                'session-existing', 'coven-code', 'running', '2026-09-03T12:00:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO automation_attempts (
+                id, run_id, occurrence_id, attempt_number, adoption_key,
+                occurrence_fence_generation, state, retry_classification,
+                authority_extension_json, not_before, opened_at
+             ) VALUES (
+                'attempt-existing', 'run-existing', 'occurrence-existing', 1,
+                'automation:run-existing:1', 1, 'dispatching', 'initial',
+                '{\"profile\":\"coven.automations.authority.v1\"}',
+                '2026-09-03T12:00:00.000Z', '2026-09-03T12:00:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TABLE receipt_link (
+                attempt_id TEXT NOT NULL
+                    REFERENCES automation_attempts(id) ON DELETE RESTRICT
+             );
+             INSERT INTO receipt_link (attempt_id) VALUES ('attempt-existing');
+
+             PRAGMA foreign_keys = OFF;
+             PRAGMA legacy_alter_table = ON;
+             BEGIN IMMEDIATE;
+             DROP TRIGGER automation_attempt_adoption_key_global_insert;
+             DROP TRIGGER automation_attempts_terminal_immutable;
+             DROP TRIGGER automation_attempts_delete_terminal_refused;
+             DROP TRIGGER automation_attempt_authority_immutable;
+             DROP TRIGGER automation_attempt_authority_delete_refused;
+             DROP INDEX idx_automation_attempts_dispatch;
+             ALTER TABLE automation_attempts
+                 RENAME TO automation_attempts_current_failure_class;",
+        )
+        .unwrap();
+        conn.execute_batch(&legacy_attempt_schema).unwrap();
+        conn.execute_batch(
+            "INSERT INTO automation_attempts (
+                id, run_id, occurrence_id, attempt_number, adoption_key,
+                occurrence_fence_generation, dispatch_generation, state,
+                failure_class, prior_attempt_number, prior_disposition,
+                retry_classification, authority_extension_json, not_before,
+                session_id, state_reason, opened_at, settled_at
+             )
+             SELECT id, run_id, occurrence_id, attempt_number, adoption_key,
+                    occurrence_fence_generation, dispatch_generation, state,
+                    failure_class, prior_attempt_number, prior_disposition,
+                    retry_classification, authority_extension_json, not_before,
+                    session_id, state_reason, opened_at, settled_at
+             FROM automation_attempts_current_failure_class;
+             DROP TABLE automation_attempts_current_failure_class;
+             CREATE INDEX idx_automation_attempts_existing_run
+                 ON automation_attempts(run_id);
+             CREATE TRIGGER automation_attempts_existing_insert
+             AFTER INSERT ON automation_attempts
+             BEGIN
+                 SELECT NEW.id;
+             END;
+             COMMIT;
+             PRAGMA legacy_alter_table = OFF;
+             PRAGMA foreign_keys = ON;",
+        )
+        .unwrap();
+        drop(conn);
+
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_initialized_store(&path).unwrap();
+
+        assert!(conn
+            .execute(
+                "UPDATE automation_attempts
+                 SET failure_class = 'not_a_failure_class'
+                 WHERE id = 'attempt-existing'",
+                [],
+            )
+            .is_err());
+        conn.execute(
+            "UPDATE automation_attempts
+             SET state = 'failed',
+                 failure_class = 'runtime_authority_unsupported',
+                 state_reason = 'runtime does not accept automation authority projections; no process started',
+                 settled_at = '2026-09-03T12:00:01.000Z'
+             WHERE id = 'attempt-existing'",
+            [],
+        )
+        .unwrap();
+        let preserved: (String, String, String, String) = conn
+            .query_row(
+                "SELECT run_id, occurrence_id, failure_class, authority_extension_json
+                 FROM automation_attempts
+                 WHERE id = 'attempt-existing'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            preserved,
+            (
+                "run-existing".to_string(),
+                "occurrence-existing".to_string(),
+                "runtime_authority_unsupported".to_string(),
+                "{\"profile\":\"coven.automations.authority.v1\"}".to_string(),
+            )
+        );
+        assert_eq!(
+            conn.query_row("PRAGMA foreign_keys", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        let foreign_key_errors: i64 = conn
+            .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(foreign_key_errors, 0);
+        let receipt_parent: String = conn
+            .query_row("PRAGMA foreign_key_list(receipt_link)", [], |row| {
+                row.get(2)
+            })
+            .unwrap();
+        assert_eq!(receipt_parent, "automation_attempts");
+        for (object_type, name) in [
+            ("index", "idx_automation_attempts_dispatch"),
+            ("trigger", "automation_attempts_terminal_immutable"),
+            ("trigger", "automation_attempts_delete_terminal_refused"),
+            ("trigger", "automation_attempt_authority_immutable"),
+            ("trigger", "automation_attempt_authority_delete_refused"),
+            ("trigger", "automation_attempt_adoption_key_global_insert"),
+            ("index", "idx_automation_attempts_existing_run"),
+            ("trigger", "automation_attempts_existing_insert"),
+        ] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master
+                     WHERE type = ?1 AND name = ?2 AND tbl_name = 'automation_attempts'",
+                    [object_type, name],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "{object_type} {name} was not preserved");
+        }
+        assert!(conn
+            .execute(
+                "UPDATE automation_attempts
+                 SET authority_extension_json = '{}'
+                 WHERE id = 'attempt-existing'",
+                [],
+            )
+            .is_err());
+        assert!(conn
+            .execute(
+                "UPDATE automation_attempts
+                 SET state_reason = 'rewritten'
+                 WHERE id = 'attempt-existing'",
+                [],
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn initialize_store_rolls_back_a_failed_no_launch_failure_class_migration() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("store.sqlite");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE automation_definitions (id TEXT PRIMARY KEY NOT NULL);
+             CREATE TABLE automation_occurrences (id TEXT PRIMARY KEY NOT NULL);
+             CREATE TABLE sessions (id TEXT PRIMARY KEY NOT NULL);
+             CREATE TABLE automation_runs (id TEXT PRIMARY KEY NOT NULL);
+             INSERT INTO automation_definitions (id) VALUES ('automation-existing');
+             INSERT INTO automation_occurrences (id) VALUES ('occurrence-existing');
+             INSERT INTO sessions (id) VALUES ('session-existing');
+             INSERT INTO automation_runs (id) VALUES ('run-existing');",
+        )
+        .unwrap();
+        let malformed_attempt_schema = AUTOMATION_ATTEMPTS_SCHEMA_SQL
+            .replace(", 'runtime_authority_unsupported'", "")
+            .replace("        state_reason TEXT,\n", "");
+        conn.execute_batch(&malformed_attempt_schema).unwrap();
+        conn.execute(
+            "INSERT INTO automation_attempts (
+                id, run_id, occurrence_id, attempt_number, adoption_key,
+                occurrence_fence_generation, state, retry_classification,
+                authority_extension_json, not_before, session_id, opened_at
+             ) VALUES (
+                'attempt-existing', 'run-existing', 'occurrence-existing', 1,
+                'automation:run-existing:1', 1, 'dispatching', 'initial',
+                '{\"profile\":\"coven.automations.authority.v1\"}',
+                '2026-09-03T12:00:00.000Z', 'session-existing',
+                '2026-09-03T12:00:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let error = initialize_store(&path)
+            .expect_err("an incompatible legacy attempt schema must fail atomically");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to copy automation attempts"),
+            "{error:#}"
+        );
+
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        let table_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table' AND name = 'automation_attempts'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!table_sql.contains("'runtime_authority_unsupported'"));
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM automation_attempts
+                 WHERE id = 'attempt-existing'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'table'
+                   AND name = 'automation_attempts_legacy_failure_class'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0
+        );
+        assert_eq!(
+            conn.query_row("PRAGMA foreign_keys", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -586,11 +586,11 @@ pub fn initialize_store(path: &Path) -> Result<()> {
     let conn = Connection::open(path)
         .with_context(|| format!("failed to open Coven store at {}", path.display()))?;
     configure_initializing_connection(&conn)?;
-    // The Ward audit migrator owns its own transaction because a legacy table
-    // rebuild must be atomic. Run it before our transaction for the remaining
-    // idempotent store schema work; nesting these transactions is invalid in
-    // SQLite. Its transaction also serializes concurrent Ward upgrades.
+    // Table-rebuild migrators own their transactions so they can change SQLite
+    // foreign-key mode safely and roll back atomically. Run them before the
+    // transaction for the remaining idempotent schema work.
     ensure_ward_audit_schema(&conn)?;
+    crate::automations::runs::ensure_runtime_authority_unsupported_failure_class(&conn)?;
     conn.execute_batch("BEGIN IMMEDIATE")
         .context("failed to acquire SQLite initialization transaction")?;
     let result = initialize_store_schema(&conn);
@@ -1019,8 +1019,8 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
     crate::automations::runs::ensure_timeout_column(conn)?;
     conn.execute_batch(crate::automations::runs::AUTOMATION_ATTEMPTS_SCHEMA_SQL)
         .context("failed to initialize automation attempts and retry state schema")?;
-    crate::automations::command_adoption::ensure_global_adoption_key_guards(conn)?;
     crate::automations::runs::ensure_authority_columns(conn)?;
+    crate::automations::command_adoption::ensure_global_adoption_key_guards(conn)?;
     crate::automations::contract::migration::migrate_legacy_contract_metadata(conn)?;
     conn.execute_batch(crate::automations::contract::events::AUTOMATION_EVENTS_SCHEMA_SQL)
         .context("failed to initialize automation events schema")?;


### PR DESCRIPTION
## Context

Refs #857.

#980 added immutable terminal Runtime Authority receipt storage and validation. This slice wires the first truthful producer case: dispatcher-controlled refusal of an authority-unaware runtime before any runtime method or ownership callback is invoked.

## Implementation

- add a default-false runtime capability query for authority-projection admission
- evaluate that capability only for authority-bound attempts and before calling the runtime
- retain the exact validated execution binding and the same selected authority adapter through dispatch
- build a typed no-launch base receipt with explicit empty exercised capabilities, actual `sideEffectClass: none`, no runtime/result/delivery claims, and durable `runtime_authority_unsupported` failure evidence
- ask the same adapter to sign fresh terminal receipt evidence around the unchanged binding; never reauthorize or reuse the binding signature
- atomically settle session, attempt, occurrence, and run with the same timestamp, append the next run-stream receipt event, commit the base receipt, link the run, and store the verified authority sidecar
- roll back every lifecycle and receipt write on signer, verifier, fence, state, event, or sidecar failure
- migrate existing attempt failure-class constraints safely before the normal store initialization transaction

## Safety boundary

- a runtime reporting no authority support is never invoked, so the proof cannot be forged by a runtime error
- authority-aware runtimes that return generic errors remain receiptless
- shutdown admission/retry, I/O, containment recovery, and launched sessions remain receiptless
- authorized risk may remain `external_mutation`, while actual observed effect is `none`
- retryable attempts never consume the run’s unique receipt slot

## Verification

- API tests: 475 passed
- runner tests: 86 passed
- receipt tests: 36 passed
- authority tests: 16 passed
- run/schema tests: 10 passed
- `cargo fmt --check`
- `cargo check -p coven-cli`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`
- staged privacy and repository secret guards
- independent spec and correctness reviews approved

## Remaining blocker

Launched-session terminal receipts still require durable authenticated runtime evidence for actual side effects, exercised capabilities, normalized results, and deliveries. This PR intentionally does not infer those facts from output, exit success, granted capabilities, or declared risk.