### PR TITLE
diagnostics: identify Windows status writer failure operations

### DIFF
--- a/crates/coven-client/src/lib.rs
+++ b/crates/coven-client/src/lib.rs
@@ -6,6 +6,8 @@ mod lifecycle;
 mod models;
 #[cfg(windows)]
 mod status;
+#[cfg(any(windows, test))]
+mod status_error;
 mod transport;
 
 pub use discovery::DaemonEndpoint;

--- a/crates/coven-client/src/status.rs
+++ b/crates/coven-client/src/status.rs
@@ -2,9 +2,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::ClientError;
+use crate::{status_error::StatusWriteStage, ClientError};
 
-const STATUS_WRITE_OPERATION: &str = "failed to write owner-only Windows daemon status";
 const WINDOWS_OWNER_ONLY_FILE_DACL_SDDL: &str = "D:P(A;;GA;;;OW)";
 
 pub fn write_owner_only_windows_daemon_status(
@@ -18,12 +17,15 @@ pub fn write_owner_only_windows_daemon_status(
             .create_new(true)
             .write(true)
             .open(&temporary_path)
-            .map_err(status_io_error)?;
-        file.write_all(contents).map_err(status_io_error)?;
+            .map_err(|error| StatusWriteStage::CreateTemporary.io_error(error))?;
+        file.write_all(contents)
+            .map_err(|error| StatusWriteStage::WriteContents.io_error(error))?;
         if !contents.ends_with(b"\n") {
-            file.write_all(b"\n").map_err(status_io_error)?;
+            file.write_all(b"\n")
+                .map_err(|error| StatusWriteStage::WriteNewline.io_error(error))?;
         }
-        file.sync_all().map_err(status_io_error)?;
+        file.sync_all()
+            .map_err(|error| StatusWriteStage::SyncTemporary.io_error(error))?;
         drop(file);
         set_owner_only_file_security(&temporary_path)?;
         replace_status_file(&temporary_path, &status_path)
@@ -75,7 +77,7 @@ fn set_owner_only_file_security(path: &Path) -> Result<(), ClientError> {
         )
     } == 0
     {
-        return Err(status_io_error(std::io::Error::last_os_error()));
+        return Err(StatusWriteStage::ConvertDescriptor.io_error(std::io::Error::last_os_error()));
     }
     let _descriptor = LocalAllocation(descriptor);
     let mut dacl_present = 0;
@@ -117,9 +119,8 @@ fn set_owner_only_file_security(path: &Path) -> Result<(), ClientError> {
         )
     };
     if status != 0 {
-        return Err(status_io_error(std::io::Error::from_raw_os_error(
-            status as i32,
-        )));
+        return Err(StatusWriteStage::ApplySecurity
+            .io_error(std::io::Error::from_raw_os_error(status as i32)));
     }
     Ok(())
 }
@@ -161,16 +162,9 @@ fn replace_status_file(temporary_path: &Path, status_path: &Path) -> Result<(), 
                     || code == ERROR_SHARING_VIOLATION as i32
         ) || std::time::Instant::now() >= deadline
         {
-            return Err(status_io_error(error));
+            return Err(StatusWriteStage::ReplaceStatus.io_error(error));
         }
         std::thread::sleep(std::time::Duration::from_millis(5));
-    }
-}
-
-fn status_io_error(source: std::io::Error) -> ClientError {
-    ClientError::Io {
-        operation: STATUS_WRITE_OPERATION,
-        source,
     }
 }
 
@@ -190,7 +184,7 @@ impl CurrentWindowsUser {
 
         let mut process_token = ptr::null_mut();
         if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut process_token) } == 0 {
-            return Err(status_io_error(std::io::Error::last_os_error()));
+            return Err(StatusWriteStage::OpenToken.io_error(std::io::Error::last_os_error()));
         }
         let _token = Handle(process_token);
         let mut bytes = 0;
@@ -216,7 +210,7 @@ impl CurrentWindowsUser {
             )
         } == 0
         {
-            return Err(status_io_error(std::io::Error::last_os_error()));
+            return Err(StatusWriteStage::ReadToken.io_error(std::io::Error::last_os_error()));
         }
         if (bytes as usize) < size_of::<TOKEN_USER>()
             || bytes as usize > words.len() * size_of::<usize>()

--- a/crates/coven-client/src/status.rs
+++ b/crates/coven-client/src/status.rs
@@ -177,7 +177,6 @@ impl CurrentWindowsUser {
         use std::mem::size_of;
         use std::ptr;
         use windows_sys::Win32::{
-            Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER},
             Security::{GetLengthSid, GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER},
             System::Threading::{GetCurrentProcess, OpenProcessToken},
         };
@@ -187,15 +186,7 @@ impl CurrentWindowsUser {
             return Err(StatusWriteStage::OpenToken.io_error(std::io::Error::last_os_error()));
         }
         let _token = Handle(process_token);
-        let mut bytes = 0;
-        let initial = unsafe {
-            GetTokenInformation(process_token, TokenUser, ptr::null_mut(), 0, &mut bytes)
-        };
-        if initial != 0 || unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER || bytes == 0 {
-            return Err(ClientError::Discovery(
-                "unable to size current Windows user token for daemon status".to_owned(),
-            ));
-        }
+        let mut bytes = Self::token_buffer_size(process_token)?;
         let word_len = (bytes as usize)
             .max(1)
             .div_ceil(std::mem::size_of::<usize>());
@@ -226,6 +217,39 @@ impl CurrentWindowsUser {
             ));
         }
         Ok(Self { words })
+    }
+
+    fn token_buffer_size(
+        process_token: windows_sys::Win32::Foundation::HANDLE,
+    ) -> Result<u32, ClientError> {
+        use windows_sys::Win32::{
+            Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER},
+            Security::{GetTokenInformation, TokenUser},
+        };
+
+        let mut bytes = 0;
+        let initial = unsafe {
+            GetTokenInformation(
+                process_token,
+                TokenUser,
+                std::ptr::null_mut(),
+                0,
+                &mut bytes,
+            )
+        };
+        if initial == 0 {
+            let code = unsafe { GetLastError() };
+            if code != ERROR_INSUFFICIENT_BUFFER {
+                return Err(StatusWriteStage::ReadToken
+                    .io_error(std::io::Error::from_raw_os_error(code as i32)));
+            }
+        }
+        if initial != 0 || bytes == 0 {
+            return Err(ClientError::Discovery(
+                "unable to size current Windows user token for daemon status".to_owned(),
+            ));
+        }
+        Ok(bytes)
     }
 
     fn sid(&self) -> windows_sys::Win32::Security::PSID {
@@ -264,6 +288,85 @@ impl Drop for LocalAllocation {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct TestHome(PathBuf);
+
+    impl TestHome {
+        fn new() -> Self {
+            let path = temporary_status_path(&std::env::temp_dir().join("daemon.json"));
+            std::fs::create_dir(&path).expect("create isolated writer test home");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestHome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn missing_status_home_identifies_temporary_creation_and_preserves_os_error() {
+        use windows_sys::Win32::Foundation::ERROR_PATH_NOT_FOUND;
+
+        let parent = TestHome::new();
+        let error = write_owner_only_windows_daemon_status(&parent.0.join("missing"), b"{}")
+            .expect_err("missing parent must reject temporary creation");
+        let ClientError::Io { operation, source } = error else {
+            panic!("temporary creation must retain its I/O error");
+        };
+        assert_eq!(
+            operation,
+            "failed to write owner-only Windows daemon status: create-temporary-file"
+        );
+        assert_eq!(source.raw_os_error(), Some(ERROR_PATH_NOT_FOUND as i32));
+        assert_eq!(std::fs::read_dir(&parent.0).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn blocked_status_replacement_identifies_operation_and_cleans_temporary_file() {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION};
+
+        let home = TestHome::new();
+        let path = home.0.join("daemon.json");
+        std::fs::write(&path, b"old").expect("create current status");
+        let reader = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(&path)
+            .expect("hold a non-sharing status reader");
+        let result = write_owner_only_windows_daemon_status(&home.0, b"new");
+        drop(reader);
+        let error = result.expect_err("non-sharing reader must prevent replacement");
+        let ClientError::Io { operation, source } = error else {
+            panic!("replacement must retain its I/O error");
+        };
+        assert_eq!(
+            operation,
+            "failed to write owner-only Windows daemon status: replace-status-file"
+        );
+        assert!(matches!(source.raw_os_error(), Some(code)
+            if code == ERROR_ACCESS_DENIED as i32 || code == ERROR_SHARING_VIOLATION as i32));
+        assert_eq!(std::fs::read(&path).unwrap(), b"old");
+        assert_eq!(std::fs::read_dir(&home.0).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn invalid_token_size_query_preserves_operation_and_os_error() {
+        use windows_sys::Win32::Foundation::ERROR_INVALID_HANDLE;
+
+        let error = CurrentWindowsUser::token_buffer_size(std::ptr::null_mut())
+            .expect_err("null token must fail the sizing query");
+        let ClientError::Io { operation, source } = error else {
+            panic!("token sizing must retain its I/O error");
+        };
+        assert_eq!(
+            operation,
+            "failed to write owner-only Windows daemon status: read-process-token"
+        );
+        assert_eq!(source.raw_os_error(), Some(ERROR_INVALID_HANDLE as i32));
+    }
 
     #[test]
     fn daemon_status_dacl_does_not_inherit_directory_aces() {

--- a/crates/coven-client/src/status_error.rs
+++ b/crates/coven-client/src/status_error.rs
@@ -1,0 +1,108 @@
+use crate::ClientError;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum StatusWriteStage {
+    CreateTemporary,
+    WriteContents,
+    WriteNewline,
+    SyncTemporary,
+    ConvertDescriptor,
+    OpenToken,
+    ReadToken,
+    ApplySecurity,
+    ReplaceStatus,
+}
+
+impl StatusWriteStage {
+    pub(crate) fn io_error(self, source: std::io::Error) -> ClientError {
+        ClientError::Io {
+            operation: match self {
+                Self::CreateTemporary => {
+                    "failed to write owner-only Windows daemon status: create-temporary-file"
+                }
+                Self::WriteContents => {
+                    "failed to write owner-only Windows daemon status: write-contents"
+                }
+                Self::WriteNewline => {
+                    "failed to write owner-only Windows daemon status: write-newline"
+                }
+                Self::SyncTemporary => {
+                    "failed to write owner-only Windows daemon status: sync-temporary-file"
+                }
+                Self::ConvertDescriptor => {
+                    "failed to write owner-only Windows daemon status: convert-security-descriptor"
+                }
+                Self::OpenToken => {
+                    "failed to write owner-only Windows daemon status: open-process-token"
+                }
+                Self::ReadToken => {
+                    "failed to write owner-only Windows daemon status: read-process-token"
+                }
+                Self::ApplySecurity => {
+                    "failed to write owner-only Windows daemon status: apply-owner-only-security"
+                }
+                Self::ReplaceStatus => {
+                    "failed to write owner-only Windows daemon status: replace-status-file"
+                }
+            },
+            source,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stages_preserve_os_errors_and_expose_only_fixed_operation_labels() {
+        let stages = [
+            (
+                StatusWriteStage::CreateTemporary,
+                "failed to write owner-only Windows daemon status: create-temporary-file",
+            ),
+            (
+                StatusWriteStage::WriteContents,
+                "failed to write owner-only Windows daemon status: write-contents",
+            ),
+            (
+                StatusWriteStage::WriteNewline,
+                "failed to write owner-only Windows daemon status: write-newline",
+            ),
+            (
+                StatusWriteStage::SyncTemporary,
+                "failed to write owner-only Windows daemon status: sync-temporary-file",
+            ),
+            (
+                StatusWriteStage::ConvertDescriptor,
+                "failed to write owner-only Windows daemon status: convert-security-descriptor",
+            ),
+            (
+                StatusWriteStage::OpenToken,
+                "failed to write owner-only Windows daemon status: open-process-token",
+            ),
+            (
+                StatusWriteStage::ReadToken,
+                "failed to write owner-only Windows daemon status: read-process-token",
+            ),
+            (
+                StatusWriteStage::ApplySecurity,
+                "failed to write owner-only Windows daemon status: apply-owner-only-security",
+            ),
+            (
+                StatusWriteStage::ReplaceStatus,
+                "failed to write owner-only Windows daemon status: replace-status-file",
+            ),
+        ];
+        for (stage, expected) in stages {
+            for code in [2, 3, 5, 32, 1307, 1314, 9999] {
+                let error = stage.io_error(std::io::Error::from_raw_os_error(code));
+                let ClientError::Io { operation, source } = error else {
+                    panic!("writer error must retain its I/O variant");
+                };
+                assert_eq!(operation, expected);
+                assert_eq!(source.raw_os_error(), Some(code));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Context

Protected Windows run [34435223248](https://github.com/OpenCoven/chat/actions/runs/34435223248) returned access denied from the atomic status writer, but every I/O failure carried the same operation label. This change identifies the failing operation with a fixed label while retaining the original OS error. Tracks #984; protected diagnosis remains pending.

## Implementation

- Map nine writer operations to fixed labels: temporary-file creation, content/newline writes, sync, descriptor conversion, process-token open/read, owner-only security application, and replacement.
- Preserve `ClientError::Io`, its original source, owner-only security, atomic replacement, retries, cleanup, and observation selection.
- Keep diagnostic mapping testable on every host; labels contain no paths, status contents, or user identifiers.
- Preserve unexpected token-sizing query OS errors under the token-read label; keep successful/zero-size validation separate.
- Add native failure tests for missing-parent creation, non-sharing-reader replacement (including original-file preservation and temporary cleanup), and invalid-token sizing.
- Compatibility: operation strings gain a fixed suffix. Chat's strict classifier must be updated and its SDK validator rebound before this source is adopted for protected validation.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — 3,377 passed, zero failed, five ignored.
- [x] `python3 scripts/check-secrets.py`
- [x] Staged privacy and secret guards.
- [x] `cargo check -p coven-client --all-targets --locked --target x86_64-pc-windows-msvc`
- [x] Regression failed with the generic label, then passed for every stage and preserved OS code.
- [x] Independent review found no issues.
- [x] Native Windows CI job `102746183953` on `367e670a01379799d89b6802e1a00bea7a0e20ef` passed, including all three new failure tests and atomic replacement.
- Linux CI encountered SQLite exit-persistence contention tracked in #986. Focused local reproduction passed; one failed-job retry passed on the same head (job `102749750528`, run attempt 2). No assertion or limit changed.
- Additional Windows-target Clippy found pre-existing `items_after_test_module` in unchanged `discovery.rs` (identical to protected source 705623e9). No suppression added; required host workspace Clippy passes.

## Risk and Rollback

Low runtime risk: only error-operation metadata changes. Revert this commit to restore the generic label. Do not mix this source with the old strict Chat classifier.

## Agent Handoff

The Linux CI retry and coordinated Chat/SDK source binding remain required. A fresh protected run must distinguish the actual failed operation before any permission, privilege, timeout, or dependency repair is proposed. This PR does not claim the underlying access-denied error is fixed.
