### PR TITLE
feat: hold authority runs for trusted terminal evidence

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -12943,6 +12943,49 @@ pub(crate) mod tests {
         release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
     }
 
+    struct TerminalDuringKillRuntime {
+        coven_home: std::path::PathBuf,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl SessionRuntime for TerminalDuringKillRuntime {
+        fn launch_session(&self, _: &SessionLaunch) -> Result<()> {
+            Ok(())
+        }
+
+        fn send_input(&self, _: &str, _: &Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, session_id: &str) -> Result<()> {
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            anyhow::ensure!(call == 0, "duplicate runtime stop");
+            let conn = store::open_store(&store_path(&self.coven_home))?;
+            let stop_fences: i64 = conn.query_row(
+                "SELECT COUNT(*)
+                 FROM automation_stop_fences
+                 WHERE session_id = ?1 AND owner = 'cancellation'",
+                [session_id],
+                |row| row.get(0),
+            )?;
+            anyhow::ensure!(
+                stop_fences == 1,
+                "cancellation must hold its stop fence before the terminal observation"
+            );
+            anyhow::ensure!(
+                store::update_session_terminal_if_active(
+                    &conn,
+                    session_id,
+                    "completed",
+                    Some(0),
+                    &current_timestamp(),
+                )?,
+                "the runtime race must terminalize an active session"
+            );
+            Ok(())
+        }
+    }
+
     #[test]
     fn cancellation_after_the_run_deadline_settles_as_timeout() -> anyhow::Result<()> {
         struct CountingKillRuntime(std::sync::atomic::AtomicUsize);
@@ -13126,6 +13169,371 @@ pub(crate) mod tests {
         let history = cancellation_history(temp_dir.path())?;
         assert_eq!(
             history["event"]["payload"]["runs"][0]["status"],
+            "succeeded"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_authority_terminal_race_after_stop_fence_recovers_across_replays_and_restarts(
+    ) -> anyhow::Result<()> {
+        let (temp_dir, run_id, attempt_id, session_id) =
+            start_running_automation_for_cancellation()?;
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        conn.execute_batch("DROP TRIGGER automation_run_authority_profile_immutable;")?;
+        conn.execute(
+            "UPDATE automation_runs
+             SET authority_profile = ?2
+             WHERE id = ?1",
+            rusqlite::params![
+                run_id,
+                crate::automations::contract::authority::AUTHORITY_PROFILE
+            ],
+        )?;
+        drop(conn);
+
+        let body = cancellation_body(
+            "adopt:cancel:cancellation-target:authority-recovery",
+            &run_id,
+            &attempt_id,
+            &session_id,
+            "recover an authority-bound terminal session",
+        );
+        let runtime = TerminalDuringKillRuntime {
+            coven_home: temp_dir.path().to_path_buf(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        for pass in 0..3 {
+            let recovered = post_cancellation(temp_dir.path(), &body, &runtime)?;
+            assert_eq!(recovered.status, 200, "pass {pass}: {}", recovered.body);
+            let recovered: Value = serde_json::from_str(&recovered.body)?;
+            assert_eq!(
+                recovered["event"]["payload"]["status"], "recovery_required",
+                "pass {pass}"
+            );
+
+            let conn = store::open_store(&store_path(temp_dir.path()))?;
+            assert_eq!(
+                crate::automations::runner::settle_finished_runs(&conn, Utc::now())
+                    .map_err(anyhow::Error::msg)?,
+                crate::automations::runner::SettlementReport::default(),
+                "pass {pass}"
+            );
+            let lifecycle: (
+                String,
+                Option<String>,
+                String,
+                String,
+                String,
+                String,
+                i64,
+                String,
+            ) = conn.query_row(
+                "SELECT o.state, o.failure_reason, r.status, a.state, s.status, c.state,
+                        (SELECT COUNT(*) FROM automation_stop_fences WHERE run_id = r.id),
+                        (
+                            SELECT outcome
+                            FROM automation_command_adoptions
+                            WHERE adoption_key = c.adoption_key
+                        )
+                 FROM automation_runs AS r
+                 JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+                 JOIN automation_attempts AS a ON a.run_id = r.id
+                 JOIN sessions AS s ON s.id = a.session_id
+                 JOIN automation_cancellations AS c ON c.run_id = r.id
+                 WHERE r.id = ?1 AND a.id = ?2",
+                rusqlite::params![run_id, attempt_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                    ))
+                },
+            )?;
+            assert_eq!(
+                lifecycle,
+                (
+                    "recovery_required".to_string(),
+                    Some(
+                        "trusted runtime terminal evidence is required before Runtime Authority settlement"
+                            .to_string()
+                    ),
+                    "running".to_string(),
+                    "started".to_string(),
+                    "completed".to_string(),
+                    "recovery_required".to_string(),
+                    0,
+                    "committed".to_string(),
+                ),
+                "pass {pass}"
+            );
+            drop(conn);
+        }
+        assert_eq!(
+            runtime.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "replay and restart must not reissue the runtime stop"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn base_terminal_race_after_stop_fence_remains_completion_won_across_replay(
+    ) -> anyhow::Result<()> {
+        let (temp_dir, run_id, attempt_id, session_id) =
+            start_running_automation_for_cancellation()?;
+        let body = cancellation_body(
+            "adopt:cancel:cancellation-target:base-terminal-race",
+            &run_id,
+            &attempt_id,
+            &session_id,
+            "completion must remain authoritative",
+        );
+        let runtime = TerminalDuringKillRuntime {
+            coven_home: temp_dir.path().to_path_buf(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        for pass in 0..3 {
+            let rejected = post_cancellation(temp_dir.path(), &body, &runtime)?;
+            assert_eq!(rejected.status, 422, "pass {pass}: {}", rejected.body);
+            let rejected: Value = serde_json::from_str(&rejected.body)?;
+            assert_eq!(
+                rejected["error"]["code"], "ILLEGAL_TRANSITION",
+                "pass {pass}"
+            );
+            assert_eq!(
+                rejected["error"]["message"],
+                "automation completion already won the cancellation race",
+                "pass {pass}"
+            );
+        }
+        assert_eq!(
+            runtime.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "replay must preserve the completion-won cancellation rejection"
+        );
+
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        assert_eq!(
+            crate::automations::runner::settle_finished_runs(&conn, Utc::now())
+                .map_err(anyhow::Error::msg)?
+                .succeeded,
+            1
+        );
+        let lifecycle: (String, String, String, String, String, i64, String) = conn.query_row(
+            "SELECT o.state, r.status, a.state, s.status, c.state,
+                    (SELECT COUNT(*) FROM automation_stop_fences WHERE run_id = r.id),
+                    (
+                        SELECT outcome
+                        FROM automation_command_adoptions
+                        WHERE adoption_key = c.adoption_key
+                    )
+             FROM automation_runs AS r
+             JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+             JOIN automation_attempts AS a ON a.run_id = r.id
+             JOIN sessions AS s ON s.id = a.session_id
+             JOIN automation_cancellations AS c ON c.run_id = r.id
+             WHERE r.id = ?1 AND a.id = ?2",
+            rusqlite::params![run_id, attempt_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            },
+        )?;
+        assert_eq!(
+            lifecycle,
+            (
+                "succeeded".to_string(),
+                "succeeded".to_string(),
+                "succeeded".to_string(),
+                "completed".to_string(),
+                "rejected".to_string(),
+                0,
+                "rejected".to_string(),
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_authority_cancellation_recovery_resumes_after_recovery_state_crash_window(
+    ) -> anyhow::Result<()> {
+        let (temp_dir, run_id, attempt_id, session_id) =
+            start_running_automation_for_cancellation()?;
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        conn.execute_batch("DROP TRIGGER automation_run_authority_profile_immutable;")?;
+        conn.execute(
+            "UPDATE automation_runs
+             SET authority_profile = ?2
+             WHERE id = ?1",
+            rusqlite::params![
+                run_id,
+                crate::automations::contract::authority::AUTHORITY_PROFILE
+            ],
+        )?;
+        drop(conn);
+
+        let body = cancellation_body(
+            "adopt:cancel:cancellation-target:authority-recovery-crash",
+            &run_id,
+            &attempt_id,
+            &session_id,
+            "recover after authority state was held",
+        );
+        crate::automations::cancellation::set_after_stop_fence_test_hook(Some(Box::new(|| {
+            panic!("synthetic crash after durable stop ownership")
+        })));
+        let crashed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            post_cancellation(temp_dir.path(), &body, &NoopSessionRuntime)
+        }));
+        assert!(crashed.is_err(), "the fixture must simulate a crash");
+
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        assert!(store::update_session_terminal_if_active(
+            &conn,
+            &session_id,
+            "completed",
+            Some(0),
+            &current_timestamp(),
+        )?);
+        crate::automations::runner::mark_terminal_stop_for_recovery(
+            &conn,
+            &run_id,
+            &session_id,
+            "cancellation stop outcome was not durably recorded",
+            Utc::now(),
+        )
+        .map_err(anyhow::Error::msg)?;
+        let expired = (Utc::now() - chrono::Duration::minutes(1)).to_rfc3339();
+        conn.execute(
+            "UPDATE automation_cancellations
+             SET execution_expires_at = ?2
+             WHERE adoption_key = ?1 AND state = 'stopping'",
+            rusqlite::params![
+                "adopt:cancel:cancellation-target:authority-recovery-crash",
+                expired
+            ],
+        )?;
+        conn.execute(
+            "UPDATE automation_stop_fences
+             SET execution_expires_at = ?2
+             WHERE operation_key = ?1",
+            rusqlite::params![
+                "adopt:cancel:cancellation-target:authority-recovery-crash",
+                expired
+            ],
+        )?;
+        drop(conn);
+
+        for pass in 0..3 {
+            let conn = store::open_store(&store_path(temp_dir.path()))?;
+            let reconciled = crate::automations::cancellation::reconcile_expired_cancellations(
+                &conn,
+                &NoopSessionRuntime,
+                Utc::now(),
+            )
+            .map_err(anyhow::Error::msg)?;
+            assert_eq!(reconciled, i64::from(pass == 0) as usize, "pass {pass}");
+            drop(conn);
+
+            let recovered = post_cancellation(temp_dir.path(), &body, &NoopSessionRuntime)?;
+            assert_eq!(recovered.status, 200, "pass {pass}: {}", recovered.body);
+            let recovered: Value = serde_json::from_str(&recovered.body)?;
+            assert_eq!(
+                recovered["event"]["payload"]["status"], "recovery_required",
+                "pass {pass}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn base_cancellation_recovery_preserves_known_terminal_completion() -> anyhow::Result<()> {
+        let (temp_dir, run_id, attempt_id, session_id) =
+            start_running_automation_for_cancellation()?;
+        let body = cancellation_body(
+            "adopt:cancel:cancellation-target:base-terminal-recovery",
+            &run_id,
+            &attempt_id,
+            &session_id,
+            "do not hide known completion",
+        );
+        crate::automations::cancellation::set_after_stop_fence_test_hook(Some(Box::new(|| {
+            panic!("synthetic crash after durable stop ownership")
+        })));
+        let crashed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            post_cancellation(temp_dir.path(), &body, &NoopSessionRuntime)
+        }));
+        assert!(crashed.is_err(), "the fixture must simulate a crash");
+
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        crate::automations::runner::mark_active_attempts_for_restart_reconciliation(
+            &conn,
+            Utc::now(),
+        )
+        .map_err(anyhow::Error::msg)?;
+        assert!(store::update_session_terminal_if_active(
+            &conn,
+            &session_id,
+            "completed",
+            Some(0),
+            &current_timestamp(),
+        )?);
+        let expired = (Utc::now() - chrono::Duration::minutes(1)).to_rfc3339();
+        conn.execute(
+            "UPDATE automation_cancellations
+             SET execution_expires_at = ?2
+             WHERE adoption_key = ?1 AND state = 'stopping'",
+            rusqlite::params![
+                "adopt:cancel:cancellation-target:base-terminal-recovery",
+                expired
+            ],
+        )?;
+        conn.execute(
+            "UPDATE automation_stop_fences
+             SET execution_expires_at = ?2
+             WHERE operation_key = ?1",
+            rusqlite::params![
+                "adopt:cancel:cancellation-target:base-terminal-recovery",
+                expired
+            ],
+        )?;
+
+        assert_eq!(
+            crate::automations::cancellation::reconcile_expired_cancellations(
+                &conn,
+                &NoopSessionRuntime,
+                Utc::now(),
+            )
+            .map_err(anyhow::Error::msg)?,
+            1
+        );
+        drop(conn);
+
+        let rejected = post_cancellation(temp_dir.path(), &body, &NoopSessionRuntime)?;
+        assert_eq!(rejected.status, 422, "{}", rejected.body);
+        let rejected: Value = serde_json::from_str(&rejected.body)?;
+        assert_eq!(rejected["error"]["code"], "ILLEGAL_TRANSITION");
+        let history = cancellation_history(temp_dir.path())?;
+        assert_eq!(
+            history["event"]["payload"]["runs"][0]["status"],
+            "succeeded"
+        );
+        assert_eq!(
+            history["event"]["payload"]["runs"][0]["attempts"][0]["state"],
             "succeeded"
         );
         Ok(())

--- a/crates/coven-cli/src/automations/cancellation.rs
+++ b/crates/coven-cli/src/automations/cancellation.rs
@@ -3,6 +3,7 @@ use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use super::contract::authority::AUTHORITY_PROFILE;
 use super::contract::canonical_json::{canonicalize, sha256_hex};
 use super::contract::error::{ErrorCode, ErrorEnvelope};
 use super::contract::types::AdoptionKey;
@@ -361,46 +362,88 @@ pub struct CancellationSuccess {
     pub replayed: bool,
 }
 
+struct CancellationLifecycle {
+    run_state: String,
+    attempt_state: String,
+    occurrence_state: String,
+    session_state: String,
+    settled_at: Option<String>,
+    authority_profile: Option<String>,
+}
+
+fn lifecycle_requires_recovery(lifecycle: &CancellationLifecycle) -> bool {
+    if lifecycle.run_state != "running" || lifecycle.occurrence_state != "recovery_required" {
+        return false;
+    }
+    let terminal_session = matches!(
+        lifecycle.session_state.as_str(),
+        "completed" | "failed" | "cancelled" | "killed" | "idle"
+    );
+    if terminal_session {
+        lifecycle.authority_profile.as_deref() == Some(AUTHORITY_PROFILE)
+            && matches!(
+                lifecycle.attempt_state.as_str(),
+                "dispatching" | "started" | "observing" | "ambiguous"
+            )
+    } else {
+        lifecycle.attempt_state == "ambiguous"
+    }
+}
+
+fn cancellation_lifecycle(
+    conn: &Connection,
+    reservation: &ReservedCancellation,
+) -> Result<Option<CancellationLifecycle>, String> {
+    conn.query_row(
+        "SELECT r.status, a.state, o.state, s.status, a.settled_at,
+                r.authority_profile
+         FROM automation_runs AS r
+         JOIN automation_attempts AS a ON a.run_id = r.id
+         JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+         JOIN sessions AS s ON s.id = a.session_id
+         WHERE r.id = ?1 AND a.id = ?2 AND a.session_id = ?3",
+        params![
+            reservation.request.run_id,
+            reservation.request.attempt_id,
+            reservation.request.runtime_correlation.session_id
+        ],
+        |row| {
+            Ok(CancellationLifecycle {
+                run_state: row.get(0)?,
+                attempt_state: row.get(1)?,
+                occurrence_state: row.get(2)?,
+                session_state: row.get(3)?,
+                settled_at: row.get(4)?,
+                authority_profile: row.get(5)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(|error| format!("failed to reconcile reserved cancellation: {error}"))
+}
+
 fn recover_settled_result(
     conn: &Connection,
     reservation: &ReservedCancellation,
     now: DateTime<Utc>,
     unknown_stop_outcome: bool,
 ) -> Result<Option<CancellationExecution>, String> {
-    let lifecycle = conn
-        .query_row(
-            "SELECT r.status, a.state, o.state, s.status, a.settled_at
-             FROM automation_runs AS r
-             JOIN automation_attempts AS a ON a.run_id = r.id
-             JOIN automation_occurrences AS o ON o.id = r.occurrence_id
-             JOIN sessions AS s ON s.id = a.session_id
-             WHERE r.id = ?1 AND a.id = ?2 AND a.session_id = ?3",
-            params![
-                reservation.request.run_id,
-                reservation.request.attempt_id,
-                reservation.request.runtime_correlation.session_id
-            ],
-            |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, String>(3)?,
-                    row.get::<_, Option<String>>(4)?,
-                ))
-            },
-        )
-        .optional()
-        .map_err(|error| format!("failed to reconcile reserved cancellation: {error}"))?;
-    let Some((run_state, attempt_state, occurrence_state, session_state, settled_at)) = lifecycle
-    else {
+    let Some(mut lifecycle) = cancellation_lifecycle(conn, reservation)? else {
         return Ok(None);
     };
+    if lifecycle_requires_recovery(&lifecycle) {
+        let payload = cancellation_payload(reservation, "recovery_required", None, None);
+        finalize_success(conn, reservation, "recovery_required", &payload, now)?;
+        return Ok(Some(CancellationExecution::Success(CancellationSuccess {
+            payload,
+            replayed: true,
+        })));
+    }
     let terminal_session = matches!(
-        session_state.as_str(),
+        lifecycle.session_state.as_str(),
         "completed" | "failed" | "cancelled" | "killed" | "idle"
     );
-    if run_state == "running" && terminal_session {
+    if lifecycle.run_state == "running" && terminal_session {
         let cancellation_owns_stop = conn
             .query_row(
                 "SELECT 1 FROM automation_stop_fences
@@ -418,7 +461,10 @@ fn recover_settled_result(
             .optional()
             .map_err(|error| format!("failed to inspect cancellation stop ownership: {error}"))?
             .is_some();
-        if unknown_stop_outcome && cancellation_owns_stop {
+        if unknown_stop_outcome
+            && cancellation_owns_stop
+            && lifecycle.occurrence_state != "recovery_required"
+        {
             super::runner::mark_terminal_stop_for_recovery(
                 conn,
                 &reservation.request.run_id,
@@ -434,8 +480,31 @@ fn recover_settled_result(
             })));
         }
         super::runner::settle_finished_runs(conn, now)?;
-        return recover_settled_result(conn, reservation, now, unknown_stop_outcome);
+        let Some(reconciled) = cancellation_lifecycle(conn, reservation)? else {
+            return Ok(None);
+        };
+        lifecycle = reconciled;
+        if lifecycle_requires_recovery(&lifecycle) {
+            let payload = cancellation_payload(reservation, "recovery_required", None, None);
+            finalize_success(conn, reservation, "recovery_required", &payload, now)?;
+            return Ok(Some(CancellationExecution::Success(CancellationSuccess {
+                payload,
+                replayed: true,
+            })));
+        }
     }
+    let CancellationLifecycle {
+        run_state,
+        attempt_state,
+        occurrence_state,
+        session_state,
+        settled_at,
+        authority_profile: _,
+    } = lifecycle;
+    let terminal_session = matches!(
+        session_state.as_str(),
+        "completed" | "failed" | "cancelled" | "killed" | "idle"
+    );
     if run_state == "cancelled"
         && attempt_state == "cancelled"
         && occurrence_state == "cancelled"
@@ -449,18 +518,6 @@ fn recover_settled_result(
             Some(&settled_at),
         );
         finalize_success(conn, reservation, "cancelled", &payload, now)?;
-        return Ok(Some(CancellationExecution::Success(CancellationSuccess {
-            payload,
-            replayed: true,
-        })));
-    }
-    if !terminal_session
-        && run_state == "running"
-        && attempt_state == "ambiguous"
-        && occurrence_state == "recovery_required"
-    {
-        let payload = cancellation_payload(reservation, "recovery_required", None, None);
-        finalize_success(conn, reservation, "recovery_required", &payload, now)?;
         return Ok(Some(CancellationExecution::Success(CancellationSuccess {
             payload,
             replayed: true,
@@ -792,45 +849,58 @@ fn execute_reserved_cancellation(
 
     match runtime.kill_session(&reservation.request.runtime_correlation.session_id) {
         Ok(()) => {
-            let settled = super::runner::settle_confirmed_stop(
+            let settlement = super::runner::settle_confirmed_stop(
                 conn,
                 &reservation.request.run_id,
                 &reservation.request.runtime_correlation.session_id,
                 super::runner::ConfirmedStop::Cancelled,
                 now,
             )?;
-            if !settled {
-                let error = typed_error(
-                    ErrorCode::IllegalTransition,
-                    "automation completion already won the cancellation race",
-                );
-                if !finalize_rejection(conn, &reservation, &error, now)? {
-                    if let Some(replay) = load_adopted_response(
-                        conn,
-                        &reservation.request.adoption_key,
-                        &reservation.digest,
-                    )? {
-                        return Ok(replay);
+            match settlement {
+                super::runner::ConfirmedStopSettlement::LostRace => {
+                    let error = typed_error(
+                        ErrorCode::IllegalTransition,
+                        "automation completion already won the cancellation race",
+                    );
+                    if !finalize_rejection(conn, &reservation, &error, now)? {
+                        if let Some(replay) = load_adopted_response(
+                            conn,
+                            &reservation.request.adoption_key,
+                            &reservation.digest,
+                        )? {
+                            return Ok(replay);
+                        }
+                        return Ok(CancellationExecution::Rejected(typed_error(
+                            ErrorCode::CancelPending,
+                            "the cancellation request is already being reconciled",
+                        )));
                     }
-                    return Ok(CancellationExecution::Rejected(typed_error(
-                        ErrorCode::CancelPending,
-                        "the cancellation request is already being reconciled",
-                    )));
+                    Ok(CancellationExecution::Rejected(error))
                 }
-                return Ok(CancellationExecution::Rejected(error));
+                super::runner::ConfirmedStopSettlement::RecoveryRequired => {
+                    let payload =
+                        cancellation_payload(&reservation, "recovery_required", None, None);
+                    finalize_success(conn, &reservation, "recovery_required", &payload, now)?;
+                    Ok(CancellationExecution::Success(CancellationSuccess {
+                        payload,
+                        replayed,
+                    }))
+                }
+                super::runner::ConfirmedStopSettlement::Settled => {
+                    let timestamp = iso(now);
+                    let payload = cancellation_payload(
+                        &reservation,
+                        "cancelled",
+                        Some(&timestamp),
+                        Some(&timestamp),
+                    );
+                    finalize_success(conn, &reservation, "cancelled", &payload, now)?;
+                    Ok(CancellationExecution::Success(CancellationSuccess {
+                        payload,
+                        replayed,
+                    }))
+                }
             }
-            let timestamp = iso(now);
-            let payload = cancellation_payload(
-                &reservation,
-                "cancelled",
-                Some(&timestamp),
-                Some(&timestamp),
-            );
-            finalize_success(conn, &reservation, "cancelled", &payload, now)?;
-            Ok(CancellationExecution::Success(CancellationSuccess {
-                payload,
-                replayed,
-            }))
         }
         Err(_) => {
             if let Err(mark_error) = super::runner::mark_unconfirmed_stop_for_recovery(

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -12,6 +12,10 @@ pub mod authority;
 pub mod error;
 pub mod events;
 pub mod migration;
+// This receiving contract intentionally has no production verifier or runtime
+// producer until a later adapter slice wires one.
+#[allow(dead_code)]
+pub mod runtime_terminal_evidence;
 // These projections are intentionally available to the following protocol slices.
 #[allow(dead_code)]
 pub mod types;

--- a/crates/coven-cli/src/automations/contract/runtime_terminal_evidence.rs
+++ b/crates/coven-cli/src/automations/contract/runtime_terminal_evidence.rs
@@ -1,0 +1,898 @@
+//! Authenticated terminal observations from an authority-aware runtime.
+//!
+//! This contract is a receiving boundary only. No production runtime emits it
+//! and no default verifier accepts it.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::ser::Serializer;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+use super::authority::{
+    AuthorityCapability, AuthorityOpaqueIdentifier, AuthoritySideEffectClass,
+    AutomationExecutionBinding,
+};
+use super::canonical_json::{canonicalize, sha256_hex};
+use super::types::{
+    AttemptId, DigestValue, ProducerIdentity, ReceiptPrivacy, RunId, SessionId, SideEffectClass,
+    TerminalOutcome,
+};
+
+pub const RUNTIME_TERMINAL_EVIDENCE_PROFILE: &str =
+    "coven.automations.runtime-terminal-evidence.v1";
+pub const RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN: &[u8] =
+    b"opencoven:coven-automations-runtime-terminal-evidence:v1";
+
+macro_rules! validated_text {
+    ($name:ident, $validator:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: String) -> Result<Self, RuntimeTerminalEvidenceError> {
+                if $validator(&value) {
+                    Ok(Self(value))
+                } else {
+                    Err(RuntimeTerminalEvidenceError::new(
+                        RuntimeTerminalEvidenceErrorCode::SchemaInvalid,
+                    ))
+                }
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+fn matches_opaque_identifier(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 256
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'@' | b'-')
+        })
+}
+
+fn matches_reason_code(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 96
+        && bytes[0].is_ascii_lowercase()
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+}
+
+fn matches_signature(value: &str) -> bool {
+    value.len() == 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+validated_text!(RuntimeTerminalEvidenceId, matches_opaque_identifier);
+validated_text!(RuntimeTerminalEvidenceReasonCode, matches_reason_code);
+validated_text!(RuntimeTerminalEvidenceKeyId, matches_opaque_identifier);
+validated_text!(RuntimeTerminalEvidenceProofRef, matches_opaque_identifier);
+validated_text!(RuntimeTerminalEvidenceSignature, matches_signature);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeTerminalEvidenceProfile {
+    #[serde(rename = "coven.automations.runtime-terminal-evidence.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RuntimeTerminalEvidenceBinding {
+    pub binding_id: AuthorityOpaqueIdentifier,
+    pub binding_digest: DigestValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RuntimeTerminalEvidenceRuntime {
+    pub runtime_id: super::types::RuntimeId,
+    pub descriptor_digest: DigestValue,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationCoverage {
+    Complete,
+    Partial,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "state",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum RuntimeSideEffects {
+    Observed {
+        maximum_class: SideEffectClass,
+        coverage: ObservationCoverage,
+    },
+    Unknown {
+        reason_code: RuntimeTerminalEvidenceReasonCode,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeEvidenceCapabilities(Vec<AuthorityCapability>);
+
+impl RuntimeEvidenceCapabilities {
+    #[must_use]
+    pub fn as_slice(&self) -> &[AuthorityCapability] {
+        &self.0
+    }
+}
+
+impl Serialize for RuntimeEvidenceCapabilities {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RuntimeEvidenceCapabilities {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let values = Vec::<AuthorityCapability>::deserialize(deserializer)?;
+        let unique = values.iter().collect::<BTreeSet<_>>().len() == values.len();
+        if values.len() <= 128 && unique {
+            Ok(Self(values))
+        } else {
+            Err(serde::de::Error::custom(
+                "runtime evidence capabilities must be unique and contain at most 128 entries",
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "state",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum RuntimeExercisedCapabilities {
+    Observed {
+        values: RuntimeEvidenceCapabilities,
+        coverage: ObservationCoverage,
+    },
+    Unknown {
+        reason_code: RuntimeTerminalEvidenceReasonCode,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "state",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum RuntimeResultEvidence {
+    Produced {
+        #[serde(
+            default,
+            deserialize_with = "super::types::deserialize_non_null_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        digest: Option<DigestValue>,
+    },
+    NotProduced,
+    Unknown {
+        reason_code: RuntimeTerminalEvidenceReasonCode,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "state",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum RuntimeDeliveryEvidence {
+    NotAttempted,
+    Committed {
+        #[serde(
+            default,
+            deserialize_with = "super::types::deserialize_non_null_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        digest: Option<DigestValue>,
+    },
+    Failed {
+        #[serde(
+            default,
+            deserialize_with = "super::types::deserialize_non_null_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        digest: Option<DigestValue>,
+    },
+    Partial {
+        #[serde(
+            default,
+            deserialize_with = "super::types::deserialize_non_null_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        digest: Option<DigestValue>,
+    },
+    Unknown {
+        reason_code: RuntimeTerminalEvidenceReasonCode,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeTerminalEvidenceAuthenticationMethod {
+    #[serde(rename = "ed25519")]
+    Ed25519,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RuntimeTerminalEvidenceAuthentication {
+    pub method: RuntimeTerminalEvidenceAuthenticationMethod,
+    pub key_id: RuntimeTerminalEvidenceKeyId,
+    pub proof_ref: RuntimeTerminalEvidenceProofRef,
+    pub signed_digest: DigestValue,
+    pub signature: RuntimeTerminalEvidenceSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RuntimeTerminalEvidence {
+    pub profile: RuntimeTerminalEvidenceProfile,
+    pub evidence_id: RuntimeTerminalEvidenceId,
+    pub session_id: SessionId,
+    pub run_id: RunId,
+    pub attempt_id: AttemptId,
+    pub binding: RuntimeTerminalEvidenceBinding,
+    pub runtime: RuntimeTerminalEvidenceRuntime,
+    pub produced_at: super::types::Timestamp,
+    pub disposition: TerminalOutcome,
+    pub side_effects: RuntimeSideEffects,
+    pub exercised_capabilities: RuntimeExercisedCapabilities,
+    pub result: RuntimeResultEvidence,
+    pub delivery: RuntimeDeliveryEvidence,
+    pub producer: ProducerIdentity,
+    pub privacy: ReceiptPrivacy,
+    pub integrity: DigestValue,
+    pub authentication: RuntimeTerminalEvidenceAuthentication,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeTerminalEvidenceClassification {
+    ReceiptEligibleComplete,
+    AuthenticatedPartialOrAmbiguous,
+    AuthenticatedUnknown,
+    PolicyViolating,
+}
+
+impl RuntimeTerminalEvidenceClassification {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReceiptEligibleComplete => "receipt_eligible_complete",
+            Self::AuthenticatedPartialOrAmbiguous => "authenticated_partial_or_ambiguous",
+            Self::AuthenticatedUnknown => "authenticated_unknown",
+            Self::PolicyViolating => "policy_violating",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedRuntimeTerminalEvidence {
+    pub evidence: RuntimeTerminalEvidence,
+    pub classification: RuntimeTerminalEvidenceClassification,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeTerminalEvidenceErrorCode {
+    SchemaInvalid,
+    IjsonInvalid,
+    IntegrityInvalid,
+    AuthenticationInvalid,
+    AuthenticationStale,
+    AuthenticationUnverifiable,
+    CorrelationMismatch,
+    AuthorityProfileRequired,
+    Conflict,
+    StoredEvidenceInvalid,
+    StoreUnavailable,
+}
+
+impl RuntimeTerminalEvidenceErrorCode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SchemaInvalid => "RUNTIME_TERMINAL_EVIDENCE_SCHEMA_INVALID",
+            Self::IjsonInvalid => "RUNTIME_TERMINAL_EVIDENCE_IJSON_INVALID",
+            Self::IntegrityInvalid => "RUNTIME_TERMINAL_EVIDENCE_INTEGRITY_INVALID",
+            Self::AuthenticationInvalid => "RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_INVALID",
+            Self::AuthenticationStale => "RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_STALE",
+            Self::AuthenticationUnverifiable => {
+                "RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_UNVERIFIABLE"
+            }
+            Self::CorrelationMismatch => "RUNTIME_TERMINAL_EVIDENCE_CORRELATION_MISMATCH",
+            Self::AuthorityProfileRequired => {
+                "RUNTIME_TERMINAL_EVIDENCE_AUTHORITY_PROFILE_REQUIRED"
+            }
+            Self::Conflict => "RUNTIME_TERMINAL_EVIDENCE_CONFLICT",
+            Self::StoredEvidenceInvalid => "RUNTIME_TERMINAL_EVIDENCE_STORED_INVALID",
+            Self::StoreUnavailable => "RUNTIME_TERMINAL_EVIDENCE_STORE_UNAVAILABLE",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeTerminalEvidenceError {
+    code: RuntimeTerminalEvidenceErrorCode,
+}
+
+impl RuntimeTerminalEvidenceError {
+    #[must_use]
+    pub const fn new(code: RuntimeTerminalEvidenceErrorCode) -> Self {
+        Self { code }
+    }
+
+    #[must_use]
+    pub const fn code(&self) -> RuntimeTerminalEvidenceErrorCode {
+        self.code
+    }
+}
+
+impl fmt::Display for RuntimeTerminalEvidenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code.as_str())
+    }
+}
+
+impl std::error::Error for RuntimeTerminalEvidenceError {}
+
+pub trait RuntimeTerminalEvidenceVerifier {
+    fn verify(
+        &self,
+        evidence: &RuntimeTerminalEvidence,
+    ) -> Result<(), RuntimeTerminalEvidenceError>;
+}
+
+pub fn verify_runtime_terminal_evidence(
+    evidence: RuntimeTerminalEvidence,
+    binding: &AutomationExecutionBinding,
+    verifier: &dyn RuntimeTerminalEvidenceVerifier,
+) -> Result<VerifiedRuntimeTerminalEvidence, RuntimeTerminalEvidenceError> {
+    validate_integrity(&evidence)?;
+    validate_binding_correlation(&evidence, binding)?;
+    verifier.verify(&evidence)?;
+    let classification = classify_runtime_terminal_evidence(&evidence, binding);
+    Ok(VerifiedRuntimeTerminalEvidence {
+        evidence,
+        classification,
+    })
+}
+
+fn validate_integrity(
+    evidence: &RuntimeTerminalEvidence,
+) -> Result<(), RuntimeTerminalEvidenceError> {
+    let mut body = serde_json::to_value(evidence).map_err(|_| {
+        RuntimeTerminalEvidenceError::new(RuntimeTerminalEvidenceErrorCode::SchemaInvalid)
+    })?;
+    let Value::Object(object) = &mut body else {
+        return Err(RuntimeTerminalEvidenceError::new(
+            RuntimeTerminalEvidenceErrorCode::SchemaInvalid,
+        ));
+    };
+    object.remove("integrity");
+    object.remove("authentication");
+    let canonical = canonicalize(&body).map_err(|_| {
+        RuntimeTerminalEvidenceError::new(RuntimeTerminalEvidenceErrorCode::IjsonInvalid)
+    })?;
+    if evidence.integrity.value.as_str() != sha256_hex(&canonical) {
+        return Err(RuntimeTerminalEvidenceError::new(
+            RuntimeTerminalEvidenceErrorCode::IntegrityInvalid,
+        ));
+    }
+    let mut authentication_preimage = Vec::with_capacity(
+        RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN.len() + canonical.len() + 1,
+    );
+    authentication_preimage.extend_from_slice(RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN);
+    authentication_preimage.push(0);
+    authentication_preimage.extend_from_slice(&canonical);
+    if evidence.authentication.signed_digest.value.as_str() != sha256_hex(&authentication_preimage)
+    {
+        return Err(RuntimeTerminalEvidenceError::new(
+            RuntimeTerminalEvidenceErrorCode::AuthenticationInvalid,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_binding_correlation(
+    evidence: &RuntimeTerminalEvidence,
+    binding: &AutomationExecutionBinding,
+) -> Result<(), RuntimeTerminalEvidenceError> {
+    if evidence.run_id != binding.base.run_id
+        || evidence.attempt_id != binding.base.attempt_id
+        || evidence.binding.binding_id != binding.binding_id
+        || evidence.binding.binding_digest != binding.integrity
+        || evidence.runtime.runtime_id != binding.runtime.runtime_id
+        || evidence.runtime.descriptor_digest != binding.runtime.descriptor_digest
+    {
+        return Err(RuntimeTerminalEvidenceError::new(
+            RuntimeTerminalEvidenceErrorCode::CorrelationMismatch,
+        ));
+    }
+    Ok(())
+}
+
+pub(in crate::automations) fn classify_runtime_terminal_evidence(
+    evidence: &RuntimeTerminalEvidence,
+    binding: &AutomationExecutionBinding,
+) -> RuntimeTerminalEvidenceClassification {
+    if policy_violating(evidence, binding) {
+        return RuntimeTerminalEvidenceClassification::PolicyViolating;
+    }
+    if has_unknown_observation(evidence) {
+        return RuntimeTerminalEvidenceClassification::AuthenticatedUnknown;
+    }
+    if complete(evidence) {
+        RuntimeTerminalEvidenceClassification::ReceiptEligibleComplete
+    } else {
+        RuntimeTerminalEvidenceClassification::AuthenticatedPartialOrAmbiguous
+    }
+}
+
+fn has_unknown_observation(evidence: &RuntimeTerminalEvidence) -> bool {
+    matches!(evidence.side_effects, RuntimeSideEffects::Unknown { .. })
+        || matches!(
+            evidence.exercised_capabilities,
+            RuntimeExercisedCapabilities::Unknown { .. }
+        )
+        || matches!(evidence.result, RuntimeResultEvidence::Unknown { .. })
+        || matches!(evidence.delivery, RuntimeDeliveryEvidence::Unknown { .. })
+}
+
+fn policy_violating(
+    evidence: &RuntimeTerminalEvidence,
+    binding: &AutomationExecutionBinding,
+) -> bool {
+    let side_effect_escalation = match evidence.side_effects {
+        RuntimeSideEffects::Observed { maximum_class, .. } => {
+            side_effect_rank(maximum_class)
+                > authority_side_effect_rank(binding.risk.side_effect_class)
+        }
+        RuntimeSideEffects::Unknown { .. } => false,
+    };
+    let capability_escalation = match &evidence.exercised_capabilities {
+        RuntimeExercisedCapabilities::Observed { values, .. } => values
+            .as_slice()
+            .iter()
+            .any(|capability| !binding.capabilities.granted.as_slice().contains(capability)),
+        RuntimeExercisedCapabilities::Unknown { .. } => false,
+    };
+    side_effect_escalation || capability_escalation
+}
+
+fn complete(evidence: &RuntimeTerminalEvidence) -> bool {
+    !matches!(evidence.disposition, TerminalOutcome::Ambiguous)
+        && matches!(
+            evidence.side_effects,
+            RuntimeSideEffects::Observed {
+                coverage: ObservationCoverage::Complete,
+                ..
+            }
+        )
+        && matches!(
+            evidence.exercised_capabilities,
+            RuntimeExercisedCapabilities::Observed {
+                coverage: ObservationCoverage::Complete,
+                ..
+            }
+        )
+        && !matches!(evidence.result, RuntimeResultEvidence::Unknown { .. })
+        && !matches!(
+            evidence.delivery,
+            RuntimeDeliveryEvidence::Partial { .. } | RuntimeDeliveryEvidence::Unknown { .. }
+        )
+}
+
+const fn side_effect_rank(class: SideEffectClass) -> u8 {
+    match class {
+        SideEffectClass::None => 0,
+        SideEffectClass::LocalRead => 1,
+        SideEffectClass::LocalWrite => 2,
+        SideEffectClass::ExternalRead => 3,
+        SideEffectClass::ExternalMutation => 4,
+        SideEffectClass::IrreversibleExternalMutation => 5,
+    }
+}
+
+const fn authority_side_effect_rank(class: AuthoritySideEffectClass) -> u8 {
+    match class {
+        AuthoritySideEffectClass::None => 0,
+        AuthoritySideEffectClass::LocalRead => 1,
+        AuthoritySideEffectClass::LocalWrite => 2,
+        AuthoritySideEffectClass::ExternalRead => 3,
+        AuthoritySideEffectClass::ExternalMutation => 4,
+        AuthoritySideEffectClass::IrreversibleExternalMutation => 5,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::{
+        verify_runtime_terminal_evidence, RuntimeTerminalEvidence,
+        RuntimeTerminalEvidenceClassification, RuntimeTerminalEvidenceError,
+        RuntimeTerminalEvidenceErrorCode, RuntimeTerminalEvidenceVerifier,
+        RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN, RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+    };
+    use crate::automations::contract::authority::AutomationExecutionBinding;
+    use crate::automations::contract::canonical_json::{canonicalize, sha256_hex};
+
+    const AUTHORITY_VECTORS: &str =
+        include_str!("../../../../../spec/coven-automations/authority/v1/test-vectors.json");
+
+    struct FixtureVerifier {
+        key_id: &'static str,
+        stale: bool,
+    }
+
+    impl RuntimeTerminalEvidenceVerifier for FixtureVerifier {
+        fn verify(
+            &self,
+            evidence: &RuntimeTerminalEvidence,
+        ) -> Result<(), RuntimeTerminalEvidenceError> {
+            if self.stale {
+                return Err(RuntimeTerminalEvidenceError::new(
+                    RuntimeTerminalEvidenceErrorCode::AuthenticationStale,
+                ));
+            }
+            if evidence.authentication.key_id.as_str() != self.key_id
+                || evidence.authentication.signature.as_str()
+                    != format!(
+                        "{}{}",
+                        evidence.authentication.signed_digest.value.as_str(),
+                        evidence.authentication.signed_digest.value.as_str()
+                    )
+            {
+                return Err(RuntimeTerminalEvidenceError::new(
+                    RuntimeTerminalEvidenceErrorCode::AuthenticationInvalid,
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    fn binding() -> AutomationExecutionBinding {
+        let vectors: Value = serde_json::from_str(AUTHORITY_VECTORS).unwrap();
+        serde_json::from_value(vectors["fixtures"]["binding"].clone()).unwrap()
+    }
+
+    fn digest(value: &str) -> Value {
+        json!({
+            "algorithm": "sha256",
+            "canonicalization": "jcs-rfc8785",
+            "value": value
+        })
+    }
+
+    fn evidence_value() -> Value {
+        json!({
+            "profile": RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+            "evidenceId": "evidence:daily-notes-1",
+            "sessionId": "session-daily-notes-1",
+            "runId": "run.daily-notes-1",
+            "attemptId": "attempt.daily-notes-1-1",
+            "binding": {
+                "bindingId": "binding:daily-notes-1",
+                "bindingDigest": digest(
+                    "a952367c28a7f29ccc69904c72dcc0f8296dfdf61a3141fb78bcba43f5c4c5c7"
+                )
+            },
+            "runtime": {
+                "runtimeId": "runtime:coven-code",
+                "descriptorDigest": digest(
+                    "7777777777777777777777777777777777777777777777777777777777777777"
+                )
+            },
+            "producedAt": "2026-09-03T12:30:00.000Z",
+            "disposition": "succeeded",
+            "sideEffects": {
+                "state": "observed",
+                "maximumClass": "local_write",
+                "coverage": "complete"
+            },
+            "exercisedCapabilities": {
+                "state": "observed",
+                "values": ["analysis.read", "artifact.write"],
+                "coverage": "complete"
+            },
+            "result": {
+                "state": "produced",
+                "digest": digest(
+                    "8888888888888888888888888888888888888888888888888888888888888888"
+                )
+            },
+            "delivery": {
+                "state": "not_attempted"
+            },
+            "producer": {
+                "component": "runtime-adapter",
+                "instanceId": "runtime-instance-1",
+                "implementationVersion": "1.0.0"
+            },
+            "privacy": {
+                "classification": "operational",
+                "retention": {
+                    "classification": "standard"
+                }
+            },
+            "integrity": digest(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+            "authentication": {
+                "method": "ed25519",
+                "keyId": "key:runtime-instance-1",
+                "proofRef": "proof:runtime-instance-1",
+                "signedDigest": digest(
+                    "0000000000000000000000000000000000000000000000000000000000000000"
+                ),
+                "signature": "0".repeat(128)
+            }
+        })
+    }
+
+    fn seal(mut value: Value) -> Value {
+        let object = value.as_object_mut().unwrap();
+        object.remove("integrity");
+        object.remove("authentication");
+        let canonical = canonicalize(&value).unwrap();
+        let integrity = sha256_hex(&canonical);
+        let mut authentication_preimage = Vec::new();
+        authentication_preimage.extend_from_slice(RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN);
+        authentication_preimage.push(0);
+        authentication_preimage.extend_from_slice(&canonical);
+        let signed_digest = sha256_hex(&authentication_preimage);
+        value["integrity"] = digest(&integrity);
+        value["authentication"] = json!({
+            "method": "ed25519",
+            "keyId": "key:runtime-instance-1",
+            "proofRef": "proof:runtime-instance-1",
+            "signedDigest": digest(&signed_digest),
+            "signature": format!("{signed_digest}{signed_digest}")
+        });
+        value
+    }
+
+    fn verified(value: Value) -> super::VerifiedRuntimeTerminalEvidence {
+        let evidence: RuntimeTerminalEvidence = serde_json::from_value(seal(value)).unwrap();
+        verify_runtime_terminal_evidence(
+            evidence,
+            &binding(),
+            &FixtureVerifier {
+                key_id: "key:runtime-instance-1",
+                stale: false,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn complete_authenticated_evidence_is_receipt_eligible() {
+        let verified = verified(evidence_value());
+
+        assert_eq!(
+            verified.classification,
+            RuntimeTerminalEvidenceClassification::ReceiptEligibleComplete
+        );
+        assert_ne!(
+            verified.evidence.integrity.value,
+            verified.evidence.authentication.signed_digest.value
+        );
+    }
+
+    #[test]
+    fn partial_and_ambiguous_observations_remain_authenticated_but_not_receipt_eligible() {
+        let mut partial = evidence_value();
+        partial["sideEffects"]["coverage"] = json!("partial");
+        assert_eq!(
+            verified(partial).classification,
+            RuntimeTerminalEvidenceClassification::AuthenticatedPartialOrAmbiguous
+        );
+
+        let mut ambiguous = evidence_value();
+        ambiguous["disposition"] = json!("ambiguous");
+        assert_eq!(
+            verified(ambiguous).classification,
+            RuntimeTerminalEvidenceClassification::AuthenticatedPartialOrAmbiguous
+        );
+    }
+
+    #[test]
+    fn every_explicit_unknown_observation_is_classified_unknown() {
+        for mutate in [
+            (|value: &mut Value| {
+                value["sideEffects"] = json!({
+                    "state": "unknown",
+                    "reasonCode": "runtime_observation_unavailable"
+                });
+            }) as fn(&mut Value),
+            |value: &mut Value| {
+                value["exercisedCapabilities"] = json!({
+                    "state": "unknown",
+                    "reasonCode": "runtime_observation_unavailable"
+                });
+            },
+            |value: &mut Value| {
+                value["result"] = json!({
+                    "state": "unknown",
+                    "reasonCode": "runtime_result_unavailable"
+                });
+            },
+            |value: &mut Value| {
+                value["delivery"] = json!({
+                    "state": "unknown",
+                    "reasonCode": "runtime_delivery_unavailable"
+                });
+            },
+        ] {
+            let mut unknown = evidence_value();
+            mutate(&mut unknown);
+            assert_eq!(
+                verified(unknown).classification.as_str(),
+                "authenticated_unknown"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_precedes_partial_but_policy_violation_precedes_unknown() {
+        let mut mixed = evidence_value();
+        mixed["sideEffects"]["coverage"] = json!("partial");
+        mixed["result"] = json!({
+            "state": "unknown",
+            "reasonCode": "runtime_result_unavailable"
+        });
+        assert_eq!(
+            verified(mixed).classification.as_str(),
+            "authenticated_unknown"
+        );
+
+        let mut violating_unknown = evidence_value();
+        violating_unknown["sideEffects"] = json!({
+            "state": "unknown",
+            "reasonCode": "runtime_observation_unavailable"
+        });
+        violating_unknown["exercisedCapabilities"]["values"] =
+            json!(["analysis.read", "artifact.write", "network.publish"]);
+        assert_eq!(
+            verified(violating_unknown).classification,
+            RuntimeTerminalEvidenceClassification::PolicyViolating
+        );
+    }
+
+    #[test]
+    fn authenticated_capability_and_side_effect_escalation_is_classified_nonconformant() {
+        let mut side_effect = evidence_value();
+        side_effect["sideEffects"]["maximumClass"] = json!("external_mutation");
+        assert_eq!(
+            verified(side_effect).classification,
+            RuntimeTerminalEvidenceClassification::PolicyViolating
+        );
+
+        let mut capability = evidence_value();
+        capability["exercisedCapabilities"]["values"] =
+            json!(["analysis.read", "artifact.write", "network.publish"]);
+        assert_eq!(
+            verified(capability).classification,
+            RuntimeTerminalEvidenceClassification::PolicyViolating
+        );
+    }
+
+    #[test]
+    fn tagged_observation_unions_reject_unknown_fields_and_nullable_inference() {
+        let mut unknown_field = evidence_value();
+        unknown_field["sideEffects"]["unexpected"] = json!(true);
+        assert!(serde_json::from_value::<RuntimeTerminalEvidence>(seal(unknown_field)).is_err());
+
+        let mut null_observation = evidence_value();
+        null_observation["sideEffects"] = Value::Null;
+        assert!(serde_json::from_value::<RuntimeTerminalEvidence>(seal(null_observation)).is_err());
+
+        let mut inferred_empty = evidence_value();
+        inferred_empty["exercisedCapabilities"] = json!([]);
+        assert!(serde_json::from_value::<RuntimeTerminalEvidence>(seal(inferred_empty)).is_err());
+    }
+
+    #[test]
+    fn tampering_wrong_verifier_and_stale_proof_fail_with_privacy_safe_typed_errors() {
+        let sealed = seal(evidence_value());
+        let mut tampered = sealed.clone();
+        tampered["sessionId"] = json!("private-attacker-session");
+        let tampered: RuntimeTerminalEvidence = serde_json::from_value(tampered).unwrap();
+        let error = verify_runtime_terminal_evidence(
+            tampered,
+            &binding(),
+            &FixtureVerifier {
+                key_id: "key:runtime-instance-1",
+                stale: false,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.code(),
+            RuntimeTerminalEvidenceErrorCode::IntegrityInvalid
+        );
+        assert!(!format!("{error:#}").contains("private-attacker-session"));
+
+        let evidence: RuntimeTerminalEvidence = serde_json::from_value(sealed.clone()).unwrap();
+        let error = verify_runtime_terminal_evidence(
+            evidence,
+            &binding(),
+            &FixtureVerifier {
+                key_id: "key:wrong",
+                stale: false,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.code(),
+            RuntimeTerminalEvidenceErrorCode::AuthenticationInvalid
+        );
+        assert!(!format!("{error:#}").contains("key:runtime-instance-1"));
+
+        let evidence: RuntimeTerminalEvidence = serde_json::from_value(sealed).unwrap();
+        let error = verify_runtime_terminal_evidence(
+            evidence,
+            &binding(),
+            &FixtureVerifier {
+                key_id: "key:runtime-instance-1",
+                stale: true,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.code(),
+            RuntimeTerminalEvidenceErrorCode::AuthenticationStale
+        );
+        assert!(!format!("{error:#}").contains("proof:runtime-instance-1"));
+    }
+}

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -20,8 +20,11 @@ pub mod leadership;
 pub mod occurrences;
 pub mod receipts;
 pub mod rrule;
+// The inbox is intentionally internal until a trusted runtime adapter exists.
 pub mod runner;
 pub mod runs;
+#[allow(dead_code)]
+pub mod runtime_terminal_evidence;
 pub mod schedule;
 pub mod store;
 

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -39,6 +39,9 @@ use super::runs::{
 use crate::api::{SessionLaunch, SessionRuntime};
 use crate::harness::HarnessLaunchMode;
 
+const RUNTIME_TERMINAL_EVIDENCE_REQUIRED_REASON: &str =
+    "trusted runtime terminal evidence is required before Runtime Authority settlement";
+
 pub(crate) fn containment_receipt_path(coven_home: &Path, session_id: &str) -> PathBuf {
     coven_home
         .join("runtime")
@@ -2841,6 +2844,13 @@ pub(crate) enum ConfirmedStop {
     TimedOut,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConfirmedStopSettlement {
+    LostRace,
+    Settled,
+    RecoveryRequired,
+}
+
 pub(crate) enum StopFenceClaim {
     Acquired,
     InProgress,
@@ -3022,7 +3032,7 @@ pub(crate) fn settle_confirmed_stop(
     session_id: &str,
     disposition: ConfirmedStop,
     now: DateTime<Utc>,
-) -> Result<bool, String> {
+) -> Result<ConfirmedStopSettlement, String> {
     let (session_status, aggregate_state, attempt_state, failure_class, state_reason, exit_code) =
         match disposition {
             ConfirmedStop::Cancelled => (
@@ -3055,10 +3065,151 @@ pub(crate) fn settle_confirmed_stop(
     )
     .map_err(|error| format!("failed to settle automation session `{session_id}`: {error:#}"))?
     {
+        let lifecycle = transaction
+            .query_row(
+                "SELECT r.authority_profile, r.occurrence_id, r.status, s.status,
+                        (
+                            SELECT a.state
+                            FROM automation_attempts AS a
+                            WHERE a.run_id = r.id
+                              AND (
+                                  a.session_id = r.session_id
+                                  OR (a.state = 'dispatching' AND a.session_id IS NULL)
+                              )
+                            ORDER BY a.attempt_number DESC
+                            LIMIT 1
+                        )
+                 FROM automation_runs AS r
+                 JOIN sessions AS s ON s.id = r.session_id
+                 WHERE r.id = ?1 AND r.session_id = ?2",
+                rusqlite::params![run_id, session_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|error| {
+                format!("failed to inspect losing automation stop settlement: {error}")
+            })?;
+        let recovery_occurrence = match lifecycle {
+            None => Err(format!(
+                "automation run `{run_id}` changed before stop settlement completed"
+            )),
+            Some((
+                authority_profile,
+                occurrence_id,
+                run_status,
+                current_session_status,
+                attempt_state,
+            )) => {
+                let terminal_session = matches!(
+                    current_session_status.as_str(),
+                    "completed" | "failed" | "cancelled" | "killed" | "idle"
+                );
+                if !terminal_session {
+                    Err(format!(
+                        "automation session `{session_id}` changed to an unexpected nonterminal state"
+                    ))
+                } else if authority_profile.as_deref() != Some(AUTHORITY_PROFILE) {
+                    Ok(None)
+                } else {
+                    let authoritative_run_settled = matches!(
+                        run_status.as_str(),
+                        "succeeded" | "failed" | "cancelled" | "timed_out"
+                    );
+                    let authoritative_attempt_settled =
+                        attempt_state.as_deref().is_some_and(|state| {
+                            matches!(state, "succeeded" | "failed" | "cancelled" | "timed_out")
+                        });
+                    if authoritative_run_settled || authoritative_attempt_settled {
+                        Ok(None)
+                    } else if run_status == "running"
+                        && attempt_state.as_deref().is_some_and(|state| {
+                            matches!(state, "dispatching" | "started" | "observing" | "ambiguous")
+                        })
+                    {
+                        occurrence_id
+                            .ok_or_else(|| {
+                                format!("running automation run `{run_id}` has no occurrence")
+                            })
+                            .map(Some)
+                    } else {
+                        Err(format!(
+                            "Runtime Authority run `{run_id}` has no unresolved lifecycle to hold"
+                        ))
+                    }
+                }
+            }
+        };
+        match recovery_occurrence {
+            Ok(Some(occurrence_id)) => {
+                hold_runtime_authority_terminal_settlement_in(
+                    &transaction,
+                    run_id,
+                    &occurrence_id,
+                    now,
+                )?;
+                transaction
+                    .execute(
+                        "DELETE FROM automation_stop_fences
+                         WHERE run_id = ?1 AND session_id = ?2",
+                        rusqlite::params![run_id, session_id],
+                    )
+                    .map_err(|error| {
+                        format!("failed to release automation stop ownership: {error}")
+                    })?;
+                transaction.commit().map_err(|error| {
+                    format!("failed to commit Runtime Authority stop hold: {error}")
+                })?;
+                return Ok(ConfirmedStopSettlement::RecoveryRequired);
+            }
+            Ok(None) => {
+                transaction.rollback().map_err(|error| {
+                    format!("failed to roll back losing stop settlement: {error}")
+                })?;
+                return Ok(ConfirmedStopSettlement::LostRace);
+            }
+            Err(error) => {
+                transaction.rollback().map_err(|rollback_error| {
+                    format!("failed to roll back invalid stop settlement: {rollback_error}")
+                })?;
+                return Err(error);
+            }
+        }
+    }
+
+    let (authority_profile, occurrence_id): (Option<String>, String) = transaction
+        .query_row(
+            "SELECT authority_profile, occurrence_id
+             FROM automation_runs
+             WHERE id = ?1 AND session_id = ?2 AND status = 'running'",
+            rusqlite::params![run_id, session_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(|error| format!("failed to read stopped run authority profile: {error}"))?
+        .ok_or_else(|| {
+            format!("automation run `{run_id}` changed before stop settlement completed")
+        })?;
+    if authority_profile.as_deref() == Some(AUTHORITY_PROFILE) {
+        hold_runtime_authority_terminal_settlement_in(&transaction, run_id, &occurrence_id, now)?;
         transaction
-            .rollback()
-            .map_err(|error| format!("failed to roll back losing stop settlement: {error}"))?;
-        return Ok(false);
+            .execute(
+                "DELETE FROM automation_stop_fences
+                 WHERE run_id = ?1 AND session_id = ?2",
+                rusqlite::params![run_id, session_id],
+            )
+            .map_err(|error| format!("failed to release automation stop ownership: {error}"))?;
+        transaction
+            .commit()
+            .map_err(|error| format!("failed to commit Runtime Authority stop hold: {error}"))?;
+        return Ok(ConfirmedStopSettlement::RecoveryRequired);
     }
 
     let attempt_changed = transaction
@@ -3111,15 +3262,8 @@ pub(crate) fn settle_confirmed_stop(
         transaction
             .rollback()
             .map_err(|error| format!("failed to roll back incomplete run stop: {error}"))?;
-        return Ok(false);
+        return Ok(ConfirmedStopSettlement::LostRace);
     }
-    let occurrence_id: String = transaction
-        .query_row(
-            "SELECT occurrence_id FROM automation_runs WHERE id = ?1",
-            [run_id],
-            |row| row.get(0),
-        )
-        .map_err(|error| format!("failed to resolve stopped run occurrence: {error}"))?;
     if !settle_occurrence(
         &transaction,
         &occurrence_id,
@@ -3144,7 +3288,7 @@ pub(crate) fn settle_confirmed_stop(
     transaction
         .commit()
         .map_err(|error| format!("failed to commit automation stop settlement: {error}"))?;
-    Ok(true)
+    Ok(ConfirmedStopSettlement::Settled)
 }
 
 pub(crate) fn mark_unconfirmed_stop_for_recovery(
@@ -3343,15 +3487,16 @@ pub fn mark_active_attempts_for_restart_reconciliation(
 }
 
 /// Reconciles nonterminal automation rows against the authoritative session
-/// ledger. A completed session with an explicit zero exit code produces
-/// success, acknowledged cancellation remains distinct, and every other
-/// terminal session disposition is a failure.
+/// ledger. Base-v1 runs retain their legacy exit-based settlement. Runtime
+/// Authority runs remain unresolved until a later adapter consumes verified
+/// terminal runtime evidence.
 pub fn settle_finished_runs(
     conn: &Connection,
     now: DateTime<Utc>,
 ) -> Result<SettlementReport, String> {
     type RunningRow = (
         String,
+        Option<String>,
         Option<String>,
         Option<String>,
         Option<String>,
@@ -3366,7 +3511,8 @@ pub fn settle_finished_runs(
     let rows: Vec<RunningRow> = {
         let mut statement = conn
             .prepare(
-                "SELECT r.id, r.occurrence_id, r.session_id, s.status, s.exit_code,
+                "SELECT r.id, r.authority_profile, r.occurrence_id, r.session_id,
+                        s.status, s.exit_code,
                         o.state, r.timeout_at,
                         COALESCE(
                             (
@@ -3412,6 +3558,7 @@ pub fn settle_finished_runs(
                     row.get(7)?,
                     row.get(8)?,
                     row.get(9)?,
+                    row.get(10)?,
                 ))
             })
             .map_err(|error| format!("failed to query automation reconciliation: {error}"))?;
@@ -3427,6 +3574,7 @@ pub fn settle_finished_runs(
     let mut report = SettlementReport::default();
     for (
         run_id,
+        authority_profile,
         occurrence_id,
         session_id,
         session_status,
@@ -3445,6 +3593,15 @@ pub fn settle_finished_runs(
             )
         });
         if !terminal_session {
+            continue;
+        }
+        if authority_profile.as_deref() == Some(AUTHORITY_PROFILE) {
+            hold_runtime_authority_terminal_settlement(
+                conn,
+                &run_id,
+                occurrence_id.as_deref(),
+                now,
+            )?;
             continue;
         }
 
@@ -3613,6 +3770,102 @@ pub fn settle_finished_runs(
     Ok(report)
 }
 
+fn hold_runtime_authority_terminal_settlement(
+    conn: &Connection,
+    run_id: &str,
+    occurrence_id: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<(), String> {
+    let occurrence_id = occurrence_id
+        .ok_or_else(|| format!("running automation run `{run_id}` has no occurrence"))?;
+    let transaction = conn
+        .unchecked_transaction()
+        .map_err(|error| format!("failed to begin Runtime Authority recovery hold: {error}"))?;
+    hold_runtime_authority_terminal_settlement_in(&transaction, run_id, occurrence_id, now)?;
+    transaction
+        .commit()
+        .map_err(|error| format!("failed to commit Runtime Authority recovery hold: {error}"))
+}
+
+fn hold_runtime_authority_terminal_settlement_in(
+    conn: &Connection,
+    run_id: &str,
+    occurrence_id: &str,
+    now: DateTime<Utc>,
+) -> Result<(), String> {
+    let now_iso = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    conn.execute(
+        "UPDATE automation_attempts
+             SET state_reason = ?2
+             WHERE run_id = ?1
+               AND state IN ('dispatching', 'started', 'observing')
+               AND state_reason IS NOT ?2",
+        rusqlite::params![run_id, RUNTIME_TERMINAL_EVIDENCE_REQUIRED_REASON],
+    )
+    .map_err(|error| {
+        format!("failed to record Runtime Authority terminal evidence hold: {error}")
+    })?;
+    let unresolved_attempts: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM automation_attempts
+             WHERE run_id = ?1
+               AND state IN ('dispatching', 'started', 'observing', 'ambiguous')",
+            [run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            format!("failed to inspect Runtime Authority terminal evidence hold: {error}")
+        })?;
+    if unresolved_attempts != 1 {
+        return Err(format!(
+            "Runtime Authority run `{run_id}` has no single unresolved attempt"
+        ));
+    }
+    conn.execute(
+        "UPDATE automation_occurrences
+             SET state = 'recovery_required',
+                 failure_reason = ?2,
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 updated_at = ?3
+             WHERE id = ?1
+               AND (
+                   state IN ('claimed', 'running')
+                   OR (
+                       state = 'recovery_required'
+                       AND failure_reason IS NOT ?2
+                   )
+               )",
+        rusqlite::params![
+            occurrence_id,
+            RUNTIME_TERMINAL_EVIDENCE_REQUIRED_REASON,
+            now_iso,
+        ],
+    )
+    .map_err(|error| {
+        format!("failed to mark Runtime Authority occurrence for recovery: {error}")
+    })?;
+    let held: Option<String> = conn
+        .query_row(
+            "SELECT state
+             FROM automation_occurrences
+             WHERE id = ?1",
+            [occurrence_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| {
+            format!("failed to verify Runtime Authority occurrence recovery hold: {error}")
+        })?;
+    if held.as_deref() != Some("recovery_required") {
+        return Err(format!(
+            "Runtime Authority occurrence `{occurrence_id}` changed during recovery hold"
+        ));
+    }
+    Ok(())
+}
+
 /// Reads and validates a stored definition for dispatch.
 pub fn load_definition_for_run(
     conn: &Connection,
@@ -3720,14 +3973,24 @@ mod tests {
         AuthorityEvidenceVerifier, AuthorityProfileError, AuthorityProfileErrorCode,
         AuthorityValidationPhase, AutomationAuthorityExtension, AUTHORITY_EXTENSION_KEY,
     };
+    use crate::automations::contract::canonical_json::{canonicalize, sha256_hex};
+    use crate::automations::contract::runtime_terminal_evidence::{
+        RuntimeTerminalEvidence, RuntimeTerminalEvidenceError, RuntimeTerminalEvidenceErrorCode,
+        RuntimeTerminalEvidenceVerifier, RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN,
+        RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+    };
     use crate::automations::contract::types::{BackoffPolicy, RetryableClass};
     use crate::automations::definition::{RoutineDefinition, RoutineRetryPolicy, RoutineStatus};
+    use crate::automations::runtime_terminal_evidence::store_runtime_terminal_evidence;
     use crate::automations::store::insert_definition;
     use crate::store::initialize_store;
     use chrono::TimeZone;
     use serde_json::json;
     use sha2::{Digest as _, Sha256};
     use std::collections::BTreeSet;
+
+    const EXPECTED_RUNTIME_TERMINAL_EVIDENCE_REQUIRED_REASON: &str =
+        "trusted runtime terminal evidence is required before Runtime Authority settlement";
 
     struct RejectingRuntime;
 
@@ -4415,6 +4678,114 @@ mod tests {
         }
     }
 
+    impl RuntimeTerminalEvidenceVerifier for VectorAuthority {
+        fn verify(
+            &self,
+            evidence: &RuntimeTerminalEvidence,
+        ) -> Result<(), RuntimeTerminalEvidenceError> {
+            if evidence.authentication.key_id.as_str() != "key:runtime-instance-1"
+                || evidence.authentication.signature.as_str()
+                    != format!(
+                        "{}{}",
+                        evidence.authentication.signed_digest.value.as_str(),
+                        evidence.authentication.signed_digest.value.as_str()
+                    )
+            {
+                return Err(RuntimeTerminalEvidenceError::new(
+                    RuntimeTerminalEvidenceErrorCode::AuthenticationInvalid,
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    fn runtime_terminal_evidence(
+        conn: &Connection,
+        run_id: &str,
+        session_id: &str,
+    ) -> RuntimeTerminalEvidence {
+        let extension_json: String = conn
+            .query_row(
+                "SELECT authority_extension_json
+                 FROM automation_attempts
+                 WHERE run_id = ?1",
+                [run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let extension: serde_json::Value = serde_json::from_str(&extension_json).unwrap();
+        let binding = &extension["executionBinding"];
+        let mut value = json!({
+            "profile": RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+            "evidenceId": format!("evidence:{run_id}"),
+            "sessionId": session_id,
+            "runId": binding["base"]["runId"],
+            "attemptId": binding["base"]["attemptId"],
+            "binding": {
+                "bindingId": binding["bindingId"],
+                "bindingDigest": binding["integrity"]
+            },
+            "runtime": {
+                "runtimeId": binding["runtime"]["runtimeId"],
+                "descriptorDigest": binding["runtime"]["descriptorDigest"]
+            },
+            "producedAt": "2026-09-03T12:30:00.000Z",
+            "disposition": "succeeded",
+            "sideEffects": {
+                "state": "observed",
+                "maximumClass": "local_write",
+                "coverage": "complete"
+            },
+            "exercisedCapabilities": {
+                "state": "observed",
+                "values": ["analysis.read", "artifact.write"],
+                "coverage": "complete"
+            },
+            "result": {"state": "not_produced"},
+            "delivery": {"state": "not_attempted"},
+            "producer": {
+                "component": "runtime-adapter",
+                "instanceId": "runtime-instance-1",
+                "implementationVersion": "1.0.0"
+            },
+            "privacy": {
+                "classification": "operational",
+                "retention": {"classification": "standard"}
+            },
+            "integrity": {
+                "algorithm": "sha256",
+                "canonicalization": "jcs-rfc8785",
+                "value": "0".repeat(64)
+            },
+            "authentication": {
+                "method": "ed25519",
+                "keyId": "key:runtime-instance-1",
+                "proofRef": "proof:runtime-instance-1",
+                "signedDigest": {
+                    "algorithm": "sha256",
+                    "canonicalization": "jcs-rfc8785",
+                    "value": "0".repeat(64)
+                },
+                "signature": "0".repeat(128)
+            }
+        });
+        let mut body = value.clone();
+        let object = body.as_object_mut().unwrap();
+        object.remove("integrity");
+        object.remove("authentication");
+        let canonical = canonicalize(&body).unwrap();
+        let integrity = sha256_hex(&canonical);
+        let mut authentication_preimage = Vec::new();
+        authentication_preimage.extend_from_slice(RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN);
+        authentication_preimage.push(0);
+        authentication_preimage.extend_from_slice(&canonical);
+        let signed_digest = sha256_hex(&authentication_preimage);
+        value["integrity"]["value"] = json!(integrity);
+        value["authentication"]["signedDigest"]["value"] = json!(signed_digest);
+        value["authentication"]["signature"] = json!(format!("{signed_digest}{signed_digest}"));
+        serde_json::from_value(value).unwrap()
+    }
+
     #[derive(Debug, Default)]
     struct CountingAuthority {
         resolve_calls: Cell<usize>,
@@ -4447,7 +4818,7 @@ mod tests {
             extension: &AutomationAuthorityExtension,
             phase: AuthorityValidationPhase,
         ) -> Result<(), AuthorityProfileError> {
-            VectorAuthority.verify(extension, phase)
+            AuthorityEvidenceVerifier::verify(&VectorAuthority, extension, phase)
         }
     }
 
@@ -4481,7 +4852,7 @@ mod tests {
             extension: &AutomationAuthorityExtension,
             phase: AuthorityValidationPhase,
         ) -> Result<(), AuthorityProfileError> {
-            VectorAuthority.verify(extension, phase)
+            AuthorityEvidenceVerifier::verify(&VectorAuthority, extension, phase)
         }
     }
 
@@ -4518,7 +4889,7 @@ mod tests {
                     "private terminal verifier detail",
                 ));
             }
-            VectorAuthority.verify(extension, phase)
+            AuthorityEvidenceVerifier::verify(&VectorAuthority, extension, phase)
         }
     }
 
@@ -4566,7 +4937,7 @@ mod tests {
             extension: &AutomationAuthorityExtension,
             phase: AuthorityValidationPhase,
         ) -> Result<(), AuthorityProfileError> {
-            VectorAuthority.verify(extension, phase)
+            AuthorityEvidenceVerifier::verify(&VectorAuthority, extension, phase)
         }
     }
 
@@ -4876,6 +5247,19 @@ mod tests {
         attempt_settled_at: Option<String>,
         session_status: String,
         session_updated_at: String,
+    }
+
+    struct RuntimeAuthorityHoldState {
+        occurrence_state: String,
+        occurrence_reason: Option<String>,
+        run_status: String,
+        exit_code: Option<i64>,
+        finished_at: Option<String>,
+        receipt_id: Option<String>,
+        attempt_state: String,
+        attempt_reason: Option<String>,
+        attempt_settled_at: Option<String>,
+        attempt_count: i64,
     }
 
     fn persist_authority_attempt(
@@ -5445,6 +5829,10 @@ mod tests {
         assert_eq!(
             super::super::contract::events::stream_head(&conn, "run", &outcome.run_id).unwrap(),
             Some(0)
+        );
+        assert_eq!(
+            settle_finished_runs(&conn, now + chrono::Duration::seconds(1)).unwrap(),
+            SettlementReport::default()
         );
         drop(conn);
 
@@ -6744,6 +7132,344 @@ mod tests {
             )
             .unwrap();
         assert_eq!(state, "succeeded");
+    }
+
+    #[test]
+    fn runtime_authority_terminal_session_without_consumed_evidence_enters_recovery_hold() {
+        let (temp, conn) = temp_store();
+        let routine = definition("authority-terminal-hold");
+        insert_definition(&conn, &routine).unwrap();
+        let launched_at = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let occurrence_id = "occurrence.authority-terminal-hold";
+        assert!(insert_claimed_occurrence(
+            &conn,
+            occurrence_id,
+            &routine.id,
+            "daemon",
+            60,
+            launched_at,
+        )
+        .unwrap());
+        let runtime = AuthorityObservingRuntime { conn: &conn };
+        let mut clock = || launched_at;
+        let cancelled = || false;
+        let mut control = DispatchControl {
+            clock: &mut clock,
+            cancelled: &cancelled,
+            authority: AutomationAuthorityMode::RuntimeAuthority(&VectorAuthority),
+            scheduler_fence: None,
+        };
+        let DispatchAttempt::Completed(outcome) = dispatch_occurrence_with_clock(
+            &conn,
+            &runtime,
+            &routine,
+            occurrence_id,
+            routine.cwd.as_deref().unwrap(),
+            launched_at,
+            &mut control,
+        )
+        .unwrap() else {
+            panic!("Runtime Authority launch must complete");
+        };
+        let session_id = outcome.session_id.as_deref().unwrap();
+        conn.execute(
+            "INSERT INTO events (id, session_id, kind, payload_json, created_at)
+             VALUES ('event-runtime-evidence-shaped-output', ?1, 'output', ?2, ?3)",
+            rusqlite::params![
+                session_id,
+                json!({
+                    "text": {
+                        "profile": RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+                        "disposition": "succeeded"
+                    }
+                })
+                .to_string(),
+                launched_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            ],
+        )
+        .unwrap();
+        let terminal_at = launched_at + chrono::Duration::seconds(5);
+        crate::store::update_session_terminal_if_active(
+            &conn,
+            session_id,
+            "completed",
+            Some(0),
+            &terminal_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settle_finished_runs(&conn, terminal_at).unwrap(),
+            SettlementReport::default()
+        );
+        let state: RuntimeAuthorityHoldState = conn
+            .query_row(
+                "SELECT o.state, o.failure_reason, r.status, r.exit_code,
+                        r.finished_at, r.receipt_id, a.state, a.state_reason,
+                        a.settled_at,
+                        (SELECT COUNT(*) FROM automation_attempts WHERE run_id = r.id)
+                 FROM automation_runs AS r
+                 JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+                 JOIN automation_attempts AS a ON a.run_id = r.id
+                 WHERE r.id = ?1",
+                [&outcome.run_id],
+                |row| {
+                    Ok(RuntimeAuthorityHoldState {
+                        occurrence_state: row.get(0)?,
+                        occurrence_reason: row.get(1)?,
+                        run_status: row.get(2)?,
+                        exit_code: row.get(3)?,
+                        finished_at: row.get(4)?,
+                        receipt_id: row.get(5)?,
+                        attempt_state: row.get(6)?,
+                        attempt_reason: row.get(7)?,
+                        attempt_settled_at: row.get(8)?,
+                        attempt_count: row.get(9)?,
+                    })
+                },
+            )
+            .unwrap();
+        assert_eq!(state.occurrence_state, "recovery_required");
+        assert_eq!(
+            state.occurrence_reason.as_deref(),
+            Some(EXPECTED_RUNTIME_TERMINAL_EVIDENCE_REQUIRED_REASON)
+        );
+        assert_eq!(state.run_status, "running");
+        assert_eq!(state.exit_code, None);
+        assert_eq!(state.finished_at, None);
+        assert_eq!(state.receipt_id, None);
+        assert_eq!(state.attempt_state, "started");
+        assert_eq!(
+            state.attempt_reason.as_deref(),
+            Some(EXPECTED_RUNTIME_TERMINAL_EVIDENCE_REQUIRED_REASON)
+        );
+        assert_eq!(state.attempt_settled_at, None);
+        assert_eq!(state.attempt_count, 1);
+        assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
+
+        assert_eq!(
+            settle_finished_runs(&conn, terminal_at + chrono::Duration::seconds(1)).unwrap(),
+            SettlementReport::default()
+        );
+        drop(conn);
+        let reopened = crate::store::open_initialized_store(&temp.path().join("store.sqlite"))
+            .expect("reopened store");
+        assert_eq!(
+            settle_finished_runs(&reopened, terminal_at + chrono::Duration::seconds(2)).unwrap(),
+            SettlementReport::default()
+        );
+        let reopened_state: (String, String, String, Option<String>, Option<String>) = reopened
+            .query_row(
+                "SELECT o.state, r.status, a.state, r.receipt_id, a.settled_at
+                 FROM automation_runs AS r
+                 JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+                 JOIN automation_attempts AS a ON a.run_id = r.id
+                 WHERE r.id = ?1",
+                [&outcome.run_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            reopened_state,
+            (
+                "recovery_required".to_string(),
+                "running".to_string(),
+                "started".to_string(),
+                None,
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn stored_runtime_evidence_is_not_consumed_without_a_production_adapter() {
+        let (_temp, conn) = temp_store();
+        let routine = definition("authority-stored-evidence-hold");
+        insert_definition(&conn, &routine).unwrap();
+        let launched_at = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+        let occurrence_id = "occurrence.authority-stored-evidence-hold";
+        assert!(insert_claimed_occurrence(
+            &conn,
+            occurrence_id,
+            &routine.id,
+            "daemon",
+            60,
+            launched_at,
+        )
+        .unwrap());
+        let runtime = AuthorityObservingRuntime { conn: &conn };
+        let mut clock = || launched_at;
+        let cancelled = || false;
+        let mut control = DispatchControl {
+            clock: &mut clock,
+            cancelled: &cancelled,
+            authority: AutomationAuthorityMode::RuntimeAuthority(&VectorAuthority),
+            scheduler_fence: None,
+        };
+        let DispatchAttempt::Completed(outcome) = dispatch_occurrence_with_clock(
+            &conn,
+            &runtime,
+            &routine,
+            occurrence_id,
+            routine.cwd.as_deref().unwrap(),
+            launched_at,
+            &mut control,
+        )
+        .unwrap() else {
+            panic!("Runtime Authority launch must complete");
+        };
+        let session_id = outcome.session_id.as_deref().unwrap();
+        let evidence = runtime_terminal_evidence(&conn, &outcome.run_id, session_id);
+        store_runtime_terminal_evidence(&conn, &evidence, &VectorAuthority).unwrap();
+        let terminal_at = launched_at + chrono::Duration::seconds(5);
+        crate::store::update_session_terminal_if_active(
+            &conn,
+            session_id,
+            "completed",
+            Some(0),
+            &terminal_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settle_finished_runs(&conn, terminal_at).unwrap(),
+            SettlementReport::default()
+        );
+        let state: (String, String, String, Option<String>) = conn
+            .query_row(
+                "SELECT o.state, r.status, a.state, r.receipt_id
+                 FROM automation_runs AS r
+                 JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+                 JOIN automation_attempts AS a ON a.run_id = r.id
+                 WHERE r.id = ?1",
+                [&outcome.run_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            state,
+            (
+                "recovery_required".to_string(),
+                "running".to_string(),
+                "started".to_string(),
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn confirmed_runtime_authority_stops_preserve_unresolved_evidence_state() {
+        for (name, disposition, expected_session_state) in [
+            (
+                "authority-confirmed-cancel",
+                ConfirmedStop::Cancelled,
+                "cancelled",
+            ),
+            (
+                "authority-confirmed-timeout",
+                ConfirmedStop::TimedOut,
+                "killed",
+            ),
+        ] {
+            let (_temp, conn) = temp_store();
+            let routine = definition(name);
+            insert_definition(&conn, &routine).unwrap();
+            let launched_at = Utc.with_ymd_and_hms(2026, 9, 3, 12, 0, 0).unwrap();
+            let occurrence_id = format!("occurrence.{name}");
+            assert!(insert_claimed_occurrence(
+                &conn,
+                &occurrence_id,
+                &routine.id,
+                "daemon",
+                60,
+                launched_at,
+            )
+            .unwrap());
+            let runtime = AuthorityObservingRuntime { conn: &conn };
+            let mut clock = || launched_at;
+            let cancelled = || false;
+            let mut control = DispatchControl {
+                clock: &mut clock,
+                cancelled: &cancelled,
+                authority: AutomationAuthorityMode::RuntimeAuthority(&VectorAuthority),
+                scheduler_fence: None,
+            };
+            let DispatchAttempt::Completed(outcome) = dispatch_occurrence_with_clock(
+                &conn,
+                &runtime,
+                &routine,
+                &occurrence_id,
+                routine.cwd.as_deref().unwrap(),
+                launched_at,
+                &mut control,
+            )
+            .unwrap() else {
+                panic!("Runtime Authority launch must complete");
+            };
+            let session_id = outcome.session_id.as_deref().unwrap();
+
+            assert_eq!(
+                settle_confirmed_stop(
+                    &conn,
+                    &outcome.run_id,
+                    session_id,
+                    disposition,
+                    launched_at + chrono::Duration::seconds(5),
+                )
+                .unwrap(),
+                ConfirmedStopSettlement::RecoveryRequired
+            );
+
+            let state: (
+                String,
+                String,
+                String,
+                Option<String>,
+                Option<String>,
+                String,
+            ) = conn
+                .query_row(
+                    "SELECT o.state, r.status, a.state, r.receipt_id, a.settled_at, s.status
+                     FROM automation_runs AS r
+                     JOIN automation_occurrences AS o ON o.id = r.occurrence_id
+                     JOIN automation_attempts AS a ON a.run_id = r.id
+                     JOIN sessions AS s ON s.id = r.session_id
+                     WHERE r.id = ?1",
+                    [&outcome.run_id],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                        ))
+                    },
+                )
+                .unwrap();
+            assert_eq!(
+                state,
+                (
+                    "recovery_required".to_string(),
+                    "running".to_string(),
+                    "started".to_string(),
+                    None,
+                    None,
+                    expected_session_state.to_string(),
+                ),
+                "{name}"
+            );
+            assert_eq!(receipt_artifact_counts(&conn, &outcome.run_id), (0, 0, 0));
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/runtime_terminal_evidence.rs
+++ b/crates/coven-cli/src/automations/runtime_terminal_evidence.rs
@@ -1,0 +1,2039 @@
+//! Immutable verifier-backed inbox for runtime terminal evidence.
+//!
+//! This module deliberately exposes only internal Rust APIs. There is no
+//! daemon action or other public submission path in this slice.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result as AnyhowResult};
+use chrono::{SecondsFormat, Utc};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use serde_json::Value;
+
+use super::contract::authority::{
+    validate_authority_profile_structure, AuthorityConsumerClass, AuthorityProfileDisposition,
+    AuthorityValidationPhase, AutomationExecutionBinding, AUTHORITY_EXTENSION_KEY,
+    AUTHORITY_PROFILE, BASE_PROFILE, RUNTIME_AUTHORITY_CAPABILITY,
+};
+use super::contract::canonical_json::canonicalize;
+use super::contract::runtime_terminal_evidence::{
+    classify_runtime_terminal_evidence, verify_runtime_terminal_evidence, RuntimeTerminalEvidence,
+    RuntimeTerminalEvidenceClassification, RuntimeTerminalEvidenceError,
+    RuntimeTerminalEvidenceErrorCode, RuntimeTerminalEvidenceVerifier,
+    VerifiedRuntimeTerminalEvidence,
+};
+use super::contract::types::ExtensionBag;
+
+pub const AUTOMATION_RUNTIME_TERMINAL_EVIDENCE_SCHEMA_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS automation_runtime_terminal_evidence (
+        evidence_id TEXT PRIMARY KEY NOT NULL,
+        attempt_id TEXT UNIQUE NOT NULL,
+        session_id TEXT UNIQUE NOT NULL,
+        run_id TEXT NOT NULL,
+        binding_id TEXT NOT NULL,
+        binding_digest TEXT UNIQUE NOT NULL CHECK (
+            length(binding_digest) = 64
+            AND binding_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        runtime_id TEXT NOT NULL,
+        descriptor_digest TEXT NOT NULL CHECK (
+            length(descriptor_digest) = 64
+            AND descriptor_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        producer_key_id TEXT NOT NULL,
+        evidence_digest TEXT NOT NULL CHECK (
+            length(evidence_digest) = 64
+            AND evidence_digest NOT GLOB '*[^0-9a-f]*'
+        ),
+        classification TEXT NOT NULL CHECK (
+            classification IN (
+                'receipt_eligible_complete',
+                'authenticated_partial_or_ambiguous',
+                'authenticated_unknown',
+                'policy_violating'
+            )
+        ),
+        produced_at TEXT NOT NULL,
+        received_at TEXT NOT NULL,
+        canonical_json TEXT NOT NULL CHECK (json_valid(canonical_json)),
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE RESTRICT,
+        FOREIGN KEY (run_id) REFERENCES automation_runs(id) ON DELETE RESTRICT,
+        FOREIGN KEY (attempt_id) REFERENCES automation_attempts(id) ON DELETE RESTRICT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_automation_runtime_terminal_evidence_run
+        ON automation_runtime_terminal_evidence(run_id);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_automation_runtime_terminal_evidence_binding
+        ON automation_runtime_terminal_evidence(binding_id);
+
+    CREATE TRIGGER IF NOT EXISTS automation_runtime_terminal_evidence_no_update
+    BEFORE UPDATE ON automation_runtime_terminal_evidence
+    BEGIN
+        SELECT RAISE(ABORT, 'automation runtime terminal evidence is immutable');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS automation_runtime_terminal_evidence_no_delete
+    BEFORE DELETE ON automation_runtime_terminal_evidence
+    BEGIN
+        SELECT RAISE(ABORT, 'automation runtime terminal evidence is immutable');
+    END;
+";
+
+pub(crate) fn ensure_runtime_terminal_evidence_schema(conn: &Connection) -> AnyhowResult<()> {
+    let table_sql: Option<String> = conn
+        .query_row(
+            "SELECT sql
+             FROM sqlite_master
+             WHERE type = 'table'
+               AND name = 'automation_runtime_terminal_evidence'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .context("failed to inspect automation runtime terminal evidence schema")?;
+    let classification_requires_upgrade = table_sql
+        .as_deref()
+        .is_some_and(|sql| !sql.contains("'authenticated_unknown'"));
+    if classification_requires_upgrade || binding_index_requires_upgrade(conn)? {
+        return migrate_runtime_terminal_evidence_schema(conn);
+    }
+    conn.execute_batch(AUTOMATION_RUNTIME_TERMINAL_EVIDENCE_SCHEMA_SQL)
+        .context("failed to initialize automation runtime terminal evidence schema")
+}
+
+fn binding_index_requires_upgrade(conn: &Connection) -> AnyhowResult<bool> {
+    let unique: Option<i64> = conn
+        .query_row(
+            "SELECT [unique]
+             FROM pragma_index_list('automation_runtime_terminal_evidence')
+             WHERE name = 'idx_automation_runtime_terminal_evidence_binding'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .context("failed to inspect runtime evidence binding index")?;
+    let Some(unique) = unique else {
+        return Ok(false);
+    };
+    let columns = conn
+        .prepare(
+            "SELECT name
+             FROM pragma_index_info('idx_automation_runtime_terminal_evidence_binding')
+             ORDER BY seqno",
+        )
+        .context("failed to inspect runtime evidence binding index columns")?
+        .query_map([], |row| row.get::<_, String>(0))
+        .context("failed to query runtime evidence binding index columns")?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read runtime evidence binding index columns")?;
+    Ok(unique != 1 || columns.len() != 1 || columns[0] != "binding_id")
+}
+
+fn migrate_runtime_terminal_evidence_schema(conn: &Connection) -> AnyhowResult<()> {
+    anyhow::ensure!(
+        conn.is_autocommit(),
+        "automation runtime terminal evidence migration requires autocommit"
+    );
+    let legacy_exists = conn
+        .query_row(
+            "SELECT 1
+             FROM sqlite_master
+             WHERE type = 'table'
+               AND name = 'automation_runtime_terminal_evidence_legacy'",
+            [],
+            |_| Ok(()),
+        )
+        .optional()
+        .context("failed to inspect legacy automation runtime terminal evidence schema")?
+        .is_some();
+    anyhow::ensure!(
+        !legacy_exists,
+        "legacy automation runtime terminal evidence table already exists"
+    );
+
+    let foreign_keys_enabled: i64 = conn
+        .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+        .context("failed to inspect SQLite foreign-key mode")?;
+    conn.pragma_update(None, "foreign_keys", false)
+        .context("failed to disable foreign keys for runtime evidence migration")?;
+    let migration = (|| -> AnyhowResult<()> {
+        let transaction = conn
+            .unchecked_transaction()
+            .context("failed to begin runtime evidence schema migration")?;
+        transaction
+            .execute_batch(
+                "DROP TRIGGER IF EXISTS automation_runtime_terminal_evidence_no_update;
+                 DROP TRIGGER IF EXISTS automation_runtime_terminal_evidence_no_delete;
+                 DROP INDEX IF EXISTS idx_automation_runtime_terminal_evidence_run;
+                 DROP INDEX IF EXISTS idx_automation_runtime_terminal_evidence_binding;
+                 ALTER TABLE automation_runtime_terminal_evidence
+                 RENAME TO automation_runtime_terminal_evidence_legacy;",
+            )
+            .context("failed to prepare runtime evidence schema migration")?;
+        transaction
+            .execute_batch(AUTOMATION_RUNTIME_TERMINAL_EVIDENCE_SCHEMA_SQL)
+            .context("failed to create upgraded runtime evidence schema")?;
+        let legacy_rows = transaction
+            .prepare(
+                "SELECT evidence_id, attempt_id, session_id, run_id, binding_id,
+                        binding_digest, runtime_id, descriptor_digest, producer_key_id,
+                        evidence_digest, classification, produced_at, received_at,
+                        canonical_json
+                 FROM automation_runtime_terminal_evidence_legacy
+                 ORDER BY evidence_id",
+            )
+            .context("failed to prepare legacy runtime evidence migration")?
+            .query_map([], |row| {
+                Ok(StoredRuntimeTerminalEvidence {
+                    evidence_id: row.get(0)?,
+                    attempt_id: row.get(1)?,
+                    session_id: row.get(2)?,
+                    run_id: row.get(3)?,
+                    binding_id: row.get(4)?,
+                    binding_digest: row.get(5)?,
+                    runtime_id: row.get(6)?,
+                    descriptor_digest: row.get(7)?,
+                    producer_key_id: row.get(8)?,
+                    evidence_digest: row.get(9)?,
+                    classification: row.get(10)?,
+                    produced_at: row.get(11)?,
+                    received_at: row.get(12)?,
+                    canonical_json: row.get(13)?,
+                })
+            })
+            .context("failed to query legacy runtime evidence")?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read legacy runtime evidence")?;
+        for stored in legacy_rows {
+            let classification = migrated_classification(&transaction, &stored)?;
+            transaction
+                .execute(
+                    "INSERT INTO automation_runtime_terminal_evidence (
+                    evidence_id, attempt_id, session_id, run_id, binding_id,
+                    binding_digest, runtime_id, descriptor_digest, producer_key_id,
+                    evidence_digest, classification, produced_at, received_at,
+                    canonical_json
+                 ) VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
+                 )",
+                    params![
+                        stored.evidence_id,
+                        stored.attempt_id,
+                        stored.session_id,
+                        stored.run_id,
+                        stored.binding_id,
+                        stored.binding_digest,
+                        stored.runtime_id,
+                        stored.descriptor_digest,
+                        stored.producer_key_id,
+                        stored.evidence_digest,
+                        classification.as_str(),
+                        stored.produced_at,
+                        stored.received_at,
+                        stored.canonical_json,
+                    ],
+                )
+                .context("failed to copy runtime evidence into upgraded schema")?;
+        }
+        transaction
+            .execute_batch("DROP TABLE automation_runtime_terminal_evidence_legacy;")
+            .context("failed to finish runtime evidence schema migration")?;
+        let foreign_key_errors: i64 = transaction
+            .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+                row.get(0)
+            })
+            .context("failed to verify foreign keys after runtime evidence migration")?;
+        anyhow::ensure!(
+            foreign_key_errors == 0,
+            "runtime evidence migration produced {foreign_key_errors} foreign-key violation(s)"
+        );
+        transaction
+            .commit()
+            .context("failed to commit runtime evidence schema migration")
+    })();
+    let restore = conn
+        .pragma_update(None, "foreign_keys", foreign_keys_enabled != 0)
+        .context("failed to restore SQLite foreign-key mode");
+    migration?;
+    restore
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeTerminalEvidenceStoreOutcome {
+    Stored,
+    Replayed,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum RuntimeTerminalEvidenceLookup<'a> {
+    EvidenceId(&'a str),
+    AttemptId(&'a str),
+}
+
+struct StoredRuntimeTerminalEvidence {
+    evidence_id: String,
+    attempt_id: String,
+    session_id: String,
+    run_id: String,
+    binding_id: String,
+    binding_digest: String,
+    runtime_id: String,
+    descriptor_digest: String,
+    producer_key_id: String,
+    evidence_digest: String,
+    classification: String,
+    produced_at: String,
+    received_at: String,
+    canonical_json: String,
+}
+
+struct DurableRuntimeTerminalEvidenceBinding {
+    run_id: String,
+    run_automation_id: String,
+    run_automation_revision: i64,
+    run_definition_digest: Option<String>,
+    run_occurrence_id: Option<String>,
+    attempt_id: String,
+    attempt_run_id: String,
+    attempt_occurrence_id: String,
+    attempt_number: i64,
+    adoption_key: String,
+    occurrence_fence_generation: i64,
+    session_id: Option<String>,
+    runtime_id: Option<String>,
+    authority_profile: Option<String>,
+    extension_json: Option<String>,
+}
+
+pub fn store_runtime_terminal_evidence(
+    conn: &Connection,
+    evidence: &RuntimeTerminalEvidence,
+    verifier: &dyn RuntimeTerminalEvidenceVerifier,
+) -> Result<RuntimeTerminalEvidenceStoreOutcome, RuntimeTerminalEvidenceError> {
+    if !conn.is_autocommit() {
+        return Err(evidence_error(
+            RuntimeTerminalEvidenceErrorCode::StoreUnavailable,
+        ));
+    }
+    let transaction = rusqlite::Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable))?;
+    let outcome = store_runtime_terminal_evidence_in(&transaction, evidence, verifier)?;
+    transaction
+        .commit()
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable))?;
+    Ok(outcome)
+}
+
+fn store_runtime_terminal_evidence_in(
+    conn: &Connection,
+    evidence: &RuntimeTerminalEvidence,
+    verifier: &dyn RuntimeTerminalEvidenceVerifier,
+) -> Result<RuntimeTerminalEvidenceStoreOutcome, RuntimeTerminalEvidenceError> {
+    let binding = pinned_binding(conn, evidence, false)?;
+    let verified = verify_runtime_terminal_evidence(evidence.clone(), &binding, verifier)?;
+    let canonical = canonical_evidence(&verified.evidence)?;
+
+    let collisions = collision_rows(conn, &verified.evidence)?;
+    if !collisions.is_empty() {
+        if collisions.len() == 1
+            && exact_stored_match(
+                &collisions[0],
+                &verified.evidence,
+                verified.classification,
+                &canonical,
+            )
+        {
+            return Ok(RuntimeTerminalEvidenceStoreOutcome::Replayed);
+        }
+        return Err(evidence_error(RuntimeTerminalEvidenceErrorCode::Conflict));
+    }
+
+    conn.execute(
+        "INSERT INTO automation_runtime_terminal_evidence (
+            evidence_id, attempt_id, session_id, run_id, binding_id,
+            binding_digest, runtime_id, descriptor_digest, producer_key_id,
+            evidence_digest, classification, produced_at, received_at,
+            canonical_json
+         ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
+         )",
+        params![
+            verified.evidence.evidence_id.as_str(),
+            verified.evidence.attempt_id.as_str(),
+            verified.evidence.session_id.as_str(),
+            verified.evidence.run_id.as_str(),
+            verified.evidence.binding.binding_id.as_str(),
+            verified.evidence.binding.binding_digest.value.as_str(),
+            verified.evidence.runtime.runtime_id.as_str(),
+            verified.evidence.runtime.descriptor_digest.value.as_str(),
+            verified.evidence.authentication.key_id.as_str(),
+            verified.evidence.integrity.value.as_str(),
+            verified.classification.as_str(),
+            verified.evidence.produced_at.as_str(),
+            Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+            canonical,
+        ],
+    )
+    .map_err(|error| {
+        if matches!(
+            error,
+            rusqlite::Error::SqliteFailure(ref code, _)
+                if code.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+                    || code.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY
+        ) {
+            evidence_error(RuntimeTerminalEvidenceErrorCode::Conflict)
+        } else {
+            evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable)
+        }
+    })?;
+    Ok(RuntimeTerminalEvidenceStoreOutcome::Stored)
+}
+
+pub fn read_verified_runtime_terminal_evidence(
+    conn: &Connection,
+    lookup: RuntimeTerminalEvidenceLookup<'_>,
+    verifier: &dyn RuntimeTerminalEvidenceVerifier,
+) -> Result<Option<VerifiedRuntimeTerminalEvidence>, RuntimeTerminalEvidenceError> {
+    if conn.is_autocommit() {
+        let transaction = conn
+            .unchecked_transaction()
+            .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable))?;
+        let evidence = read_verified_runtime_terminal_evidence_in(&transaction, lookup, verifier)?;
+        transaction
+            .commit()
+            .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable))?;
+        return Ok(evidence);
+    }
+    read_verified_runtime_terminal_evidence_in(conn, lookup, verifier)
+}
+
+fn read_verified_runtime_terminal_evidence_in(
+    conn: &Connection,
+    lookup: RuntimeTerminalEvidenceLookup<'_>,
+    verifier: &dyn RuntimeTerminalEvidenceVerifier,
+) -> Result<Option<VerifiedRuntimeTerminalEvidence>, RuntimeTerminalEvidenceError> {
+    let stored = match lookup {
+        RuntimeTerminalEvidenceLookup::EvidenceId(evidence_id) => {
+            read_stored(conn, "evidence_id", evidence_id)?
+        }
+        RuntimeTerminalEvidenceLookup::AttemptId(attempt_id) => {
+            read_stored(conn, "attempt_id", attempt_id)?
+        }
+    };
+    let Some(stored) = stored else {
+        return Ok(None);
+    };
+    let evidence: RuntimeTerminalEvidence = serde_json::from_str(&stored.canonical_json)
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid))?;
+    let canonical = canonical_evidence(&evidence)
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid))?;
+    if !exact_stored_match(
+        &stored,
+        &evidence,
+        classification_from_str(&stored.classification)?,
+        &canonical,
+    ) {
+        return Err(evidence_error(
+            RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid,
+        ));
+    }
+    let binding = pinned_binding(conn, &evidence, true)?;
+    let verified = verify_runtime_terminal_evidence(evidence, &binding, verifier)?;
+    if verified.classification.as_str() != stored.classification {
+        return Err(evidence_error(
+            RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid,
+        ));
+    }
+    Ok(Some(verified))
+}
+
+fn read_stored(
+    conn: &Connection,
+    column: &str,
+    value: &str,
+) -> Result<Option<StoredRuntimeTerminalEvidence>, RuntimeTerminalEvidenceError> {
+    let sql = format!(
+        "SELECT evidence_id, attempt_id, session_id, run_id, binding_id,
+                binding_digest, runtime_id, descriptor_digest, producer_key_id,
+                evidence_digest, classification, produced_at, received_at,
+                canonical_json
+         FROM automation_runtime_terminal_evidence WHERE {column} = ?1"
+    );
+    conn.query_row(&sql, [value], |row| {
+        Ok(StoredRuntimeTerminalEvidence {
+            evidence_id: row.get(0)?,
+            attempt_id: row.get(1)?,
+            session_id: row.get(2)?,
+            run_id: row.get(3)?,
+            binding_id: row.get(4)?,
+            binding_digest: row.get(5)?,
+            runtime_id: row.get(6)?,
+            descriptor_digest: row.get(7)?,
+            producer_key_id: row.get(8)?,
+            evidence_digest: row.get(9)?,
+            classification: row.get(10)?,
+            produced_at: row.get(11)?,
+            received_at: row.get(12)?,
+            canonical_json: row.get(13)?,
+        })
+    })
+    .optional()
+    .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable))
+}
+
+fn collision_rows(
+    conn: &Connection,
+    evidence: &RuntimeTerminalEvidence,
+) -> Result<Vec<StoredRuntimeTerminalEvidence>, RuntimeTerminalEvidenceError> {
+    let rows = conn
+        .prepare(
+            "SELECT evidence_id, attempt_id, session_id, run_id, binding_id,
+                    binding_digest, runtime_id, descriptor_digest, producer_key_id,
+                    evidence_digest, classification, produced_at, received_at,
+                    canonical_json
+             FROM automation_runtime_terminal_evidence
+             WHERE evidence_id = ?1
+                OR attempt_id = ?2
+                OR session_id = ?3
+                OR binding_id = ?4
+                OR binding_digest = ?5
+             LIMIT 2",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map(
+                    params![
+                        evidence.evidence_id.as_str(),
+                        evidence.attempt_id.as_str(),
+                        evidence.session_id.as_str(),
+                        evidence.binding.binding_id.as_str(),
+                        evidence.binding.binding_digest.value.as_str(),
+                    ],
+                    |row| {
+                        Ok(StoredRuntimeTerminalEvidence {
+                            evidence_id: row.get(0)?,
+                            attempt_id: row.get(1)?,
+                            session_id: row.get(2)?,
+                            run_id: row.get(3)?,
+                            binding_id: row.get(4)?,
+                            binding_digest: row.get(5)?,
+                            runtime_id: row.get(6)?,
+                            descriptor_digest: row.get(7)?,
+                            producer_key_id: row.get(8)?,
+                            evidence_digest: row.get(9)?,
+                            classification: row.get(10)?,
+                            produced_at: row.get(11)?,
+                            received_at: row.get(12)?,
+                            canonical_json: row.get(13)?,
+                        })
+                    },
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable))?;
+    Ok(rows)
+}
+
+fn exact_stored_match(
+    stored: &StoredRuntimeTerminalEvidence,
+    evidence: &RuntimeTerminalEvidence,
+    classification: RuntimeTerminalEvidenceClassification,
+    canonical: &str,
+) -> bool {
+    stored.evidence_id == evidence.evidence_id.as_str()
+        && stored.attempt_id == evidence.attempt_id.as_str()
+        && stored.session_id == evidence.session_id.as_str()
+        && stored.run_id == evidence.run_id.as_str()
+        && stored.binding_id == evidence.binding.binding_id.as_str()
+        && stored.binding_digest == evidence.binding.binding_digest.value.as_str()
+        && stored.runtime_id == evidence.runtime.runtime_id.as_str()
+        && stored.descriptor_digest == evidence.runtime.descriptor_digest.value.as_str()
+        && stored.producer_key_id == evidence.authentication.key_id.as_str()
+        && stored.evidence_digest == evidence.integrity.value.as_str()
+        && stored.classification == classification.as_str()
+        && stored.produced_at == evidence.produced_at.as_str()
+        && chrono::DateTime::parse_from_rfc3339(&stored.received_at).is_ok()
+        && stored.canonical_json == canonical
+}
+
+fn pinned_binding(
+    conn: &Connection,
+    evidence: &RuntimeTerminalEvidence,
+    stored_read: bool,
+) -> Result<AutomationExecutionBinding, RuntimeTerminalEvidenceError> {
+    let durable: Option<DurableRuntimeTerminalEvidenceBinding> = conn
+        .query_row(
+            "SELECT run.id, run.automation_id, run.automation_revision,
+                    run.definition_digest, run.occurrence_id,
+                    attempt.id, attempt.run_id, attempt.occurrence_id,
+                    attempt.attempt_number, attempt.adoption_key,
+                    attempt.occurrence_fence_generation, attempt.session_id,
+                    run.runtime, run.authority_profile, attempt.authority_extension_json
+             FROM automation_attempts AS attempt
+             JOIN automation_runs AS run ON run.id = attempt.run_id
+             JOIN sessions AS session ON session.id = attempt.session_id
+             WHERE attempt.id = ?1",
+            [evidence.attempt_id.as_str()],
+            |row| {
+                Ok(DurableRuntimeTerminalEvidenceBinding {
+                    run_id: row.get(0)?,
+                    run_automation_id: row.get(1)?,
+                    run_automation_revision: row.get(2)?,
+                    run_definition_digest: row.get(3)?,
+                    run_occurrence_id: row.get(4)?,
+                    attempt_id: row.get(5)?,
+                    attempt_run_id: row.get(6)?,
+                    attempt_occurrence_id: row.get(7)?,
+                    attempt_number: row.get(8)?,
+                    adoption_key: row.get(9)?,
+                    occurrence_fence_generation: row.get(10)?,
+                    session_id: row.get(11)?,
+                    runtime_id: row.get(12)?,
+                    authority_profile: row.get(13)?,
+                    extension_json: row.get(14)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoreUnavailable))?;
+    let Some(durable) = durable else {
+        return Err(correlation_error(stored_read));
+    };
+    if durable.authority_profile.as_deref() != Some(AUTHORITY_PROFILE) {
+        return Err(evidence_error(if stored_read {
+            RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid
+        } else {
+            RuntimeTerminalEvidenceErrorCode::AuthorityProfileRequired
+        }));
+    }
+    let extension_json = durable
+        .extension_json
+        .as_deref()
+        .ok_or_else(|| correlation_error(stored_read))?;
+    let extension: Value = serde_json::from_str(extension_json)
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid))?;
+    let extensions = ExtensionBag::new(BTreeMap::from([(
+        AUTHORITY_EXTENSION_KEY.to_string(),
+        extension,
+    )]))
+    .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid))?;
+    let disposition = validate_authority_profile_structure(
+        &extensions,
+        AuthorityConsumerClass::RuntimeAuthorityV1,
+        &[BASE_PROFILE, AUTHORITY_PROFILE],
+        &[RUNTIME_AUTHORITY_CAPABILITY],
+        AuthorityValidationPhase::PreDispatch,
+    )
+    .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid))?;
+    let AuthorityProfileDisposition::Validated(extension) = disposition else {
+        return Err(evidence_error(
+            RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid,
+        ));
+    };
+    validate_durable_correlation(
+        &durable,
+        &extension.execution_binding,
+        evidence,
+        stored_read,
+    )?;
+    Ok(extension.execution_binding)
+}
+
+fn validate_durable_correlation(
+    durable: &DurableRuntimeTerminalEvidenceBinding,
+    binding: &AutomationExecutionBinding,
+    evidence: &RuntimeTerminalEvidence,
+    stored_read: bool,
+) -> Result<(), RuntimeTerminalEvidenceError> {
+    let base = &binding.base;
+    if durable.run_id != base.run_id.as_str()
+        || durable.run_automation_id != base.automation_id.as_str()
+        || u64::try_from(durable.run_automation_revision).ok()
+            != Some(base.automation_revision.get())
+        || durable.run_definition_digest.as_deref() != Some(base.definition_digest.value.as_str())
+        || durable.run_occurrence_id.as_deref() != Some(base.occurrence_id.as_str())
+        || durable.attempt_id != base.attempt_id.as_str()
+        || durable.attempt_run_id != base.run_id.as_str()
+        || durable.attempt_occurrence_id != base.occurrence_id.as_str()
+        || u64::try_from(durable.attempt_number).ok() != Some(base.attempt_number.get())
+        || durable.adoption_key != base.adoption_key.as_str()
+        || u64::try_from(durable.occurrence_fence_generation).ok()
+            != Some(base.occurrence_fence_generation.get())
+        || durable.session_id.as_deref() != Some(evidence.session_id.as_str())
+        || durable.runtime_id.as_deref() != Some(binding.runtime.runtime_id.as_str())
+        || durable.run_id != evidence.run_id.as_str()
+        || durable.attempt_id != evidence.attempt_id.as_str()
+        || durable.runtime_id.as_deref() != Some(evidence.runtime.runtime_id.as_str())
+    {
+        return Err(correlation_error(stored_read));
+    }
+    Ok(())
+}
+
+fn migrated_classification(
+    conn: &Connection,
+    stored: &StoredRuntimeTerminalEvidence,
+) -> AnyhowResult<RuntimeTerminalEvidenceClassification> {
+    let invalid = || anyhow::anyhow!("legacy automation runtime terminal evidence is invalid");
+    let evidence: RuntimeTerminalEvidence =
+        serde_json::from_str(&stored.canonical_json).map_err(|_| invalid())?;
+    let canonical = canonical_evidence(&evidence).map_err(|_| invalid())?;
+    let stored_classification =
+        classification_from_str(&stored.classification).map_err(|_| invalid())?;
+    anyhow::ensure!(
+        exact_stored_match(stored, &evidence, stored_classification, &canonical),
+        "legacy automation runtime terminal evidence is invalid"
+    );
+    if stored_classification
+        != RuntimeTerminalEvidenceClassification::AuthenticatedPartialOrAmbiguous
+    {
+        return Ok(stored_classification);
+    }
+    let binding = pinned_binding(conn, &evidence, true).map_err(|_| invalid())?;
+    Ok(classify_runtime_terminal_evidence(&evidence, &binding))
+}
+
+fn canonical_evidence(
+    evidence: &RuntimeTerminalEvidence,
+) -> Result<String, RuntimeTerminalEvidenceError> {
+    let canonical = canonicalize(evidence)
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::IjsonInvalid))?;
+    String::from_utf8(canonical)
+        .map_err(|_| evidence_error(RuntimeTerminalEvidenceErrorCode::IjsonInvalid))
+}
+
+fn classification_from_str(
+    value: &str,
+) -> Result<RuntimeTerminalEvidenceClassification, RuntimeTerminalEvidenceError> {
+    match value {
+        "receipt_eligible_complete" => {
+            Ok(RuntimeTerminalEvidenceClassification::ReceiptEligibleComplete)
+        }
+        "authenticated_partial_or_ambiguous" => {
+            Ok(RuntimeTerminalEvidenceClassification::AuthenticatedPartialOrAmbiguous)
+        }
+        "authenticated_unknown" => Ok(RuntimeTerminalEvidenceClassification::AuthenticatedUnknown),
+        "policy_violating" => Ok(RuntimeTerminalEvidenceClassification::PolicyViolating),
+        _ => Err(evidence_error(
+            RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid,
+        )),
+    }
+}
+
+fn correlation_error(stored_read: bool) -> RuntimeTerminalEvidenceError {
+    evidence_error(if stored_read {
+        RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid
+    } else {
+        RuntimeTerminalEvidenceErrorCode::CorrelationMismatch
+    })
+}
+
+const fn evidence_error(code: RuntimeTerminalEvidenceErrorCode) -> RuntimeTerminalEvidenceError {
+    RuntimeTerminalEvidenceError::new(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use rusqlite::{params, Connection};
+    use serde_json::{json, Value};
+
+    use super::{
+        canonical_evidence, read_verified_runtime_terminal_evidence,
+        store_runtime_terminal_evidence, RuntimeTerminalEvidenceLookup,
+        RuntimeTerminalEvidenceStoreOutcome, AUTOMATION_RUNTIME_TERMINAL_EVIDENCE_SCHEMA_SQL,
+    };
+    use crate::automations::contract::authority::test_support::{fixture, resign_binding};
+    use crate::automations::contract::canonical_json::{canonicalize, sha256_hex};
+    use crate::automations::contract::runtime_terminal_evidence::{
+        RuntimeTerminalEvidence, RuntimeTerminalEvidenceClassification,
+        RuntimeTerminalEvidenceError, RuntimeTerminalEvidenceErrorCode,
+        RuntimeTerminalEvidenceVerifier, RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN,
+        RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+    };
+    use crate::store::initialize_store;
+
+    struct FixtureVerifier {
+        key_id: &'static str,
+        stale: bool,
+    }
+
+    impl RuntimeTerminalEvidenceVerifier for FixtureVerifier {
+        fn verify(
+            &self,
+            evidence: &RuntimeTerminalEvidence,
+        ) -> Result<(), RuntimeTerminalEvidenceError> {
+            if self.stale {
+                return Err(RuntimeTerminalEvidenceError::new(
+                    RuntimeTerminalEvidenceErrorCode::AuthenticationStale,
+                ));
+            }
+            if evidence.authentication.key_id.as_str() != self.key_id
+                || evidence.authentication.signature.as_str()
+                    != format!(
+                        "{}{}",
+                        evidence.authentication.signed_digest.value.as_str(),
+                        evidence.authentication.signed_digest.value.as_str()
+                    )
+            {
+                return Err(RuntimeTerminalEvidenceError::new(
+                    RuntimeTerminalEvidenceErrorCode::AuthenticationInvalid,
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    fn verifier() -> FixtureVerifier {
+        FixtureVerifier {
+            key_id: "key:runtime-instance-1",
+            stale: false,
+        }
+    }
+
+    fn digest(value: &str) -> Value {
+        json!({
+            "algorithm": "sha256",
+            "canonicalization": "jcs-rfc8785",
+            "value": value
+        })
+    }
+
+    fn seal(mut value: Value) -> Value {
+        let object = value.as_object_mut().unwrap();
+        object.remove("integrity");
+        object.remove("authentication");
+        let canonical = canonicalize(&value).unwrap();
+        let integrity = sha256_hex(&canonical);
+        let mut authentication_preimage = Vec::new();
+        authentication_preimage.extend_from_slice(RUNTIME_TERMINAL_EVIDENCE_AUTHENTICATION_DOMAIN);
+        authentication_preimage.push(0);
+        authentication_preimage.extend_from_slice(&canonical);
+        let signed_digest = sha256_hex(&authentication_preimage);
+        value["integrity"] = digest(&integrity);
+        value["authentication"] = json!({
+            "method": "ed25519",
+            "keyId": "key:runtime-instance-1",
+            "proofRef": "proof:runtime-instance-1",
+            "signedDigest": digest(&signed_digest),
+            "signature": format!("{signed_digest}{signed_digest}")
+        });
+        value
+    }
+
+    fn evidence_value(binding: &Value, session_id: &str, evidence_id: &str) -> Value {
+        json!({
+            "profile": RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+            "evidenceId": evidence_id,
+            "sessionId": session_id,
+            "runId": binding["base"]["runId"],
+            "attemptId": binding["base"]["attemptId"],
+            "binding": {
+                "bindingId": binding["bindingId"],
+                "bindingDigest": binding["integrity"]
+            },
+            "runtime": {
+                "runtimeId": binding["runtime"]["runtimeId"],
+                "descriptorDigest": binding["runtime"]["descriptorDigest"]
+            },
+            "producedAt": "2026-09-03T12:30:00.000Z",
+            "disposition": "succeeded",
+            "sideEffects": {
+                "state": "observed",
+                "maximumClass": "local_write",
+                "coverage": "complete"
+            },
+            "exercisedCapabilities": {
+                "state": "observed",
+                "values": ["analysis.read", "artifact.write"],
+                "coverage": "complete"
+            },
+            "result": {
+                "state": "produced",
+                "digest": digest(
+                    "8888888888888888888888888888888888888888888888888888888888888888"
+                )
+            },
+            "delivery": {
+                "state": "not_attempted"
+            },
+            "producer": {
+                "component": "runtime-adapter",
+                "instanceId": "runtime-instance-1",
+                "implementationVersion": "1.0.0"
+            },
+            "privacy": {
+                "classification": "operational",
+                "retention": {
+                    "classification": "standard"
+                }
+            },
+            "integrity": digest(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+            "authentication": {
+                "method": "ed25519",
+                "keyId": "key:runtime-instance-1",
+                "proofRef": "proof:runtime-instance-1",
+                "signedDigest": digest(
+                    "0000000000000000000000000000000000000000000000000000000000000000"
+                ),
+                "signature": "0".repeat(128)
+            }
+        })
+    }
+
+    struct Fixture {
+        _temp: tempfile::TempDir,
+        path: std::path::PathBuf,
+        conn: Connection,
+        binding: Value,
+        evidence: RuntimeTerminalEvidence,
+    }
+
+    fn seed() -> Fixture {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("runtime-evidence.sqlite");
+        initialize_store(&path).unwrap();
+        let conn = crate::store::open_initialized_store(&path).unwrap();
+        let binding = fixture("binding");
+        let extension = json!({
+            "profile": "coven.automations.authority.v1",
+            "kind": "AutomationAuthorityExtension",
+            "executionBinding": binding,
+            "receiptEvidence": null
+        });
+        conn.execute(
+            "INSERT INTO sessions (
+                id, project_root, harness, title, status, created_at, updated_at
+             ) VALUES (
+                'session-daily-notes-1', '/work/project', 'runtime:coven-code',
+                'Runtime evidence fixture', 'completed',
+                '2026-09-03T12:00:00.000Z', '2026-09-03T12:30:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO automation_occurrences (
+                id, automation_id, automation_revision, definition_digest,
+                scheduled_for, kind, state, attempt, created_at, updated_at
+             ) VALUES (
+                'occurrence.daily-notes-20260903', 'daily-notes', 4,
+                '1111111111111111111111111111111111111111111111111111111111111111',
+                '2026-09-03T12:00:00.000Z', 'scheduled', 'running', 1,
+                '2026-09-03T12:00:00.000Z', '2026-09-03T12:00:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO automation_runs (
+                id, automation_id, automation_revision, definition_digest,
+                occurrence_id, authority_profile, session_id, familiar_id,
+                runtime, status, started_at
+             ) VALUES (
+                'run.daily-notes-1', 'daily-notes', 4,
+                '1111111111111111111111111111111111111111111111111111111111111111',
+                'occurrence.daily-notes-20260903', 'coven.automations.authority.v1',
+                'session-daily-notes-1', 'charm', 'runtime:coven-code',
+                'running', '2026-09-03T12:00:00.000Z'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO automation_attempts (
+                id, run_id, occurrence_id, attempt_number, adoption_key,
+                occurrence_fence_generation, dispatch_generation, state,
+                retry_classification, authority_extension_json, not_before,
+                session_id, opened_at
+             ) VALUES (
+                'attempt.daily-notes-1-1', 'run.daily-notes-1',
+                'occurrence.daily-notes-20260903', 1, 'adopt:daily-notes-1-1',
+                7, 1, 'observing', 'initial', ?1,
+                '2026-09-03T12:00:00.000Z', 'session-daily-notes-1',
+                '2026-09-03T12:00:00.000Z'
+             )",
+            [serde_json::to_string(&extension).unwrap()],
+        )
+        .unwrap();
+        let evidence = serde_json::from_value(seal(evidence_value(
+            &extension["executionBinding"],
+            "session-daily-notes-1",
+            "evidence:daily-notes-1",
+        )))
+        .unwrap();
+        Fixture {
+            _temp: temp,
+            path,
+            conn,
+            binding: extension["executionBinding"].clone(),
+            evidence,
+        }
+    }
+
+    fn replace_evidence(
+        fixture: &Fixture,
+        mutate: impl FnOnce(&mut Value),
+    ) -> RuntimeTerminalEvidence {
+        let mut value = evidence_value(
+            &fixture.binding,
+            "session-daily-notes-1",
+            "evidence:daily-notes-1",
+        );
+        mutate(&mut value);
+        serde_json::from_value(seal(value)).unwrap()
+    }
+
+    fn replace_inbox_with_legacy_row(
+        fixture: &Fixture,
+        evidence: &RuntimeTerminalEvidence,
+        classification: &str,
+        canonical_override: Option<&str>,
+    ) {
+        fixture
+            .conn
+            .execute_batch("DROP TABLE automation_runtime_terminal_evidence;")
+            .unwrap();
+        let legacy_schema = AUTOMATION_RUNTIME_TERMINAL_EVIDENCE_SCHEMA_SQL
+            .replace("                'authenticated_unknown',\n", "");
+        fixture.conn.execute_batch(&legacy_schema).unwrap();
+        fixture
+            .conn
+            .pragma_update(None, "foreign_keys", false)
+            .unwrap();
+        let canonical = canonical_override
+            .map(str::to_string)
+            .unwrap_or_else(|| canonical_evidence(evidence).unwrap());
+        fixture
+            .conn
+            .execute(
+                "INSERT INTO automation_runtime_terminal_evidence (
+                    evidence_id, attempt_id, session_id, run_id, binding_id,
+                    binding_digest, runtime_id, descriptor_digest, producer_key_id,
+                    evidence_digest, classification, produced_at, received_at,
+                    canonical_json
+                 ) VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
+                 )",
+                params![
+                    evidence.evidence_id.as_str(),
+                    evidence.attempt_id.as_str(),
+                    evidence.session_id.as_str(),
+                    evidence.run_id.as_str(),
+                    evidence.binding.binding_id.as_str(),
+                    evidence.binding.binding_digest.value.as_str(),
+                    evidence.runtime.runtime_id.as_str(),
+                    evidence.runtime.descriptor_digest.value.as_str(),
+                    evidence.authentication.key_id.as_str(),
+                    evidence.integrity.value.as_str(),
+                    classification,
+                    evidence.produced_at.as_str(),
+                    "2026-09-03T12:31:00.000Z",
+                    canonical,
+                ],
+            )
+            .unwrap();
+        fixture
+            .conn
+            .pragma_update(None, "foreign_keys", true)
+            .unwrap();
+    }
+
+    fn advance_run_to_second_attempt(fixture: &Fixture, binding_id: &str) -> Value {
+        let mut second_binding = fixture.binding.clone();
+        second_binding["bindingId"] = json!(binding_id);
+        second_binding["base"]["attemptId"] = json!("attempt.daily-notes-1-2");
+        second_binding["base"]["attemptNumber"] = json!(2);
+        second_binding["base"]["adoptionKey"] = json!("adopt:daily-notes-1-2");
+        second_binding["approval"]["consumption"]["attemptNumber"] = json!(2);
+        resign_binding(&mut second_binding);
+        let extension = json!({
+            "profile": "coven.automations.authority.v1",
+            "kind": "AutomationAuthorityExtension",
+            "executionBinding": second_binding,
+            "receiptEvidence": null
+        });
+        fixture
+            .conn
+            .execute(
+                "UPDATE automation_attempts
+                 SET state = 'failed',
+                     failure_class = 'runtime_error',
+                     state_reason = 'retrying after first attempt',
+                     settled_at = '2026-09-03T12:31:00.000Z'
+                 WHERE id = 'attempt.daily-notes-1-1'",
+                [],
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute_batch(
+                "INSERT INTO sessions (
+                    id, project_root, harness, title, status, created_at, updated_at
+                 ) VALUES (
+                    'session-daily-notes-2', '/work/project', 'runtime:coven-code',
+                    'Second runtime evidence fixture', 'running',
+                    '2026-09-03T12:32:00.000Z', '2026-09-03T12:32:00.000Z'
+                 );",
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute(
+                "INSERT INTO automation_attempts (
+                    id, run_id, occurrence_id, attempt_number, adoption_key,
+                    occurrence_fence_generation, dispatch_generation, state,
+                    prior_attempt_number, prior_disposition, retry_classification,
+                    authority_extension_json, not_before, session_id, opened_at
+                 ) VALUES (
+                    'attempt.daily-notes-1-2', 'run.daily-notes-1',
+                    'occurrence.daily-notes-20260903', 2, 'adopt:daily-notes-1-2',
+                    7, 2, 'started', 1, 'failed', 'automatic_retry', ?1,
+                    '2026-09-03T12:32:00.000Z', 'session-daily-notes-2',
+                    '2026-09-03T12:32:00.000Z'
+                 )",
+                [serde_json::to_string(&extension).unwrap()],
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute(
+                "UPDATE automation_runs
+                 SET session_id = 'session-daily-notes-2'
+                 WHERE id = 'run.daily-notes-1'",
+                [],
+            )
+            .unwrap();
+        extension["executionBinding"].clone()
+    }
+
+    #[test]
+    fn initialized_store_contains_the_immutable_runtime_terminal_evidence_schema() {
+        let fixture = seed();
+        assert!(AUTOMATION_RUNTIME_TERMINAL_EVIDENCE_SCHEMA_SQL
+            .contains("automation_runtime_terminal_evidence"));
+        let table_sql: String = fixture
+            .conn
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table' AND name = 'automation_runtime_terminal_evidence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(table_sql.contains("attempt_id TEXT UNIQUE NOT NULL"));
+        assert!(table_sql.contains("session_id TEXT UNIQUE NOT NULL"));
+        assert!(table_sql.contains("binding_digest TEXT UNIQUE NOT NULL"));
+        assert!(!table_sql.contains("run_id TEXT UNIQUE"));
+        for trigger in [
+            "automation_runtime_terminal_evidence_no_update",
+            "automation_runtime_terminal_evidence_no_delete",
+        ] {
+            let count: i64 = fixture
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master
+                     WHERE type = 'trigger' AND name = ?1",
+                    [trigger],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "{trigger}");
+        }
+    }
+
+    #[test]
+    fn complete_evidence_is_stored_replayed_read_and_survives_reopen() {
+        let fixture = seed();
+        assert_eq!(
+            store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap(),
+            RuntimeTerminalEvidenceStoreOutcome::Stored
+        );
+        assert_eq!(
+            store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap(),
+            RuntimeTerminalEvidenceStoreOutcome::Replayed
+        );
+        let by_id = read_verified_runtime_terminal_evidence(
+            &fixture.conn,
+            RuntimeTerminalEvidenceLookup::EvidenceId("evidence:daily-notes-1"),
+            &verifier(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            by_id.classification,
+            RuntimeTerminalEvidenceClassification::ReceiptEligibleComplete
+        );
+        let by_attempt = read_verified_runtime_terminal_evidence(
+            &fixture.conn,
+            RuntimeTerminalEvidenceLookup::AttemptId("attempt.daily-notes-1-1"),
+            &verifier(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(by_attempt, by_id);
+
+        assert!(fixture
+            .conn
+            .execute(
+                "UPDATE automation_runtime_terminal_evidence
+                 SET received_at = '2026-09-03T13:00:00.000Z'",
+                [],
+            )
+            .is_err());
+        assert!(fixture
+            .conn
+            .execute("DELETE FROM automation_runtime_terminal_evidence", [])
+            .is_err());
+        drop(fixture.conn);
+        let reopened = crate::store::open_initialized_store(&fixture.path).unwrap();
+        assert!(read_verified_runtime_terminal_evidence(
+            &reopened,
+            RuntimeTerminalEvidenceLookup::AttemptId("attempt.daily-notes-1-1"),
+            &verifier(),
+        )
+        .unwrap()
+        .is_some());
+    }
+
+    #[test]
+    fn store_requires_its_own_immediate_transaction_for_replay_safety() {
+        let fixture = seed();
+        let transaction = fixture.conn.unchecked_transaction().unwrap();
+
+        let error = store_runtime_terminal_evidence(&transaction, &fixture.evidence, &verifier())
+            .unwrap_err();
+
+        assert_eq!(
+            error.code(),
+            RuntimeTerminalEvidenceErrorCode::StoreUnavailable
+        );
+        let count: i64 = transaction
+            .query_row(
+                "SELECT COUNT(*) FROM automation_runtime_terminal_evidence",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn existing_inbox_schema_is_upgraded_for_unknown_and_unique_binding_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("legacy-runtime-evidence.sqlite");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE automation_runtime_terminal_evidence (
+                evidence_id TEXT PRIMARY KEY NOT NULL,
+                attempt_id TEXT UNIQUE NOT NULL,
+                session_id TEXT UNIQUE NOT NULL,
+                run_id TEXT NOT NULL,
+                binding_id TEXT NOT NULL,
+                binding_digest TEXT UNIQUE NOT NULL,
+                runtime_id TEXT NOT NULL,
+                descriptor_digest TEXT NOT NULL,
+                producer_key_id TEXT NOT NULL,
+                evidence_digest TEXT NOT NULL,
+                classification TEXT NOT NULL CHECK (
+                    classification IN (
+                        'receipt_eligible_complete',
+                        'authenticated_partial_or_ambiguous',
+                        'policy_violating'
+                    )
+                ),
+                produced_at TEXT NOT NULL,
+                received_at TEXT NOT NULL,
+                canonical_json TEXT NOT NULL CHECK (json_valid(canonical_json))
+            );",
+        )
+        .unwrap();
+        drop(conn);
+
+        initialize_store(&path).unwrap();
+        let reopened = crate::store::open_initialized_store(&path).unwrap();
+        let table_sql: String = reopened
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table' AND name = 'automation_runtime_terminal_evidence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(table_sql.contains("'authenticated_unknown'"));
+        let binding_index: (String, i64) = reopened
+            .query_row(
+                "SELECT name, [unique]
+                 FROM pragma_index_list('automation_runtime_terminal_evidence')
+                 WHERE name = 'idx_automation_runtime_terminal_evidence_binding'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            binding_index,
+            (
+                "idx_automation_runtime_terminal_evidence_binding".to_string(),
+                1
+            )
+        );
+    }
+
+    #[test]
+    fn migration_reclassifies_legacy_unknown_and_preserves_partial_and_policy_precedence() {
+        for (name, mutate, legacy_classification, expected) in [
+            (
+                "unknown",
+                (|value: &mut Value| {
+                    value["delivery"] = json!({
+                        "state": "unknown",
+                        "reasonCode": "runtime_delivery_unavailable"
+                    });
+                }) as fn(&mut Value),
+                "authenticated_partial_or_ambiguous",
+                RuntimeTerminalEvidenceClassification::AuthenticatedUnknown,
+            ),
+            (
+                "partial",
+                (|value: &mut Value| value["sideEffects"]["coverage"] = json!("partial"))
+                    as fn(&mut Value),
+                "authenticated_partial_or_ambiguous",
+                RuntimeTerminalEvidenceClassification::AuthenticatedPartialOrAmbiguous,
+            ),
+            (
+                "policy-violating-unknown",
+                (|value: &mut Value| {
+                    value["sideEffects"] = json!({
+                        "state": "unknown",
+                        "reasonCode": "runtime_observation_unavailable"
+                    });
+                    value["exercisedCapabilities"]["values"] =
+                        json!(["analysis.read", "artifact.write", "network.publish"]);
+                }) as fn(&mut Value),
+                "policy_violating",
+                RuntimeTerminalEvidenceClassification::PolicyViolating,
+            ),
+        ] {
+            let fixture = seed();
+            let evidence = replace_evidence(&fixture, mutate);
+            replace_inbox_with_legacy_row(&fixture, &evidence, legacy_classification, None);
+            drop(fixture.conn);
+
+            initialize_store(&fixture.path).unwrap();
+            let reopened = crate::store::open_initialized_store(&fixture.path).unwrap();
+            let persisted: String = reopened
+                .query_row(
+                    "SELECT classification
+                     FROM automation_runtime_terminal_evidence
+                     WHERE evidence_id = 'evidence:daily-notes-1'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(persisted, expected.as_str(), "{name}");
+            let verified = read_verified_runtime_terminal_evidence(
+                &reopened,
+                RuntimeTerminalEvidenceLookup::EvidenceId("evidence:daily-notes-1"),
+                &verifier(),
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(verified.evidence, evidence, "{name}");
+            assert_eq!(verified.classification, expected, "{name}");
+            assert_eq!(
+                store_runtime_terminal_evidence(&reopened, &evidence, &verifier()).unwrap(),
+                RuntimeTerminalEvidenceStoreOutcome::Replayed,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_legacy_evidence_rolls_back_without_disclosure() {
+        let fixture = seed();
+        replace_inbox_with_legacy_row(
+            &fixture,
+            &fixture.evidence,
+            "authenticated_partial_or_ambiguous",
+            Some(r#"{"private":"migration-secret"}"#),
+        );
+        drop(fixture.conn);
+
+        let error = initialize_store(&fixture.path)
+            .expect_err("malformed legacy evidence must abort initialization");
+        let chain = format!("{error:#}");
+        assert!(chain.contains("legacy automation runtime terminal evidence is invalid"));
+        assert!(!chain.contains("migration-secret"));
+
+        let reopened = Connection::open(&fixture.path).unwrap();
+        let table_sql: String = reopened
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table' AND name = 'automation_runtime_terminal_evidence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!table_sql.contains("'authenticated_unknown'"));
+        let preserved: (String, String) = reopened
+            .query_row(
+                "SELECT classification, canonical_json
+                 FROM automation_runtime_terminal_evidence",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            preserved,
+            (
+                "authenticated_partial_or_ambiguous".to_string(),
+                r#"{"private":"migration-secret"}"#.to_string(),
+            )
+        );
+        let legacy_table_count: i64 = reopened
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'table'
+                   AND name = 'automation_runtime_terminal_evidence_legacy'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy_table_count, 0);
+    }
+
+    #[test]
+    fn orphaned_legacy_evidence_rolls_back_the_schema_and_data() {
+        let fixture = seed();
+        let orphan: RuntimeTerminalEvidence = serde_json::from_value(seal(json!({
+            "profile": RUNTIME_TERMINAL_EVIDENCE_PROFILE,
+            "evidenceId": "evidence:private-orphan",
+            "sessionId": "session-private-orphan",
+            "runId": "run.private-orphan",
+            "attemptId": "attempt.private-orphan",
+            "binding": {
+                "bindingId": fixture.binding["bindingId"],
+                "bindingDigest": fixture.binding["integrity"]
+            },
+            "runtime": {
+                "runtimeId": fixture.binding["runtime"]["runtimeId"],
+                "descriptorDigest": fixture.binding["runtime"]["descriptorDigest"]
+            },
+            "producedAt": "2026-09-03T12:30:00.000Z",
+            "disposition": "succeeded",
+            "sideEffects": {
+                "state": "observed",
+                "maximumClass": "local_write",
+                "coverage": "complete"
+            },
+            "exercisedCapabilities": {
+                "state": "observed",
+                "values": ["analysis.read", "artifact.write"],
+                "coverage": "complete"
+            },
+            "result": {
+                "state": "not_produced"
+            },
+            "delivery": {
+                "state": "not_attempted"
+            },
+            "producer": {
+                "component": "runtime-adapter",
+                "instanceId": "runtime-instance-1",
+                "implementationVersion": "1.0.0"
+            },
+            "privacy": {
+                "classification": "operational",
+                "retention": {
+                    "classification": "standard"
+                }
+            },
+            "integrity": digest(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+            "authentication": {
+                "method": "ed25519",
+                "keyId": "key:runtime-instance-1",
+                "proofRef": "proof:runtime-instance-1",
+                "signedDigest": digest(
+                    "0000000000000000000000000000000000000000000000000000000000000000"
+                ),
+                "signature": "0".repeat(128)
+            }
+        })))
+        .unwrap();
+        replace_inbox_with_legacy_row(&fixture, &orphan, "receipt_eligible_complete", None);
+        drop(fixture.conn);
+
+        let error =
+            initialize_store(&fixture.path).expect_err("orphaned legacy evidence must fail");
+        let chain = format!("{error:#}");
+        assert!(chain.contains("foreign-key violation"));
+        assert!(!chain.contains("private-orphan"));
+
+        let reopened = Connection::open(&fixture.path).unwrap();
+        let table_sql: String = reopened
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table' AND name = 'automation_runtime_terminal_evidence'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!table_sql.contains("'authenticated_unknown'"));
+        let preserved: (String, String, String, String) = reopened
+            .query_row(
+                "SELECT evidence_id, attempt_id, session_id, run_id
+                 FROM automation_runtime_terminal_evidence",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            preserved,
+            (
+                "evidence:private-orphan".to_string(),
+                "attempt.private-orphan".to_string(),
+                "session-private-orphan".to_string(),
+                "run.private-orphan".to_string(),
+            )
+        );
+        let legacy_table_count: i64 = reopened
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'table'
+                   AND name = 'automation_runtime_terminal_evidence_legacy'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy_table_count, 0);
+    }
+
+    #[test]
+    fn same_name_non_unique_binding_index_is_upgraded() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("non-unique-binding-index.sqlite");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE automation_runtime_terminal_evidence (
+                evidence_id TEXT PRIMARY KEY NOT NULL,
+                attempt_id TEXT UNIQUE NOT NULL,
+                session_id TEXT UNIQUE NOT NULL,
+                run_id TEXT NOT NULL,
+                binding_id TEXT NOT NULL,
+                binding_digest TEXT UNIQUE NOT NULL,
+                runtime_id TEXT NOT NULL,
+                descriptor_digest TEXT NOT NULL,
+                producer_key_id TEXT NOT NULL,
+                evidence_digest TEXT NOT NULL,
+                classification TEXT NOT NULL CHECK (
+                    classification IN (
+                        'receipt_eligible_complete',
+                        'authenticated_partial_or_ambiguous',
+                        'authenticated_unknown',
+                        'policy_violating'
+                    )
+                ),
+                produced_at TEXT NOT NULL,
+                received_at TEXT NOT NULL,
+                canonical_json TEXT NOT NULL CHECK (json_valid(canonical_json))
+            );
+            CREATE INDEX idx_automation_runtime_terminal_evidence_binding
+                ON automation_runtime_terminal_evidence(binding_id);",
+        )
+        .unwrap();
+        drop(conn);
+
+        initialize_store(&path).unwrap();
+        let reopened = crate::store::open_initialized_store(&path).unwrap();
+        let binding_index: i64 = reopened
+            .query_row(
+                "SELECT [unique]
+                 FROM pragma_index_list('automation_runtime_terminal_evidence')
+                 WHERE name = 'idx_automation_runtime_terminal_evidence_binding'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(binding_index, 1);
+    }
+
+    #[test]
+    fn authenticated_partial_unknown_and_policy_violating_evidence_survives_reopen() {
+        for (name, mutate, expected) in [
+            (
+                "partial",
+                (|value: &mut Value| value["sideEffects"]["coverage"] = json!("partial"))
+                    as fn(&mut Value),
+                "authenticated_partial_or_ambiguous",
+            ),
+            (
+                "unknown",
+                (|value: &mut Value| {
+                    value["sideEffects"] = json!({
+                        "state": "unknown",
+                        "reasonCode": "runtime_observation_unavailable"
+                    });
+                    value["exercisedCapabilities"] = json!({
+                        "state": "unknown",
+                        "reasonCode": "runtime_observation_unavailable"
+                    });
+                    value["result"] = json!({
+                        "state": "unknown",
+                        "reasonCode": "runtime_result_unavailable"
+                    });
+                    value["delivery"] = json!({
+                        "state": "unknown",
+                        "reasonCode": "runtime_delivery_unavailable"
+                    });
+                }) as fn(&mut Value),
+                "authenticated_unknown",
+            ),
+            (
+                "violation",
+                (|value: &mut Value| {
+                    value["exercisedCapabilities"]["values"] =
+                        json!(["analysis.read", "network.publish"]);
+                }) as fn(&mut Value),
+                "policy_violating",
+            ),
+        ] {
+            let fixture = seed();
+            let evidence = replace_evidence(&fixture, mutate);
+            assert_eq!(
+                store_runtime_terminal_evidence(&fixture.conn, &evidence, &verifier()).unwrap(),
+                RuntimeTerminalEvidenceStoreOutcome::Stored,
+                "{name}"
+            );
+            let persisted: String = fixture
+                .conn
+                .query_row(
+                    "SELECT classification
+                     FROM automation_runtime_terminal_evidence
+                     WHERE evidence_id = 'evidence:daily-notes-1'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(persisted, expected, "{name}");
+            drop(fixture.conn);
+            let reopened = crate::store::open_initialized_store(&fixture.path).unwrap();
+            let stored = read_verified_runtime_terminal_evidence(
+                &reopened,
+                RuntimeTerminalEvidenceLookup::EvidenceId("evidence:daily-notes-1"),
+                &verifier(),
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(stored.classification.as_str(), expected, "{name}");
+        }
+    }
+
+    #[test]
+    fn earlier_attempt_evidence_survives_a_later_session_launch_and_reopen() {
+        let fixture = seed();
+        store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap();
+        advance_run_to_second_attempt(&fixture, "binding:daily-notes-1-second");
+
+        drop(fixture.conn);
+        let reopened = crate::store::open_initialized_store(&fixture.path).unwrap();
+        let stored = read_verified_runtime_terminal_evidence(
+            &reopened,
+            RuntimeTerminalEvidenceLookup::AttemptId("attempt.daily-notes-1-1"),
+            &verifier(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(stored.evidence.session_id.as_str(), "session-daily-notes-1");
+        assert_eq!(stored.evidence.run_id.as_str(), "run.daily-notes-1");
+    }
+
+    #[test]
+    fn binding_id_conflict_is_atomic_while_identical_replay_remains_idempotent() {
+        let fixture = seed();
+        assert_eq!(
+            store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap(),
+            RuntimeTerminalEvidenceStoreOutcome::Stored
+        );
+        assert_eq!(
+            store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap(),
+            RuntimeTerminalEvidenceStoreOutcome::Replayed
+        );
+        let original_binding_id = fixture.evidence.binding.binding_id.as_str().to_string();
+        let second_binding = advance_run_to_second_attempt(&fixture, &original_binding_id);
+        let second: RuntimeTerminalEvidence = serde_json::from_value(seal(evidence_value(
+            &second_binding,
+            "session-daily-notes-2",
+            "evidence:daily-notes-2",
+        )))
+        .unwrap();
+
+        let error =
+            store_runtime_terminal_evidence(&fixture.conn, &second, &verifier()).unwrap_err();
+        assert_eq!(error.code(), RuntimeTerminalEvidenceErrorCode::Conflict);
+        let rows: i64 = fixture
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM automation_runtime_terminal_evidence",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn store_rejects_exact_correlation_mismatches_and_unbound_authority_profiles() {
+        for mutate in [
+            (|value: &mut Value| value["sessionId"] = json!("session-other")) as fn(&mut Value),
+            |value: &mut Value| value["runId"] = json!("run.other"),
+            |value: &mut Value| value["attemptId"] = json!("attempt.other"),
+            |value: &mut Value| value["binding"]["bindingId"] = json!("binding:other"),
+            |value: &mut Value| {
+                value["binding"]["bindingDigest"]["value"] = json!("1".repeat(64));
+            },
+            |value: &mut Value| value["runtime"]["runtimeId"] = json!("runtime:other"),
+            |value: &mut Value| {
+                value["runtime"]["descriptorDigest"]["value"] = json!("2".repeat(64));
+            },
+        ] {
+            let fixture = seed();
+            let evidence = replace_evidence(&fixture, mutate);
+            let error =
+                store_runtime_terminal_evidence(&fixture.conn, &evidence, &verifier()).unwrap_err();
+            assert_eq!(
+                error.code(),
+                RuntimeTerminalEvidenceErrorCode::CorrelationMismatch
+            );
+        }
+
+        let fixture = seed();
+        fixture
+            .conn
+            .execute_batch(
+                "DROP TRIGGER automation_run_authority_profile_immutable;
+                 UPDATE automation_runs SET authority_profile = NULL;",
+            )
+            .unwrap();
+        let error = store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier())
+            .unwrap_err();
+        assert_eq!(
+            error.code(),
+            RuntimeTerminalEvidenceErrorCode::AuthorityProfileRequired
+        );
+    }
+
+    #[test]
+    fn durable_run_and_attempt_identity_tampering_refuses_store_and_read_privacy_safely() {
+        for (tamper, private_marker) in [
+            (
+                "UPDATE automation_runs
+                 SET automation_id = 'private-run-automation-id'",
+                "private-run-automation-id",
+            ),
+            (
+                "UPDATE automation_runs
+                 SET definition_digest =
+                     '9999999999999999999999999999999999999999999999999999999999999999'",
+                "9999999999999999999999999999999999999999999999999999999999999999",
+            ),
+            (
+                "INSERT INTO automation_occurrences (
+                    id, automation_id, automation_revision, definition_digest,
+                    scheduled_for, kind, state, attempt, created_at, updated_at
+                 ) VALUES (
+                    'occurrence.private-other', 'daily-notes', 4,
+                    '1111111111111111111111111111111111111111111111111111111111111111',
+                    '2026-09-04T12:00:00.000Z', 'scheduled', 'running', 1,
+                    '2026-09-04T12:00:00.000Z', '2026-09-04T12:00:00.000Z'
+                 );
+                 UPDATE automation_attempts
+                 SET occurrence_id = 'occurrence.private-other'",
+                "occurrence.private-other",
+            ),
+            (
+                "UPDATE automation_attempts
+                 SET attempt_number = 2,
+                     prior_attempt_number = 1,
+                     prior_disposition = 'failed'",
+                "attempt_number",
+            ),
+            (
+                "UPDATE automation_attempts
+                 SET adoption_key = 'private-attempt-adoption-key'",
+                "private-attempt-adoption-key",
+            ),
+            (
+                "UPDATE automation_attempts
+                 SET occurrence_fence_generation = 8",
+                "occurrence_fence_generation",
+            ),
+        ] {
+            let fixture = seed();
+            fixture.conn.execute_batch(tamper).unwrap();
+            let error =
+                store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier())
+                    .unwrap_err();
+            assert_eq!(
+                error.code(),
+                RuntimeTerminalEvidenceErrorCode::CorrelationMismatch
+            );
+            assert!(!format!("{error:#}").contains(private_marker));
+
+            let fixture = seed();
+            store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap();
+            fixture.conn.execute_batch(tamper).unwrap();
+            let error = read_verified_runtime_terminal_evidence(
+                &fixture.conn,
+                RuntimeTerminalEvidenceLookup::EvidenceId("evidence:daily-notes-1"),
+                &verifier(),
+            )
+            .unwrap_err();
+            assert_eq!(
+                error.code(),
+                RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid
+            );
+            assert!(!format!("{error:#}").contains(private_marker));
+        }
+    }
+
+    #[test]
+    fn verifier_refusals_are_privacy_safe_and_never_store_rows() {
+        for verifier in [
+            FixtureVerifier {
+                key_id: "key:wrong",
+                stale: false,
+            },
+            FixtureVerifier {
+                key_id: "key:runtime-instance-1",
+                stale: true,
+            },
+        ] {
+            let fixture = seed();
+            let error =
+                store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier)
+                    .unwrap_err();
+            assert!(matches!(
+                error.code(),
+                RuntimeTerminalEvidenceErrorCode::AuthenticationInvalid
+                    | RuntimeTerminalEvidenceErrorCode::AuthenticationStale
+            ));
+            assert!(!format!("{error:#}").contains("proof:runtime-instance-1"));
+            let count: i64 = fixture
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM automation_runtime_terminal_evidence",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0);
+        }
+    }
+
+    #[test]
+    fn conflicting_replay_is_refused() {
+        let fixture = seed();
+        assert_eq!(
+            store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap(),
+            RuntimeTerminalEvidenceStoreOutcome::Stored
+        );
+        let conflicting = replace_evidence(&fixture, |value| {
+            value["evidenceId"] = json!("evidence:conflict");
+            value["delivery"] = json!({
+                "state": "failed",
+                "digest": digest(
+                    "9999999999999999999999999999999999999999999999999999999999999999"
+                )
+            });
+        });
+        let error =
+            store_runtime_terminal_evidence(&fixture.conn, &conflicting, &verifier()).unwrap_err();
+        assert_eq!(error.code(), RuntimeTerminalEvidenceErrorCode::Conflict);
+    }
+
+    #[test]
+    fn read_rejects_tampered_json_and_denormalized_indexes_without_disclosure() {
+        for tamper in [
+            "UPDATE automation_runtime_terminal_evidence
+             SET canonical_json = '{\"private\":\"attacker-content\"}'",
+            "UPDATE automation_runtime_terminal_evidence
+             SET producer_key_id = 'key:tampered-private'",
+            "UPDATE automation_runtime_terminal_evidence
+             SET received_at = 'not-a-timestamp'",
+        ] {
+            let fixture = seed();
+            store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap();
+            fixture
+                .conn
+                .execute_batch(
+                    "DROP TRIGGER automation_runtime_terminal_evidence_no_update;
+                     DROP TRIGGER automation_runtime_terminal_evidence_no_delete;",
+                )
+                .unwrap();
+            fixture.conn.execute_batch(tamper).unwrap();
+
+            let error = read_verified_runtime_terminal_evidence(
+                &fixture.conn,
+                RuntimeTerminalEvidenceLookup::EvidenceId("evidence:daily-notes-1"),
+                &verifier(),
+            )
+            .unwrap_err();
+            assert_eq!(
+                error.code(),
+                RuntimeTerminalEvidenceErrorCode::StoredEvidenceInvalid
+            );
+            let chain = format!("{error:#}");
+            assert!(!chain.contains("attacker-content"));
+            assert!(!chain.contains("tampered-private"));
+        }
+    }
+
+    #[test]
+    fn missing_evidence_returns_none() {
+        let fixture = seed();
+        assert_eq!(
+            read_verified_runtime_terminal_evidence(
+                &fixture.conn,
+                RuntimeTerminalEvidenceLookup::EvidenceId("evidence:missing"),
+                &verifier(),
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn run_id_is_indexed_but_all_replay_identity_columns_are_unique() {
+        let fixture = seed();
+        let indexes: Vec<(String, i64)> = fixture
+            .conn
+            .prepare("PRAGMA index_list(automation_runtime_terminal_evidence)")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(indexes.iter().any(|(name, unique)| name
+            == "idx_automation_runtime_terminal_evidence_run"
+            && *unique == 0));
+        assert!(indexes.iter().any(|(name, unique)| name
+            == "idx_automation_runtime_terminal_evidence_binding"
+            && *unique == 1));
+        assert!(indexes.iter().filter(|(_, unique)| *unique == 1).count() >= 3);
+    }
+
+    #[test]
+    fn canonical_replay_conflicts_across_a_second_session_and_attempt() {
+        let fixture = seed();
+        store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap();
+
+        let mut second_binding = fixture.binding.clone();
+        second_binding["base"]["occurrenceId"] = json!("occurrence.daily-notes-20260904");
+        second_binding["base"]["occurrenceKey"] = json!("daily-notes@2026-09-04T12:00:00.000Z");
+        second_binding["base"]["runId"] = json!("run.daily-notes-2");
+        second_binding["base"]["attemptId"] = json!("attempt.daily-notes-2-1");
+        second_binding["base"]["adoptionKey"] = json!("adopt:daily-notes-2-1");
+        second_binding["approval"]["consumption"]["occurrenceId"] =
+            json!("occurrence.daily-notes-20260904");
+        second_binding["approval"]["consumption"]["runId"] = json!("run.daily-notes-2");
+        resign_binding(&mut second_binding);
+        let extension = json!({
+            "profile": "coven.automations.authority.v1",
+            "kind": "AutomationAuthorityExtension",
+            "executionBinding": second_binding,
+            "receiptEvidence": null
+        });
+        fixture
+            .conn
+            .execute_batch(
+                "INSERT INTO sessions (
+                    id, project_root, harness, title, status, created_at, updated_at
+                 ) VALUES (
+                    'session-daily-notes-2', '/work/project', 'runtime:coven-code',
+                    'Second runtime evidence fixture', 'completed',
+                    '2026-09-04T12:00:00.000Z', '2026-09-04T12:30:00.000Z'
+                 );
+                 INSERT INTO automation_occurrences (
+                    id, automation_id, automation_revision, definition_digest,
+                    scheduled_for, kind, state, attempt, created_at, updated_at
+                 ) VALUES (
+                    'occurrence.daily-notes-20260904', 'daily-notes', 4,
+                    '1111111111111111111111111111111111111111111111111111111111111111',
+                    '2026-09-04T12:00:00.000Z', 'scheduled', 'running', 1,
+                    '2026-09-04T12:00:00.000Z', '2026-09-04T12:00:00.000Z'
+                 );",
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute(
+                "INSERT INTO automation_runs (
+                    id, automation_id, automation_revision, definition_digest,
+                    occurrence_id, authority_profile, session_id, familiar_id,
+                    runtime, status, started_at
+                 ) VALUES (
+                    'run.daily-notes-2', 'daily-notes', 4,
+                    '1111111111111111111111111111111111111111111111111111111111111111',
+                    'occurrence.daily-notes-20260904', 'coven.automations.authority.v1',
+                    'session-daily-notes-2', 'charm', 'runtime:coven-code',
+                    'running', '2026-09-04T12:00:00.000Z'
+                 )",
+                [],
+            )
+            .unwrap();
+        fixture
+            .conn
+            .execute(
+                "INSERT INTO automation_attempts (
+                    id, run_id, occurrence_id, attempt_number, adoption_key,
+                    occurrence_fence_generation, dispatch_generation, state,
+                    retry_classification, authority_extension_json, not_before,
+                    session_id, opened_at
+                 ) VALUES (
+                    'attempt.daily-notes-2-1', 'run.daily-notes-2',
+                    'occurrence.daily-notes-20260904', 1, 'adopt:daily-notes-2-1',
+                    7, 1, 'observing', 'initial', ?1,
+                    '2026-09-04T12:00:00.000Z', 'session-daily-notes-2',
+                    '2026-09-04T12:00:00.000Z'
+                 )",
+                [serde_json::to_string(&extension).unwrap()],
+            )
+            .unwrap();
+        let second: RuntimeTerminalEvidence = serde_json::from_value(seal(evidence_value(
+            &extension["executionBinding"],
+            "session-daily-notes-2",
+            "evidence:daily-notes-1",
+        )))
+        .unwrap();
+
+        let error =
+            store_runtime_terminal_evidence(&fixture.conn, &second, &verifier()).unwrap_err();
+        assert_eq!(error.code(), RuntimeTerminalEvidenceErrorCode::Conflict);
+    }
+
+    #[test]
+    fn received_at_is_coven_owned_and_parseable() {
+        let fixture = seed();
+        store_runtime_terminal_evidence(&fixture.conn, &fixture.evidence, &verifier()).unwrap();
+        let received_at: String = fixture
+            .conn
+            .query_row(
+                "SELECT received_at FROM automation_runtime_terminal_evidence",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        chrono::DateTime::parse_from_rfc3339(&received_at).unwrap();
+        assert!(
+            chrono::Utc.with_ymd_and_hms(2026, 9, 3, 12, 30, 0).unwrap()
+                <= chrono::DateTime::parse_from_rfc3339(&received_at)
+                    .unwrap()
+                    .with_timezone(&chrono::Utc)
+        );
+    }
+}

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -591,6 +591,7 @@ pub fn initialize_store(path: &Path) -> Result<()> {
     // transaction for the remaining idempotent schema work.
     ensure_ward_audit_schema(&conn)?;
     crate::automations::runs::ensure_runtime_authority_unsupported_failure_class(&conn)?;
+    crate::automations::runtime_terminal_evidence::ensure_runtime_terminal_evidence_schema(&conn)?;
     conn.execute_batch("BEGIN IMMEDIATE")
         .context("failed to acquire SQLite initialization transaction")?;
     let result = initialize_store_schema(&conn);

--- a/docs/architecture/coven-automations-receipt-delivery.md
+++ b/docs/architecture/coven-automations-receipt-delivery.md
@@ -7,7 +7,48 @@ Parent program: #854
 This document separates the shipped runtime path from the frozen
 `coven.automations.v1` contract. The contract defines an
 `AutomationReceipt`; the current runtime has an immutable commitment seam and
-an owner-local base-receipt read, but no production terminal-evidence producer.
+an owner-local base-receipt read. Coven now also owns a proposed, internal
+runtime-terminal-evidence contract and immutable inbox, but it has no
+production producer, verifier adapter, or consumption path.
+
+## Runtime terminal evidence receiving boundary
+
+The profile `coven.automations.runtime-terminal-evidence.v1` is a Coven-owned,
+non-production receiving contract for authority-bound launched sessions. It
+pins the evidence, session, run, attempt, dispatch binding, and runtime
+descriptor; authenticates a domain-separated digest over JCS canonical bytes;
+and carries typed terminal observations rather than nullable inference.
+
+Side effects and exercised capabilities are each either `observed` with
+`complete` or `partial` coverage, or `unknown` with a bounded reason code.
+Results and deliveries likewise distinguish explicit outcomes from unknown
+state. Unknown effects never mean `none`, and unknown capabilities never mean
+an empty set. Verified evidence is classified as receipt-eligible complete,
+authenticated partial/ambiguous, authenticated unknown, or policy-violating.
+Classification precedence is deterministic: policy violations take precedence
+over unknown observations, unknown observations take precedence over partial or
+ambiguous observations, and only complete conforming evidence is receipt
+eligible. Authenticated capability or side-effect escalation remains immutable
+evidence and is classified nonconformant instead of being rejected or erased.
+
+`automation_runtime_terminal_evidence` is an append-only internal inbox. Every
+store and read rechecks JCS integrity, caller-supplied authentication,
+the exact attempt-owned session plus run/attempt correlation, and the exact
+pinned Runtime Authority binding and runtime descriptor. Identical canonical
+replay is idempotent; collisions or tampering fail closed with privacy-safe
+typed errors. The store operation owns an immediate transaction and refuses a
+caller-owned transaction so concurrent identical submissions cannot turn an
+idempotent replay into a snapshot race.
+
+This slice intentionally adds no daemon action or other public submission
+endpoint, advertises no runtime capability, and constructs no launched-session
+receipt. No accepting verifier exists. Until a production runtime adapter can
+submit and consume trustworthy evidence, reconciliation places terminal
+Runtime Authority sessions on the existing recovery-required surface and
+leaves their run and attempt unresolved. Output text, exit status, granted
+capabilities, and merely stored but unconsumed inbox rows cannot settle them.
+The already-terminal dispatcher-controlled no-launch refusal remains separate,
+and base-v1 reconciliation is unchanged.
 
 ## Evidence boundary
 
@@ -37,12 +78,15 @@ terminal session evidence
   -> status, timestamp, summary/log presentation
 ```
 
-The required v1 path now has a durable commitment seam but no production
-producer:
+The required v1 path now has durable commitment and terminal-evidence receiving
+seams but no production producer, verifier adapter, or evidence consumer:
 
 ```text
-terminal evidence
-  -> [missing producer] immutable base receipt + authority sidecar correlation
+runtime terminal observation
+  -> [missing producer/verifier adapter]
+  -> immutable verified inbox
+  -> [missing evidence consumer]
+  -> immutable base receipt + authority sidecar correlation
   -> immutable receipt commitment + run reference + receipt event
   -> owner-local base read (principal-aware sensitive reads still missing)
   -> SDK verification result
@@ -57,10 +101,11 @@ The first path is useful operational history. It is not an
 | Surface | Status | Evidence and consequence |
 | --- | --- | --- |
 | Frozen base receipt contract | Existing | `spec/coven-automations/v1/automation-receipt.schema.json:1-141` defines immutable correlation, outcome, side-effect, integrity, producer, and privacy fields. `AutomationReceipt` verifies its JCS SHA-256 digest during deserialization (`crates/coven-cli/src/automations/contract/types.rs:2075-2200`). This proves object validation, not production. |
-| Terminal session reconciliation | Existing, partial v1 projection | `settle_finished_runs` treats only `completed` plus exit code `0` before the deadline as success, settles occurrence and active attempt, finishes the run, and commits atomically. All other terminal session evidence becomes failed (`crates/coven-cli/src/automations/runner.rs:1973-2164`). |
+| Terminal session reconciliation | Base v1 existing; Runtime Authority held | Base-v1 runs retain the existing exit/timeout/cancellation settlement. A still-running Runtime Authority run with a terminal session is moved to the existing recovery-required occurrence surface before reconciliation interprets exit code or output; its run and attempt remain unresolved, no retry is created, and no receipt is committed. Repeated passes and restart are idempotent. |
 | Retry and timeout settlement | Existing, partial v1 projection | Rejected pre-ownership launches persist failed attempts and either schedule a new adopted attempt or finish the run (`crates/coven-cli/src/automations/runner.rs:505-662`). A waiting retry that exceeds the run deadline records an attempt as `timed_out` but finishes the run as `failed` (`runner.rs:1793-1868`). |
 | Occurrence distinctions | Existing, narrower than the v1 schema | Production occurrence rows use `planned`, `claimed`, `running`, `succeeded`, `failed`, and `skipped`; stale planned slots become `skipped` during claim (`crates/coven-cli/src/automations/occurrences.rs:127-179`), while settlement accepts only `succeeded` or `failed` (`occurrences.rs:371-413`). `skipped` is occurrence evidence, not a receipt outcome. |
 | Receipt construction | Missing | The contract type validates integrity, but no production settlement branch constructs an `AutomationReceipt`. Coven still lacks authoritative terminal inputs for per-action side-effect class, exercised capabilities, result/delivery digests, producer authentication, and authority receipt evidence, so the legacy run projection must not fabricate them. |
+| Runtime terminal evidence contract and inbox | Proposed internal seam; production adapters missing | `coven.automations.runtime-terminal-evidence.v1` defines closed typed observations, JCS integrity, domain-separated authentication, privacy/retention, exact binding/runtime correlation, and receipt-eligibility classification. `automation_runtime_terminal_evidence` stores verified canonical evidence immutably and preserves authenticated policy violations. There is no public submission action, no accepting production verifier, no runtime capability advertisement, and reconciliation does not consume these rows yet. |
 | Durable receipt persistence | Immutable commitment seam exists; production producer missing | `automation_receipts` stores one validated receipt per run and terminal attempt. `commit_receipt` exact-correlates the typed receipt and `receipt.recorded` event to durable run/attempt state, inserts the immutable receipt, sets `automation_runs.receipt_id`, and appends the event under one savepoint (`crates/coven-cli/src/automations/receipts.rs`). Database triggers refuse receipt mutation/deletion and receipt-reference reassignment. No normal settlement path calls the seam yet. |
 | Receipt idempotency and restart recovery | Commitment replay is safe; settlement replay remains missing | Replaying the identical receipt/event returns the committed result without a second row or event. A changed body, receipt ID, run/attempt correlation, or event fails closed, and event-append failure rolls back the receipt and run reference. Restart settlement still needs a producer that deterministically reconstructs the same terminal evidence. |
 | Run/attempt correlation inputs | Existing, with immutable authority slots | Runs pin definition revision/digest, occurrence, and nullable authority profile; attempts pin run, occurrence, attempt number, adoption key, occurrence fence, dispatch generation, session, and nullable authority-extension JSON (`crates/coven-cli/src/automations/runs.rs`). Database triggers prevent a pinned run profile or attempt extension from being rewritten and prevent deletion of an authority-bound attempt. |


### PR DESCRIPTION
## Context

Refs #857.

#983 proves and receipts the deterministic no-launch case. Launched Runtime Authority sessions still cannot be truthfully settled from exit code, output, granted capabilities, or declared risk. This PR defines the receiving boundary for authenticated runtime terminal observations and keeps those runs fail closed until a production adapter exists.

## Implementation

- add proposed `coven.automations.runtime-terminal-evidence.v1` typed evidence with exact session/run/attempt/binding/runtime correlation
- model side effects, exercised capabilities, result, and delivery as explicit observed/partial/unknown tagged states
- classify evidence as receipt-eligible complete, authenticated partial/ambiguous, authenticated unknown, or policy-violating; unknown never becomes `none` or `[]`
- verify JCS integrity and domain-separated producer authentication through a caller-supplied verifier with no accepting production default
- add an immutable one-per-evidence/attempt/session/binding inbox with replay/conflict protection, full read-time index and pinned-binding revalidation, and privacy-safe corruption errors
- preserve authenticated capability/side-effect escalation as policy-violating evidence rather than dropping it
- keep launched Runtime Authority runs unresolved/recovery-required across completion, timeout, cancellation, restart, and repeated reconciliation when trusted complete evidence is unavailable
- preserve Base v1 reconciliation and #983 dispatcher-controlled no-launch receipts
- document that no public submission path, capability advertisement, runtime producer, or launched receipt consumer exists yet

## Safety invariants

- model/tool output resembling evidence is ignored
- exit code and session status prove termination only, not effects or capabilities
- evidence for earlier attempts remains readable after later attempts change the run session pointer
- cancellation races cannot convert a terminal session into an authoritative completion or recurse indefinitely
- migrations reclassify legacy unknown evidence, validate foreign keys, and roll back malformed/orphaned data
- no automatic retry or false terminal receipt occurs for missing/partial/unknown evidence

## Verification

- runtime evidence contract/inbox tests: 27 passed
- runner reconciliation tests: 89 passed
- cancellation tests: 31 passed
- store tests: 179 passed before main integration
- `cargo fmt --check`
- workspace `cargo check --locked`
- targeted Clippy with `-D warnings`
- staged privacy and repository secret guards
- independent spec and correctness reviews approved

## Remaining blocker

This PR deliberately remains `productionReady: false`. Closing #857 still requires an upstream runtime adapter contract and at least one production adapter that signs durable evidence before terminal publication, followed by atomic consumption into launched-session receipts and cross-repository conformance. No current Codex, Claude, or Copilot runtime provides that authenticated evidence channel.