### PR TITLE
feat: negotiate automation capabilities

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -17539,6 +17539,165 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn control_actions_preserve_validation_precedence_over_capability_refusal() -> anyhow::Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let complete_definition = json!({
+            "schemaVersion": 1,
+            "id": "validation-precedence",
+            "name": "Validation precedence",
+            "status": "PAUSED",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "local",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "prompt": "Must not be stored."
+        });
+        let cases = [
+            ("partial", json!({"misfire": "backfill"})),
+            ("malformed-retry", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["retry"] = json!({
+                    "maxAttempts": 3,
+                    "backoffPolicy": ["linear"]
+                });
+                definition
+            }),
+            ("unknown-field", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["futureField"] = json!("must fail closed");
+                definition
+            }),
+            ("malformed-rich-policy", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["policies"] = json!({
+                    "retry": {"retryableClasses": [1]}
+                });
+                definition
+            }),
+            ("malformed-rrule", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["rrule"] = json!("FREQ=DAILY;BYHOUR=not-a-number");
+                definition
+            }),
+            ("malformed-retention", {
+                let mut definition = complete_definition;
+                definition["outputTarget"] = json!("result.md");
+                definition["policies"] = json!({
+                    "retention": {
+                        "occurrenceHistory": {"classification": false}
+                    }
+                });
+                definition
+            }),
+        ];
+
+        for (case, definition) in cases {
+            let body = json!({
+                "action": "coven.automations.definition.create.v1",
+                "adoptionKey": format!("adopt:create:validation-precedence:{case}"),
+                "definition": definition
+            })
+            .to_string();
+            let response = handle_request_with_body(
+                "POST",
+                "/api/v1/actions",
+                temp_dir.path(),
+                None,
+                Some(&body),
+            )?;
+
+            assert_eq!(response.status, 400, "{case}: {}", response.body);
+            let body: Value = serde_json::from_str(&response.body)?;
+            assert_eq!(body["error"]["code"], "VALIDATION_FAILED", "{case}");
+        }
+
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        let definition_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM automation_definitions", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(definition_count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn control_actions_refuse_unsupported_rich_policy_variants() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        for (case, policies, expected_variant) in [
+            (
+                "retry-class",
+                json!({
+                    "retry": {
+                        "retryableClasses": ["runtime_unavailable", "ambiguous"]
+                    }
+                }),
+                "retry.safe-classes.ambiguous",
+            ),
+            (
+                "retention",
+                json!({
+                    "retention": {
+                        "occurrenceHistory": {"classification": "standard"},
+                        "runLogs": {"classification": "ephemeral"}
+                    }
+                }),
+                "retention.ephemeral",
+            ),
+        ] {
+            let body = json!({
+                "action": "coven.automations.definition.create.v1",
+                "adoptionKey": format!("adopt:create:unsupported-policy:{case}"),
+                "definition": {
+                    "schemaVersion": 1,
+                    "id": format!("unsupported-policy-{case}"),
+                    "name": "Unsupported policy",
+                    "status": "PAUSED",
+                    "rrule": "FREQ=DAILY;BYHOUR=9",
+                    "timezone": "local",
+                    "misfire": "latest",
+                    "overlap": "forbid",
+                    "timeoutMinutes": 30,
+                    "runtime": "coven-code",
+                    "prompt": "Must not be stored.",
+                    "policies": policies
+                }
+            })
+            .to_string();
+            let response = handle_request_with_body(
+                "POST",
+                "/api/v1/actions",
+                temp_dir.path(),
+                None,
+                Some(&body),
+            )?;
+
+            assert_eq!(response.status, 422, "{case}: {}", response.body);
+            let body: Value = serde_json::from_str(&response.body)?;
+            assert_eq!(body["error"]["code"], "CAPABILITY_UNSUPPORTED", "{case}");
+            assert_eq!(
+                body["error"]["details"]["variant"], expected_variant,
+                "{case}"
+            );
+        }
+
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        let definition_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM automation_definitions", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(definition_count, 0);
+        Ok(())
+    }
+
+    #[test]
     fn control_actions_durably_reject_unsupported_create_and_revise_variants() -> anyhow::Result<()>
     {
         let temp_dir = tempfile::tempdir()?;

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -17812,7 +17812,11 @@ pub(crate) mod tests {
                 "timeoutMinutes": 30,
                 "runtime": "coven-code",
                 "prompt": "Must not be stored.",
-                "action": {"variant": "pipeline"}
+                "action": {
+                    "variant": "pipeline",
+                    "version": 1,
+                    "steps": [{"prompt": "First step"}]
+                }
             }
         });
         let response = handle_request_with_body(

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -15753,6 +15753,18 @@ pub(crate) mod tests {
         let temp_dir = tempfile::tempdir()?;
 
         let response = handle_request("GET", "/api/v1/capabilities", temp_dir.path(), None)?;
+        let body: Value = serde_json::from_str(&response.body)?;
+        let expected: Value = serde_json::from_str(include_str!(
+            "../../../spec/coven-automations/v1/capabilities.json"
+        ))?;
+        let automations = body["capabilities"]
+            .as_array()
+            .and_then(|capabilities| {
+                capabilities
+                    .iter()
+                    .find(|capability| capability["id"] == "coven.automations")
+            })
+            .expect("catalog includes coven.automations");
 
         assert_eq!(response.status, 200);
         assert!(response.body.contains(r#""id":"coven.sessions""#));
@@ -15761,6 +15773,8 @@ pub(crate) mod tests {
         assert!(response.body.contains(r#""id":"coven.control.actions""#));
         assert!(response.body.contains(r#""id":"desktop.automation""#));
         assert!(response.body.contains(r#""policy":"requiresApproval""#));
+        assert_eq!(automations["variantNegotiation"], expected);
+        assert!(body.get("harness_capabilities").is_none());
         Ok(())
     }
 
@@ -17497,7 +17511,7 @@ pub(crate) mod tests {
                 "id": "bad schedule!",
                 "name": "Bad",
                 "status": "PAUSED",
-                "rrule": "FREQ=HOURLY",
+                "rrule": "FREQ=DAILY;BYHOUR=9",
                 "timezone": "local",
                 "misfire": "latest",
                 "overlap": "forbid",
@@ -17521,6 +17535,200 @@ pub(crate) mod tests {
             .contains("coven.automations.definition.create.v1"));
         assert!(response.body.contains(r#""code":"VALIDATION_FAILED""#));
         assert!(!response.body.contains(r#""accepted":true"#));
+        Ok(())
+    }
+
+    #[test]
+    fn control_actions_durably_reject_unsupported_create_and_revise_variants() -> anyhow::Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let unsupported_create = json!({
+            "action": "coven.automations.definition.create.v1",
+            "adoptionKey": "adopt:create:unsupported-http:0001",
+            "definition": {
+                "schemaVersion": 1,
+                "id": "unsupported-create-http",
+                "name": "Unsupported create",
+                "status": "PAUSED",
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "local",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 30,
+                "runtime": "coven-code",
+                "outputTarget": "result.md",
+                "prompt": "Must not be stored."
+            }
+        });
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&unsupported_create.to_string()),
+        )?;
+        assert_eq!(response.status, 422);
+        let first_create: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(first_create["ok"], false);
+        assert_eq!(first_create["accepted"], false);
+        assert_eq!(first_create["status"], "rejected");
+        assert_eq!(first_create["error"]["code"], "CAPABILITY_UNSUPPORTED");
+        assert_eq!(
+            first_create["error"]["message"],
+            "automation definition uses a variant not supported by the negotiated contract profile"
+        );
+        assert_eq!(
+            first_create["error"]["details"]["variant"],
+            "outputTarget.atomic"
+        );
+        assert_eq!(
+            first_create["error"]["details"]["contractProfile"],
+            "coven.automations.v1"
+        );
+        assert!(first_create.get("event").is_none());
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&unsupported_create.to_string()),
+        )?;
+        assert_eq!(response.status, 422);
+        assert_eq!(serde_json::from_str::<Value>(&response.body)?, first_create);
+
+        let mut changed_create = unsupported_create.clone();
+        changed_create["definition"]["outputTarget"] = json!("different.md");
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&changed_create.to_string()),
+        )?;
+        assert_eq!(response.status, 409);
+        assert!(response
+            .body
+            .contains(r#""code":"ADOPTION_REPLAY_MISMATCH""#));
+
+        let valid_create = json!({
+            "action": "coven.automations.definition.create.v1",
+            "adoptionKey": "adopt:create:revise-http:0001",
+            "definition": {
+                "schemaVersion": 1,
+                "id": "revise-http",
+                "name": "Original",
+                "status": "PAUSED",
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "local",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 30,
+                "runtime": "coven-code",
+                "prompt": "Original prompt."
+            }
+        });
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&valid_create.to_string()),
+        )?;
+        assert_eq!(response.status, 200);
+
+        let unsupported_revise = json!({
+            "action": "coven.automations.definition.revise.v1",
+            "adoptionKey": "adopt:revise:unsupported-http:0002",
+            "expectedRevision": 1,
+            "definition": {
+                "schemaVersion": 1,
+                "id": "revise-http",
+                "name": "Must not land",
+                "status": "PAUSED",
+                "rrule": "FREQ=DAILY;BYHOUR=9",
+                "timezone": "local",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 30,
+                "runtime": "coven-code",
+                "prompt": "Must not be stored.",
+                "action": {"variant": "pipeline"}
+            }
+        });
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&unsupported_revise.to_string()),
+        )?;
+        assert_eq!(response.status, 422);
+        let first_revise: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(first_revise["ok"], false);
+        assert_eq!(first_revise["accepted"], false);
+        assert_eq!(first_revise["status"], "rejected");
+        assert_eq!(first_revise["error"]["code"], "CAPABILITY_UNSUPPORTED");
+        assert_eq!(
+            first_revise["error"]["details"]["variant"],
+            "action.pipeline"
+        );
+        assert_eq!(
+            first_revise["error"]["details"]["contractProfile"],
+            "coven.automations.v1"
+        );
+        assert!(first_revise.get("event").is_none());
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&unsupported_revise.to_string()),
+        )?;
+        assert_eq!(response.status, 422);
+        assert_eq!(serde_json::from_str::<Value>(&response.body)?, first_revise);
+
+        let mut changed_revise = unsupported_revise;
+        changed_revise["definition"]["action"]["variant"] = json!("batch");
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&changed_revise.to_string()),
+        )?;
+        assert_eq!(response.status, 409);
+        assert!(response
+            .body
+            .contains(r#""code":"ADOPTION_REPLAY_MISMATCH""#));
+
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        let definition = crate::automations::store::get_definition(&conn, "revise-http")?
+            .expect("original definition remains");
+        assert_eq!(definition.revision, 1);
+        assert!(definition.definition_json.contains(r#""name":"Original""#));
+        assert!(
+            crate::automations::store::get_definition(&conn, "unsupported-create-http")?.is_none()
+        );
+        let definition_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM automation_events
+             WHERE stream_kind = 'automation'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(definition_events, 1);
+        let rejected_adoptions: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM automation_command_adoptions
+             WHERE outcome = 'rejected'
+               AND adoption_key IN (
+                   'adopt:create:unsupported-http:0001',
+                   'adopt:revise:unsupported-http:0002'
+               )",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(rejected_adoptions, 2);
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -17576,8 +17576,66 @@ pub(crate) mod tests {
                 let mut definition = complete_definition.clone();
                 definition["outputTarget"] = json!("result.md");
                 definition["policies"] = json!({
-                    "retry": {"retryableClasses": [1]}
+                    "retry": {
+                        "maxAttempts": 2,
+                        "backoffPolicy": "none",
+                        "retryableClasses": [1]
+                    }
                 });
+                definition
+            }),
+            ("malformed-rich-schedule", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["trigger"] = json!({
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {
+                        "rrule": "FREQ=YEARLY;BYHOUR=not-a-number",
+                        "timezone": "utc"
+                    }
+                });
+                definition
+            }),
+            ("missing-rich-schedule-version", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["trigger"] = json!({
+                    "variant": "schedule",
+                    "schedule": {
+                        "rrule": "FREQ=DAILY",
+                        "timezone": "utc"
+                    }
+                });
+                definition
+            }),
+            ("fixed-rich-retry-missing-seconds", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["policies"] = json!({
+                    "retry": {
+                        "maxAttempts": 2,
+                        "backoffPolicy": "fixed"
+                    }
+                });
+                definition
+            }),
+            ("supported-rich-action-missing-version", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["action"] = json!({
+                    "variant": "familiarInvocation",
+                    "prompt": "Run it."
+                });
+                definition
+            }),
+            ("unsupported-rich-condition-missing-version", {
+                let mut definition = complete_definition.clone();
+                definition["outputTarget"] = json!("result.md");
+                definition["conditions"] = json!([{
+                    "variant": "branch",
+                    "branch": {"expression": "result.ok"}
+                }]);
                 definition
             }),
             ("malformed-rrule", {
@@ -17636,6 +17694,8 @@ pub(crate) mod tests {
                 "retry-class",
                 json!({
                     "retry": {
+                        "maxAttempts": 2,
+                        "backoffPolicy": "none",
                         "retryableClasses": ["runtime_unavailable", "ambiguous"]
                     }
                 }),

--- a/crates/coven-cli/src/automations/capability_negotiation.rs
+++ b/crates/coven-cli/src/automations/capability_negotiation.rs
@@ -4,7 +4,11 @@ use std::sync::OnceLock;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-use super::definition::RoutineDefinition;
+use super::contract::types::{
+    FamiliarInvocationAction, RetryableClass, TimeoutPolicy, Timestamp, WorkingDirectory,
+};
+use super::definition::{RoutineDefinition, RoutineTimezone};
+use super::rrule::parse_rrule;
 
 const CAPABILITIES_JSON: &str =
     include_str!("../../../../spec/coven-automations/v1/capabilities.json");
@@ -71,20 +75,33 @@ pub fn capability_profile() -> &'static CapabilityProfile {
 
 #[must_use]
 pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
+    preflight_definition_with_profile(definition, capability_profile())
+}
+
+fn preflight_definition_with_profile(
+    definition: &Value,
+    profile: &CapabilityProfile,
+) -> Option<UnsupportedVariant> {
     let definition = definition.as_object()?;
 
     if let Some(trigger) = definition.get("trigger").and_then(Value::as_object) {
         if let Some(variant) = trigger.get("variant").and_then(Value::as_str) {
-            if variant != "schedule" {
-                return unsupported_from_component("trigger", variant, false);
+            if !supports(&profile.supported.triggers, variant) {
+                return unsupported_from_component(profile, "trigger", variant, false);
             }
-            if let Some(schedule) = trigger.get("schedule").and_then(Value::as_object) {
-                if schedule.get("timezone").and_then(Value::as_str) == Some("local") {
-                    return Some(unsupported("timezone.local.durable".to_owned()));
-                }
-                if let Some(rrule) = schedule.get("rrule").and_then(Value::as_str) {
-                    if let Some(unsupported) = unsupported_rrule_frequency(rrule) {
-                        return Some(unsupported);
+            if variant == "schedule" {
+                if let Some(schedule) = trigger.get("schedule").and_then(Value::as_object) {
+                    if let Some(timezone) =
+                        schedule.get("timezone").and_then(schedule_timezone_variant)
+                    {
+                        if !supports(&profile.supported.trigger_policies, timezone) {
+                            return Some(unsupported(profile, timezone.to_owned()));
+                        }
+                    }
+                    if let Some(rrule) = schedule.get("rrule").and_then(Value::as_str) {
+                        if let Some(unsupported) = unsupported_rrule_frequency(profile, rrule) {
+                            return Some(unsupported);
+                        }
                     }
                 }
             }
@@ -98,8 +115,12 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
                 .and_then(|condition| condition.get("variant"))
                 .and_then(Value::as_str)
             {
-                if let Some(unsupported) = unsupported_from_component("condition", variant, false) {
-                    return Some(unsupported);
+                if !supports(&profile.supported.conditions, variant) {
+                    if let Some(unsupported) =
+                        unsupported_from_component(profile, "condition", variant, false)
+                    {
+                        return Some(unsupported);
+                    }
                 }
             }
         }
@@ -107,8 +128,8 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
 
     if let Some(action) = definition.get("action").and_then(Value::as_object) {
         if let Some(variant) = action.get("variant").and_then(Value::as_str) {
-            if variant != "familiarInvocation" {
-                return unsupported_from_component("action", variant, false);
+            if !supports(&profile.supported.actions, variant) {
+                return unsupported_from_component(profile, "action", variant, false);
             }
         }
     }
@@ -120,8 +141,8 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
             .and_then(|misfire| misfire.get("disposition"))
             .and_then(Value::as_str)
         {
-            if disposition != "latest" {
-                return unsupported_from_component("misfire", disposition, false);
+            if !supports_exact_value(&profile.supported.trigger_policies, "misfire", disposition) {
+                return unsupported_from_component(profile, "misfire", disposition, false);
             }
         }
         if let Some(overlap) = policies
@@ -130,8 +151,8 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
             .and_then(|concurrency| concurrency.get("overlap"))
             .and_then(Value::as_str)
         {
-            if overlap != "forbid" {
-                return unsupported_from_component("overlap", overlap, false);
+            if !supports_exact_value(&profile.supported.trigger_policies, "overlap", overlap) {
+                return unsupported_from_component(profile, "overlap", overlap, false);
             }
         }
         if let Some(backoff) = policies
@@ -140,8 +161,12 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
             .and_then(|retry| retry.get("backoffPolicy"))
             .and_then(Value::as_str)
         {
-            if !matches!(backoff, "none" | "fixed" | "exponential") {
-                return unsupported_from_component("retry.backoff", backoff, false);
+            if !supports_exact_value(
+                &profile.supported.trigger_policies,
+                "retry.backoff",
+                backoff,
+            ) {
+                return unsupported_from_component(profile, "retry.backoff", backoff, false);
             }
         }
         if let Some(retryable_classes) = policies
@@ -152,11 +177,9 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
             .filter(|classes| classes.iter().all(Value::is_string))
         {
             for retryable_class in retryable_classes.iter().filter_map(Value::as_str) {
-                if !matches!(
-                    retryable_class,
-                    "transient_dispatch" | "lease_expired" | "runtime_unavailable"
-                ) {
+                if !retryable_class_is_supported(retryable_class) {
                     return unsupported_from_component(
+                        profile,
                         "retry.safe-classes",
                         retryable_class,
                         false,
@@ -171,7 +194,13 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
                 .is_some()
             {
                 if let Some(mode) = delivery.get("mode").and_then(Value::as_str) {
-                    return unsupported_from_component("outputTarget", mode, false);
+                    if !supports_exact_value(
+                        &profile.supported.delivery_policies,
+                        "outputTarget",
+                        mode,
+                    ) {
+                        return unsupported_from_component(profile, "outputTarget", mode, false);
+                    }
                 }
             }
         }
@@ -183,8 +212,17 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
                     .and_then(|retention_class| retention_class.get("classification"))
                     .and_then(Value::as_str)
                 {
-                    if classification != "standard" {
-                        return unsupported_from_component("retention", classification, false);
+                    if !supports_exact_value(
+                        &profile.supported.retention_policies,
+                        "retention",
+                        classification,
+                    ) {
+                        return unsupported_from_component(
+                            profile,
+                            "retention",
+                            classification,
+                            false,
+                        );
                     }
                 }
             }
@@ -192,13 +230,13 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
     }
 
     if let Some(misfire) = definition.get("misfire").and_then(Value::as_str) {
-        if misfire != "latest" {
-            return unsupported_from_component("misfire", misfire, false);
+        if !supports_exact_value(&profile.supported.trigger_policies, "misfire", misfire) {
+            return unsupported_from_component(profile, "misfire", misfire, false);
         }
     }
     if let Some(overlap) = definition.get("overlap").and_then(Value::as_str) {
-        if overlap != "forbid" {
-            return unsupported_from_component("overlap", overlap, false);
+        if !supports_exact_value(&profile.supported.trigger_policies, "overlap", overlap) {
+            return unsupported_from_component(profile, "overlap", overlap, false);
         }
     }
     if let Some(backoff) = definition
@@ -207,19 +245,51 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
         .and_then(|retry| retry.get("backoffPolicy"))
         .and_then(Value::as_str)
     {
-        if !matches!(backoff, "none" | "fixed" | "exponential") {
-            return unsupported_from_component("retry.backoff", backoff, false);
+        if !supports_exact_value(
+            &profile.supported.trigger_policies,
+            "retry.backoff",
+            backoff,
+        ) {
+            return unsupported_from_component(profile, "retry.backoff", backoff, false);
+        }
+    }
+    if let Some(retryable_classes) = definition
+        .get("retry")
+        .and_then(Value::as_object)
+        .and_then(|retry| retry.get("retryableClasses"))
+        .and_then(Value::as_array)
+        .filter(|classes| classes.iter().all(Value::is_string))
+    {
+        for retryable_class in retryable_classes.iter().filter_map(Value::as_str) {
+            if !retryable_class_is_supported(retryable_class) {
+                return unsupported_from_component(
+                    profile,
+                    "retry.safe-classes",
+                    retryable_class,
+                    false,
+                );
+            }
         }
     }
     if definition
         .get("outputTarget")
         .and_then(Value::as_str)
         .is_some()
+        && !supports(&profile.supported.delivery_policies, "outputTarget.atomic")
     {
-        return Some(unsupported("outputTarget.atomic".to_owned()));
+        return Some(unsupported(profile, "outputTarget.atomic".to_owned()));
+    }
+    if let Some(timezone) = definition.get("timezone") {
+        if let Some(timezone_variant @ ("timezone.utc" | "timezone.iana")) =
+            schedule_timezone_variant(timezone)
+        {
+            if !supports(&profile.supported.trigger_policies, timezone_variant) {
+                return Some(unsupported(profile, timezone_variant.to_owned()));
+            }
+        }
     }
     if let Some(rrule) = definition.get("rrule").and_then(Value::as_str) {
-        if let Some(unsupported) = unsupported_rrule_frequency(rrule) {
+        if let Some(unsupported) = unsupported_rrule_frequency(profile, rrule) {
             return Some(unsupported);
         }
     }
@@ -230,23 +300,21 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
 pub fn negotiate_definition(definition: &Value) -> Result<DefinitionNegotiation, String> {
     let Some(unsupported) = preflight_definition(definition) else {
         return RoutineDefinition::from_json(definition)
-            .and_then(RoutineDefinition::resolve_timezone_for_persistence)
             .map(Box::new)
             .map(DefinitionNegotiation::Supported);
     };
 
-    let projection = validation_projection(definition);
-    RoutineDefinition::from_json(&projection)
-        .and_then(RoutineDefinition::resolve_timezone_for_persistence)?;
+    let projection = validation_projection(definition, capability_profile());
+    RoutineDefinition::from_json(&projection)?;
     Ok(DefinitionNegotiation::Unsupported(unsupported))
 }
 
-fn validation_projection(definition: &Value) -> Value {
+fn validation_projection(definition: &Value, profile: &CapabilityProfile) -> Value {
     let Value::Object(mut projection) = definition.clone() else {
         return definition.clone();
     };
 
-    neutralize_flat_unsupported_values(&mut projection);
+    neutralize_flat_unsupported_values(&mut projection, profile);
     for key in ["trigger", "conditions", "action", "policies"] {
         if projection
             .get(key)
@@ -259,18 +327,27 @@ fn validation_projection(definition: &Value) -> Value {
     Value::Object(projection)
 }
 
-fn neutralize_flat_unsupported_values(definition: &mut Map<String, Value>) {
+fn neutralize_flat_unsupported_values(
+    definition: &mut Map<String, Value>,
+    profile: &CapabilityProfile,
+) {
     if definition
         .get("misfire")
         .and_then(Value::as_str)
-        .is_some_and(|misfire| misfire != "latest")
+        .is_some_and(|misfire| {
+            !supports_exact_value(&profile.supported.trigger_policies, "misfire", misfire)
+                && unsupported_component(misfire, false).is_some()
+        })
     {
         definition.insert("misfire".to_owned(), Value::String("latest".to_owned()));
     }
     if definition
         .get("overlap")
         .and_then(Value::as_str)
-        .is_some_and(|overlap| overlap != "forbid")
+        .is_some_and(|overlap| {
+            !supports_exact_value(&profile.supported.trigger_policies, "overlap", overlap)
+                && unsupported_component(overlap, false).is_some()
+        })
     {
         definition.insert("overlap".to_owned(), Value::String("forbid".to_owned()));
     }
@@ -278,30 +355,57 @@ fn neutralize_flat_unsupported_values(definition: &mut Map<String, Value>) {
         if retry
             .get("backoffPolicy")
             .and_then(Value::as_str)
-            .is_some_and(|backoff| !matches!(backoff, "none" | "fixed" | "exponential"))
+            .is_some_and(|backoff| {
+                !supports_exact_value(
+                    &profile.supported.trigger_policies,
+                    "retry.backoff",
+                    backoff,
+                ) && unsupported_component(backoff, false).is_some()
+            })
         {
             retry.insert("backoffPolicy".to_owned(), Value::String("none".to_owned()));
         }
+        if let Some(retryable_classes) = retry
+            .get_mut("retryableClasses")
+            .and_then(Value::as_array_mut)
+            .filter(|classes| classes.iter().all(Value::is_string))
+        {
+            for retryable_class in retryable_classes {
+                let should_neutralize = retryable_class.as_str().is_some_and(|retryable_class| {
+                    !retryable_class.trim().is_empty()
+                        && !retryable_class_is_supported(retryable_class)
+                });
+                if should_neutralize {
+                    *retryable_class = Value::String("transient_dispatch".to_owned());
+                }
+            }
+        }
     }
-    if definition.get("outputTarget").is_some_and(Value::is_string) {
+    if definition.get("outputTarget").is_some_and(Value::is_string)
+        && !supports(&profile.supported.delivery_policies, "outputTarget.atomic")
+    {
         definition.remove("outputTarget");
     }
     if let Some(rrule) = definition.get("rrule").and_then(Value::as_str) {
-        if unsupported_rrule_frequency(rrule).is_some() {
-            let frequency = if rrule.split(';').any(|part| {
-                part.split_once('=')
-                    .is_some_and(|(key, _)| key.trim().eq_ignore_ascii_case("BYDAY"))
-            }) {
-                "WEEKLY"
-            } else {
-                "DAILY"
-            };
+        if unsupported_rrule_frequency_value(rrule).is_some() {
             definition.insert(
                 "rrule".to_owned(),
-                Value::String(neutralize_rrule_frequency(rrule, frequency)),
+                Value::String(supported_rrule_projection(rrule)),
             );
         }
     }
+}
+
+fn supported_rrule_projection(rrule: &str) -> String {
+    let frequency = if rrule.split(';').any(|part| {
+        part.split_once('=')
+            .is_some_and(|(key, _)| key.trim().eq_ignore_ascii_case("BYDAY"))
+    }) {
+        "WEEKLY"
+    } else {
+        "DAILY"
+    };
+    neutralize_rrule_frequency(rrule, frequency)
 }
 
 fn neutralize_rrule_frequency(rrule: &str, supported_frequency: &str) -> String {
@@ -338,13 +442,8 @@ fn trigger_hint_is_well_formed(value: &Value) -> bool {
         return unsupported_union_hint_is_well_formed(trigger);
     }
     has_only_fields(trigger, &["variant", "version", "schedule"])
-        && !variant.trim().is_empty()
-        && optional_version_is_well_formed(trigger.get("version"))
-        && optional_schedule_is_well_formed(trigger.get("schedule"))
-}
-
-fn optional_schedule_is_well_formed(schedule: Option<&Value>) -> bool {
-    schedule.is_none_or(schedule_is_well_formed)
+        && trigger.get("version").is_some_and(is_version_one)
+        && trigger.get("schedule").is_some_and(schedule_is_well_formed)
 }
 
 fn schedule_is_well_formed(value: &Value) -> bool {
@@ -352,18 +451,40 @@ fn schedule_is_well_formed(value: &Value) -> bool {
         return false;
     };
     has_only_fields(schedule, &["rrule", "timezone"])
-        && schedule.get("rrule").is_some_and(Value::is_string)
-        && schedule.get("timezone").is_some_and(Value::is_string)
+        && schedule
+            .get("rrule")
+            .and_then(Value::as_str)
+            .is_some_and(schedule_rrule_is_well_formed)
+        && schedule
+            .get("timezone")
+            .is_some_and(schedule_timezone_is_well_formed)
+}
+
+fn schedule_rrule_is_well_formed(rrule: &str) -> bool {
+    if !(1..=512).contains(&rrule.chars().count()) {
+        return false;
+    }
+    let validation_rrule = if unsupported_rrule_frequency_value(rrule).is_some() {
+        supported_rrule_projection(rrule)
+    } else {
+        rrule.to_owned()
+    };
+    parse_rrule(&validation_rrule).is_ok()
+}
+
+fn schedule_timezone_is_well_formed(timezone: &Value) -> bool {
+    serde_json::from_value::<RoutineTimezone>(timezone.clone()).is_ok()
 }
 
 fn conditions_hint_is_well_formed(value: &Value) -> bool {
     value.as_array().is_some_and(|conditions| {
-        conditions.iter().all(|condition| {
-            let Some(condition) = condition.as_object() else {
-                return false;
-            };
-            unsupported_union_hint_is_well_formed(condition)
-        })
+        conditions.len() <= 16
+            && conditions.iter().all(|condition| {
+                let Some(condition) = condition.as_object() else {
+                    return false;
+                };
+                unsupported_union_hint_is_well_formed(condition)
+            })
     })
 }
 
@@ -377,11 +498,7 @@ fn action_hint_is_well_formed(value: &Value) -> bool {
     if variant != "familiarInvocation" {
         return unsupported_union_hint_is_well_formed(action);
     }
-    has_only_fields(action, &["variant", "version", "prompt", "cwd"])
-        && !variant.trim().is_empty()
-        && optional_version_is_well_formed(action.get("version"))
-        && optional_string_is_well_formed(action.get("prompt"))
-        && optional_string_is_well_formed(action.get("cwd"))
+    serde_json::from_value::<FamiliarInvocationAction>(value.clone()).is_ok()
 }
 
 fn unsupported_union_hint_is_well_formed(union: &Map<String, Value>) -> bool {
@@ -389,7 +506,7 @@ fn unsupported_union_hint_is_well_formed(union: &Map<String, Value>) -> bool {
         .get("variant")
         .and_then(Value::as_str)
         .is_some_and(|variant| !variant.trim().is_empty())
-        && optional_version_is_well_formed(union.get("version"))
+        && union.get("version").is_some_and(is_version_one)
 }
 
 fn policies_hint_is_well_formed(value: &Value) -> bool {
@@ -420,14 +537,7 @@ fn policies_hint_is_well_formed(value: &Value) -> bool {
 }
 
 fn timeout_hint_is_well_formed(value: &Value) -> bool {
-    let Some(timeout) = value.as_object() else {
-        return false;
-    };
-    has_only_fields(timeout, &["perRunMinutes"])
-        && timeout
-            .get("perRunMinutes")
-            .and_then(Value::as_u64)
-            .is_some_and(|minutes| (1..=44_640).contains(&minutes))
+    serde_json::from_value::<TimeoutPolicy>(value.clone()).is_ok()
 }
 
 fn retry_hint_is_well_formed(value: &Value) -> bool {
@@ -444,17 +554,24 @@ fn retry_hint_is_well_formed(value: &Value) -> bool {
                 "retryableClasses",
             ],
         )
-        || !retry.get("maxAttempts").is_none_or(|value| {
-            value
-                .as_u64()
-                .is_some_and(|attempts| (1..=10).contains(&attempts))
-        })
-        || !optional_string_is_well_formed(retry.get("backoffPolicy"))
+        || !retry
+            .get("maxAttempts")
+            .and_then(Value::as_u64)
+            .is_some_and(|attempts| (1..=10).contains(&attempts))
+        || retry
+            .get("backoffPolicy")
+            .and_then(Value::as_str)
+            .is_none_or(|backoff| backoff.trim().is_empty())
         || !retry.get("backoffSeconds").is_none_or(|value| {
             value
                 .as_u64()
                 .is_some_and(|seconds| (1..=86_400).contains(&seconds))
         })
+    {
+        return false;
+    }
+    if retry.get("backoffPolicy").and_then(Value::as_str) == Some("fixed")
+        && retry.get("backoffSeconds").is_none()
     {
         return false;
     }
@@ -477,17 +594,25 @@ fn delivery_hint_is_well_formed(value: &Value) -> bool {
     let Some(delivery) = value.as_object() else {
         return false;
     };
-    has_only_fields(delivery, &["outputTarget", "mode"])
-        && delivery.get("outputTarget").is_some_and(Value::is_string)
-        && delivery.get("mode").is_some_and(Value::is_string)
+    if !has_only_fields(delivery, &["outputTarget", "mode"])
+        || !delivery.get("outputTarget").is_none_or(|output_target| {
+            serde_json::from_value::<WorkingDirectory>(output_target.clone()).is_ok()
+        })
+        || delivery
+            .get("mode")
+            .is_some_and(|mode| mode.as_str().is_none_or(|mode| mode.trim().is_empty()))
+    {
+        return false;
+    }
+    delivery.get("outputTarget").is_none() || delivery.get("mode").is_some()
 }
 
 fn retention_hint_is_well_formed(value: &Value) -> bool {
     let Some(retention) = value.as_object() else {
         return false;
     };
-    !retention.is_empty()
-        && has_only_fields(retention, &["occurrenceHistory", "runLogs", "receipts"])
+    has_only_fields(retention, &["occurrenceHistory", "runLogs", "receipts"])
+        && retention.get("occurrenceHistory").is_some()
         && retention.values().all(retention_class_is_well_formed)
 }
 
@@ -500,33 +625,56 @@ fn retention_class_is_well_formed(value: &Value) -> bool {
             .get("classification")
             .and_then(Value::as_str)
             .is_some_and(|classification| !classification.trim().is_empty())
-        && optional_string_is_well_formed(retention_class.get("deleteAfter"))
+        && retention_class
+            .get("deleteAfter")
+            .is_none_or(|delete_after| {
+                serde_json::from_value::<Timestamp>(delete_after.clone()).is_ok()
+            })
 }
 
 fn single_string_field_is_well_formed(value: &Value, field: &str) -> bool {
     let Some(object) = value.as_object() else {
         return false;
     };
-    has_only_fields(object, &[field]) && object.get(field).is_some_and(Value::is_string)
+    has_only_fields(object, &[field])
+        && object
+            .get(field)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
 }
 
 fn has_only_fields(object: &Map<String, Value>, allowed: &[&str]) -> bool {
     object.keys().all(|key| allowed.contains(&key.as_str()))
 }
 
-fn optional_version_is_well_formed(version: Option<&Value>) -> bool {
-    version.is_none_or(is_version_one)
-}
-
 fn is_version_one(value: &Value) -> bool {
     value.as_u64() == Some(1)
 }
 
-fn optional_string_is_well_formed(value: Option<&Value>) -> bool {
-    value.is_none_or(Value::is_string)
+fn retryable_class_is_supported(value: &str) -> bool {
+    serde_json::from_value::<RetryableClass>(Value::String(value.to_owned())).is_ok()
 }
 
-fn unsupported_rrule_frequency(rrule: &str) -> Option<UnsupportedVariant> {
+fn schedule_timezone_variant(value: &Value) -> Option<&'static str> {
+    match serde_json::from_value::<RoutineTimezone>(value.clone()).ok()? {
+        RoutineTimezone::Local => Some("timezone.local.durable"),
+        RoutineTimezone::Utc => Some("timezone.utc"),
+        RoutineTimezone::Iana(_) => Some("timezone.iana"),
+    }
+}
+
+fn supports(variants: &[VariantCapability], variant: &str) -> bool {
+    variants
+        .iter()
+        .any(|supported| supported.variant == variant)
+}
+
+fn supports_exact_value(variants: &[VariantCapability], prefix: &str, value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty() && supports(variants, &format!("{prefix}.{value}"))
+}
+
+fn unsupported_rrule_frequency_value(rrule: &str) -> Option<&str> {
     let mut frequency = None;
     for part in rrule
         .split(';')
@@ -549,14 +697,32 @@ fn unsupported_rrule_frequency(rrule: &str) -> Option<UnsupportedVariant> {
     if frequency.eq_ignore_ascii_case("DAILY") || frequency.eq_ignore_ascii_case("WEEKLY") {
         return None;
     }
-    unsupported_from_component("trigger.schedule.frequency", frequency, true)
+    Some(frequency)
+}
+
+fn unsupported_rrule_frequency(
+    profile: &CapabilityProfile,
+    rrule: &str,
+) -> Option<UnsupportedVariant> {
+    unsupported_from_component(
+        profile,
+        "trigger.schedule.frequency",
+        unsupported_rrule_frequency_value(rrule)?,
+        true,
+    )
 }
 
 fn unsupported_from_component(
+    profile: &CapabilityProfile,
     prefix: &str,
     value: &str,
     lowercase: bool,
 ) -> Option<UnsupportedVariant> {
+    let component = unsupported_component(value, lowercase)?;
+    Some(unsupported(profile, format!("{prefix}.{component}")))
+}
+
+fn unsupported_component(value: &str, lowercase: bool) -> Option<String> {
     let value = value.trim();
     if value.is_empty() {
         return None;
@@ -574,11 +740,10 @@ fn unsupported_from_component(
     } else {
         "unknown".to_owned()
     };
-    Some(unsupported(format!("{prefix}.{component}")))
+    Some(component)
 }
 
-fn unsupported(variant: String) -> UnsupportedVariant {
-    let profile = capability_profile();
+fn unsupported(profile: &CapabilityProfile, variant: String) -> UnsupportedVariant {
     let reason = profile
         .refused
         .iter()
@@ -598,12 +763,60 @@ mod tests {
     use super::*;
     use serde_json::{json, Value};
 
+    #[derive(Clone, Copy)]
+    enum SupportedCollection {
+        Trigger,
+        Condition,
+        Action,
+        TriggerPolicy,
+        DeliveryPolicy,
+        RetentionPolicy,
+    }
+
+    fn supported_variants_mut(
+        profile: &mut CapabilityProfile,
+        collection: SupportedCollection,
+    ) -> &mut Vec<VariantCapability> {
+        match collection {
+            SupportedCollection::Trigger => &mut profile.supported.triggers,
+            SupportedCollection::Condition => &mut profile.supported.conditions,
+            SupportedCollection::Action => &mut profile.supported.actions,
+            SupportedCollection::TriggerPolicy => &mut profile.supported.trigger_policies,
+            SupportedCollection::DeliveryPolicy => &mut profile.supported.delivery_policies,
+            SupportedCollection::RetentionPolicy => &mut profile.supported.retention_policies,
+        }
+    }
+
+    fn advertise(profile: &mut CapabilityProfile, collection: SupportedCollection, variant: &str) {
+        supported_variants_mut(profile, collection).push(VariantCapability {
+            variant: variant.to_owned(),
+            profile: None,
+            notes: None,
+        });
+    }
+
     fn assert_variant(definition: Value, expected: &str) {
         let unsupported = preflight_definition(&definition)
             .unwrap_or_else(|| panic!("expected unsupported variant `{expected}`"));
         assert_eq!(unsupported.variant, expected);
         assert!(!unsupported.reason.is_empty());
         assert!(unsupported.reason.len() <= 500);
+    }
+
+    fn complete_definition() -> Value {
+        json!({
+            "schemaVersion": 1,
+            "id": "negotiation-test",
+            "name": "Negotiation test",
+            "status": "PAUSED",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "local",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "runtime": "coven-code",
+            "prompt": "Exercise capability negotiation."
+        })
     }
 
     #[test]
@@ -750,9 +963,200 @@ mod tests {
         ] {
             assert_variant(
                 json!({"policies": {"retry": {
+                    "maxAttempts": 2,
+                    "backoffPolicy": "none",
                     "retryableClasses": ["transient_dispatch", retryable_class]
                 }}}),
                 expected,
+            );
+        }
+    }
+
+    #[test]
+    fn flat_retryable_classes_are_negotiated_after_structural_validation() {
+        let mut definition = complete_definition();
+        definition["retry"] = json!({
+            "maxAttempts": 2,
+            "backoffPolicy": "none",
+            "retryableClasses": ["transient_dispatch", "ambiguous"]
+        });
+
+        let negotiation = negotiate_definition(&definition).unwrap();
+        let DefinitionNegotiation::Unsupported(unsupported) = negotiation else {
+            panic!("unknown flat retryable class must be refused");
+        };
+        assert_eq!(unsupported.variant, "retry.safe-classes.ambiguous");
+    }
+
+    #[test]
+    fn rich_schedule_validation_preserves_malformed_nested_values() {
+        for (case, trigger) in [
+            (
+                "unsupported-frequency-with-malformed-hour",
+                json!({
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {
+                        "rrule": "FREQ=YEARLY;BYHOUR=not-a-number",
+                        "timezone": "utc"
+                    }
+                }),
+            ),
+            (
+                "local-timezone-with-malformed-hour",
+                json!({
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {
+                        "rrule": "FREQ=DAILY;BYHOUR=not-a-number",
+                        "timezone": "local"
+                    }
+                }),
+            ),
+            (
+                "malformed-timezone",
+                json!({
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {
+                        "rrule": "FREQ=DAILY",
+                        "timezone": "Mars/Olympus"
+                    }
+                }),
+            ),
+            (
+                "missing-version",
+                json!({
+                    "variant": "schedule",
+                    "schedule": {
+                        "rrule": "FREQ=DAILY",
+                        "timezone": "utc"
+                    }
+                }),
+            ),
+            (
+                "missing-schedule",
+                json!({
+                    "variant": "schedule",
+                    "version": 1
+                }),
+            ),
+        ] {
+            let mut definition = complete_definition();
+            definition["outputTarget"] = json!("result.md");
+            definition["trigger"] = trigger;
+
+            assert!(
+                negotiate_definition(&definition).is_err(),
+                "{case} must remain a validation failure"
+            );
+        }
+    }
+
+    #[test]
+    fn rich_schedule_allows_valid_unsupported_frequency_negotiation() {
+        let mut definition = complete_definition();
+        definition["trigger"] = json!({
+            "variant": "schedule",
+            "version": 1,
+            "schedule": {
+                "rrule": "FREQ=YEARLY;BYHOUR=9",
+                "timezone": "utc"
+            }
+        });
+
+        let negotiation = negotiate_definition(&definition).unwrap();
+        let DefinitionNegotiation::Unsupported(unsupported) = negotiation else {
+            panic!("unsupported frequency must be refused");
+        };
+        assert_eq!(unsupported.variant, "trigger.schedule.frequency.yearly");
+    }
+
+    #[test]
+    fn rich_union_hints_require_version_one_and_supported_action_fields() {
+        for (case, key, hint) in [
+            (
+                "unsupported-trigger-without-version",
+                "trigger",
+                json!({"variant": "webhook", "webhook": {}}),
+            ),
+            (
+                "unsupported-condition-without-version",
+                "conditions",
+                json!([{"variant": "branch", "branch": {}}]),
+            ),
+            (
+                "unsupported-action-without-version",
+                "action",
+                json!({"variant": "pipeline", "steps": []}),
+            ),
+            (
+                "supported-action-without-version",
+                "action",
+                json!({"variant": "familiarInvocation", "prompt": "Run it."}),
+            ),
+            (
+                "supported-action-with-empty-prompt",
+                "action",
+                json!({"variant": "familiarInvocation", "version": 1, "prompt": ""}),
+            ),
+        ] {
+            let mut definition = complete_definition();
+            definition["outputTarget"] = json!("result.md");
+            definition[key] = hint;
+
+            assert!(
+                negotiate_definition(&definition).is_err(),
+                "{case} must remain a validation failure"
+            );
+        }
+    }
+
+    #[test]
+    fn each_present_rich_policy_subsection_must_satisfy_its_schema_shape() {
+        for (case, policies) in [
+            (
+                "retry-missing-max-attempts",
+                json!({"retry": {"backoffPolicy": "none"}}),
+            ),
+            (
+                "retry-missing-backoff-policy",
+                json!({"retry": {"maxAttempts": 2}}),
+            ),
+            (
+                "fixed-retry-missing-backoff-seconds",
+                json!({"retry": {"maxAttempts": 2, "backoffPolicy": "fixed"}}),
+            ),
+            (
+                "non-fixed-retry-invalid-backoff-seconds",
+                json!({
+                    "retry": {
+                        "maxAttempts": 2,
+                        "backoffPolicy": "none",
+                        "backoffSeconds": "soon"
+                    }
+                }),
+            ),
+            (
+                "retention-missing-occurrence-history",
+                json!({
+                    "retention": {
+                        "receipts": {"classification": "standard"}
+                    }
+                }),
+            ),
+            (
+                "delivery-target-missing-mode",
+                json!({"delivery": {"outputTarget": "result.md"}}),
+            ),
+        ] {
+            let mut definition = complete_definition();
+            definition["outputTarget"] = json!("result.md");
+            definition["policies"] = policies;
+
+            assert!(
+                negotiate_definition(&definition).is_err(),
+                "{case} must remain a validation failure"
             );
         }
     }
@@ -788,8 +1192,16 @@ mod tests {
             json!({"action": {"variant": []}}),
             json!({"policies": {"misfire": "backfill"}}),
             json!({"policies": {"delivery": {"mode": "atomic"}}}),
-            json!({"policies": {"retry": {"retryableClasses": "runtime_unavailable"}}}),
-            json!({"policies": {"retry": {"retryableClasses": [1]}}}),
+            json!({"policies": {"retry": {
+                "maxAttempts": 2,
+                "backoffPolicy": "none",
+                "retryableClasses": "runtime_unavailable"
+            }}}),
+            json!({"policies": {"retry": {
+                "maxAttempts": 2,
+                "backoffPolicy": "none",
+                "retryableClasses": [1]
+            }}}),
             json!({"policies": {"retention": {"occurrenceHistory": "standard"}}}),
             json!({"policies": {"retention": {
                 "occurrenceHistory": {"classification": 1}
@@ -816,7 +1228,9 @@ mod tests {
                 "misfire": {"disposition": "latest"},
                 "concurrency": {"overlap": "forbid"},
                 "retry": {
+                    "maxAttempts": 2,
                     "backoffPolicy": "fixed",
+                    "backoffSeconds": 5,
                     "retryableClasses": [
                         "transient_dispatch",
                         "lease_expired",
@@ -845,6 +1259,8 @@ mod tests {
 
         let private_retry_class = format!("secret-{}", "x".repeat(500));
         let unsupported = preflight_definition(&json!({"policies": {"retry": {
+            "maxAttempts": 2,
+            "backoffPolicy": "none",
             "retryableClasses": [private_retry_class]
         }}}))
         .unwrap();
@@ -952,6 +1368,201 @@ mod tests {
                 None,
                 "advertised delivery policy `{}` was refused",
                 supported.variant
+            );
+        }
+        for supported in &profile.supported.retention_policies {
+            let classification =
+                supported
+                    .variant
+                    .strip_prefix("retention.")
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "missing preflight fixture for supported retention policy `{}`",
+                            supported.variant
+                        )
+                    });
+            assert_eq!(
+                preflight_definition(&json!({"policies": {"retention": {
+                    "occurrenceHistory": {"classification": classification}
+                }}})),
+                None,
+                "advertised retention policy `{}` was refused",
+                supported.variant
+            );
+        }
+    }
+
+    #[test]
+    fn removing_an_implemented_exact_variant_from_the_profile_refuses_it() {
+        for (collection, supported_variant, expected_variant, definition) in [
+            (
+                SupportedCollection::Trigger,
+                "schedule",
+                "trigger.schedule",
+                json!({"trigger": {
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {"rrule": "FREQ=DAILY", "timezone": "utc"}
+                }}),
+            ),
+            (
+                SupportedCollection::Action,
+                "familiarInvocation",
+                "action.familiarInvocation",
+                json!({"action": {
+                    "variant": "familiarInvocation",
+                    "version": 1,
+                    "prompt": "Run it."
+                }}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "misfire.latest",
+                "misfire.latest",
+                json!({"misfire": "latest"}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "overlap.forbid",
+                "overlap.forbid",
+                json!({"overlap": "forbid"}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "retry.backoff.none",
+                "retry.backoff.none",
+                json!({"retry": {"backoffPolicy": "none"}}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "retry.backoff.fixed",
+                "retry.backoff.fixed",
+                json!({"retry": {"backoffPolicy": "fixed"}}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "retry.backoff.exponential",
+                "retry.backoff.exponential",
+                json!({"retry": {"backoffPolicy": "exponential"}}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "timezone.utc",
+                "timezone.utc",
+                json!({"trigger": {
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {"rrule": "FREQ=DAILY", "timezone": "utc"}
+                }}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "timezone.iana",
+                "timezone.iana",
+                json!({"trigger": {
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {
+                        "rrule": "FREQ=DAILY",
+                        "timezone": "America/Chicago"
+                    }
+                }}),
+            ),
+            (
+                SupportedCollection::RetentionPolicy,
+                "retention.standard",
+                "retention.standard",
+                json!({"policies": {"retention": {
+                    "occurrenceHistory": {"classification": "standard"}
+                }}}),
+            ),
+        ] {
+            let mut profile = capability_profile().clone();
+            supported_variants_mut(&mut profile, collection)
+                .retain(|supported| supported.variant != supported_variant);
+
+            let unsupported = preflight_definition_with_profile(&definition, &profile)
+                .unwrap_or_else(|| {
+                    panic!("removed variant `{supported_variant}` was still accepted")
+                });
+            assert_eq!(unsupported.variant, expected_variant);
+        }
+    }
+
+    #[test]
+    fn advertising_an_exact_variant_removes_its_capability_refusal() {
+        for (collection, variant, definition) in [
+            (
+                SupportedCollection::Trigger,
+                "webhook",
+                json!({"trigger": {
+                    "variant": "webhook",
+                    "version": 1,
+                    "webhook": {"url": "https://example.invalid/hook"}
+                }}),
+            ),
+            (
+                SupportedCollection::Condition,
+                "branch",
+                json!({"conditions": [{
+                    "variant": "branch",
+                    "version": 1,
+                    "branch": {"expression": "result.ok"}
+                }]}),
+            ),
+            (
+                SupportedCollection::Action,
+                "pipeline",
+                json!({"action": {
+                    "variant": "pipeline",
+                    "version": 1,
+                    "steps": [{"prompt": "first"}]
+                }}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "misfire.backfill",
+                json!({"misfire": "backfill"}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "overlap.parallel",
+                json!({"overlap": "parallel"}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "retry.backoff.linear",
+                json!({"retry": {"backoffPolicy": "linear"}}),
+            ),
+            (
+                SupportedCollection::TriggerPolicy,
+                "timezone.local.durable",
+                json!({"trigger": {
+                    "variant": "schedule",
+                    "version": 1,
+                    "schedule": {"rrule": "FREQ=DAILY", "timezone": "local"}
+                }}),
+            ),
+            (
+                SupportedCollection::DeliveryPolicy,
+                "outputTarget.atomic",
+                json!({"outputTarget": "result.md"}),
+            ),
+            (
+                SupportedCollection::RetentionPolicy,
+                "retention.extended",
+                json!({"policies": {"retention": {
+                    "occurrenceHistory": {"classification": "extended"}
+                }}}),
+            ),
+        ] {
+            let mut profile = capability_profile().clone();
+            advertise(&mut profile, collection, variant);
+
+            assert_eq!(
+                preflight_definition_with_profile(&definition, &profile),
+                None,
+                "advertised variant `{variant}` was still refused"
             );
         }
     }

--- a/crates/coven-cli/src/automations/capability_negotiation.rs
+++ b/crates/coven-cli/src/automations/capability_negotiation.rs
@@ -1,0 +1,418 @@
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const CAPABILITIES_JSON: &str =
+    include_str!("../../../../spec/coven-automations/v1/capabilities.json");
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilityProfile {
+    pub version: u32,
+    pub contract_profile: String,
+    pub description: String,
+    pub supported: SupportedVariants,
+    pub experimental: Vec<VariantCapability>,
+    pub refused: Vec<RefusedVariant>,
+    pub negotiation_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SupportedVariants {
+    pub triggers: Vec<VariantCapability>,
+    pub conditions: Vec<VariantCapability>,
+    pub actions: Vec<VariantCapability>,
+    pub trigger_policies: Vec<VariantCapability>,
+    pub delivery_policies: Vec<VariantCapability>,
+    pub retention_policies: Vec<VariantCapability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VariantCapability {
+    pub variant: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RefusedVariant {
+    pub variant: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedVariant {
+    pub variant: String,
+    pub reason: String,
+}
+
+pub fn capability_profile() -> &'static CapabilityProfile {
+    static PROFILE: OnceLock<CapabilityProfile> = OnceLock::new();
+    PROFILE.get_or_init(|| {
+        serde_json::from_str(CAPABILITIES_JSON)
+            .expect("packaged coven.automations.v1 capabilities must be valid")
+    })
+}
+
+#[must_use]
+pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
+    let definition = definition.as_object()?;
+
+    if let Some(trigger) = definition.get("trigger").and_then(Value::as_object) {
+        if let Some(variant) = trigger.get("variant").and_then(Value::as_str) {
+            if variant != "schedule" {
+                return unsupported_from_component("trigger", variant, false);
+            }
+            if let Some(schedule) = trigger.get("schedule").and_then(Value::as_object) {
+                if schedule.get("timezone").and_then(Value::as_str) == Some("local") {
+                    return Some(unsupported("timezone.local.durable".to_owned()));
+                }
+                if let Some(rrule) = schedule.get("rrule").and_then(Value::as_str) {
+                    if let Some(unsupported) = unsupported_rrule_frequency(rrule) {
+                        return Some(unsupported);
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(conditions) = definition.get("conditions").and_then(Value::as_array) {
+        for condition in conditions {
+            if let Some(variant) = condition
+                .as_object()
+                .and_then(|condition| condition.get("variant"))
+                .and_then(Value::as_str)
+            {
+                if let Some(unsupported) = unsupported_from_component("condition", variant, false) {
+                    return Some(unsupported);
+                }
+            }
+        }
+    }
+
+    if let Some(action) = definition.get("action").and_then(Value::as_object) {
+        if let Some(variant) = action.get("variant").and_then(Value::as_str) {
+            if variant != "familiarInvocation" {
+                return unsupported_from_component("action", variant, false);
+            }
+        }
+    }
+
+    if let Some(policies) = definition.get("policies").and_then(Value::as_object) {
+        if let Some(disposition) = policies
+            .get("misfire")
+            .and_then(Value::as_object)
+            .and_then(|misfire| misfire.get("disposition"))
+            .and_then(Value::as_str)
+        {
+            if disposition != "latest" {
+                return unsupported_from_component("misfire", disposition, false);
+            }
+        }
+        if let Some(overlap) = policies
+            .get("concurrency")
+            .and_then(Value::as_object)
+            .and_then(|concurrency| concurrency.get("overlap"))
+            .and_then(Value::as_str)
+        {
+            if overlap != "forbid" {
+                return unsupported_from_component("overlap", overlap, false);
+            }
+        }
+        if let Some(backoff) = policies
+            .get("retry")
+            .and_then(Value::as_object)
+            .and_then(|retry| retry.get("backoffPolicy"))
+            .and_then(Value::as_str)
+        {
+            if !matches!(backoff, "none" | "fixed" | "exponential") {
+                return unsupported_from_component("retry.backoff", backoff, false);
+            }
+        }
+        if let Some(delivery) = policies.get("delivery").and_then(Value::as_object) {
+            if delivery
+                .get("outputTarget")
+                .and_then(Value::as_str)
+                .is_some()
+            {
+                if let Some(mode) = delivery.get("mode").and_then(Value::as_str) {
+                    return unsupported_from_component("outputTarget", mode, false);
+                }
+            }
+        }
+    }
+
+    if let Some(misfire) = definition.get("misfire").and_then(Value::as_str) {
+        if misfire != "latest" {
+            return unsupported_from_component("misfire", misfire, false);
+        }
+    }
+    if let Some(overlap) = definition.get("overlap").and_then(Value::as_str) {
+        if overlap != "forbid" {
+            return unsupported_from_component("overlap", overlap, false);
+        }
+    }
+    if let Some(backoff) = definition
+        .get("retry")
+        .and_then(Value::as_object)
+        .and_then(|retry| retry.get("backoffPolicy"))
+        .and_then(Value::as_str)
+    {
+        if !matches!(backoff, "none" | "fixed" | "exponential") {
+            return unsupported_from_component("retry.backoff", backoff, false);
+        }
+    }
+    if definition
+        .get("outputTarget")
+        .and_then(Value::as_str)
+        .is_some()
+    {
+        return Some(unsupported("outputTarget.atomic".to_owned()));
+    }
+    if let Some(rrule) = definition.get("rrule").and_then(Value::as_str) {
+        if let Some(unsupported) = unsupported_rrule_frequency(rrule) {
+            return Some(unsupported);
+        }
+    }
+
+    None
+}
+
+fn unsupported_rrule_frequency(rrule: &str) -> Option<UnsupportedVariant> {
+    let mut frequency = None;
+    for part in rrule
+        .split(';')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        let (key, value) = part.split_once('=')?;
+        if key.trim().eq_ignore_ascii_case("FREQ") {
+            if frequency.is_some() {
+                return None;
+            }
+            let value = value.trim();
+            if value.is_empty() {
+                return None;
+            }
+            frequency = Some(value);
+        }
+    }
+    let frequency = frequency?;
+    if frequency.eq_ignore_ascii_case("DAILY") || frequency.eq_ignore_ascii_case("WEEKLY") {
+        return None;
+    }
+    unsupported_from_component("trigger.schedule.frequency", frequency, true)
+}
+
+fn unsupported_from_component(
+    prefix: &str,
+    value: &str,
+    lowercase: bool,
+) -> Option<UnsupportedVariant> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let component = if value.len() <= 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        if lowercase {
+            value.to_ascii_lowercase()
+        } else {
+            value.to_owned()
+        }
+    } else {
+        "unknown".to_owned()
+    };
+    Some(unsupported(format!("{prefix}.{component}")))
+}
+
+fn unsupported(variant: String) -> UnsupportedVariant {
+    let profile = capability_profile();
+    let reason = profile
+        .refused
+        .iter()
+        .find(|refused| refused.variant == variant)
+        .map(|refused| refused.reason.clone())
+        .unwrap_or_else(|| {
+            format!(
+                "This variant is not supported by the {} capability profile.",
+                profile.contract_profile
+            )
+        });
+    UnsupportedVariant { variant, reason }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn assert_variant(definition: Value, expected: &str) {
+        let unsupported = preflight_definition(&definition)
+            .unwrap_or_else(|| panic!("expected unsupported variant `{expected}`"));
+        assert_eq!(unsupported.variant, expected);
+        assert!(!unsupported.reason.is_empty());
+        assert!(unsupported.reason.len() <= 500);
+    }
+
+    #[test]
+    fn capability_negotiation_classifies_flat_compatibility_variants() {
+        for (definition, expected) in [
+            (json!({"outputTarget": "result.md"}), "outputTarget.atomic"),
+            (json!({"misfire": "backfill"}), "misfire.backfill"),
+            (json!({"overlap": "allow"}), "overlap.allow"),
+            (
+                json!({"retry": {"backoffPolicy": "linear"}}),
+                "retry.backoff.linear",
+            ),
+            (
+                json!({"rrule": "FREQ=MONTHLY;BYHOUR=9"}),
+                "trigger.schedule.frequency.monthly",
+            ),
+        ] {
+            assert_variant(definition, expected);
+        }
+    }
+
+    #[test]
+    fn capability_negotiation_classifies_nested_variant_hints() {
+        for (definition, expected) in [
+            (
+                json!({"trigger": {"variant": "webhook"}}),
+                "trigger.webhook",
+            ),
+            (
+                json!({"conditions": [{"variant": "branch"}]}),
+                "condition.branch",
+            ),
+            (
+                json!({"action": {"variant": "pipeline"}}),
+                "action.pipeline",
+            ),
+            (
+                json!({"trigger": {
+                    "variant": "schedule",
+                    "schedule": {"rrule": "FREQ=YEARLY", "timezone": "utc"}
+                }}),
+                "trigger.schedule.frequency.yearly",
+            ),
+            (
+                json!({"trigger": {
+                    "variant": "schedule",
+                    "schedule": {"rrule": "FREQ=DAILY", "timezone": "local"}
+                }}),
+                "timezone.local.durable",
+            ),
+            (
+                json!({"policies": {"misfire": {"disposition": "backfill"}}}),
+                "misfire.backfill",
+            ),
+            (
+                json!({"policies": {"concurrency": {"overlap": "parallel"}}}),
+                "overlap.parallel",
+            ),
+            (
+                json!({"policies": {"retry": {"backoffPolicy": "linear"}}}),
+                "retry.backoff.linear",
+            ),
+            (
+                json!({"policies": {
+                    "delivery": {"outputTarget": "result.md", "mode": "atomic"}
+                }}),
+                "outputTarget.atomic",
+            ),
+            (
+                json!({"policies": {
+                    "delivery": {"outputTarget": "result.md", "mode": "stream"}
+                }}),
+                "outputTarget.stream",
+            ),
+        ] {
+            assert_variant(definition, expected);
+        }
+    }
+
+    #[test]
+    fn capability_negotiation_leaves_malformed_types_for_validation() {
+        for definition in [
+            json!({"outputTarget": {"private": "value"}}),
+            json!({"misfire": 1}),
+            json!({"overlap": false}),
+            json!({"retry": {"backoffPolicy": ["linear"]}}),
+            json!({"rrule": 1}),
+            json!({"rrule": "FREQ=DAILY;BYHOUR=not-a-number"}),
+            json!({"trigger": {"variant": 1}}),
+            json!({"conditions": {"variant": "branch"}}),
+            json!({"conditions": [{"variant": 1}]}),
+            json!({"action": {"variant": []}}),
+            json!({"policies": {"misfire": "backfill"}}),
+            json!({"policies": {"delivery": {"mode": "atomic"}}}),
+        ] {
+            assert_eq!(preflight_definition(&definition), None, "{definition}");
+        }
+    }
+
+    #[test]
+    fn capability_negotiation_does_not_refuse_supported_variant_hints() {
+        let definition = json!({
+            "rrule": "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "retry": {"backoffPolicy": "exponential"},
+            "trigger": {
+                "variant": "schedule",
+                "schedule": {"rrule": "FREQ=DAILY", "timezone": "utc"}
+            },
+            "conditions": [],
+            "action": {"variant": "familiarInvocation"},
+            "policies": {
+                "misfire": {"disposition": "latest"},
+                "concurrency": {"overlap": "forbid"},
+                "retry": {"backoffPolicy": "fixed"}
+            }
+        });
+
+        assert_eq!(preflight_definition(&definition), None);
+    }
+
+    #[test]
+    fn capability_negotiation_bounds_untrusted_variant_identifiers() {
+        let private_value = format!("secret-{}", "x".repeat(500));
+        let unsupported =
+            preflight_definition(&json!({"trigger": {"variant": private_value}})).unwrap();
+
+        assert_eq!(unsupported.variant, "trigger.unknown");
+        assert!(!unsupported.reason.contains("secret"));
+    }
+
+    #[test]
+    fn capability_negotiation_recognizes_every_expressible_refused_variant() {
+        for refused in &capability_profile().refused {
+            let definition = match refused.variant.as_str() {
+                "trigger.webhook" => json!({"trigger": {"variant": "webhook"}}),
+                "action.pipeline" => json!({"action": {"variant": "pipeline"}}),
+                "misfire.backfill" => json!({"misfire": "backfill"}),
+                "timezone.local.durable" => json!({"trigger": {
+                    "variant": "schedule",
+                    "schedule": {"rrule": "FREQ=DAILY", "timezone": "local"}
+                }}),
+                "outputTarget.atomic" => json!({"outputTarget": "result.md"}),
+                variant => panic!("no preflight fixture for refused variant `{variant}`"),
+            };
+
+            let unsupported = preflight_definition(&definition)
+                .unwrap_or_else(|| panic!("preflight missed `{}`", refused.variant));
+            assert_eq!(unsupported.variant, refused.variant);
+            assert_eq!(unsupported.reason, refused.reason);
+        }
+    }
+}

--- a/crates/coven-cli/src/automations/capability_negotiation.rs
+++ b/crates/coven-cli/src/automations/capability_negotiation.rs
@@ -1,7 +1,10 @@
+use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
+
+use super::definition::RoutineDefinition;
 
 const CAPABILITIES_JSON: &str =
     include_str!("../../../../spec/coven-automations/v1/capabilities.json");
@@ -50,6 +53,12 @@ pub struct RefusedVariant {
 pub struct UnsupportedVariant {
     pub variant: String,
     pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DefinitionNegotiation {
+    Supported(Box<RoutineDefinition>),
+    Unsupported(UnsupportedVariant),
 }
 
 pub fn capability_profile() -> &'static CapabilityProfile {
@@ -135,6 +144,26 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
                 return unsupported_from_component("retry.backoff", backoff, false);
             }
         }
+        if let Some(retryable_classes) = policies
+            .get("retry")
+            .and_then(Value::as_object)
+            .and_then(|retry| retry.get("retryableClasses"))
+            .and_then(Value::as_array)
+            .filter(|classes| classes.iter().all(Value::is_string))
+        {
+            for retryable_class in retryable_classes.iter().filter_map(Value::as_str) {
+                if !matches!(
+                    retryable_class,
+                    "transient_dispatch" | "lease_expired" | "runtime_unavailable"
+                ) {
+                    return unsupported_from_component(
+                        "retry.safe-classes",
+                        retryable_class,
+                        false,
+                    );
+                }
+            }
+        }
         if let Some(delivery) = policies.get("delivery").and_then(Value::as_object) {
             if delivery
                 .get("outputTarget")
@@ -143,6 +172,20 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
             {
                 if let Some(mode) = delivery.get("mode").and_then(Value::as_str) {
                     return unsupported_from_component("outputTarget", mode, false);
+                }
+            }
+        }
+        if let Some(retention) = policies.get("retention").and_then(Value::as_object) {
+            for field in ["occurrenceHistory", "runLogs", "receipts"] {
+                if let Some(classification) = retention
+                    .get(field)
+                    .and_then(Value::as_object)
+                    .and_then(|retention_class| retention_class.get("classification"))
+                    .and_then(Value::as_str)
+                {
+                    if classification != "standard" {
+                        return unsupported_from_component("retention", classification, false);
+                    }
                 }
             }
         }
@@ -182,6 +225,308 @@ pub fn preflight_definition(definition: &Value) -> Option<UnsupportedVariant> {
     }
 
     None
+}
+
+pub fn negotiate_definition(definition: &Value) -> Result<DefinitionNegotiation, String> {
+    let Some(unsupported) = preflight_definition(definition) else {
+        return RoutineDefinition::from_json(definition)
+            .and_then(RoutineDefinition::resolve_timezone_for_persistence)
+            .map(Box::new)
+            .map(DefinitionNegotiation::Supported);
+    };
+
+    let projection = validation_projection(definition);
+    RoutineDefinition::from_json(&projection)
+        .and_then(RoutineDefinition::resolve_timezone_for_persistence)?;
+    Ok(DefinitionNegotiation::Unsupported(unsupported))
+}
+
+fn validation_projection(definition: &Value) -> Value {
+    let Value::Object(mut projection) = definition.clone() else {
+        return definition.clone();
+    };
+
+    neutralize_flat_unsupported_values(&mut projection);
+    for key in ["trigger", "conditions", "action", "policies"] {
+        if projection
+            .get(key)
+            .is_some_and(|value| rich_hint_is_well_formed(key, value))
+        {
+            projection.remove(key);
+        }
+    }
+
+    Value::Object(projection)
+}
+
+fn neutralize_flat_unsupported_values(definition: &mut Map<String, Value>) {
+    if definition
+        .get("misfire")
+        .and_then(Value::as_str)
+        .is_some_and(|misfire| misfire != "latest")
+    {
+        definition.insert("misfire".to_owned(), Value::String("latest".to_owned()));
+    }
+    if definition
+        .get("overlap")
+        .and_then(Value::as_str)
+        .is_some_and(|overlap| overlap != "forbid")
+    {
+        definition.insert("overlap".to_owned(), Value::String("forbid".to_owned()));
+    }
+    if let Some(retry) = definition.get_mut("retry").and_then(Value::as_object_mut) {
+        if retry
+            .get("backoffPolicy")
+            .and_then(Value::as_str)
+            .is_some_and(|backoff| !matches!(backoff, "none" | "fixed" | "exponential"))
+        {
+            retry.insert("backoffPolicy".to_owned(), Value::String("none".to_owned()));
+        }
+    }
+    if definition.get("outputTarget").is_some_and(Value::is_string) {
+        definition.remove("outputTarget");
+    }
+    if let Some(rrule) = definition.get("rrule").and_then(Value::as_str) {
+        if unsupported_rrule_frequency(rrule).is_some() {
+            let frequency = if rrule.split(';').any(|part| {
+                part.split_once('=')
+                    .is_some_and(|(key, _)| key.trim().eq_ignore_ascii_case("BYDAY"))
+            }) {
+                "WEEKLY"
+            } else {
+                "DAILY"
+            };
+            definition.insert(
+                "rrule".to_owned(),
+                Value::String(neutralize_rrule_frequency(rrule, frequency)),
+            );
+        }
+    }
+}
+
+fn neutralize_rrule_frequency(rrule: &str, supported_frequency: &str) -> String {
+    rrule
+        .split(';')
+        .map(|part| match part.split_once('=') {
+            Some((key, _)) if key.trim().eq_ignore_ascii_case("FREQ") => {
+                format!("{key}={supported_frequency}")
+            }
+            _ => part.to_owned(),
+        })
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+fn rich_hint_is_well_formed(key: &str, value: &Value) -> bool {
+    match key {
+        "trigger" => trigger_hint_is_well_formed(value),
+        "conditions" => conditions_hint_is_well_formed(value),
+        "action" => action_hint_is_well_formed(value),
+        "policies" => policies_hint_is_well_formed(value),
+        _ => false,
+    }
+}
+
+fn trigger_hint_is_well_formed(value: &Value) -> bool {
+    let Some(trigger) = value.as_object() else {
+        return false;
+    };
+    if !has_only_fields(trigger, &["variant", "version", "schedule"]) {
+        return false;
+    }
+    let Some(variant) = trigger.get("variant").and_then(Value::as_str) else {
+        return false;
+    };
+    if variant.trim().is_empty()
+        || !optional_version_is_well_formed(trigger.get("version"))
+        || !optional_schedule_is_well_formed(trigger.get("schedule"))
+    {
+        return false;
+    }
+    true
+}
+
+fn optional_schedule_is_well_formed(schedule: Option<&Value>) -> bool {
+    schedule.is_none_or(schedule_is_well_formed)
+}
+
+fn schedule_is_well_formed(value: &Value) -> bool {
+    let Some(schedule) = value.as_object() else {
+        return false;
+    };
+    has_only_fields(schedule, &["rrule", "timezone"])
+        && schedule.get("rrule").is_some_and(Value::is_string)
+        && schedule.get("timezone").is_some_and(Value::is_string)
+}
+
+fn conditions_hint_is_well_formed(value: &Value) -> bool {
+    value.as_array().is_some_and(|conditions| {
+        conditions.iter().all(|condition| {
+            let Some(condition) = condition.as_object() else {
+                return false;
+            };
+            has_only_fields(condition, &["variant", "version"])
+                && condition
+                    .get("variant")
+                    .and_then(Value::as_str)
+                    .is_some_and(|variant| !variant.trim().is_empty())
+                && optional_version_is_well_formed(condition.get("version"))
+        })
+    })
+}
+
+fn action_hint_is_well_formed(value: &Value) -> bool {
+    let Some(action) = value.as_object() else {
+        return false;
+    };
+    if !has_only_fields(action, &["variant", "version", "prompt", "cwd"]) {
+        return false;
+    }
+    let Some(variant) = action.get("variant").and_then(Value::as_str) else {
+        return false;
+    };
+    if variant.trim().is_empty()
+        || !optional_version_is_well_formed(action.get("version"))
+        || !optional_string_is_well_formed(action.get("prompt"))
+        || !optional_string_is_well_formed(action.get("cwd"))
+    {
+        return false;
+    }
+    true
+}
+
+fn policies_hint_is_well_formed(value: &Value) -> bool {
+    let Some(policies) = value.as_object() else {
+        return false;
+    };
+    !policies.is_empty()
+        && has_only_fields(
+            policies,
+            &[
+                "timeout",
+                "retry",
+                "concurrency",
+                "misfire",
+                "delivery",
+                "retention",
+            ],
+        )
+        && policies.iter().all(|(key, value)| match key.as_str() {
+            "timeout" => timeout_hint_is_well_formed(value),
+            "retry" => retry_hint_is_well_formed(value),
+            "concurrency" => single_string_field_is_well_formed(value, "overlap"),
+            "misfire" => single_string_field_is_well_formed(value, "disposition"),
+            "delivery" => delivery_hint_is_well_formed(value),
+            "retention" => retention_hint_is_well_formed(value),
+            _ => false,
+        })
+}
+
+fn timeout_hint_is_well_formed(value: &Value) -> bool {
+    let Some(timeout) = value.as_object() else {
+        return false;
+    };
+    has_only_fields(timeout, &["perRunMinutes"])
+        && timeout
+            .get("perRunMinutes")
+            .and_then(Value::as_u64)
+            .is_some_and(|minutes| (1..=44_640).contains(&minutes))
+}
+
+fn retry_hint_is_well_formed(value: &Value) -> bool {
+    let Some(retry) = value.as_object() else {
+        return false;
+    };
+    if retry.is_empty()
+        || !has_only_fields(
+            retry,
+            &[
+                "maxAttempts",
+                "backoffPolicy",
+                "backoffSeconds",
+                "retryableClasses",
+            ],
+        )
+        || !retry.get("maxAttempts").is_none_or(|value| {
+            value
+                .as_u64()
+                .is_some_and(|attempts| (1..=10).contains(&attempts))
+        })
+        || !optional_string_is_well_formed(retry.get("backoffPolicy"))
+        || !retry.get("backoffSeconds").is_none_or(|value| {
+            value
+                .as_u64()
+                .is_some_and(|seconds| (1..=86_400).contains(&seconds))
+        })
+    {
+        return false;
+    }
+    let Some(retryable_classes) = retry.get("retryableClasses") else {
+        return true;
+    };
+    let Some(retryable_classes) = retryable_classes.as_array() else {
+        return false;
+    };
+    let mut unique = BTreeSet::new();
+    retryable_classes.iter().all(|value| {
+        value
+            .as_str()
+            .filter(|value| !value.trim().is_empty())
+            .is_some_and(|value| unique.insert(value))
+    })
+}
+
+fn delivery_hint_is_well_formed(value: &Value) -> bool {
+    let Some(delivery) = value.as_object() else {
+        return false;
+    };
+    has_only_fields(delivery, &["outputTarget", "mode"])
+        && delivery.get("outputTarget").is_some_and(Value::is_string)
+        && delivery.get("mode").is_some_and(Value::is_string)
+}
+
+fn retention_hint_is_well_formed(value: &Value) -> bool {
+    let Some(retention) = value.as_object() else {
+        return false;
+    };
+    !retention.is_empty()
+        && has_only_fields(retention, &["occurrenceHistory", "runLogs", "receipts"])
+        && retention.values().all(retention_class_is_well_formed)
+}
+
+fn retention_class_is_well_formed(value: &Value) -> bool {
+    let Some(retention_class) = value.as_object() else {
+        return false;
+    };
+    has_only_fields(retention_class, &["classification", "deleteAfter"])
+        && retention_class
+            .get("classification")
+            .and_then(Value::as_str)
+            .is_some_and(|classification| !classification.trim().is_empty())
+        && optional_string_is_well_formed(retention_class.get("deleteAfter"))
+}
+
+fn single_string_field_is_well_formed(value: &Value, field: &str) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    has_only_fields(object, &[field]) && object.get(field).is_some_and(Value::is_string)
+}
+
+fn has_only_fields(object: &Map<String, Value>, allowed: &[&str]) -> bool {
+    object.keys().all(|key| allowed.contains(&key.as_str()))
+}
+
+fn optional_version_is_well_formed(version: Option<&Value>) -> bool {
+    version.is_none_or(is_version_one)
+}
+
+fn is_version_one(value: &Value) -> bool {
+    value.as_u64() == Some(1)
+}
+
+fn optional_string_is_well_formed(value: Option<&Value>) -> bool {
+    value.is_none_or(Value::is_string)
 }
 
 fn unsupported_rrule_frequency(rrule: &str) -> Option<UnsupportedVariant> {
@@ -342,6 +687,37 @@ mod tests {
     }
 
     #[test]
+    fn capability_negotiation_classifies_unknown_retryable_classes() {
+        for (retryable_class, expected) in [
+            ("ambiguous", "retry.safe-classes.ambiguous"),
+            ("operator_required", "retry.safe-classes.operator_required"),
+        ] {
+            assert_variant(
+                json!({"policies": {"retry": {
+                    "retryableClasses": ["transient_dispatch", retryable_class]
+                }}}),
+                expected,
+            );
+        }
+    }
+
+    #[test]
+    fn capability_negotiation_classifies_unsupported_retention_classes() {
+        for (field, classification, expected) in [
+            ("occurrenceHistory", "ephemeral", "retention.ephemeral"),
+            ("runLogs", "extended", "retention.extended"),
+            ("receipts", "forever", "retention.forever"),
+        ] {
+            assert_variant(
+                json!({"policies": {"retention": {
+                    field: {"classification": classification}
+                }}}),
+                expected,
+            );
+        }
+    }
+
+    #[test]
     fn capability_negotiation_leaves_malformed_types_for_validation() {
         for definition in [
             json!({"outputTarget": {"private": "value"}}),
@@ -356,6 +732,12 @@ mod tests {
             json!({"action": {"variant": []}}),
             json!({"policies": {"misfire": "backfill"}}),
             json!({"policies": {"delivery": {"mode": "atomic"}}}),
+            json!({"policies": {"retry": {"retryableClasses": "runtime_unavailable"}}}),
+            json!({"policies": {"retry": {"retryableClasses": [1]}}}),
+            json!({"policies": {"retention": {"occurrenceHistory": "standard"}}}),
+            json!({"policies": {"retention": {
+                "occurrenceHistory": {"classification": 1}
+            }}}),
         ] {
             assert_eq!(preflight_definition(&definition), None, "{definition}");
         }
@@ -377,7 +759,19 @@ mod tests {
             "policies": {
                 "misfire": {"disposition": "latest"},
                 "concurrency": {"overlap": "forbid"},
-                "retry": {"backoffPolicy": "fixed"}
+                "retry": {
+                    "backoffPolicy": "fixed",
+                    "retryableClasses": [
+                        "transient_dispatch",
+                        "lease_expired",
+                        "runtime_unavailable"
+                    ]
+                },
+                "retention": {
+                    "occurrenceHistory": {"classification": "standard"},
+                    "runLogs": {"classification": "standard"},
+                    "receipts": {"classification": "standard"}
+                }
             }
         });
 
@@ -391,6 +785,15 @@ mod tests {
             preflight_definition(&json!({"trigger": {"variant": private_value}})).unwrap();
 
         assert_eq!(unsupported.variant, "trigger.unknown");
+        assert!(!unsupported.reason.contains("secret"));
+
+        let private_retry_class = format!("secret-{}", "x".repeat(500));
+        let unsupported = preflight_definition(&json!({"policies": {"retry": {
+            "retryableClasses": [private_retry_class]
+        }}}))
+        .unwrap();
+
+        assert_eq!(unsupported.variant, "retry.safe-classes.unknown");
         assert!(!unsupported.reason.contains("secret"));
     }
 

--- a/crates/coven-cli/src/automations/capability_negotiation.rs
+++ b/crates/coven-cli/src/automations/capability_negotiation.rs
@@ -331,19 +331,16 @@ fn trigger_hint_is_well_formed(value: &Value) -> bool {
     let Some(trigger) = value.as_object() else {
         return false;
     };
-    if !has_only_fields(trigger, &["variant", "version", "schedule"]) {
-        return false;
-    }
     let Some(variant) = trigger.get("variant").and_then(Value::as_str) else {
         return false;
     };
-    if variant.trim().is_empty()
-        || !optional_version_is_well_formed(trigger.get("version"))
-        || !optional_schedule_is_well_formed(trigger.get("schedule"))
-    {
-        return false;
+    if variant != "schedule" {
+        return unsupported_union_hint_is_well_formed(trigger);
     }
-    true
+    has_only_fields(trigger, &["variant", "version", "schedule"])
+        && !variant.trim().is_empty()
+        && optional_version_is_well_formed(trigger.get("version"))
+        && optional_schedule_is_well_formed(trigger.get("schedule"))
 }
 
 fn optional_schedule_is_well_formed(schedule: Option<&Value>) -> bool {
@@ -365,12 +362,7 @@ fn conditions_hint_is_well_formed(value: &Value) -> bool {
             let Some(condition) = condition.as_object() else {
                 return false;
             };
-            has_only_fields(condition, &["variant", "version"])
-                && condition
-                    .get("variant")
-                    .and_then(Value::as_str)
-                    .is_some_and(|variant| !variant.trim().is_empty())
-                && optional_version_is_well_formed(condition.get("version"))
+            unsupported_union_hint_is_well_formed(condition)
         })
     })
 }
@@ -379,20 +371,25 @@ fn action_hint_is_well_formed(value: &Value) -> bool {
     let Some(action) = value.as_object() else {
         return false;
     };
-    if !has_only_fields(action, &["variant", "version", "prompt", "cwd"]) {
-        return false;
-    }
     let Some(variant) = action.get("variant").and_then(Value::as_str) else {
         return false;
     };
-    if variant.trim().is_empty()
-        || !optional_version_is_well_formed(action.get("version"))
-        || !optional_string_is_well_formed(action.get("prompt"))
-        || !optional_string_is_well_formed(action.get("cwd"))
-    {
-        return false;
+    if variant != "familiarInvocation" {
+        return unsupported_union_hint_is_well_formed(action);
     }
-    true
+    has_only_fields(action, &["variant", "version", "prompt", "cwd"])
+        && !variant.trim().is_empty()
+        && optional_version_is_well_formed(action.get("version"))
+        && optional_string_is_well_formed(action.get("prompt"))
+        && optional_string_is_well_formed(action.get("cwd"))
+}
+
+fn unsupported_union_hint_is_well_formed(union: &Map<String, Value>) -> bool {
+    union
+        .get("variant")
+        .and_then(Value::as_str)
+        .is_some_and(|variant| !variant.trim().is_empty())
+        && optional_version_is_well_formed(union.get("version"))
 }
 
 fn policies_hint_is_well_formed(value: &Value) -> bool {
@@ -683,6 +680,65 @@ mod tests {
             ),
         ] {
             assert_variant(definition, expected);
+        }
+    }
+
+    #[test]
+    fn unsupported_union_payloads_do_not_require_supported_variant_fields() {
+        for (key, definition, expected) in [
+            (
+                "trigger",
+                json!({"trigger": {
+                    "variant": "webhook",
+                    "version": 1,
+                    "webhook": {"url": "https://example.invalid/hook"}
+                }}),
+                "trigger.webhook",
+            ),
+            (
+                "conditions",
+                json!({"conditions": [{
+                    "variant": "branch",
+                    "version": 1,
+                    "branch": {"expression": "result.ok"}
+                }]}),
+                "condition.branch",
+            ),
+            (
+                "action",
+                json!({"action": {
+                    "variant": "pipeline",
+                    "version": 1,
+                    "steps": [{"prompt": "first"}]
+                }}),
+                "action.pipeline",
+            ),
+        ] {
+            assert_variant(definition.clone(), expected);
+            assert!(
+                rich_hint_is_well_formed(key, definition.get(key).unwrap()),
+                "{key}"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_union_hints_with_invalid_versions_remain_validation_errors() {
+        for (key, value) in [
+            (
+                "trigger",
+                json!({"variant": "webhook", "version": 2, "webhook": {}}),
+            ),
+            (
+                "conditions",
+                json!([{"variant": "branch", "version": "one", "branch": {}}]),
+            ),
+            (
+                "action",
+                json!({"variant": "pipeline", "version": false, "steps": []}),
+            ),
+        ] {
+            assert!(!rich_hint_is_well_formed(key, &value));
         }
     }
 

--- a/crates/coven-cli/src/automations/capability_negotiation.rs
+++ b/crates/coven-cli/src/automations/capability_negotiation.rs
@@ -415,4 +415,85 @@ mod tests {
             assert_eq!(unsupported.reason, refused.reason);
         }
     }
+
+    #[test]
+    fn capability_negotiation_does_not_refuse_advertised_supported_variants() {
+        let profile = capability_profile();
+
+        for supported in &profile.supported.triggers {
+            assert_eq!(
+                preflight_definition(&json!({"trigger": {"variant": supported.variant}})),
+                None,
+                "advertised trigger `{}` was refused",
+                supported.variant
+            );
+        }
+        for supported in &profile.supported.conditions {
+            assert_eq!(
+                preflight_definition(&json!({"conditions": [{"variant": supported.variant}]})),
+                None,
+                "advertised condition `{}` was refused",
+                supported.variant
+            );
+        }
+        for supported in &profile.supported.actions {
+            assert_eq!(
+                preflight_definition(&json!({"action": {"variant": supported.variant}})),
+                None,
+                "advertised action `{}` was refused",
+                supported.variant
+            );
+        }
+        for supported in &profile.supported.trigger_policies {
+            let definition = match supported.variant.as_str() {
+                "misfire.latest" => json!({"misfire": "latest"}),
+                "overlap.forbid" => json!({"overlap": "forbid"}),
+                variant if variant.starts_with("retry.backoff.") => {
+                    let value = variant.trim_start_matches("retry.backoff.");
+                    json!({"retry": {"backoffPolicy": value}})
+                }
+                "timezone.utc" => json!({"trigger": {
+                    "variant": "schedule",
+                    "schedule": {"timezone": "utc"}
+                }}),
+                "timezone.iana" => json!({"trigger": {
+                    "variant": "schedule",
+                    "schedule": {"timezone": "America/Chicago"}
+                }}),
+                "timeout.required"
+                | "dst.gap.skip"
+                | "dst.fold.first"
+                | "retry.attempts"
+                | "retry.safe-classes"
+                | "retry.exhaustion-quarantine" => continue,
+                variant => panic!("missing preflight fixture for supported policy `{variant}`"),
+            };
+            assert_eq!(
+                preflight_definition(&definition),
+                None,
+                "advertised policy `{}` was refused",
+                supported.variant
+            );
+        }
+        for supported in &profile.supported.delivery_policies {
+            let mode = supported
+                .variant
+                .strip_prefix("outputTarget.")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "missing preflight fixture for supported delivery policy `{}`",
+                        supported.variant
+                    )
+                });
+            assert_eq!(
+                preflight_definition(&json!({"policies": {"delivery": {
+                    "outputTarget": "result.md",
+                    "mode": mode
+                }}})),
+                None,
+                "advertised delivery policy `{}` was refused",
+                supported.variant
+            );
+        }
+    }
 }

--- a/crates/coven-cli/src/automations/command_adoption.rs
+++ b/crates/coven-cli/src/automations/command_adoption.rs
@@ -7,6 +7,7 @@ use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use super::capability_negotiation::{capability_profile, preflight_definition, UnsupportedVariant};
 use super::contract::canonical_json::{canonicalize, sha256_hex};
 use super::contract::error::{AdoptionConflictOutcome, ErrorAdoption, ErrorCode, ErrorEnvelope};
 use super::contract::types::{AdoptionKey, PositiveInteger};
@@ -430,6 +431,12 @@ fn canonical_command(command: &DefinitionCommand) -> Result<Value> {
 }
 
 fn adoption_definition_preimage(definition: &Value) -> Result<Value> {
+    if preflight_definition(definition).is_some() {
+        return Ok(json!({
+            "kind": "unsupported",
+            "value": lossless_json_fingerprint(definition),
+        }));
+    }
     match RoutineDefinition::from_json(definition) {
         Ok(definition) => Ok(json!({
             "kind": "valid",
@@ -950,6 +957,9 @@ fn apply_create(
     definition_value: &Value,
     adopted_at: &str,
 ) -> Result<DefinitionCommandResponse> {
+    if let Some(unsupported) = preflight_definition(definition_value) {
+        return Ok(capability_unsupported(unsupported));
+    }
     let definition = match RoutineDefinition::from_json(definition_value)
         .and_then(RoutineDefinition::resolve_timezone_for_persistence)
     {
@@ -1011,6 +1021,9 @@ fn apply_revise(
     expected_revision: Option<u64>,
     adopted_at: &str,
 ) -> Result<DefinitionCommandResponse> {
+    if let Some(unsupported) = preflight_definition(definition_value) {
+        return Ok(capability_unsupported(unsupported));
+    }
     let definition = match RoutineDefinition::from_json(definition_value)
         .and_then(RoutineDefinition::resolve_timezone_for_persistence)
     {
@@ -1317,6 +1330,32 @@ fn rejected(
     }
 }
 
+fn capability_unsupported(unsupported: UnsupportedVariant) -> DefinitionCommandResponse {
+    let error = ErrorEnvelope::try_new(
+        ErrorCode::CapabilityUnsupported,
+        "automation definition uses a variant not supported by the negotiated contract profile",
+        false,
+    )
+    .expect("static unsupported-capability message is valid")
+    .with_details(BTreeMap::from([
+        (
+            "contractProfile".to_owned(),
+            Value::String(capability_profile().contract_profile.clone()),
+        ),
+        ("reason".to_owned(), Value::String(unsupported.reason)),
+        ("variant".to_owned(), Value::String(unsupported.variant)),
+    ]));
+    DefinitionCommandResponse {
+        outcome: DefinitionCommandOutcome::Rejected,
+        revision: None,
+        result: None,
+        error: Some(error),
+        replay_first_committed_at: None,
+        event_ref: None,
+        mutation_committed: false,
+    }
+}
+
 fn protocol_error(code: ErrorCode, message: impl Into<String>) -> ErrorEnvelope {
     let message = message.into();
     let bounded = if message.is_empty() {
@@ -1394,6 +1433,176 @@ mod tests {
             |row| row.get(0),
         )
         .unwrap()
+    }
+
+    fn definition_event_count(conn: &Connection, automation_id: &str) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM automation_events
+             WHERE stream_kind = 'automation' AND stream_id = ?1",
+            [automation_id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn unsupported_create_is_durably_rejected_without_mutation_or_event() {
+        let (_temp, conn) = temp_store();
+        let mut unsupported = definition("unsupported-create", "Unsupported");
+        unsupported["outputTarget"] = json!("result.md");
+        let command = DefinitionCommand::Create {
+            definition: unsupported.clone(),
+        };
+
+        let first = execute_definition_command(
+            &conn,
+            "adopt:create:unsupported:0001",
+            command.clone(),
+            "2026-09-03T09:00:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(first.outcome, DefinitionCommandOutcome::Rejected);
+        let first_error = first.error.as_ref().unwrap();
+        assert_eq!(first_error.code(), ErrorCode::CapabilityUnsupported);
+        let first_error = serde_json::to_value(first_error).unwrap();
+        assert_eq!(
+            first_error["details"],
+            json!({
+                "contractProfile": "coven.automations.v1",
+                "reason": "The wire shape is reserved, but no current implementation has a pinned-revision, crash-recoverable delivery state machine. Refuse with CAPABILITY_UNSUPPORTED.",
+                "variant": "outputTarget.atomic"
+            })
+        );
+        assert!(get_definition(&conn, "unsupported-create")
+            .unwrap()
+            .is_none());
+        assert_eq!(definition_event_count(&conn, "unsupported-create"), 0);
+        assert_eq!(adoption_count(&conn), 1);
+
+        let replay = execute_definition_command(
+            &conn,
+            "adopt:create:unsupported:0001",
+            command,
+            "2026-09-03T09:01:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(replay.outcome, DefinitionCommandOutcome::Rejected);
+        assert_eq!(
+            serde_json::to_value(replay.error.unwrap()).unwrap(),
+            first_error
+        );
+        assert_eq!(adoption_count(&conn), 1);
+        assert_eq!(definition_event_count(&conn, "unsupported-create"), 0);
+
+        unsupported["outputTarget"] = json!("different.md");
+        let mismatch = execute_definition_command(
+            &conn,
+            "adopt:create:unsupported:0001",
+            DefinitionCommand::Create {
+                definition: unsupported,
+            },
+            "2026-09-03T09:02:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(
+            mismatch.error.unwrap().code(),
+            ErrorCode::AdoptionReplayMismatch
+        );
+        assert_eq!(adoption_count(&conn), 1);
+        assert_eq!(definition_event_count(&conn, "unsupported-create"), 0);
+    }
+
+    #[test]
+    fn unsupported_revise_is_durably_rejected_without_revision_or_event_change() {
+        let (_temp, conn) = temp_store();
+        execute_definition_command(
+            &conn,
+            "adopt:create:revise-target:0001",
+            DefinitionCommand::Create {
+                definition: definition("revise-target", "Original"),
+            },
+            "2026-09-03T09:00:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(definition_event_count(&conn, "revise-target"), 1);
+
+        let mut unsupported = definition("revise-target", "Must not land");
+        unsupported["misfire"] = json!("backfill");
+        let command = DefinitionCommand::Revise {
+            definition: unsupported.clone(),
+            expected_revision: Some(1),
+        };
+        let first = execute_definition_command(
+            &conn,
+            "adopt:revise:unsupported:0002",
+            command.clone(),
+            "2026-09-03T09:01:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(first.outcome, DefinitionCommandOutcome::Rejected);
+        let first_error = first.error.as_ref().unwrap();
+        assert_eq!(first_error.code(), ErrorCode::CapabilityUnsupported);
+        let first_error = serde_json::to_value(first_error).unwrap();
+        assert_eq!(first_error["details"]["variant"], "misfire.backfill");
+        assert_eq!(
+            first_error["details"]["contractProfile"],
+            "coven.automations.v1"
+        );
+        let stored = get_definition(&conn, "revise-target").unwrap().unwrap();
+        assert_eq!(stored.revision, 1);
+        assert!(stored.definition_json.contains(r#""name":"Original""#));
+        assert_eq!(definition_event_count(&conn, "revise-target"), 1);
+
+        let replay = execute_definition_command(
+            &conn,
+            "adopt:revise:unsupported:0002",
+            command,
+            "2026-09-03T09:02:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(replay.outcome, DefinitionCommandOutcome::Rejected);
+        assert_eq!(
+            serde_json::to_value(replay.error.unwrap()).unwrap(),
+            first_error
+        );
+        assert_eq!(definition_event_count(&conn, "revise-target"), 1);
+
+        unsupported["misfire"] = json!("all");
+        let mismatch = execute_definition_command(
+            &conn,
+            "adopt:revise:unsupported:0002",
+            DefinitionCommand::Revise {
+                definition: unsupported,
+                expected_revision: Some(1),
+            },
+            "2026-09-03T09:03:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(
+            mismatch.error.unwrap().code(),
+            ErrorCode::AdoptionReplayMismatch
+        );
+        assert_eq!(adoption_count(&conn), 2);
+        assert_eq!(definition_event_count(&conn, "revise-target"), 1);
+    }
+
+    #[test]
+    fn legacy_create_keeps_output_target_validation_behavior() {
+        let (_temp, conn) = temp_store();
+        let mut unsupported = definition("legacy-output", "Legacy output");
+        unsupported["outputTarget"] = json!("result.md");
+
+        let response = execute_definition_command(
+            &conn,
+            "legacy-output-target",
+            DefinitionCommand::LegacyCreate {
+                definition: unsupported,
+            },
+            "2026-09-03T09:00:00.000Z",
+        )
+        .unwrap();
+
+        assert_eq!(response.error.unwrap().code(), ErrorCode::ValidationFailed);
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/command_adoption.rs
+++ b/crates/coven-cli/src/automations/command_adoption.rs
@@ -7,7 +7,9 @@ use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use super::capability_negotiation::{capability_profile, preflight_definition, UnsupportedVariant};
+use super::capability_negotiation::{
+    capability_profile, negotiate_definition, DefinitionNegotiation, UnsupportedVariant,
+};
 use super::contract::canonical_json::{canonicalize, sha256_hex};
 use super::contract::error::{AdoptionConflictOutcome, ErrorAdoption, ErrorCode, ErrorEnvelope};
 use super::contract::types::{AdoptionKey, PositiveInteger};
@@ -431,14 +433,12 @@ fn canonical_command(command: &DefinitionCommand) -> Result<Value> {
 }
 
 fn adoption_definition_preimage(definition: &Value) -> Result<Value> {
-    if preflight_definition(definition).is_some() {
-        return Ok(json!({
+    match negotiate_definition(definition) {
+        Ok(DefinitionNegotiation::Unsupported(_)) => Ok(json!({
             "kind": "unsupported",
             "value": lossless_json_fingerprint(definition),
-        }));
-    }
-    match RoutineDefinition::from_json(definition) {
-        Ok(definition) => Ok(json!({
+        })),
+        Ok(DefinitionNegotiation::Supported(definition)) => Ok(json!({
             "kind": "valid",
             "value": serde_json::to_value(definition)
                 .context("failed to normalize routine definition for adoption")?,
@@ -957,16 +957,12 @@ fn apply_create(
     definition_value: &Value,
     adopted_at: &str,
 ) -> Result<DefinitionCommandResponse> {
-    if let Some(unsupported) = preflight_definition(definition_value) {
-        return Ok(capability_unsupported(unsupported));
-    }
-    let definition = match RoutineDefinition::from_json(definition_value)
-        .and_then(RoutineDefinition::resolve_timezone_for_persistence)
-    {
-        Ok(definition) => definition,
-        Err(error) => {
-            return Ok(rejected(ErrorCode::ValidationFailed, error, None));
+    let definition = match negotiate_definition(definition_value) {
+        Ok(DefinitionNegotiation::Supported(definition)) => *definition,
+        Ok(DefinitionNegotiation::Unsupported(unsupported)) => {
+            return Ok(capability_unsupported(unsupported));
         }
+        Err(error) => return Ok(rejected(ErrorCode::ValidationFailed, error, None)),
     };
     if definition.status == super::definition::RoutineStatus::Disabled {
         return Ok(rejected(
@@ -1021,16 +1017,12 @@ fn apply_revise(
     expected_revision: Option<u64>,
     adopted_at: &str,
 ) -> Result<DefinitionCommandResponse> {
-    if let Some(unsupported) = preflight_definition(definition_value) {
-        return Ok(capability_unsupported(unsupported));
-    }
-    let definition = match RoutineDefinition::from_json(definition_value)
-        .and_then(RoutineDefinition::resolve_timezone_for_persistence)
-    {
-        Ok(definition) => definition,
-        Err(error) => {
-            return Ok(rejected(ErrorCode::ValidationFailed, error, None));
+    let definition = match negotiate_definition(definition_value) {
+        Ok(DefinitionNegotiation::Supported(definition)) => *definition,
+        Ok(DefinitionNegotiation::Unsupported(unsupported)) => {
+            return Ok(capability_unsupported(unsupported));
         }
+        Err(error) => return Ok(rejected(ErrorCode::ValidationFailed, error, None)),
     };
     let Some(current) = current_definition_state(conn, &definition.id)? else {
         return Ok(rejected(
@@ -1510,6 +1502,176 @@ mod tests {
         );
         assert_eq!(adoption_count(&conn), 1);
         assert_eq!(definition_event_count(&conn, "unsupported-create"), 0);
+    }
+
+    #[test]
+    fn unsupported_partial_create_remains_a_durable_validation_rejection() {
+        let (_temp, conn) = temp_store();
+        let command = DefinitionCommand::Create {
+            definition: json!({"misfire": "backfill"}),
+        };
+
+        let first = execute_definition_command(
+            &conn,
+            "adopt:create:partial-unsupported:0001",
+            command.clone(),
+            "2026-09-03T09:00:00.000Z",
+        )
+        .unwrap();
+
+        assert_eq!(first.outcome, DefinitionCommandOutcome::Rejected);
+        assert_eq!(
+            first.error.as_ref().map(ErrorEnvelope::code),
+            Some(ErrorCode::ValidationFailed)
+        );
+        assert_eq!(adoption_count(&conn), 1);
+        assert!(list_definitions(&conn).unwrap().is_empty());
+
+        let replay = execute_definition_command(
+            &conn,
+            "adopt:create:partial-unsupported:0001",
+            command,
+            "2026-09-03T09:01:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(replay.outcome, DefinitionCommandOutcome::Rejected);
+        assert_eq!(replay.error, first.error);
+        assert_eq!(adoption_count(&conn), 1);
+
+        let changed = execute_definition_command(
+            &conn,
+            "adopt:create:partial-unsupported:0001",
+            DefinitionCommand::Create {
+                definition: definition("partial-unsupported", "Corrected"),
+            },
+            "2026-09-03T09:02:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(
+            changed.error.as_ref().map(ErrorEnvelope::code),
+            Some(ErrorCode::AdoptionReplayMismatch)
+        );
+        assert!(list_definitions(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn unsupported_create_does_not_mask_independent_validation_failures() {
+        let (_temp, conn) = temp_store();
+
+        let mut malformed_retry = definition("malformed-retry", "Malformed retry");
+        malformed_retry["outputTarget"] = json!("result.md");
+        malformed_retry["retry"] = json!({
+            "maxAttempts": 3,
+            "backoffPolicy": ["linear"]
+        });
+
+        let mut unknown_field = definition("unknown-field", "Unknown field");
+        unknown_field["outputTarget"] = json!("result.md");
+        unknown_field["futureField"] = json!("must fail closed");
+
+        let mut malformed_rich_policy =
+            definition("malformed-rich-policy", "Malformed rich policy");
+        malformed_rich_policy["outputTarget"] = json!("result.md");
+        malformed_rich_policy["policies"] = json!({
+            "retry": {"retryableClasses": "runtime_unavailable"}
+        });
+
+        let mut malformed_rrule = definition("malformed-rrule", "Malformed RRULE");
+        malformed_rrule["outputTarget"] = json!("result.md");
+        malformed_rrule["rrule"] = json!("FREQ=DAILY;BYHOUR=not-a-number");
+
+        let mut malformed_retention = definition("malformed-retention", "Malformed retention");
+        malformed_retention["outputTarget"] = json!("result.md");
+        malformed_retention["policies"] = json!({
+            "retention": {
+                "occurrenceHistory": {"classification": 1}
+            }
+        });
+
+        for (index, invalid) in [
+            malformed_retry,
+            unknown_field,
+            malformed_rich_policy,
+            malformed_rrule,
+            malformed_retention,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let response = execute_definition_command(
+                &conn,
+                &format!("adopt:create:unsupported-invalid:{index:04}"),
+                DefinitionCommand::Create {
+                    definition: invalid,
+                },
+                "2026-09-03T09:00:00.000Z",
+            )
+            .unwrap();
+
+            assert_eq!(
+                response.error.as_ref().map(ErrorEnvelope::code),
+                Some(ErrorCode::ValidationFailed),
+                "case {index}"
+            );
+        }
+
+        assert_eq!(adoption_count(&conn), 5);
+        assert!(list_definitions(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rich_policy_variants_are_refused_only_when_the_flat_definition_is_valid() {
+        let (_temp, conn) = temp_store();
+
+        let mut retry = definition("unsupported-retry-class", "Unsupported retry class");
+        retry["policies"] = json!({
+            "retry": {
+                "retryableClasses": ["transient_dispatch", "ambiguous"]
+            }
+        });
+        let retry_response = execute_definition_command(
+            &conn,
+            "adopt:create:unsupported-retry-class:0001",
+            DefinitionCommand::Create { definition: retry },
+            "2026-09-03T09:00:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(
+            retry_response.error.as_ref().map(ErrorEnvelope::code),
+            Some(ErrorCode::CapabilityUnsupported)
+        );
+        assert_eq!(
+            serde_json::to_value(retry_response.error.unwrap()).unwrap()["details"]["variant"],
+            "retry.safe-classes.ambiguous"
+        );
+
+        let mut retention = definition("unsupported-retention", "Unsupported retention");
+        retention["policies"] = json!({
+            "retention": {
+                "occurrenceHistory": {"classification": "standard"},
+                "receipts": {"classification": "extended"}
+            }
+        });
+        let retention_response = execute_definition_command(
+            &conn,
+            "adopt:create:unsupported-retention:0001",
+            DefinitionCommand::Create {
+                definition: retention,
+            },
+            "2026-09-03T09:00:00.000Z",
+        )
+        .unwrap();
+        assert_eq!(
+            retention_response.error.as_ref().map(ErrorEnvelope::code),
+            Some(ErrorCode::CapabilityUnsupported)
+        );
+        assert_eq!(
+            serde_json::to_value(retention_response.error.unwrap()).unwrap()["details"]["variant"],
+            "retention.extended"
+        );
+
+        assert_eq!(adoption_count(&conn), 2);
+        assert!(list_definitions(&conn).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/command_adoption.rs
+++ b/crates/coven-cli/src/automations/command_adoption.rs
@@ -958,7 +958,14 @@ fn apply_create(
     adopted_at: &str,
 ) -> Result<DefinitionCommandResponse> {
     let definition = match negotiate_definition(definition_value) {
-        Ok(DefinitionNegotiation::Supported(definition)) => *definition,
+        Ok(DefinitionNegotiation::Supported(definition)) => {
+            match definition.resolve_timezone_for_persistence() {
+                Ok(definition) => definition,
+                Err(error) => {
+                    return Ok(rejected(ErrorCode::ValidationFailed, error, None));
+                }
+            }
+        }
         Ok(DefinitionNegotiation::Unsupported(unsupported)) => {
             return Ok(capability_unsupported(unsupported));
         }
@@ -1018,7 +1025,14 @@ fn apply_revise(
     adopted_at: &str,
 ) -> Result<DefinitionCommandResponse> {
     let definition = match negotiate_definition(definition_value) {
-        Ok(DefinitionNegotiation::Supported(definition)) => *definition,
+        Ok(DefinitionNegotiation::Supported(definition)) => {
+            match definition.resolve_timezone_for_persistence() {
+                Ok(definition) => definition,
+                Err(error) => {
+                    return Ok(rejected(ErrorCode::ValidationFailed, error, None));
+                }
+            }
+        }
         Ok(DefinitionNegotiation::Unsupported(unsupported)) => {
             return Ok(capability_unsupported(unsupported));
         }
@@ -1437,6 +1451,10 @@ mod tests {
         .unwrap()
     }
 
+    fn definition_command_fingerprint(command: &DefinitionCommand) -> String {
+        sha256_hex(&canonicalize(&canonical_command(command).unwrap()).unwrap())
+    }
+
     #[test]
     fn unsupported_create_is_durably_rejected_without_mutation_or_event() {
         let (_temp, conn) = temp_store();
@@ -1573,7 +1591,11 @@ mod tests {
             definition("malformed-rich-policy", "Malformed rich policy");
         malformed_rich_policy["outputTarget"] = json!("result.md");
         malformed_rich_policy["policies"] = json!({
-            "retry": {"retryableClasses": "runtime_unavailable"}
+            "retry": {
+                "maxAttempts": 2,
+                "backoffPolicy": "none",
+                "retryableClasses": "runtime_unavailable"
+            }
         });
 
         let mut malformed_rrule = definition("malformed-rrule", "Malformed RRULE");
@@ -1626,6 +1648,8 @@ mod tests {
         let mut retry = definition("unsupported-retry-class", "Unsupported retry class");
         retry["policies"] = json!({
             "retry": {
+                "maxAttempts": 2,
+                "backoffPolicy": "none",
                 "retryableClasses": ["transient_dispatch", "ambiguous"]
             }
         });
@@ -1930,6 +1954,234 @@ mod tests {
         );
         assert_eq!(list_definitions(&conn).unwrap().len(), 1);
         assert_eq!(adoption_count(&conn), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_command_fingerprint_is_stable_across_timezone_environments() {
+        const CHILD_ENV: &str = "COVEN_TEST_LOCAL_COMMAND_FINGERPRINT_CHILD";
+        const TEST_NAME: &str =
+            "automations::command_adoption::tests::local_command_fingerprint_is_stable_across_timezone_environments";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let command = DefinitionCommand::Create {
+                definition: definition("stable-local-fingerprint", "Stable local fingerprint"),
+            };
+            let canonical = canonical_command(&command).unwrap();
+            assert_eq!(canonical["definition"]["value"]["timezone"], "local");
+            println!("fingerprint={}", definition_command_fingerprint(&command));
+            return;
+        }
+
+        let fingerprint_for = |timezone: &str| {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", TEST_NAME, "--nocapture"])
+                .env(CHILD_ENV, "1")
+                .env("TZ", timezone)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "child fingerprint assertion failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout)
+                .unwrap()
+                .lines()
+                .find_map(|line| line.strip_prefix("fingerprint="))
+                .expect("child emitted fingerprint")
+                .to_owned()
+        };
+
+        assert_eq!(
+            fingerprint_for("Pacific/Kiritimati"),
+            fingerprint_for("America/Chicago")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_resolution_failure_is_durably_rejected_and_replayed() {
+        const CHILD_ENV: &str = "COVEN_TEST_LOCAL_RESOLUTION_REJECTION_CHILD";
+        const TEST_NAME: &str =
+            "automations::command_adoption::tests::local_resolution_failure_is_durably_rejected_and_replayed";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let (_temp, conn) = temp_store();
+            let command = DefinitionCommand::Create {
+                definition: definition("local-resolution-failure", "Local resolution failure"),
+            };
+            unsafe {
+                std::env::set_var("TZ", ":/tmp/coven-invalid-zoneinfo");
+            }
+            let first = execute_definition_command(
+                &conn,
+                "adopt:create:local-resolution-failure:0001",
+                command.clone(),
+                "2026-09-03T09:00:00.000Z",
+            )
+            .unwrap();
+
+            assert_eq!(first.outcome, DefinitionCommandOutcome::Rejected);
+            assert_eq!(
+                first.error.as_ref().map(ErrorEnvelope::code),
+                Some(ErrorCode::ValidationFailed)
+            );
+            assert!(get_definition(&conn, "local-resolution-failure")
+                .unwrap()
+                .is_none());
+            assert_eq!(definition_event_count(&conn, "local-resolution-failure"), 0);
+            assert_eq!(adoption_count(&conn), 1);
+
+            unsafe {
+                std::env::set_var("TZ", "Pacific/Kiritimati");
+            }
+            let replay = execute_definition_command(
+                &conn,
+                "adopt:create:local-resolution-failure:0001",
+                command,
+                "2026-09-03T09:01:00.000Z",
+            )
+            .unwrap();
+
+            assert_eq!(replay.outcome, DefinitionCommandOutcome::Rejected);
+            assert_eq!(replay.error, first.error);
+            assert!(get_definition(&conn, "local-resolution-failure")
+                .unwrap()
+                .is_none());
+            assert_eq!(definition_event_count(&conn, "local-resolution-failure"), 0);
+            assert_eq!(adoption_count(&conn), 1);
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .env(CHILD_ENV, "1")
+            .status()
+            .unwrap();
+
+        assert!(status.success(), "child timezone assertion failed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn revise_local_resolution_failure_is_durable_without_mutation_or_event() {
+        const CHILD_ENV: &str = "COVEN_TEST_REVISE_LOCAL_RESOLUTION_REJECTION_CHILD";
+        const TEST_NAME: &str =
+            "automations::command_adoption::tests::revise_local_resolution_failure_is_durable_without_mutation_or_event";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let (_temp, conn) = temp_store();
+            let mut original = definition("local-revise-failure", "Original");
+            original["timezone"] = json!("utc");
+            execute_definition_command(
+                &conn,
+                "adopt:create:local-revise-failure:0001",
+                DefinitionCommand::Create {
+                    definition: original,
+                },
+                "2026-09-03T09:00:00.000Z",
+            )
+            .unwrap();
+
+            let command = DefinitionCommand::Revise {
+                definition: definition("local-revise-failure", "Must not land"),
+                expected_revision: Some(1),
+            };
+            unsafe {
+                std::env::set_var("TZ", ":/tmp/coven-invalid-zoneinfo");
+            }
+            let first = execute_definition_command(
+                &conn,
+                "adopt:revise:local-resolution-failure:0002",
+                command.clone(),
+                "2026-09-03T09:01:00.000Z",
+            )
+            .unwrap();
+
+            assert_eq!(
+                first.error.as_ref().map(ErrorEnvelope::code),
+                Some(ErrorCode::ValidationFailed)
+            );
+            let stored = get_definition(&conn, "local-revise-failure")
+                .unwrap()
+                .unwrap();
+            assert_eq!(stored.revision, 1);
+            assert_eq!(stored.name, "Original");
+            assert_eq!(definition_event_count(&conn, "local-revise-failure"), 1);
+
+            unsafe {
+                std::env::set_var("TZ", "America/Chicago");
+            }
+            let replay = execute_definition_command(
+                &conn,
+                "adopt:revise:local-resolution-failure:0002",
+                command,
+                "2026-09-03T09:02:00.000Z",
+            )
+            .unwrap();
+
+            assert_eq!(replay.outcome, DefinitionCommandOutcome::Rejected);
+            assert_eq!(replay.error, first.error);
+            let stored = get_definition(&conn, "local-revise-failure")
+                .unwrap()
+                .unwrap();
+            assert_eq!(stored.revision, 1);
+            assert_eq!(stored.name, "Original");
+            assert_eq!(definition_event_count(&conn, "local-revise-failure"), 1);
+            assert_eq!(adoption_count(&conn), 2);
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .env(CHILD_ENV, "1")
+            .status()
+            .unwrap();
+
+        assert!(status.success(), "child timezone assertion failed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_compatibility_input_persists_the_exact_tz_override() {
+        const CHILD_ENV: &str = "COVEN_TEST_LOCAL_PERSISTENCE_CHILD";
+        const TEST_NAME: &str =
+            "automations::command_adoption::tests::local_compatibility_input_persists_the_exact_tz_override";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let (_temp, conn) = temp_store();
+            let response = execute_definition_command(
+                &conn,
+                "adopt:create:exact-local-normalized:0001",
+                DefinitionCommand::Create {
+                    definition: definition("exact-local-normalized", "Exact local normalized"),
+                },
+                "2026-09-03T09:00:00.000Z",
+            )
+            .unwrap();
+
+            assert_eq!(response.outcome, DefinitionCommandOutcome::Committed);
+            let record = get_definition(&conn, "exact-local-normalized")
+                .unwrap()
+                .unwrap();
+            let stored: Value = serde_json::from_str(&record.definition_json).unwrap();
+            assert_eq!(stored["timezone"], "Pacific/Kiritimati");
+            assert_eq!(
+                response.result.unwrap()["routine"]["timezone"],
+                "Pacific/Kiritimati"
+            );
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .env(CHILD_ENV, "1")
+            .env("TZ", "Pacific/Kiritimati")
+            .status()
+            .unwrap();
+
+        assert!(status.success(), "child timezone assertion failed");
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod authority_projection;
 pub mod cancellation;
+pub mod capability_negotiation;
 pub mod command_adoption;
 pub mod contract;
 pub mod daemon_tick;

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -16,6 +16,9 @@ pub struct Capability {
     pub status: CapabilityStatus,
     pub policy: CapabilityPolicy,
     pub actions: Vec<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant_negotiation:
+        Option<&'static crate::automations::capability_negotiation::CapabilityProfile>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -78,6 +81,7 @@ pub fn capabilities() -> CapabilityCatalog {
                 status: CapabilityStatus::Available,
                 policy: CapabilityPolicy::Allow,
                 actions: vec![],
+                variant_negotiation: None,
             },
             Capability {
                 id: "coven.travel",
@@ -86,6 +90,7 @@ pub fn capabilities() -> CapabilityCatalog {
                 status: CapabilityStatus::Available,
                 policy: CapabilityPolicy::Allow,
                 actions: vec![],
+                variant_negotiation: None,
             },
             Capability {
                 id: "coven.scheduler",
@@ -94,6 +99,7 @@ pub fn capabilities() -> CapabilityCatalog {
                 status: CapabilityStatus::Available,
                 policy: CapabilityPolicy::Allow,
                 actions: vec![],
+                variant_negotiation: None,
             },
             Capability {
                 id: "coven.control.actions",
@@ -102,6 +108,7 @@ pub fn capabilities() -> CapabilityCatalog {
                 status: CapabilityStatus::Available,
                 policy: CapabilityPolicy::Allow,
                 actions: vec!["coven.capabilities.refresh"],
+                variant_negotiation: None,
             },
             Capability {
                 id: "coven.automations",
@@ -135,6 +142,9 @@ pub fn capabilities() -> CapabilityCatalog {
                     "coven.automations.occurrence.get.v1",
                     "coven.automations.unquarantine",
                 ],
+                variant_negotiation: Some(
+                    crate::automations::capability_negotiation::capability_profile(),
+                ),
             },
             Capability {
                 id: "desktop.automation",
@@ -143,6 +153,7 @@ pub fn capabilities() -> CapabilityCatalog {
                 status: CapabilityStatus::Planned,
                 policy: CapabilityPolicy::RequiresApproval,
                 actions: vec![],
+                variant_negotiation: None,
             },
         ],
     }
@@ -1636,6 +1647,31 @@ mod tests {
     struct OwnershipThenErrorRuntime;
     struct RejectedRuntime;
     struct RetryableRejectedRuntime;
+
+    #[test]
+    fn automation_capability_negotiation_matches_the_packaged_profile() {
+        let catalog = serde_json::to_value(capabilities()).unwrap();
+        let expected: Value = serde_json::from_str(include_str!(
+            "../../../spec/coven-automations/v1/capabilities.json"
+        ))
+        .unwrap();
+        let capabilities = catalog["capabilities"].as_array().unwrap();
+        let automations = capabilities
+            .iter()
+            .find(|capability| capability["id"] == "coven.automations")
+            .unwrap();
+
+        assert_eq!(automations["variantNegotiation"], expected);
+        for capability in capabilities
+            .iter()
+            .filter(|capability| capability["id"] != "coven.automations")
+        {
+            assert!(
+                capability.get("variantNegotiation").is_none(),
+                "unrelated capability changed: {capability}"
+            );
+        }
+    }
 
     #[test]
     fn tick_action_plans_but_does_not_claim_without_scheduler_authority() {

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -328,6 +328,14 @@ Known enum values in `v1`:
 
 Clients should ignore unknown future capability ids and action ids unless they explicitly support them.
 
+Capability entries may also carry an optional `variantNegotiation` object. It
+is currently present only on `coven.automations`, where its value is the exact
+typed projection of
+[`spec/coven-automations/v1/capabilities.json`](../spec/coven-automations/v1/capabilities.json),
+including `version`, `contractProfile`, `supported`, `experimental`, `refused`,
+and `negotiationRules`. Entries without variant negotiation omit the field, so
+the catalog remains distinct from the harness manifests below.
+
 ## Harness capability manifests (`v1`)
 
 Distinct from the control-plane catalog above, `GET /api/v1/capabilities/harnesses` returns what each installed harness brings (global instructions, skills, plugins) plus Coven-owned skills, and `GET /api/v1/capabilities/:harnessId` returns a single harness's manifest. Both accept `?refresh=1` to invalidate the 5-minute scan cache. This surface keeps the snake_case field names pinned by `specs/coven-harness-capabilities/`:

--- a/docs/architecture/coven-automations-v1.md
+++ b/docs/architecture/coven-automations-v1.md
@@ -399,13 +399,23 @@ capability refusal. Rules:
 - Refusal is per-variant and additive: refusing one variant says nothing about others.
 - The current control route accepts the flat #816 `RoutineDefinition` JSON. Its
   negative-negotiation projection maps flat `outputTarget`, `misfire`,
-  `overlap`, retry `backoffPolicy`, and unsupported RRULE frequencies to stable
-  variant identifiers. It also recognizes richer nested `trigger`,
-  `conditions`, `action`, retryable-class, retention, and other policy hints
-  only to classify a refusal when the surrounding flat compatibility
-  definition is otherwise valid; a nested shape composed solely of supported
-  hints still proceeds to ordinary flat definition validation and is not
-  accepted as the normative rich object.
+  `overlap`, retry `backoffPolicy`/`retryableClasses`, exact timezones, and
+  unsupported RRULE frequencies to stable variant identifiers. Exact
+  trigger/action/condition and policy support is read from the packaged
+  capability profile; RRULE grammar and retryable failure-class vocabulary
+  remain owned by the Rust schema types. It also recognizes richer nested
+  `trigger`, `conditions`, `action`, retention, and other policy hints only to
+  classify a refusal when the surrounding flat compatibility definition is
+  otherwise valid.
+- A rich hint is removable only when every supplied subsection satisfies its
+  v1 structural requirements. The schedule and familiar-invocation unions
+  require `version: 1` plus their required fields; schedule RRULEs are parsed
+  after neutralizing only an unsupported `FREQ`, timezone syntax is validated
+  without resolving host `local`, retry conditionals are enforced, and
+  unsupported unions require a non-empty discriminator and `version: 1`.
+  Unknown members on an unsupported union remain opaque. A nested shape
+  composed solely of supported hints still proceeds to ordinary flat
+  definition validation and is not accepted as the normative rich object.
 - Malformed types, missing required fields, and malformed syntax within a
   supported RRULE frequency remain `VALIDATION_FAILED`. Unsupported
   identifiers are bounded to identifier-like ASCII components before they are
@@ -414,7 +424,11 @@ capability refusal. Rules:
   preflight. Their rejections are stored in the existing adoption ledger, so
   exact retries replay the same rejection and changed requests return
   `ADOPTION_REPLAY_MISMATCH`; rejected commands mutate no definition, revision,
-  occurrence, run, or event. Legacy create/update/import behavior is unchanged.
+  occurrence, run, or event. Adoption canonicalization serializes the parsed
+  unresolved compatibility definition, so `timezone: local` fingerprints do
+  not depend on the daemon host. Create/revise resolve `local` only immediately
+  before persistence; resolution failures become durable `VALIDATION_FAILED`
+  outcomes. Legacy create/update/import behavior is unchanged.
 - Unknown values inside a supported variant are still unknown variants.
 - The negative path is also a schema property: v1 unions are closed, so an unknown variant fails schema validation before negotiation is even needed; producers that relax schema validation in future profiles still refuse at the capability layer.
 

--- a/docs/architecture/coven-automations-v1.md
+++ b/docs/architecture/coven-automations-v1.md
@@ -401,9 +401,11 @@ capability refusal. Rules:
   negative-negotiation projection maps flat `outputTarget`, `misfire`,
   `overlap`, retry `backoffPolicy`, and unsupported RRULE frequencies to stable
   variant identifiers. It also recognizes richer nested `trigger`,
-  `conditions`, `action`, and policy hints only to classify a refusal; a nested
-  shape composed solely of supported hints still proceeds to ordinary flat
-  definition validation and is not accepted as the normative rich object.
+  `conditions`, `action`, retryable-class, retention, and other policy hints
+  only to classify a refusal when the surrounding flat compatibility
+  definition is otherwise valid; a nested shape composed solely of supported
+  hints still proceeds to ordinary flat definition validation and is not
+  accepted as the normative rich object.
 - Malformed types, missing required fields, and malformed syntax within a
   supported RRULE frequency remain `VALIDATION_FAILED`. Unsupported
   identifiers are bounded to identifier-like ASCII components before they are

--- a/docs/architecture/coven-automations-v1.md
+++ b/docs/architecture/coven-automations-v1.md
@@ -415,12 +415,12 @@ capability refusal. Rules:
   exact retries replay the same rejection and changed requests return
   `ADOPTION_REPLAY_MISMATCH`; rejected commands mutate no definition, revision,
   occurrence, run, or event. Legacy create/update/import behavior is unchanged.
+- Unknown values inside a supported variant are still unknown variants.
+- The negative path is also a schema property: v1 unions are closed, so an unknown variant fails schema validation before negotiation is even needed; producers that relax schema validation in future profiles still refuse at the capability layer.
 
 This slice does not implement the rich `AutomationDefinition` persistence
 boundary, the remaining normative commands, broader changefeed work, or
 cross-repository canaries required to complete #855.
-- Unknown values inside a supported variant are still unknown variants.
-- The negative path is also a schema property: v1 unions are closed, so an unknown variant fails schema validation before negotiation is even needed; producers that relax schema validation in future profiles still refuse at the capability layer.
 
 ## Canonicalization and digests
 

--- a/docs/architecture/coven-automations-v1.md
+++ b/docs/architecture/coven-automations-v1.md
@@ -31,7 +31,7 @@ The #816 foundation is a valid v1 Rust implementation, but the public contract i
 5. **No versioned event envelope or replay reducer.** `ControlEvent` (`control_plane.rs`) has `kind/action/origin/intentId/payload` but no schema version, no event id, no per-stream sequence, and no timestamps; there is no changefeed at all — Cave polls list/get endpoints.
 6. **Lifecycle semantics are stringly typed and partial.** Occurrences distinguish `scheduled` from `manual` sources, but states remain free strings (`'planned'/'claimed'/'running'/'succeeded'/'failed'/'skipped'` in `crates/coven-cli/src/automations/occurrences.rs`). Settlement terminal states are exactly `[succeeded, failed]` (`OCCURRENCE_TERMINAL_STATES`), stale planned fences collapse to `skipped`, and lease recovery maps straight to `failed` with reason `lease expired` (`recover_expired_leases`). There are no eligible/dispatching/recovering/cancelled/timed_out states, no run state machine beyond `status` strings, and no attempt object at all — only an `attempt` counter incremented by claim (`claim_due_occurrence`).
 7. **No receipts, no digests, no integrity anywhere** in the automations module; run outcomes are ledger rows (`automation_runs.log_json`, `exit_code`) with no tamper-evident summary.
-8. **No capability negotiation.** `capabilities()` (`control_plane.rs`) lists action ids, but nothing lets a client ask which trigger/action/policy variants an implementation executes, and nothing forces a definition with an unsupported variant to fail explicitly.
+8. **Capability negotiation is intentionally partial.** `capabilities()` (`control_plane.rs`) advertises the exact packaged `capabilities.json` profile on the `coven.automations` catalog entry, and adopted `definition.create.v1` / `definition.revise.v1` commands perform negative negotiation before deserializing the current definition model. The accepted control-action body is still the flat #816 `RoutineDefinition` compatibility shape; richer `AutomationDefinition` trigger/action/policy objects are inspected only far enough to return a typed unsupported-variant refusal and are not accepted or persisted by this slice.
 9. **Adoption-key gaps.** Run and occurrence ids are wall-clock derived (`fresh_id`, `crates/coven-cli/src/automations/runner.rs` — `format!("{prefix}-{millis}")`), so a retried `coven.automations.run` command can create a second occurrence/run rather than replaying the first outcome.
 
 ## Contract profile and versioning
@@ -387,10 +387,36 @@ Deterministic failure injection certifies the currently implemented durability b
 
 ## Capability negotiation
 
-`capabilities.json` lists supported v1 variants (trigger `schedule`, action `familiarInvocation`, policies `misfire.latest`, `overlap.forbid`, `timeout.required`, retention `standard`), an empty `experimental` list, and explicit `refused` entries (`trigger.webhook`, `action.pipeline`, `misfire.backfill`, `outputTarget.atomic`) with reasons. The delivery shape remains reserved in the schema and type projection, but schema validity does not override capability refusal. Rules:
+`capabilities.json` lists the complete supported, experimental, and refused
+base-v1 variant profile. The daemon deserializes those packaged bytes into a
+strong Rust projection and publishes that exact object as
+`coven.automations.variantNegotiation` in `GET /api/v1/capabilities`; unrelated
+catalog entries omit the optional field. The delivery shape remains reserved
+in the schema and type projection, but schema validity does not override
+capability refusal. Rules:
 
 - A definition referencing a variant absent from the producer's supported list MUST be refused with `CAPABILITY_UNSUPPORTED`, naming the variant. Nothing is guessed, defaulted, or silently downgraded — the same fail-closed stance as the #816 RRULE vocabulary gate (`rrule.rs` refuses unsupported frequencies instead of approximating).
 - Refusal is per-variant and additive: refusing one variant says nothing about others.
+- The current control route accepts the flat #816 `RoutineDefinition` JSON. Its
+  negative-negotiation projection maps flat `outputTarget`, `misfire`,
+  `overlap`, retry `backoffPolicy`, and unsupported RRULE frequencies to stable
+  variant identifiers. It also recognizes richer nested `trigger`,
+  `conditions`, `action`, and policy hints only to classify a refusal; a nested
+  shape composed solely of supported hints still proceeds to ordinary flat
+  definition validation and is not accepted as the normative rich object.
+- Malformed types, missing required fields, and malformed syntax within a
+  supported RRULE frequency remain `VALIDATION_FAILED`. Unsupported
+  identifiers are bounded to identifier-like ASCII components before they are
+  returned, and response messages never echo nested request values.
+- Only adopted `definition.create.v1` and `definition.revise.v1` use this
+  preflight. Their rejections are stored in the existing adoption ledger, so
+  exact retries replay the same rejection and changed requests return
+  `ADOPTION_REPLAY_MISMATCH`; rejected commands mutate no definition, revision,
+  occurrence, run, or event. Legacy create/update/import behavior is unchanged.
+
+This slice does not implement the rich `AutomationDefinition` persistence
+boundary, the remaining normative commands, broader changefeed work, or
+cross-repository canaries required to complete #855.
 - Unknown values inside a supported variant are still unknown variants.
 - The negative path is also a schema property: v1 unions are closed, so an unknown variant fails schema validation before negotiation is even needed; producers that relax schema validation in future profiles still refuse at the capability layer.
 

--- a/docs/reference/api-capabilities.md
+++ b/docs/reference/api-capabilities.md
@@ -25,6 +25,13 @@ values, and forward-compatibility rules are pinned in the
 { "capabilities": [ { "id", "label", "adapter", "status", "policy", "actions" } ] }
 ```
 
+The `coven.automations` entry additionally includes optional
+`variantNegotiation`, exactly matching the packaged
+`spec/coven-automations/v1/capabilities.json` object. It advertises the
+contract profile and version plus supported, experimental, and refused
+trigger/action/policy variants and the negative-negotiation rules. Other
+catalog entries omit this field.
+
 To refresh it, `POST /api/v1/actions` with action id `coven.capabilities.refresh`.
 
 ## Harness capability aggregate

--- a/docs/reference/api-capabilities.md
+++ b/docs/reference/api-capabilities.md
@@ -33,6 +33,11 @@ contract profile and version plus supported, experimental, and refused
 trigger/action/policy variants and the negative-negotiation rules. Other
 catalog entries omit this field.
 
+Versioned automation create/revise enforcement reads these machine-readable
+variant identifiers directly. Rich definition objects remain negotiation hints
+only in this slice: they must satisfy their v1 required and conditional fields,
+and are never persisted as accepted `AutomationDefinition` values.
+
 To refresh it, `POST /api/v1/actions` with action id `coven.capabilities.refresh`.
 
 ## Harness capability aggregate

--- a/docs/reference/api-capabilities.md
+++ b/docs/reference/api-capabilities.md
@@ -4,6 +4,7 @@ read_when:
   - Looking up the capabilities API
 title: "Capabilities endpoint"
 description: "Reference for the /api/v1/capabilities routes: the control-plane catalog on the bare path, the harness capability aggregate at /capabilities/harnesses, and single-harness manifests at /capabilities/:harnessId."
+source_adjacent_reason: "This page is source-adjacent API reference documenting behavior implemented in the coven-cli API handlers and contract."
 ---
 
 Coven exposes two capability concepts on adjacent paths. Do not confuse them:


### PR DESCRIPTION
## Summary

- advertise the exact packaged `coven.automations.v1` variant-negotiation profile on the daemon capability catalog
- reject recognizable unsupported trigger, action, schedule, retry, overlap, misfire, timezone, and output-delivery variants with typed `CAPABILITY_UNSUPPORTED`
- persist and replay unsupported create/revise outcomes through the existing command-adoption ledger without mutating definitions or emitting lifecycle events

Advances #855.

## Readiness packet

**Why now:** `spec/coven-automations/v1/capabilities.json` already defines base-v1 support and refusal semantics, but clients could not discover that profile operationally and v1 definition commands collapsed unsupported variants into generic validation failures.

**Contract:** `GET /api/v1/capabilities` now includes the exact typed artifact projection as `variantNegotiation` only on `coven.automations`. Other capability entries retain their existing shape.

**Negative negotiation:** adopted `definition.create.v1` and `definition.revise.v1` inspect raw JSON before flat compatibility deserialization. Recognizable unsupported or unknown variants return HTTP 422 with:

```json
{
  "code": "CAPABILITY_UNSUPPORTED",
  "details": {
    "contractProfile": "coven.automations.v1",
    "variant": "outputTarget.atomic"
  }
}
```

Malformed types, missing fields, and malformed supported RRULE syntax remain `VALIDATION_FAILED`. Returned variant identifiers are bounded and never echo arbitrary nested request values.

**Adoption semantics:** the unsupported request participates in the same lossless adoption fingerprint as other invalid commands. Exact retries replay the stored rejection; changed payloads with the same key return `ADOPTION_REPLAY_MISMATCH`. Rejections do not create or revise a definition and do not append an automation event.

**Compatibility:** direct `RoutineDefinition::from_json` callers and legacy create/update/import routes retain their existing behavior. Rich normative `AutomationDefinition` objects are inspected only far enough to classify unsupported hints; this PR does not make that rich shape executable.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `npm ci --no-audit --no-fund && npm run build && npm test` in `packages/channels` after rebasing the current `origin/main` dependency update
- signed commit and DCO sign-off verified

## Smoke-test notes

End-to-end control-action tests cover unsupported create and revise requests, HTTP 422 mapping, stable structured details, exact replay, changed-payload mismatch, unchanged revision/history, and absence of fabricated events. Capability API tests compare the published `variantNegotiation` value directly with the packaged artifact.

## Remaining #855 work

This does not close #855. The rich normative definition persistence boundary, remaining command-surface parity, and complete external artifact/changefeed certification remain separate slices.
