### PR TITLE
test: diagnose concurrent prompt-delivery cancellation phases

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -7571,10 +7571,12 @@ mod tests {
             vec![b'x'; 1024 * 1024],
         )?;
         let (launched_tx, launched_rx) = std::sync::mpsc::channel();
+        let (writing_tx, writing_rx) = std::sync::mpsc::channel();
         let runtime = Arc::new(PromptCancellationApiRuntime {
             inner: LiveSessionRuntime::with_coven_home(temp_dir.path().to_path_buf()),
             command: Mutex::new(Some(command)),
             launched: Mutex::new(Some(launched_tx)),
+            prompt_write_started: Mutex::new(Some(writing_tx)),
             await_root_exit_before_activate: None,
         });
         let body = serde_json::json!({
@@ -7599,7 +7601,8 @@ mod tests {
             let _ = response_tx.send(response);
         });
 
-        let session_id = launched_rx.recv_timeout(Duration::from_secs(2))?;
+        let session_id =
+            receive_prompt_launch_notification(&launched_rx, &response_rx, Duration::from_secs(2))?;
         let child_pid = await_daemon_shutdown_descendant_pid(&pid_file)?;
         let registration_deadline = Instant::now() + Duration::from_secs(2);
         while !runtime
@@ -7615,6 +7618,11 @@ mod tests {
             );
             std::thread::sleep(Duration::from_millis(5));
         }
+        receive_prompt_delivery_phase(
+            &writing_rx,
+            "prompt writer entry before kill",
+            registration_deadline.saturating_duration_since(Instant::now()),
+        )?;
 
         let kill = crate::api::handle_request_with_runtime(
             "POST",
@@ -7625,7 +7633,12 @@ mod tests {
             runtime.as_ref(),
         )?;
         assert_eq!(kill.status, 202, "{}", kill.body);
-        let launch = response_rx.recv_timeout(Duration::from_secs(2))??;
+        let launch = receive_prompt_delivery_phase(
+            &response_rx,
+            "launch response after kill",
+            Duration::from_secs(2),
+        )?
+        .context("API launch returned an error after concurrent kill")?;
         assert_eq!(launch.status, 500, "{}", launch.body);
         let conn = crate::store::open_store(&temp_dir.path().join(crate::STORE_FILE_NAME))?;
         let row = crate::store::get_session(&conn, &session_id)?
@@ -7633,6 +7646,92 @@ mod tests {
         assert_eq!(row.status, "killed");
         await_daemon_shutdown_descendant_exit(child_pid, "concurrent API cancellation")?;
         Ok(())
+    }
+
+    fn receive_prompt_delivery_phase<T>(
+        receiver: &std::sync::mpsc::Receiver<T>,
+        phase: &str,
+        timeout: Duration,
+    ) -> Result<T> {
+        let started = Instant::now();
+        receiver.recv_timeout(timeout).with_context(|| {
+            format!(
+                "{phase}: elapsed={:?}, budget={timeout:?}",
+                started.elapsed()
+            )
+        })
+    }
+
+    fn receive_prompt_launch_notification(
+        notification: &std::sync::mpsc::Receiver<String>,
+        response: &std::sync::mpsc::Receiver<Result<crate::api::ApiResponse>>,
+        timeout: Duration,
+    ) -> Result<String> {
+        receive_prompt_delivery_phase(notification, "runtime launch notification", timeout)
+            .with_context(|| {
+                let early_response = match response.try_recv() {
+                    Ok(Ok(response)) => format!("HTTP {}: {}", response.status, response.body),
+                    Ok(Err(error)) => format!("API error: {error:#}"),
+                    Err(std::sync::mpsc::TryRecvError::Empty) => "still pending".to_owned(),
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        "channel disconnected without a response".to_owned()
+                    }
+                };
+                format!("early launch response: {early_response}")
+            })
+    }
+
+    #[test]
+    fn prompt_delivery_phase_timeout_identifies_phase_and_elapsed() {
+        let (_sender, receiver) = std::sync::mpsc::channel::<()>();
+        let error =
+            receive_prompt_delivery_phase(&receiver, "launch response after kill", Duration::ZERO)
+                .expect_err("an empty channel must report the awaited phase");
+        let diagnostic = format!("{error:#}");
+        assert!(
+            diagnostic.contains("launch response after kill"),
+            "{diagnostic}"
+        );
+        assert!(diagnostic.contains("elapsed="), "{diagnostic}");
+        assert!(
+            diagnostic.contains("timed out waiting on channel"),
+            "{diagnostic}"
+        );
+    }
+
+    #[test]
+    fn prompt_delivery_notification_timeout_reports_early_response() {
+        let (_launched, notification) = std::sync::mpsc::channel::<String>();
+        let (response_tx, response_rx) = std::sync::mpsc::channel();
+        response_tx
+            .send(Ok(crate::api::ApiResponse {
+                status: 500,
+                content_type: "application/json",
+                body: r#"{"error":"fixture launch failed"}"#.to_owned(),
+            }))
+            .unwrap();
+        let error = receive_prompt_launch_notification(&notification, &response_rx, Duration::ZERO)
+            .expect_err("missing launch notification must include the early response");
+        let diagnostic = format!("{error:#}");
+        assert!(
+            diagnostic.contains("runtime launch notification"),
+            "{diagnostic}"
+        );
+        assert!(diagnostic.contains("elapsed="), "{diagnostic}");
+        assert!(diagnostic.contains("HTTP 500"), "{diagnostic}");
+        assert!(diagnostic.contains("fixture launch failed"), "{diagnostic}");
+    }
+
+    #[test]
+    fn prompt_delivery_notification_timeout_reports_early_error() {
+        let (_launched, notification) = std::sync::mpsc::channel::<String>();
+        let (response_tx, response_rx) = std::sync::mpsc::channel();
+        response_tx
+            .send(Err(anyhow::anyhow!("fixture admission failed")))
+            .unwrap();
+        let error = receive_prompt_launch_notification(&notification, &response_rx, Duration::ZERO)
+            .expect_err("missing launch notification must include an early API error");
+        assert!(format!("{error:#}").contains("fixture admission failed"));
     }
 
     #[cfg(any(unix, windows))]
@@ -7654,6 +7753,7 @@ mod tests {
             inner: LiveSessionRuntime::with_coven_home(temp_dir.path().to_path_buf()),
             command: Mutex::new(Some(command)),
             launched: Mutex::new(Some(launched_tx)),
+            prompt_write_started: Mutex::new(None),
             await_root_exit_before_activate: Some(pid_file.clone()),
         };
         let body = serde_json::json!({
@@ -8168,6 +8268,7 @@ mod tests {
         inner: LiveSessionRuntime,
         command: Mutex<Option<pty_runner::HarnessCommand>>,
         launched: Mutex<Option<std::sync::mpsc::Sender<String>>>,
+        prompt_write_started: Mutex<Option<std::sync::mpsc::Sender<()>>>,
         await_root_exit_before_activate: Option<PathBuf>,
     }
 
@@ -8184,7 +8285,10 @@ mod tests {
                 .take()
                 .context("prompt-cancellation fixture command was already consumed")?;
             let (observer, registration) = self.inner.observer_for_session(launch.id.clone());
-            let piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+            let mut piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+            if let Some(sender) = self.prompt_write_started.lock().unwrap().take() {
+                piped.notify_prompt_write_started_for_test(sender)?;
+            }
             if let Some(pid_file) = &self.await_root_exit_before_activate {
                 let pid = await_daemon_shutdown_descendant_pid(pid_file)?;
                 await_daemon_shutdown_descendant_exit(pid, "successful pre-delivery root exit")?;

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4112,6 +4112,8 @@ struct PipedPromptDelivery {
     stdin: Option<std::process::ChildStdin>,
     prompt: Option<Vec<u8>>,
     outcome: Arc<PipedPromptOutcome>,
+    #[cfg(test)]
+    write_started: Option<mpsc::Sender<()>>,
 }
 
 struct PipedPromptOutcome {
@@ -4154,6 +4156,18 @@ impl PipedPromptOutcome {
 }
 
 impl PipedSession {
+    #[cfg(test)]
+    pub(crate) fn notify_prompt_write_started_for_test(
+        &mut self,
+        sender: mpsc::Sender<()>,
+    ) -> Result<()> {
+        self.prompt_delivery
+            .as_mut()
+            .context("prompt-write notification requires an initial stdin prompt")?
+            .write_started = Some(sender);
+        Ok(())
+    }
+
     pub(crate) fn cancellation_handle(&self) -> SharedStrictChildProcessTree {
         self.process_tree.clone()
     }
@@ -4212,7 +4226,14 @@ impl PipedPromptDelivery {
             .prompt
             .take()
             .context("piped prompt bytes were already consumed")?;
-        let result = deliver_piped_prompt(stdin, prompt, timeout, process_tree);
+        let result = deliver_piped_prompt(
+            stdin,
+            prompt,
+            timeout,
+            process_tree,
+            #[cfg(test)]
+            self.write_started.take(),
+        );
         outcome.finish(result.is_ok());
         result
     }
@@ -4232,6 +4253,7 @@ fn deliver_piped_prompt(
     prompt: Vec<u8>,
     timeout: Duration,
     process_tree: &SharedStrictChildProcessTree,
+    #[cfg(test)] write_started: Option<mpsc::Sender<()>>,
 ) -> Result<()> {
     if process_tree.is_terminated() {
         return Err(cleanup_piped_launch_failure(
@@ -4247,6 +4269,11 @@ fn deliver_piped_prompt(
         .name("coven-piped-prompt".into())
         .spawn(move || {
             let mut stdin = stdin;
+            // Test-only entry evidence; it does not claim the OS write is blocked.
+            #[cfg(test)]
+            if let Some(started) = write_started {
+                started.send(()).expect("prompt-write entry receiver");
+            }
             let result = stdin
                 .write_all(&prompt)
                 .and_then(|_| stdin.flush())
@@ -4480,6 +4507,8 @@ pub fn spawn_piped_with_observer(
                     stdin: Some(stdin),
                     prompt: Some(prompt),
                     outcome: Arc::clone(&prompt_outcome),
+                    #[cfg(test)]
+                    write_started: None,
                 }),
             )
         } else {


### PR DESCRIPTION
## Scope
Refs#992. Isolated follow-up to the Windows workspace channel timeout that blocked Threads integration. This is diagnostic/test-synchronization work, not a claimed production repair.

## Changes
Both channel receives identify phase, elapsed time and unchanged budget. Missing launch notification exposes an early synthetic API response/error if available. A per-session cfg(test) notification establishes writer-thread entry before kill using the remaining original registration deadline; it does not claim the OS write is already blocked. Three focused regressions cover error context.

## Evidence and limits
Six focused prompt_delivery cases pass, including concurrent API kill. Normal cargo check, native Clippy and Windows-GNU test compilation pass; untouched Windows warnings remain. Native hosted Windows evidence is pending. Existing HTTP202/500, killed-state and descendant-exit assertions are unchanged. No production API, cancellation behavior, timeout increase, skip or serialized acceptance. Rollback is a normal revert; no schema/migration or authority gate change. Shared Threads#931 is untouched.