### PR TITLE
fix(client): retain the published Unix socket path

### DIFF
--- a/crates/coven-client/src/discovery.rs
+++ b/crates/coven-client/src/discovery.rs
@@ -69,13 +69,12 @@ impl DaemonEndpoint {
                     socket_candidate.display()
                 )));
             }
-            // Resolve symlinked ancestors and `..` before the definitive
-            // metadata checks, then retain this exact validated path.
-            let socket = std::fs::canonicalize(&socket_candidate).map_err(|source| {
-                selected_unix_socket_discovery_error(&socket_candidate, source, "resolve")
-            })?;
+            // The home already resolves symlinked ancestors and `..`. Retain
+            // the selected leaf: on macOS, canonicalizing a hard-linked socket
+            // can return its temporary publication alias, which is then unlinked.
+            let socket = socket_candidate;
             let metadata = std::fs::symlink_metadata(&socket).map_err(|source| {
-                selected_unix_socket_discovery_error(&socket_candidate, source, "inspect")
+                selected_unix_socket_discovery_error(&socket, source, "inspect")
             })?;
             if metadata.file_type().is_symlink() || !metadata.file_type().is_socket() {
                 return Err(ClientError::Discovery(format!(

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -642,6 +642,41 @@ fn discovers_only_an_owner_local_unix_socket() {
     assert!(endpoint.is_owner_local());
 }
 
+#[test]
+fn discovery_retains_published_socket_when_staging_link_is_removed() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    let home = TestHome::new();
+    let staged = home.path.join(".staged");
+    let published = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&staged).expect("bind staged daemon socket");
+    fs::set_permissions(&staged, fs::Permissions::from_mode(0o600)).expect("protect staged socket");
+    fs::hard_link(&staged, &published).expect("publish private daemon socket");
+
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover published socket");
+    fs::remove_file(&staged).expect("remove staging alias after discovery");
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept through published socket");
+        let mut request = String::new();
+        stream.read_to_string(&mut request).expect("read health");
+        assert!(request.starts_with("GET /api/v1/health HTTP/1.1\r\n"));
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{HEALTH}",
+            HEALTH.len()
+        )
+        .expect("respond through published socket");
+    });
+    let mut client = DaemonClient::new(endpoint);
+    client
+        .health()
+        .expect("staging cleanup must not invalidate the selected published endpoint");
+    server.join().expect("daemon thread");
+}
+
 #[cfg(unix)]
 #[test]
 fn reads_a_framed_health_fixture_without_waiting_for_socket_close() {


### PR DESCRIPTION
## Objective and scope

Refs #1002. Extract the proven two-file repair from draft #931 commit
`42f5e7122cf4ef518fa1fc8c14d87b3dc8ab2525` onto main, independently of the
Windows startup investigation.

On macOS, canonicalizing a hard-linked Unix socket can select its temporary
publication alias. Removing that alias then invalidates the cached endpoint,
although the authenticated socket remains published as `coven.sock`.
Keep the selected leaf beneath the already-canonical home.

## Contracts and authority impact

Consulted `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, the client manifest,
`crates/coven-client/src/discovery.rs`, Unix connection/peer validation in
`crates/coven-client/src/transport/unix.rs`, and `tests/health.rs`.

Both symlink checks, socket type, ownership, permissions, device/inode binding,
and peer-identity validation remain intact. Transport code is unchanged.
There are no API, dependency, schema, migration, or deadline changes. Fixtures
are synthetic and use the existing isolated home allocator.

## Evidence

On current-main base `735e2f056a39eea1312662985fef34526f2ae90c`, the new real
socket regression failed natively on macOS with `ENOENT` after staging removal.
After the production repair:

```sh
cargo test --locked -p coven-client --test health
# 41 passed
cargo test --locked -p coven-client --lib -- discovery::tests transport::unix::tests
# 37 passed
cargo clippy --locked -p coven-client --all-targets -- -D warnings
cargo fmt -p coven-client --check
```

Parent independently reviewed the diff and repeated both test selections.
The regression uses real bind, private permissions, hard-link publication,
discovery, alias removal, and an authenticated client request/reply; it does
not mock canonicalization. Native CI `34487860355` passed at head
`eb180326b86c0095116b7761ec8f62d9d55d9391`, testing merge
`993c566613b6bbbc043b2ea548e474750e0e5ce5`. Linux executed the new regression
and all 41 health cases; Windows workspace, Linux lint, policy, dependency
audit, and the required PR gate passed. macOS was skipped by CI classification;
the native local macOS red/green evidence is recorded above. The health target
is Unix-only, so Windows compilation cannot count as executing this regression.
The repair already participated in real-daemon journeys in #931, but that
draft's broader acceptance remains open.

## Rollback and limitations

Revert the two-file patch; no state migration is required. Reverting can
reintroduce the stale-alias failure. This PR does not resolve Windows startup
reliability, advance the Threads compatibility pin, merge the authority stack,
or provide human coherence/freeze approval.
