### PR TITLE
feat: verify automation conformance results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,10 +305,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -364,6 +379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +405,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -809,6 +836,7 @@ dependencies = [
  "iana-time-zone",
  "interprocess",
  "json5",
+ "jsonschema",
  "libc",
  "p256",
  "portable-pty",
@@ -1413,6 +1441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,8 +1609,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1665,6 +1713,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1763,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
+dependencies = [
+ "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1941,9 +2010,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2527,6 +2598,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a806f80c1f5560431009ce5ec29b59d38f950e0cd7db5f1b8925e6d8104e21"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.19.1",
+ "fraction",
+ "getrandom 0.3.4",
+ "itoa",
+ "jsonschema-macros",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-bigint",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-macros"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ac41a7411c029f7f9971881ccf12c8190411a0ab5caf53c07b07eabbea253e"
+dependencies = [
+ "jsonschema-macros-core",
+ "proc-macro2",
+]
+
+[[package]]
+name = "jsonschema-macros-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29ab02b2d2d1b26f9c7709c7985ced2d163cb570dedd38bd8467ef31e5dbc3c"
+dependencies = [
+ "fancy-regex 0.19.1",
+ "indexmap",
+ "jsonschema-regex",
+ "percent-encoding",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "referencing",
+ "regex",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb862addfa7782108933abcf842fe25334523a9df5b89ea4d9620e3dd7b42181"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05cd404c5ff6e2731dbbf7e290a27417750acfb59e329560a1d0af384c93fb0"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "getrandom 0.3.4",
+ "num-bigint",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+ "zmij",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2893,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mime"
@@ -3008,14 +3170,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
+name = "num"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -3055,11 +3237,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3270,6 +3463,12 @@ dependencies = [
  "lzma-rust2",
  "ureq",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -3593,6 +3792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -3946,6 +4154,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b4a92fac7e28c27de3ad26df2ecb9e652f227b258e845af034052e5b22c96c"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.0",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -4802,7 +5047,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bitflags 2.13.0",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset",
@@ -5277,6 +5522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,6 +5701,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5466,6 +5727,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -6262,6 +6529,6 @@ checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -48,7 +48,7 @@ qrcode = { version = "0.14", default-features = false }
 # loading payloads. Keep SQLite bundled so the locked library version provides it.
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json = { version = "1", features = ["arbitrary_precision", "raw_value"] }
 serde_jcs = "0.2"
 serde_yaml_ng = "0.10"
 sha2 = "0.11"

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -81,4 +81,5 @@ widestring = "1"
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Threading", "Win32_System_JobObjects", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
+jsonschema = { version = "0.56.0", default-features = false, features = ["arbitrary-precision"] }
 tempfile = "3"

--- a/crates/coven-cli/src/automations/contract/conformance.rs
+++ b/crates/coven-cli/src/automations/contract/conformance.rs
@@ -38,6 +38,7 @@ pub enum ConformanceResultError {
     RunnerVersionMismatch,
     RunnerArtifactDigestMismatch,
     VectorSetDigestMismatch,
+    SubjectArtifactMismatch,
     ProfileDuplicate,
     SuiteDuplicate,
     SuiteSetMismatch,
@@ -83,6 +84,7 @@ impl fmt::Display for ConformanceResultError {
                 "conformance runner artifact digest does not match"
             }
             Self::VectorSetDigestMismatch => "conformance vector set digest does not match",
+            Self::SubjectArtifactMismatch => "conformance subject artifact does not match",
             Self::ProfileDuplicate => "conformance profile results contain a duplicate",
             Self::SuiteDuplicate => "conformance suite results contain a duplicate",
             Self::SuiteSetMismatch => "conformance required suite results do not match",
@@ -447,6 +449,22 @@ pub struct ConformanceRunnerBinding {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceArtifactPlatform {
+    pub os: ConformanceEnvironmentFact,
+    pub arch: ConformanceEnvironmentFact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceSubjectArtifactBinding {
+    pub artifact_id: ConformanceResultId,
+    pub artifact_version: ConformanceVersion,
+    pub platform: ConformanceArtifactPlatform,
+    pub sha256: Sha256Digest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ConformanceEnvironment {
     pub os: ConformanceEnvironmentFact,
     pub arch: ConformanceEnvironmentFact,
@@ -498,6 +516,7 @@ pub struct ConformanceResultStatement {
     pub source: ConformanceSourceBinding,
     pub protocol_artifact: ConformanceProtocolArtifactBinding,
     pub runner: ConformanceRunnerBinding,
+    pub subject_artifact: ConformanceSubjectArtifactBinding,
     pub environment: ConformanceEnvironment,
     pub observed_at: ConformanceTimestamp,
     #[serde(
@@ -616,6 +635,7 @@ pub struct ExpectedArtifactBinding {
     source: ExpectedSourceBinding,
     protocol_artifact: ExpectedProtocolArtifactBinding,
     runner: ExpectedRunnerBinding,
+    subject_artifact: ExpectedSubjectArtifactBinding,
 }
 
 impl ExpectedArtifactBinding {
@@ -624,12 +644,43 @@ impl ExpectedArtifactBinding {
         source: ExpectedSourceBinding,
         protocol_artifact: ExpectedProtocolArtifactBinding,
         runner: ExpectedRunnerBinding,
+        subject_artifact: ExpectedSubjectArtifactBinding,
     ) -> Self {
         Self {
             source,
             protocol_artifact,
             runner,
+            subject_artifact,
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedSubjectArtifactBinding {
+    artifact_id: ConformanceResultId,
+    artifact_version: ConformanceVersion,
+    platform: ConformanceArtifactPlatform,
+    sha256: Sha256Digest,
+}
+
+impl ExpectedSubjectArtifactBinding {
+    pub fn new(
+        artifact_id: impl Into<String>,
+        artifact_version: impl Into<String>,
+        os: impl Into<String>,
+        arch: impl Into<String>,
+        sha256: impl Into<String>,
+    ) -> Result<Self, ConformanceResultError> {
+        Ok(Self {
+            artifact_id: ConformanceResultId::new(artifact_id)?,
+            artifact_version: ConformanceVersion::new(artifact_version)?,
+            platform: ConformanceArtifactPlatform {
+                os: ConformanceEnvironmentFact::new(os)?,
+                arch: ConformanceEnvironmentFact::new(arch)?,
+            },
+            sha256: Sha256Digest::new(sha256.into())
+                .map_err(|_| ConformanceResultError::SchemaInvalid)?,
+        })
     }
 }
 
@@ -934,6 +985,13 @@ fn verify_exact_binding(
     }
     if statement.runner.vector_set_sha256 != expected.runner.vector_set_sha256 {
         return Err(ConformanceResultError::VectorSetDigestMismatch);
+    }
+    if statement.subject_artifact.artifact_id != expected.subject_artifact.artifact_id
+        || statement.subject_artifact.artifact_version != expected.subject_artifact.artifact_version
+        || statement.subject_artifact.platform != expected.subject_artifact.platform
+        || statement.subject_artifact.sha256 != expected.subject_artifact.sha256
+    {
+        return Err(ConformanceResultError::SubjectArtifactMismatch);
     }
     Ok(())
 }

--- a/crates/coven-cli/src/automations/contract/conformance.rs
+++ b/crates/coven-cli/src/automations/contract/conformance.rs
@@ -1,0 +1,1111 @@
+//! Portable Coven Automations v1 conformance-result verification.
+//!
+//! This module verifies result envelopes produced elsewhere. It does not run
+//! conformance suites, certify Coven, or provide a production signer or trust
+//! root.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use chrono::{DateTime, Duration, Utc};
+use p256::ecdsa::signature::Verifier;
+use p256::ecdsa::{Signature, VerifyingKey};
+use serde::ser::Serializer;
+use serde::{Deserialize, Deserializer, Serialize};
+
+use super::canonical_json::{canonicalize, sha256_hex, MAX_SAFE_INTEGER};
+use super::types::{deserialize_non_null_option, DigestValue, Sha256Digest};
+
+const MAX_PROFILE_RESULTS: usize = 7;
+const MAX_SUITES_PER_PROFILE: usize = 128;
+const MAX_TRUST_POLICY_AGE: Duration = Duration::days(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConformanceResultError {
+    TrustPolicyInvalid,
+    SchemaInvalid,
+    StatementDigestMismatch,
+    SourceRepositoryMismatch,
+    SourceCommitMismatch,
+    BundleSchemaVersionMismatch,
+    BundleSourceCommitMismatch,
+    BundleDigestMismatch,
+    ContractContentDigestMismatch,
+    FileCountMismatch,
+    RunnerNameMismatch,
+    RunnerVersionMismatch,
+    RunnerArtifactDigestMismatch,
+    VectorSetDigestMismatch,
+    ProfileDuplicate,
+    SuiteDuplicate,
+    SuiteSetMismatch,
+    PassedSuiteEvidenceMissing,
+    ProfileStatusInconsistent,
+    OverallStatusInconsistent,
+    FullProfileIncomplete,
+    ReleasePolicyMissing,
+    PolicyBindingMismatch,
+    EvidenceExpirationRequired,
+    EvidenceChronologyInvalid,
+    EvidenceNotYetValid,
+    EvidenceStale,
+    EvidenceExpired,
+    RequiredProfileMissing,
+    RequiredProfileNotPassed,
+    RequiredSuiteSetMismatch,
+    EnvironmentNotAllowed,
+    AuthenticationRequired,
+    AuthenticationKeyUntrusted,
+    AuthenticationEncodingInvalid,
+    AuthenticationInvalid,
+}
+
+impl fmt::Display for ConformanceResultError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TrustPolicyInvalid => "conformance trust policy is invalid",
+            Self::SchemaInvalid => "conformance result schema is invalid",
+            Self::StatementDigestMismatch => "conformance statement digest is invalid",
+            Self::SourceRepositoryMismatch => "conformance source repository does not match",
+            Self::SourceCommitMismatch => "conformance source commit does not match",
+            Self::BundleSchemaVersionMismatch => "conformance bundle schema version does not match",
+            Self::BundleSourceCommitMismatch => "conformance bundle source commit does not match",
+            Self::BundleDigestMismatch => "conformance bundle digest does not match",
+            Self::ContractContentDigestMismatch => {
+                "conformance contract content digest does not match"
+            }
+            Self::FileCountMismatch => "conformance artifact file count does not match",
+            Self::RunnerNameMismatch => "conformance runner name does not match",
+            Self::RunnerVersionMismatch => "conformance runner version does not match",
+            Self::RunnerArtifactDigestMismatch => {
+                "conformance runner artifact digest does not match"
+            }
+            Self::VectorSetDigestMismatch => "conformance vector set digest does not match",
+            Self::ProfileDuplicate => "conformance profile results contain a duplicate",
+            Self::SuiteDuplicate => "conformance suite results contain a duplicate",
+            Self::SuiteSetMismatch => "conformance required suite results do not match",
+            Self::PassedSuiteEvidenceMissing => "passed conformance suite is missing evidence",
+            Self::ProfileStatusInconsistent => "conformance profile status is inconsistent",
+            Self::OverallStatusInconsistent => "conformance overall status is inconsistent",
+            Self::FullProfileIncomplete => "full conformance profile is missing a passed component",
+            Self::ReleasePolicyMissing => "release conformance policy is unavailable",
+            Self::PolicyBindingMismatch => "release conformance policy does not match",
+            Self::EvidenceExpirationRequired => "release conformance expiration is required",
+            Self::EvidenceChronologyInvalid => "release conformance chronology is invalid",
+            Self::EvidenceNotYetValid => "release conformance evidence is not yet valid",
+            Self::EvidenceStale => "release conformance evidence is stale",
+            Self::EvidenceExpired => "release conformance evidence is expired",
+            Self::RequiredProfileMissing => "required conformance profile is missing",
+            Self::RequiredProfileNotPassed => "required conformance profile did not pass",
+            Self::RequiredSuiteSetMismatch => "required conformance suite inventory does not match",
+            Self::EnvironmentNotAllowed => "conformance environment is not allowed",
+            Self::AuthenticationRequired => "release conformance authentication is required",
+            Self::AuthenticationKeyUntrusted => "conformance authentication key is not trusted",
+            Self::AuthenticationEncodingInvalid => "conformance authentication encoding is invalid",
+            Self::AuthenticationInvalid => "conformance authentication is invalid",
+        })
+    }
+}
+
+impl std::error::Error for ConformanceResultError {}
+
+macro_rules! validated_text {
+    ($name:ident, $validator:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, ConformanceResultError> {
+                let value = value.into();
+                if $validator(&value) {
+                    Ok(Self(value))
+                } else {
+                    Err(ConformanceResultError::SchemaInvalid)
+                }
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+fn matches_opaque_identifier(value: &str, maximum: usize) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= maximum
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'@' | b'-')
+        })
+}
+
+fn matches_result_id(value: &str) -> bool {
+    matches_opaque_identifier(value, 160)
+}
+
+fn matches_policy_id(value: &str) -> bool {
+    matches_opaque_identifier(value, 160)
+}
+
+fn matches_key_id(value: &str) -> bool {
+    matches_opaque_identifier(value, 160)
+}
+
+fn matches_suite_id(value: &str) -> bool {
+    matches_opaque_identifier(value, 128)
+}
+
+fn matches_repository(value: &str) -> bool {
+    let Some((scheme, location)) = value.split_once("://") else {
+        return false;
+    };
+    !scheme.is_empty()
+        && scheme.as_bytes()[0].is_ascii_alphabetic()
+        && scheme
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+        && !location.is_empty()
+        && value.len() <= 512
+        && location
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"!#$%&'()*+,./:;=?@_~-".contains(&byte))
+}
+
+fn matches_source_commit(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn matches_version(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 96
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'+' | b':' | b'-')
+        })
+}
+
+fn matches_environment_fact(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 128
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'+' | b':' | b'-')
+        })
+}
+
+fn matches_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let punctuation_matches = match bytes.len() {
+        20 => {
+            bytes[4] == b'-'
+                && bytes[7] == b'-'
+                && bytes[10] == b'T'
+                && bytes[13] == b':'
+                && bytes[16] == b':'
+                && bytes[19] == b'Z'
+        }
+        24 => {
+            bytes[4] == b'-'
+                && bytes[7] == b'-'
+                && bytes[10] == b'T'
+                && bytes[13] == b':'
+                && bytes[16] == b':'
+                && bytes[19] == b'.'
+                && bytes[23] == b'Z'
+        }
+        _ => false,
+    };
+    punctuation_matches
+        && bytes.iter().enumerate().all(|(index, byte)| {
+            matches!(index, 4 | 7 | 10 | 13 | 16 | 19 | 23) || byte.is_ascii_digit()
+        })
+        && DateTime::parse_from_rfc3339(value).is_ok()
+}
+
+fn matches_signature(value: &str) -> bool {
+    (1..=128).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+validated_text!(ConformanceResultId, matches_result_id);
+validated_text!(ConformancePolicyId, matches_policy_id);
+validated_text!(ConformanceKeyId, matches_key_id);
+validated_text!(ConformanceSuiteId, matches_suite_id);
+validated_text!(ConformanceRepository, matches_repository);
+validated_text!(ConformanceSourceCommit, matches_source_commit);
+validated_text!(ConformanceVersion, matches_version);
+validated_text!(ConformanceEnvironmentFact, matches_environment_fact);
+validated_text!(ConformanceTimestamp, matches_timestamp);
+validated_text!(ConformanceSignature, matches_signature);
+
+impl ConformanceTimestamp {
+    fn as_datetime(&self) -> Result<DateTime<Utc>, ConformanceResultError> {
+        DateTime::parse_from_rfc3339(self.as_str())
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|_| ConformanceResultError::SchemaInvalid)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConformanceResultSchemaVersion {
+    #[serde(rename = "coven.automations.conformance-result.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConformanceContractProfile {
+    #[serde(rename = "coven.automations.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConformanceProfile {
+    Structural,
+    SchedulerReliability,
+    RuntimeAuthority,
+    Continuity,
+    Privacy,
+    Interoperability,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConformanceStatus {
+    Passed,
+    Failed,
+    Incomplete,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformancePolicyBinding {
+    pub policy_id: ConformancePolicyId,
+    pub policy_version: ConformanceVersion,
+    pub digest: Sha256Digest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ConformanceDecisionScope {
+    AuditOnly,
+    ReleaseEligibility {
+        #[serde(rename = "policyBinding")]
+        policy_binding: ConformancePolicyBinding,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceSourceBinding {
+    pub repository: ConformanceRepository,
+    pub commit: ConformanceSourceCommit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ConformanceFileCount(u64);
+
+impl ConformanceFileCount {
+    pub fn new(value: u64) -> Result<Self, ConformanceResultError> {
+        if (1..=MAX_SAFE_INTEGER).contains(&value) {
+            Ok(Self(value))
+        } else {
+            Err(ConformanceResultError::SchemaInvalid)
+        }
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl Serialize for ConformanceFileCount {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConformanceFileCount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let number = serde_json::Number::deserialize(deserializer)?;
+        parse_exact_positive_integer(&number.to_string())
+            .and_then(Self::new)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+fn parse_exact_positive_integer(value: &str) -> Result<u64, ConformanceResultError> {
+    if value.starts_with('-') {
+        return Err(ConformanceResultError::SchemaInvalid);
+    }
+    let (mantissa, exponent) =
+        value
+            .split_once(['e', 'E'])
+            .map_or((value, 0_i32), |(mantissa, exponent)| {
+                exponent
+                    .parse::<i32>()
+                    .map(|exponent| (mantissa, exponent))
+                    .unwrap_or((mantissa, i32::MIN))
+            });
+    if exponent == i32::MIN {
+        return Err(ConformanceResultError::SchemaInvalid);
+    }
+    let (whole, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    let mut digits = String::with_capacity(whole.len() + fraction.len());
+    digits.push_str(whole);
+    digits.push_str(fraction);
+    let first_nonzero = digits.find(|character| character != '0');
+    let Some(first_nonzero) = first_nonzero else {
+        return Err(ConformanceResultError::SchemaInvalid);
+    };
+    digits.drain(..first_nonzero);
+
+    let decimal_places =
+        i64::try_from(fraction.len()).map_err(|_| ConformanceResultError::SchemaInvalid)?;
+    let scale = decimal_places - i64::from(exponent);
+    if scale > 0 {
+        let scale = usize::try_from(scale).map_err(|_| ConformanceResultError::SchemaInvalid)?;
+        if scale >= digits.len()
+            || !digits[digits.len() - scale..]
+                .bytes()
+                .all(|byte| byte == b'0')
+        {
+            return Err(ConformanceResultError::SchemaInvalid);
+        }
+        digits.truncate(digits.len() - scale);
+    } else if scale < 0 {
+        let zeros = usize::try_from(-scale).map_err(|_| ConformanceResultError::SchemaInvalid)?;
+        if digits.len().saturating_add(zeros) > MAX_SAFE_INTEGER.to_string().len() {
+            return Err(ConformanceResultError::SchemaInvalid);
+        }
+        digits.extend(std::iter::repeat_n('0', zeros));
+    }
+
+    digits
+        .parse::<u64>()
+        .map_err(|_| ConformanceResultError::SchemaInvalid)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceProtocolArtifactBinding {
+    pub bundle_schema_version: ConformanceVersion,
+    pub source_commit: ConformanceSourceCommit,
+    pub bundle_sha256: Sha256Digest,
+    pub contract_content_sha256: Sha256Digest,
+    pub file_count: ConformanceFileCount,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceRunnerBinding {
+    pub name: ConformanceResultId,
+    pub version: ConformanceVersion,
+    pub artifact_sha256: Sha256Digest,
+    pub vector_set_sha256: Sha256Digest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceEnvironment {
+    pub os: ConformanceEnvironmentFact,
+    pub arch: ConformanceEnvironmentFact,
+    pub runtime: ConformanceEnvironmentFact,
+}
+
+impl ConformanceEnvironment {
+    pub fn new(
+        os: impl Into<String>,
+        arch: impl Into<String>,
+        runtime: impl Into<String>,
+    ) -> Result<Self, ConformanceResultError> {
+        Ok(Self {
+            os: ConformanceEnvironmentFact::new(os)?,
+            arch: ConformanceEnvironmentFact::new(arch)?,
+            runtime: ConformanceEnvironmentFact::new(runtime)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceSuiteResult {
+    pub suite_id: ConformanceSuiteId,
+    pub status: ConformanceStatus,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub evidence_digest: Option<DigestValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceProfileResult {
+    pub profile: ConformanceProfile,
+    pub status: ConformanceStatus,
+    pub required_suites: Vec<ConformanceSuiteId>,
+    pub suite_results: Vec<ConformanceSuiteResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceResultStatement {
+    pub contract_profile: ConformanceContractProfile,
+    pub result_id: ConformanceResultId,
+    pub decision_scope: ConformanceDecisionScope,
+    pub source: ConformanceSourceBinding,
+    pub protocol_artifact: ConformanceProtocolArtifactBinding,
+    pub runner: ConformanceRunnerBinding,
+    pub environment: ConformanceEnvironment,
+    pub observed_at: ConformanceTimestamp,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub expires_at: Option<ConformanceTimestamp>,
+    pub profile_results: Vec<ConformanceProfileResult>,
+    pub overall_status: ConformanceStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConformanceAuthenticationMethod {
+    #[serde(rename = "p256-sha256")]
+    P256Sha256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceAuthentication {
+    pub method: ConformanceAuthenticationMethod,
+    pub key_id: ConformanceKeyId,
+    pub signature: ConformanceSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConformanceResult {
+    pub schema_version: ConformanceResultSchemaVersion,
+    pub statement: ConformanceResultStatement,
+    pub statement_digest: DigestValue,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_non_null_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub authentication: Option<ConformanceAuthentication>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedSourceBinding {
+    repository: ConformanceRepository,
+    commit: ConformanceSourceCommit,
+}
+
+impl ExpectedSourceBinding {
+    pub fn new(
+        repository: impl Into<String>,
+        commit: impl Into<String>,
+    ) -> Result<Self, ConformanceResultError> {
+        Ok(Self {
+            repository: ConformanceRepository::new(repository)?,
+            commit: ConformanceSourceCommit::new(commit)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedProtocolArtifactBinding {
+    bundle_schema_version: ConformanceVersion,
+    source_commit: ConformanceSourceCommit,
+    bundle_sha256: Sha256Digest,
+    contract_content_sha256: Sha256Digest,
+    file_count: ConformanceFileCount,
+}
+
+impl ExpectedProtocolArtifactBinding {
+    pub fn new(
+        bundle_schema_version: impl Into<String>,
+        source_commit: impl Into<String>,
+        bundle_sha256: impl Into<String>,
+        contract_content_sha256: impl Into<String>,
+        file_count: u64,
+    ) -> Result<Self, ConformanceResultError> {
+        Ok(Self {
+            bundle_schema_version: ConformanceVersion::new(bundle_schema_version)?,
+            source_commit: ConformanceSourceCommit::new(source_commit)?,
+            bundle_sha256: Sha256Digest::new(bundle_sha256.into())
+                .map_err(|_| ConformanceResultError::SchemaInvalid)?,
+            contract_content_sha256: Sha256Digest::new(contract_content_sha256.into())
+                .map_err(|_| ConformanceResultError::SchemaInvalid)?,
+            file_count: ConformanceFileCount::new(file_count)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedRunnerBinding {
+    name: ConformanceResultId,
+    version: ConformanceVersion,
+    artifact_sha256: Sha256Digest,
+    vector_set_sha256: Sha256Digest,
+}
+
+impl ExpectedRunnerBinding {
+    pub fn new(
+        name: impl Into<String>,
+        version: impl Into<String>,
+        artifact_sha256: impl Into<String>,
+        vector_set_sha256: impl Into<String>,
+    ) -> Result<Self, ConformanceResultError> {
+        Ok(Self {
+            name: ConformanceResultId::new(name)?,
+            version: ConformanceVersion::new(version)?,
+            artifact_sha256: Sha256Digest::new(artifact_sha256.into())
+                .map_err(|_| ConformanceResultError::SchemaInvalid)?,
+            vector_set_sha256: Sha256Digest::new(vector_set_sha256.into())
+                .map_err(|_| ConformanceResultError::SchemaInvalid)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedArtifactBinding {
+    source: ExpectedSourceBinding,
+    protocol_artifact: ExpectedProtocolArtifactBinding,
+    runner: ExpectedRunnerBinding,
+}
+
+impl ExpectedArtifactBinding {
+    #[must_use]
+    pub const fn new(
+        source: ExpectedSourceBinding,
+        protocol_artifact: ExpectedProtocolArtifactBinding,
+        runner: ExpectedRunnerBinding,
+    ) -> Self {
+        Self {
+            source,
+            protocol_artifact,
+            runner,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedPolicyBinding {
+    policy_id: ConformancePolicyId,
+    policy_version: ConformanceVersion,
+    digest: Sha256Digest,
+}
+
+impl ExpectedPolicyBinding {
+    pub fn new(
+        policy_id: impl Into<String>,
+        policy_version: impl Into<String>,
+        digest: impl Into<String>,
+    ) -> Result<Self, ConformanceResultError> {
+        Ok(Self {
+            policy_id: ConformancePolicyId::new(policy_id)?,
+            policy_version: ConformanceVersion::new(policy_version)?,
+            digest: Sha256Digest::new(digest.into())
+                .map_err(|_| ConformanceResultError::SchemaInvalid)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceProfileRequirement {
+    profile: ConformanceProfile,
+    required_suites: BTreeSet<ConformanceSuiteId>,
+}
+
+impl ConformanceProfileRequirement {
+    pub fn new<I, S>(
+        profile: ConformanceProfile,
+        required_suites: I,
+    ) -> Result<Self, ConformanceResultError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut suites = BTreeSet::new();
+        for suite_id in required_suites {
+            let suite_id = ConformanceSuiteId::new(suite_id)
+                .map_err(|_| ConformanceResultError::TrustPolicyInvalid)?;
+            if !suites.insert(suite_id) || suites.len() > MAX_SUITES_PER_PROFILE {
+                return Err(ConformanceResultError::TrustPolicyInvalid);
+            }
+        }
+        if suites.is_empty() {
+            return Err(ConformanceResultError::TrustPolicyInvalid);
+        }
+        Ok(Self {
+            profile,
+            required_suites: suites,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConformanceTrustPolicy {
+    release_policy: Option<ExpectedPolicyBinding>,
+    required_profiles: BTreeMap<ConformanceProfile, BTreeSet<ConformanceSuiteId>>,
+    allowed_environments: BTreeSet<ConformanceEnvironment>,
+    max_evidence_age: Duration,
+    trusted_keys: BTreeMap<ConformanceKeyId, VerifyingKey>,
+}
+
+impl ConformanceTrustPolicy {
+    pub fn new<I, E>(
+        release_policy: Option<ExpectedPolicyBinding>,
+        required_profiles: I,
+        allowed_environments: E,
+        max_evidence_age: Duration,
+    ) -> Result<Self, ConformanceResultError>
+    where
+        I: IntoIterator<Item = ConformanceProfileRequirement>,
+        E: IntoIterator<Item = ConformanceEnvironment>,
+    {
+        if max_evidence_age <= Duration::zero() || max_evidence_age > MAX_TRUST_POLICY_AGE {
+            return Err(ConformanceResultError::TrustPolicyInvalid);
+        }
+        let mut required = BTreeMap::new();
+        for requirement in required_profiles {
+            if required
+                .insert(requirement.profile, requirement.required_suites)
+                .is_some()
+            {
+                return Err(ConformanceResultError::TrustPolicyInvalid);
+            }
+        }
+        if required.len() > MAX_PROFILE_RESULTS {
+            return Err(ConformanceResultError::TrustPolicyInvalid);
+        }
+        if required.contains_key(&ConformanceProfile::Full)
+            && [
+                ConformanceProfile::Structural,
+                ConformanceProfile::SchedulerReliability,
+                ConformanceProfile::RuntimeAuthority,
+                ConformanceProfile::Continuity,
+                ConformanceProfile::Privacy,
+                ConformanceProfile::Interoperability,
+            ]
+            .iter()
+            .any(|component| !required.contains_key(component))
+        {
+            return Err(ConformanceResultError::TrustPolicyInvalid);
+        }
+
+        let mut environments = BTreeSet::new();
+        for environment in allowed_environments {
+            if !environments.insert(environment) {
+                return Err(ConformanceResultError::TrustPolicyInvalid);
+            }
+        }
+
+        let release_inventory_missing = required.is_empty() || environments.is_empty();
+        let audit_inventory_present = !required.is_empty() || !environments.is_empty();
+        if (release_policy.is_some() && release_inventory_missing)
+            || (release_policy.is_none() && audit_inventory_present)
+        {
+            return Err(ConformanceResultError::TrustPolicyInvalid);
+        }
+
+        Ok(Self {
+            release_policy,
+            required_profiles: required,
+            allowed_environments: environments,
+            max_evidence_age,
+            trusted_keys: BTreeMap::new(),
+        })
+    }
+
+    pub fn trust_key(
+        &mut self,
+        key_id: impl Into<String>,
+        verifying_key: VerifyingKey,
+    ) -> Result<(), ConformanceResultError> {
+        let key_id = ConformanceKeyId::new(key_id)?;
+        if self.trusted_keys.contains_key(&key_id) {
+            return Err(ConformanceResultError::TrustPolicyInvalid);
+        }
+        self.trusted_keys.insert(key_id, verifying_key);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConformanceVerificationClass {
+    AuditOnly,
+    ReleaseEligibility,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedConformanceResult {
+    result: ConformanceResult,
+    classification: ConformanceVerificationClass,
+    authentication_verified: bool,
+}
+
+impl VerifiedConformanceResult {
+    #[must_use]
+    pub const fn classification(&self) -> ConformanceVerificationClass {
+        self.classification
+    }
+
+    #[must_use]
+    pub const fn authentication_verified(&self) -> bool {
+        self.authentication_verified
+    }
+
+    #[must_use]
+    pub const fn result(&self) -> &ConformanceResult {
+        &self.result
+    }
+}
+
+pub fn verify_conformance_result(
+    bytes: &[u8],
+    expected: &ExpectedArtifactBinding,
+    now: DateTime<Utc>,
+    trust_policy: &ConformanceTrustPolicy,
+) -> Result<VerifiedConformanceResult, ConformanceResultError> {
+    let result: ConformanceResult =
+        serde_json::from_slice(bytes).map_err(|_| ConformanceResultError::SchemaInvalid)?;
+    let canonical_statement =
+        canonicalize(&result.statement).map_err(|_| ConformanceResultError::SchemaInvalid)?;
+    if sha256_hex(&canonical_statement) != result.statement_digest.value.as_str() {
+        return Err(ConformanceResultError::StatementDigestMismatch);
+    }
+
+    verify_exact_binding(&result.statement, expected)?;
+    let profile_statuses = validate_profile_semantics(&result.statement)?;
+
+    let (classification, authentication_verified) = match &result.statement.decision_scope {
+        ConformanceDecisionScope::AuditOnly => {
+            let verified = if let Some(authentication) = &result.authentication {
+                verify_authentication(authentication, &canonical_statement, trust_policy)?;
+                true
+            } else {
+                false
+            };
+            (ConformanceVerificationClass::AuditOnly, verified)
+        }
+        ConformanceDecisionScope::ReleaseEligibility { policy_binding } => {
+            let expected_policy = trust_policy
+                .release_policy
+                .as_ref()
+                .ok_or(ConformanceResultError::ReleasePolicyMissing)?;
+            if policy_binding.policy_id != expected_policy.policy_id
+                || policy_binding.policy_version != expected_policy.policy_version
+                || policy_binding.digest != expected_policy.digest
+            {
+                return Err(ConformanceResultError::PolicyBindingMismatch);
+            }
+
+            if !trust_policy
+                .allowed_environments
+                .contains(&result.statement.environment)
+            {
+                return Err(ConformanceResultError::EnvironmentNotAllowed);
+            }
+
+            verify_release_timing(&result.statement, now, trust_policy.max_evidence_age)?;
+            for (required, required_suites) in &trust_policy.required_profiles {
+                let status = profile_statuses
+                    .get(required)
+                    .ok_or(ConformanceResultError::RequiredProfileMissing)?;
+                if *status != ConformanceStatus::Passed {
+                    return Err(ConformanceResultError::RequiredProfileNotPassed);
+                }
+                let profile_result = result
+                    .statement
+                    .profile_results
+                    .iter()
+                    .find(|profile_result| profile_result.profile == *required)
+                    .ok_or(ConformanceResultError::RequiredProfileMissing)?;
+                if profile_result.required_suites.len() != required_suites.len()
+                    || profile_result
+                        .required_suites
+                        .iter()
+                        .any(|suite_id| !required_suites.contains(suite_id))
+                {
+                    return Err(ConformanceResultError::RequiredSuiteSetMismatch);
+                }
+            }
+
+            let authentication = result
+                .authentication
+                .as_ref()
+                .ok_or(ConformanceResultError::AuthenticationRequired)?;
+            verify_authentication(authentication, &canonical_statement, trust_policy)?;
+            (ConformanceVerificationClass::ReleaseEligibility, true)
+        }
+    };
+
+    Ok(VerifiedConformanceResult {
+        result,
+        classification,
+        authentication_verified,
+    })
+}
+
+fn verify_exact_binding(
+    statement: &ConformanceResultStatement,
+    expected: &ExpectedArtifactBinding,
+) -> Result<(), ConformanceResultError> {
+    if statement.source.repository != expected.source.repository {
+        return Err(ConformanceResultError::SourceRepositoryMismatch);
+    }
+    if statement.source.commit != expected.source.commit {
+        return Err(ConformanceResultError::SourceCommitMismatch);
+    }
+    if statement.protocol_artifact.bundle_schema_version
+        != expected.protocol_artifact.bundle_schema_version
+    {
+        return Err(ConformanceResultError::BundleSchemaVersionMismatch);
+    }
+    if statement.protocol_artifact.source_commit != statement.source.commit
+        || statement.protocol_artifact.source_commit != expected.protocol_artifact.source_commit
+    {
+        return Err(ConformanceResultError::BundleSourceCommitMismatch);
+    }
+    if statement.protocol_artifact.bundle_sha256 != expected.protocol_artifact.bundle_sha256 {
+        return Err(ConformanceResultError::BundleDigestMismatch);
+    }
+    if statement.protocol_artifact.contract_content_sha256
+        != expected.protocol_artifact.contract_content_sha256
+    {
+        return Err(ConformanceResultError::ContractContentDigestMismatch);
+    }
+    if statement.protocol_artifact.file_count != expected.protocol_artifact.file_count {
+        return Err(ConformanceResultError::FileCountMismatch);
+    }
+    if statement.runner.name != expected.runner.name {
+        return Err(ConformanceResultError::RunnerNameMismatch);
+    }
+    if statement.runner.version != expected.runner.version {
+        return Err(ConformanceResultError::RunnerVersionMismatch);
+    }
+    if statement.runner.artifact_sha256 != expected.runner.artifact_sha256 {
+        return Err(ConformanceResultError::RunnerArtifactDigestMismatch);
+    }
+    if statement.runner.vector_set_sha256 != expected.runner.vector_set_sha256 {
+        return Err(ConformanceResultError::VectorSetDigestMismatch);
+    }
+    Ok(())
+}
+
+fn validate_profile_semantics(
+    statement: &ConformanceResultStatement,
+) -> Result<BTreeMap<ConformanceProfile, ConformanceStatus>, ConformanceResultError> {
+    if statement.profile_results.is_empty() || statement.profile_results.len() > MAX_PROFILE_RESULTS
+    {
+        return Err(ConformanceResultError::SchemaInvalid);
+    }
+
+    let mut statuses = BTreeMap::new();
+    for profile_result in &statement.profile_results {
+        if statuses
+            .insert(profile_result.profile, profile_result.status)
+            .is_some()
+        {
+            return Err(ConformanceResultError::ProfileDuplicate);
+        }
+        validate_profile_result(profile_result)?;
+    }
+
+    if derive_overall_status(statuses.values().copied()) != statement.overall_status {
+        return Err(ConformanceResultError::OverallStatusInconsistent);
+    }
+
+    if statuses.get(&ConformanceProfile::Full) == Some(&ConformanceStatus::Passed) {
+        for component in [
+            ConformanceProfile::Structural,
+            ConformanceProfile::SchedulerReliability,
+            ConformanceProfile::RuntimeAuthority,
+            ConformanceProfile::Continuity,
+            ConformanceProfile::Privacy,
+            ConformanceProfile::Interoperability,
+        ] {
+            if statuses.get(&component) != Some(&ConformanceStatus::Passed) {
+                return Err(ConformanceResultError::FullProfileIncomplete);
+            }
+        }
+    }
+
+    Ok(statuses)
+}
+
+fn validate_profile_result(
+    profile: &ConformanceProfileResult,
+) -> Result<(), ConformanceResultError> {
+    if profile.required_suites.is_empty()
+        || profile.required_suites.len() > MAX_SUITES_PER_PROFILE
+        || profile.suite_results.len() > MAX_SUITES_PER_PROFILE
+    {
+        return Err(ConformanceResultError::SchemaInvalid);
+    }
+
+    let mut required = BTreeSet::new();
+    for suite_id in &profile.required_suites {
+        if !required.insert(suite_id) {
+            return Err(ConformanceResultError::SuiteDuplicate);
+        }
+    }
+
+    let mut observed = BTreeSet::new();
+    for suite in &profile.suite_results {
+        if !observed.insert(&suite.suite_id) {
+            return Err(ConformanceResultError::SuiteDuplicate);
+        }
+        if suite.status == ConformanceStatus::Passed && suite.evidence_digest.is_none() {
+            return Err(ConformanceResultError::PassedSuiteEvidenceMissing);
+        }
+    }
+    if required != observed {
+        return Err(ConformanceResultError::SuiteSetMismatch);
+    }
+
+    let statuses = profile
+        .suite_results
+        .iter()
+        .map(|suite| suite.status)
+        .collect::<Vec<_>>();
+    let consistent = match profile.status {
+        ConformanceStatus::Passed => statuses
+            .iter()
+            .all(|status| *status == ConformanceStatus::Passed),
+        ConformanceStatus::Failed => statuses.contains(&ConformanceStatus::Failed),
+        ConformanceStatus::Incomplete => {
+            !statuses.contains(&ConformanceStatus::Failed)
+                && statuses
+                    .iter()
+                    .any(|status| *status != ConformanceStatus::Passed)
+                && statuses
+                    .iter()
+                    .any(|status| *status != ConformanceStatus::NotApplicable)
+        }
+        ConformanceStatus::NotApplicable => statuses
+            .iter()
+            .all(|status| *status == ConformanceStatus::NotApplicable),
+    };
+    if !consistent {
+        return Err(ConformanceResultError::ProfileStatusInconsistent);
+    }
+    Ok(())
+}
+
+fn derive_overall_status(
+    statuses: impl IntoIterator<Item = ConformanceStatus>,
+) -> ConformanceStatus {
+    let statuses = statuses.into_iter().collect::<Vec<_>>();
+    if statuses.contains(&ConformanceStatus::Failed) {
+        ConformanceStatus::Failed
+    } else if statuses
+        .iter()
+        .all(|status| *status == ConformanceStatus::Passed)
+    {
+        ConformanceStatus::Passed
+    } else if statuses
+        .iter()
+        .all(|status| *status == ConformanceStatus::NotApplicable)
+    {
+        ConformanceStatus::NotApplicable
+    } else {
+        ConformanceStatus::Incomplete
+    }
+}
+
+fn verify_release_timing(
+    statement: &ConformanceResultStatement,
+    now: DateTime<Utc>,
+    max_age: Duration,
+) -> Result<(), ConformanceResultError> {
+    let observed_at = statement.observed_at.as_datetime()?;
+    let expires_at = statement
+        .expires_at
+        .as_ref()
+        .ok_or(ConformanceResultError::EvidenceExpirationRequired)?
+        .as_datetime()?;
+    if expires_at <= observed_at {
+        return Err(ConformanceResultError::EvidenceChronologyInvalid);
+    }
+    if observed_at > now {
+        return Err(ConformanceResultError::EvidenceNotYetValid);
+    }
+    if now >= expires_at {
+        return Err(ConformanceResultError::EvidenceExpired);
+    }
+    if now.signed_duration_since(observed_at) > max_age {
+        return Err(ConformanceResultError::EvidenceStale);
+    }
+    Ok(())
+}
+
+fn verify_authentication(
+    authentication: &ConformanceAuthentication,
+    canonical_statement: &[u8],
+    trust_policy: &ConformanceTrustPolicy,
+) -> Result<(), ConformanceResultError> {
+    let verifying_key = trust_policy
+        .trusted_keys
+        .get(&authentication.key_id)
+        .ok_or(ConformanceResultError::AuthenticationKeyUntrusted)?;
+    let signature_bytes = URL_SAFE_NO_PAD
+        .decode(authentication.signature.as_str())
+        .map_err(|_| ConformanceResultError::AuthenticationEncodingInvalid)?;
+    if URL_SAFE_NO_PAD.encode(&signature_bytes) != authentication.signature.as_str() {
+        return Err(ConformanceResultError::AuthenticationEncodingInvalid);
+    }
+    let signature = Signature::from_der(&signature_bytes)
+        .map_err(|_| ConformanceResultError::AuthenticationEncodingInvalid)?;
+    if signature.to_der().as_bytes() != signature_bytes {
+        return Err(ConformanceResultError::AuthenticationEncodingInvalid);
+    }
+    verifying_key
+        .verify(canonical_statement, &signature)
+        .map_err(|_| ConformanceResultError::AuthenticationInvalid)
+}

--- a/crates/coven-cli/src/automations/contract/conformance_tests.rs
+++ b/crates/coven-cli/src/automations/contract/conformance_tests.rs
@@ -1,0 +1,1166 @@
+use std::fs;
+use std::path::Path;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use chrono::{DateTime, Duration, Utc};
+use p256::ecdsa::signature::Signer;
+use p256::ecdsa::{Signature, SigningKey};
+use serde_json::{json, Value};
+
+use super::canonical_json::{canonicalize, sha256_hex, MAX_SAFE_INTEGER};
+use super::conformance::{
+    verify_conformance_result, ConformanceEnvironment, ConformanceProfile,
+    ConformanceProfileRequirement, ConformanceResult, ConformanceResultError,
+    ConformanceTrustPolicy, ConformanceVerificationClass, ExpectedArtifactBinding,
+    ExpectedPolicyBinding, ExpectedProtocolArtifactBinding, ExpectedRunnerBinding,
+    ExpectedSourceBinding,
+};
+
+const SOURCE_REPOSITORY: &str = "https://example.invalid/OpenCoven/coven";
+const SOURCE_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
+const BUNDLE_SCHEMA_VERSION: &str = "coven.automations.bundle.v1";
+const BUNDLE_SHA256: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const CONTENT_SHA256: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+const RUNNER_NAME: &str = "fixture-conformance-runner";
+const RUNNER_VERSION: &str = "1.0.0-test";
+const RUNNER_SHA256: &str = "3333333333333333333333333333333333333333333333333333333333333333";
+const VECTOR_SHA256: &str = "4444444444444444444444444444444444444444444444444444444444444444";
+const POLICY_ID: &str = "release-policy";
+const POLICY_VERSION: &str = "2026-09-10";
+const POLICY_DIGEST: &str = "5555555555555555555555555555555555555555555555555555555555555555";
+const KEY_ID: &str = "fixture-release-key";
+
+type MutationCase = (&'static str, fn(&mut Value), ConformanceResultError);
+
+fn now() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-09-10T13:00:00.000Z")
+        .expect("fixed test timestamp")
+        .with_timezone(&Utc)
+}
+
+fn digest(seed: char) -> String {
+    seed.to_string().repeat(64)
+}
+
+fn suite_result(suite_id: &str, seed: char) -> Value {
+    json!({
+        "suiteId": suite_id,
+        "status": "passed",
+        "evidenceDigest": {
+            "algorithm": "sha256",
+            "canonicalization": "jcs-rfc8785",
+            "value": digest(seed)
+        }
+    })
+}
+
+fn passed_profile(profile: &str, suite_id: &str, seed: char) -> Value {
+    json!({
+        "profile": profile,
+        "status": "passed",
+        "requiredSuites": [suite_id],
+        "suiteResults": [suite_result(suite_id, seed)]
+    })
+}
+
+fn base_statement(
+    decision_scope: Value,
+    profile_results: Vec<Value>,
+    overall_status: &str,
+) -> Value {
+    json!({
+        "contractProfile": "coven.automations.v1",
+        "resultId": "fixture-conformance-result",
+        "decisionScope": decision_scope,
+        "source": {
+            "repository": SOURCE_REPOSITORY,
+            "commit": SOURCE_COMMIT
+        },
+        "protocolArtifact": {
+            "bundleSchemaVersion": BUNDLE_SCHEMA_VERSION,
+            "sourceCommit": SOURCE_COMMIT,
+            "bundleSha256": BUNDLE_SHA256,
+            "contractContentSha256": CONTENT_SHA256,
+            "fileCount": 19
+        },
+        "runner": {
+            "name": RUNNER_NAME,
+            "version": RUNNER_VERSION,
+            "artifactSha256": RUNNER_SHA256,
+            "vectorSetSha256": VECTOR_SHA256
+        },
+        "environment": {
+            "os": "linux",
+            "arch": "x86_64",
+            "runtime": "rust-1.89"
+        },
+        "observedAt": "2026-09-10T12:55:00.000Z",
+        "expiresAt": "2026-09-10T13:30:00.000Z",
+        "profileResults": profile_results,
+        "overallStatus": overall_status
+    })
+}
+
+fn audit_result() -> Value {
+    let statement = base_statement(
+        json!({"kind": "audit_only"}),
+        vec![json!({
+            "profile": "structural",
+            "status": "incomplete",
+            "requiredSuites": ["schema-validation"],
+            "suiteResults": [{
+                "suiteId": "schema-validation",
+                "status": "incomplete"
+            }]
+        })],
+        "incomplete",
+    );
+    result_with_statement(statement)
+}
+
+fn release_result() -> Value {
+    let profiles = vec![
+        passed_profile("structural", "schema-validation", 'a'),
+        passed_profile("scheduler_reliability", "scheduler-reliability", 'b'),
+        passed_profile("runtime_authority", "runtime-authority", 'c'),
+        passed_profile("continuity", "continuity", 'd'),
+        passed_profile("privacy", "privacy", 'e'),
+        passed_profile("interoperability", "interoperability", 'f'),
+        passed_profile("full", "full-profile", '6'),
+    ];
+    let statement = base_statement(
+        json!({
+            "kind": "release_eligibility",
+            "policyBinding": {
+                "policyId": POLICY_ID,
+                "policyVersion": POLICY_VERSION,
+                "digest": POLICY_DIGEST
+            }
+        }),
+        profiles,
+        "passed",
+    );
+    result_with_statement(statement)
+}
+
+fn result_with_statement(statement: Value) -> Value {
+    let statement_digest = sha256_hex(&canonicalize(&statement).expect("canonical statement"));
+    json!({
+        "schemaVersion": "coven.automations.conformance-result.v1",
+        "statement": statement,
+        "statementDigest": {
+            "algorithm": "sha256",
+            "canonicalization": "jcs-rfc8785",
+            "value": statement_digest
+        }
+    })
+}
+
+fn refresh_digest(result: &mut Value) {
+    result["statementDigest"]["value"] = json!(sha256_hex(
+        &canonicalize(&result["statement"]).expect("canonical statement")
+    ));
+}
+
+fn signing_key(seed: u8) -> SigningKey {
+    let deterministic_scalar =
+        p256::SecretKey::from_slice(&[seed; 32]).expect("valid deterministic scalar");
+    SigningKey::from(deterministic_scalar)
+}
+
+fn sign_result(result: &mut Value, key_id: &str, key: &SigningKey) {
+    refresh_digest(result);
+    let canonical = canonicalize(&result["statement"]).expect("canonical statement");
+    let signature: Signature = key.sign(&canonical);
+    result["authentication"] = json!({
+        "method": "p256-sha256",
+        "keyId": key_id,
+        "signature": URL_SAFE_NO_PAD.encode(signature.to_der().as_bytes())
+    });
+}
+
+fn expected_binding() -> ExpectedArtifactBinding {
+    expected_binding_with_file_count(19)
+}
+
+fn expected_binding_with_file_count(file_count: u64) -> ExpectedArtifactBinding {
+    ExpectedArtifactBinding::new(
+        ExpectedSourceBinding::new(SOURCE_REPOSITORY, SOURCE_COMMIT)
+            .expect("valid expected source"),
+        ExpectedProtocolArtifactBinding::new(
+            BUNDLE_SCHEMA_VERSION,
+            SOURCE_COMMIT,
+            BUNDLE_SHA256,
+            CONTENT_SHA256,
+            file_count,
+        )
+        .expect("valid expected protocol artifact"),
+        ExpectedRunnerBinding::new(RUNNER_NAME, RUNNER_VERSION, RUNNER_SHA256, VECTOR_SHA256)
+            .expect("valid expected runner"),
+    )
+}
+
+fn expected_policy() -> ExpectedPolicyBinding {
+    ExpectedPolicyBinding::new(POLICY_ID, POLICY_VERSION, POLICY_DIGEST)
+        .expect("valid expected policy")
+}
+
+fn audit_trust_policy() -> ConformanceTrustPolicy {
+    ConformanceTrustPolicy::new(None, [], [], Duration::hours(1)).expect("valid audit trust policy")
+}
+
+fn environment(os: &str, arch: &str, runtime: &str) -> ConformanceEnvironment {
+    ConformanceEnvironment::new(os, arch, runtime).expect("valid conformance environment")
+}
+
+fn fixture_environment() -> ConformanceEnvironment {
+    environment("linux", "x86_64", "rust-1.89")
+}
+
+fn profile_requirement(profile: ConformanceProfile) -> ConformanceProfileRequirement {
+    let suite = match profile {
+        ConformanceProfile::Structural => "schema-validation",
+        ConformanceProfile::SchedulerReliability => "scheduler-reliability",
+        ConformanceProfile::RuntimeAuthority => "runtime-authority",
+        ConformanceProfile::Continuity => "continuity",
+        ConformanceProfile::Privacy => "privacy",
+        ConformanceProfile::Interoperability => "interoperability",
+        ConformanceProfile::Full => "full-profile",
+    };
+    ConformanceProfileRequirement::new(profile, [suite]).expect("valid profile requirement")
+}
+
+fn release_trust_policy(
+    required_profiles: impl IntoIterator<Item = ConformanceProfile>,
+) -> ConformanceTrustPolicy {
+    let mut required_profiles = required_profiles.into_iter().collect::<Vec<_>>();
+    if required_profiles.contains(&ConformanceProfile::Full) {
+        for component in [
+            ConformanceProfile::Structural,
+            ConformanceProfile::SchedulerReliability,
+            ConformanceProfile::RuntimeAuthority,
+            ConformanceProfile::Continuity,
+            ConformanceProfile::Privacy,
+            ConformanceProfile::Interoperability,
+        ] {
+            if !required_profiles.contains(&component) {
+                required_profiles.push(component);
+            }
+        }
+    }
+    let requirements = required_profiles
+        .into_iter()
+        .map(profile_requirement)
+        .collect::<Vec<_>>();
+    let mut policy = ConformanceTrustPolicy::new(
+        Some(expected_policy()),
+        requirements,
+        [fixture_environment()],
+        Duration::hours(1),
+    )
+    .expect("valid release trust policy");
+    policy
+        .trust_key(KEY_ID, signing_key(7).verifying_key().to_owned())
+        .expect("valid trusted key");
+    policy
+}
+
+fn verify(
+    result: &Value,
+    trust_policy: &ConformanceTrustPolicy,
+) -> Result<super::conformance::VerifiedConformanceResult, ConformanceResultError> {
+    verify_conformance_result(
+        &serde_json::to_vec(result).expect("serialize fixture"),
+        &expected_binding(),
+        now(),
+        trust_policy,
+    )
+}
+
+fn bytes_with_file_count_lexeme(result: &Value, lexeme: &str) -> Vec<u8> {
+    let serialized = serde_json::to_string(result).expect("serialize fixture");
+    let file_count = result["statement"]["protocolArtifact"]["fileCount"]
+        .as_u64()
+        .expect("integer fixture fileCount");
+    let replaced = serialized.replacen(
+        &format!("\"fileCount\":{file_count}"),
+        &format!("\"fileCount\":{lexeme}"),
+        1,
+    );
+    assert_ne!(replaced, serialized, "fixture fileCount must be replaced");
+    replaced.into_bytes()
+}
+
+fn remove_profile(result: &mut Value, profile: &str) {
+    result["statement"]["profileResults"]
+        .as_array_mut()
+        .expect("profile results")
+        .retain(|candidate| candidate["profile"] != profile);
+    refresh_digest(result);
+}
+
+fn profile_mut<'a>(result: &'a mut Value, profile: &str) -> &'a mut Value {
+    result["statement"]["profileResults"]
+        .as_array_mut()
+        .expect("profile results")
+        .iter_mut()
+        .find(|candidate| candidate["profile"] == profile)
+        .expect("profile fixture")
+}
+
+#[test]
+fn checked_in_schema_vectors_manifest_and_types_are_listed() {
+    let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../spec/coven-automations/v1");
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(spec_dir.join("conformance-result.schema.json"))
+            .expect("checked-in conformance result schema"),
+    )
+    .expect("schema JSON");
+    let vectors: Value = serde_json::from_str(
+        &fs::read_to_string(spec_dir.join("conformance-result.vectors.json"))
+            .expect("checked-in conformance result vectors"),
+    )
+    .expect("vectors JSON");
+    let manifest: Value = serde_json::from_str(
+        &fs::read_to_string(spec_dir.join("conformance-manifest.json"))
+            .expect("checked-in conformance manifest"),
+    )
+    .expect("manifest JSON");
+    let declarations = fs::read_to_string(spec_dir.join("coven.automations.v1.d.ts"))
+        .expect("TypeScript contract");
+
+    assert_eq!(
+        schema["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    assert_eq!(
+        vectors["schemaVersion"],
+        "coven.automations.conformance-result-vectors.v1"
+    );
+    let case_names = vectors["cases"]
+        .as_array()
+        .expect("conformance result cases")
+        .iter()
+        .map(|case| case["name"].as_str().expect("case name"))
+        .collect::<Vec<_>>();
+    for expected in [
+        "unsigned-audit-incomplete-valid",
+        "statement-digest-tampered-invalid",
+        "all-not-applicable-cannot-pass",
+        "full-pass-missing-component-invalid",
+    ] {
+        assert!(
+            case_names.contains(&expected),
+            "missing vector case: {expected}"
+        );
+    }
+    assert!(manifest["schemas"]
+        .as_array()
+        .expect("schema list")
+        .contains(&json!("conformance-result.schema.json")));
+    assert_eq!(
+        manifest["conformanceResultVectors"],
+        "conformance-result.vectors.json"
+    );
+    for expected in [
+        "export type ConformanceProfile =",
+        "\"scheduler_reliability\"",
+        "\"runtime_authority\"",
+        "export type ConformanceStatus = \"passed\" | \"failed\" | \"incomplete\" | \"not_applicable\";",
+        "export interface ConformanceReleaseEligibilityStatement",
+        "export type ConformanceResultStatement =",
+        "export type ConformanceResult =",
+        "authentication: ConformanceResultAuthentication;",
+        "method: \"p256-sha256\";",
+    ] {
+        assert!(
+            declarations.contains(expected),
+            "missing TypeScript projection: {expected}"
+        );
+    }
+}
+
+#[test]
+fn checked_in_conformance_result_vectors_match_verifier_semantics() {
+    let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../spec/coven-automations/v1");
+    let vectors: Value = serde_json::from_str(
+        &fs::read_to_string(spec_dir.join("conformance-result.vectors.json"))
+            .expect("checked-in conformance result vectors"),
+    )
+    .expect("vectors JSON");
+
+    for case in vectors["cases"].as_array().expect("vector cases") {
+        let name = case["name"].as_str().expect("case name");
+        let object = &case["object"];
+        match case["expectation"].as_str().expect("case expectation") {
+            "accept" => {
+                let verified = verify(object, &audit_trust_policy())
+                    .unwrap_or_else(|error| panic!("{name} must verify: {error}"));
+                assert_eq!(
+                    verified.classification(),
+                    ConformanceVerificationClass::AuditOnly,
+                    "{name}"
+                );
+            }
+            "reject" => {
+                let expected = match case["expectedError"].as_str().expect("expected error") {
+                    "statement_digest_mismatch" => ConformanceResultError::StatementDigestMismatch,
+                    "profile_status_inconsistent" => {
+                        ConformanceResultError::ProfileStatusInconsistent
+                    }
+                    "full_profile_incomplete" => ConformanceResultError::FullProfileIncomplete,
+                    _ => panic!("unknown checked-in expected error for {name}"),
+                };
+                assert_eq!(
+                    verify(object, &audit_trust_policy()).expect_err("invalid vector must fail"),
+                    expected,
+                    "{name}"
+                );
+            }
+            _ => panic!("unknown checked-in expectation for {name}"),
+        }
+    }
+}
+
+#[test]
+fn valid_audit_and_release_fixtures_round_trip_strictly() {
+    let audit = audit_result();
+    let audit_projection: ConformanceResult =
+        serde_json::from_value(audit.clone()).expect("valid audit projection");
+    assert_eq!(
+        serde_json::to_value(audit_projection).expect("serialize audit projection"),
+        audit
+    );
+
+    let mut release = release_result();
+    sign_result(&mut release, KEY_ID, &signing_key(7));
+    let release_projection: ConformanceResult =
+        serde_json::from_value(release.clone()).expect("valid release projection");
+    assert_eq!(
+        serde_json::to_value(release_projection).expect("serialize release projection"),
+        release
+    );
+
+    let mut unknown = audit_result();
+    unknown["statement"]["environment"]["host"] = json!("secret-host");
+    assert!(serde_json::from_value::<ConformanceResult>(unknown).is_err());
+
+    for separator in ["t", " "] {
+        let mut invalid_timestamp = audit_result();
+        invalid_timestamp["statement"]["observedAt"] =
+            json!(format!("2026-09-10{separator}12:55:00.000Z"));
+        refresh_digest(&mut invalid_timestamp);
+        assert!(
+            serde_json::from_value::<ConformanceResult>(invalid_timestamp).is_err(),
+            "timestamp separator {separator:?} must match the published schema"
+        );
+    }
+
+    let long_scheme = "averylongcustomrepositoryscheme://host/repository";
+    ExpectedSourceBinding::new(long_scheme, SOURCE_COMMIT)
+        .expect("schema-valid repository schemes must not gain a Rust-only length limit");
+    let mut long_scheme_result = audit_result();
+    long_scheme_result["statement"]["source"]["repository"] = json!(long_scheme);
+    assert!(serde_json::from_value::<ConformanceResult>(long_scheme_result).is_ok());
+}
+
+#[test]
+fn file_count_accepts_json_schema_integer_forms_and_normalizes_serialization() {
+    for (lexeme, expected) in [
+        ("19.0", 19),
+        ("1.9e1", 19),
+        ("9007199254740991.0", MAX_SAFE_INTEGER),
+    ] {
+        let mut result = audit_result();
+        result["statement"]["protocolArtifact"]["fileCount"] = json!(expected);
+        refresh_digest(&mut result);
+        let bytes = bytes_with_file_count_lexeme(&result, lexeme);
+        let projection: ConformanceResult =
+            serde_json::from_slice(&bytes).expect("mathematically integral fileCount");
+        assert_eq!(
+            serde_json::to_value(projection).expect("serialize conformance result")["statement"]
+                ["protocolArtifact"]["fileCount"],
+            json!(expected),
+            "{lexeme}"
+        );
+        verify_conformance_result(
+            &bytes,
+            &expected_binding_with_file_count(expected),
+            now(),
+            &audit_trust_policy(),
+        )
+        .unwrap_or_else(|error| panic!("{lexeme} must verify: {error}"));
+    }
+}
+
+#[test]
+fn file_count_rejects_fractional_nonpositive_and_unsafe_values() {
+    for lexeme in [
+        "19.5",
+        "19.0000000000000001",
+        "1.90000000000000001e1",
+        "0",
+        "-1",
+        "9007199254740991.0000000000000001",
+        "9007199254740992",
+    ] {
+        let bytes = bytes_with_file_count_lexeme(&audit_result(), lexeme);
+        assert!(
+            serde_json::from_slice::<ConformanceResult>(&bytes).is_err(),
+            "{lexeme}"
+        );
+        assert_eq!(
+            verify_conformance_result(&bytes, &expected_binding(), now(), &audit_trust_policy(),)
+                .expect_err("invalid fileCount must fail"),
+            ConformanceResultError::SchemaInvalid,
+            "{lexeme}"
+        );
+    }
+}
+
+#[test]
+fn statement_digest_tampering_is_rejected() {
+    let mut result = audit_result();
+    result["statement"]["resultId"] = json!("tampered-result");
+    assert_eq!(
+        verify(&result, &audit_trust_policy()).expect_err("tampering must fail"),
+        ConformanceResultError::StatementDigestMismatch
+    );
+}
+
+#[test]
+fn every_exact_source_artifact_and_runner_mismatch_is_rejected() {
+    let cases: Vec<MutationCase> = vec![
+        (
+            "source repository",
+            |value| {
+                value["statement"]["source"]["repository"] =
+                    json!("https://example.invalid/other/repository");
+            },
+            ConformanceResultError::SourceRepositoryMismatch,
+        ),
+        (
+            "source commit",
+            |value| {
+                value["statement"]["source"]["commit"] = json!("f".repeat(40));
+            },
+            ConformanceResultError::SourceCommitMismatch,
+        ),
+        (
+            "bundle schema version",
+            |value| {
+                value["statement"]["protocolArtifact"]["bundleSchemaVersion"] =
+                    json!("coven.automations.bundle.v2");
+            },
+            ConformanceResultError::BundleSchemaVersionMismatch,
+        ),
+        (
+            "bundle source commit",
+            |value| {
+                value["statement"]["protocolArtifact"]["sourceCommit"] = json!("e".repeat(40));
+            },
+            ConformanceResultError::BundleSourceCommitMismatch,
+        ),
+        (
+            "bundle digest",
+            |value| {
+                value["statement"]["protocolArtifact"]["bundleSha256"] = json!("a".repeat(64));
+            },
+            ConformanceResultError::BundleDigestMismatch,
+        ),
+        (
+            "content digest",
+            |value| {
+                value["statement"]["protocolArtifact"]["contractContentSha256"] =
+                    json!("b".repeat(64));
+            },
+            ConformanceResultError::ContractContentDigestMismatch,
+        ),
+        (
+            "file count",
+            |value| {
+                value["statement"]["protocolArtifact"]["fileCount"] = json!(20);
+            },
+            ConformanceResultError::FileCountMismatch,
+        ),
+        (
+            "runner name",
+            |value| {
+                value["statement"]["runner"]["name"] = json!("other-runner");
+            },
+            ConformanceResultError::RunnerNameMismatch,
+        ),
+        (
+            "runner version",
+            |value| {
+                value["statement"]["runner"]["version"] = json!("2.0.0");
+            },
+            ConformanceResultError::RunnerVersionMismatch,
+        ),
+        (
+            "runner artifact digest",
+            |value| {
+                value["statement"]["runner"]["artifactSha256"] = json!("c".repeat(64));
+            },
+            ConformanceResultError::RunnerArtifactDigestMismatch,
+        ),
+        (
+            "vector digest",
+            |value| {
+                value["statement"]["runner"]["vectorSetSha256"] = json!("d".repeat(64));
+            },
+            ConformanceResultError::VectorSetDigestMismatch,
+        ),
+    ];
+
+    for (name, mutate, expected) in cases {
+        let mut result = audit_result();
+        mutate(&mut result);
+        refresh_digest(&mut result);
+        assert_eq!(
+            verify(&result, &audit_trust_policy()).expect_err("mismatch must fail"),
+            expected,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn unsigned_audit_is_accepted_only_as_audit_result() {
+    let policy = release_trust_policy([ConformanceProfile::Full]);
+    let verified = verify(&audit_result(), &policy).expect("unsigned audit is allowed");
+    assert_eq!(
+        verified.classification(),
+        ConformanceVerificationClass::AuditOnly
+    );
+    assert!(!verified.authentication_verified());
+}
+
+#[test]
+fn audit_authentication_is_fail_closed_when_present() {
+    let mut result = audit_result();
+    sign_result(&mut result, "untrusted-audit-key", &signing_key(7));
+    assert_eq!(
+        verify(&result, &release_trust_policy([ConformanceProfile::Full]))
+            .expect_err("present untrusted audit signature must fail"),
+        ConformanceResultError::AuthenticationKeyUntrusted
+    );
+
+    let mut invalid = audit_result();
+    sign_result(&mut invalid, KEY_ID, &signing_key(8));
+    assert_eq!(
+        verify(&invalid, &release_trust_policy([ConformanceProfile::Full]))
+            .expect_err("present invalid audit signature must fail"),
+        ConformanceResultError::AuthenticationInvalid
+    );
+}
+
+#[test]
+fn release_requires_exact_policy_binding() {
+    let mut missing = release_result();
+    missing["statement"]["decisionScope"]
+        .as_object_mut()
+        .expect("decision scope")
+        .remove("policyBinding");
+    refresh_digest(&mut missing);
+    assert_eq!(
+        verify(&missing, &release_trust_policy([ConformanceProfile::Full]))
+            .expect_err("missing policy binding"),
+        ConformanceResultError::SchemaInvalid
+    );
+
+    let mut wrong = release_result();
+    wrong["statement"]["decisionScope"]["policyBinding"]["digest"] = json!("9".repeat(64));
+    refresh_digest(&mut wrong);
+    assert_eq!(
+        verify(&wrong, &release_trust_policy([ConformanceProfile::Full]))
+            .expect_err("wrong policy binding"),
+        ConformanceResultError::PolicyBindingMismatch
+    );
+
+    let mut signed = release_result();
+    sign_result(&mut signed, KEY_ID, &signing_key(7));
+    let policy = audit_trust_policy();
+    assert_eq!(
+        verify(&signed, &policy).expect_err("release policy must be caller supplied"),
+        ConformanceResultError::ReleasePolicyMissing
+    );
+}
+
+#[test]
+fn release_authentication_fails_closed() {
+    let trust = release_trust_policy([ConformanceProfile::Full]);
+
+    assert_eq!(
+        verify(&release_result(), &trust).expect_err("missing authentication"),
+        ConformanceResultError::AuthenticationRequired
+    );
+
+    let mut unknown = release_result();
+    sign_result(&mut unknown, "unknown-key", &signing_key(7));
+    assert_eq!(
+        verify(&unknown, &trust).expect_err("unknown key"),
+        ConformanceResultError::AuthenticationKeyUntrusted
+    );
+
+    let mut invalid = release_result();
+    sign_result(&mut invalid, KEY_ID, &signing_key(8));
+    assert_eq!(
+        verify(&invalid, &trust).expect_err("wrong signing key"),
+        ConformanceResultError::AuthenticationInvalid
+    );
+
+    let mut non_der = release_result();
+    sign_result(&mut non_der, KEY_ID, &signing_key(7));
+    let canonical = canonicalize(&non_der["statement"]).expect("canonical statement");
+    let raw_signature: Signature = signing_key(7).sign(&canonical);
+    non_der["authentication"]["signature"] =
+        json!(URL_SAFE_NO_PAD.encode(raw_signature.to_bytes()));
+    assert_eq!(
+        verify(&non_der, &trust).expect_err("raw signature is not canonical DER"),
+        ConformanceResultError::AuthenticationEncodingInvalid
+    );
+
+    let mut padded = release_result();
+    sign_result(&mut padded, KEY_ID, &signing_key(7));
+    let signature = padded["authentication"]["signature"]
+        .as_str()
+        .expect("signature string");
+    padded["authentication"]["signature"] = json!(format!("{signature}="));
+    assert_eq!(
+        verify(&padded, &trust).expect_err("base64url padding is not canonical"),
+        ConformanceResultError::SchemaInvalid
+    );
+}
+
+#[test]
+fn release_timing_must_be_fresh_current_and_unexpired() {
+    let trust = release_trust_policy([ConformanceProfile::Full]);
+    let mut missing_expiry = release_result();
+    missing_expiry["statement"]
+        .as_object_mut()
+        .expect("statement")
+        .remove("expiresAt");
+    sign_result(&mut missing_expiry, KEY_ID, &signing_key(7));
+    assert_eq!(
+        verify(&missing_expiry, &trust).expect_err("release expiry is required"),
+        ConformanceResultError::EvidenceExpirationRequired
+    );
+
+    let cases = [
+        (
+            "not yet valid",
+            "2026-09-10T13:01:00.000Z",
+            "2026-09-10T14:00:00.000Z",
+            ConformanceResultError::EvidenceNotYetValid,
+        ),
+        (
+            "stale",
+            "2026-09-10T10:00:00.000Z",
+            "2026-09-10T14:00:00.000Z",
+            ConformanceResultError::EvidenceStale,
+        ),
+        (
+            "expired",
+            "2026-09-10T12:55:00.000Z",
+            "2026-09-10T12:59:59.000Z",
+            ConformanceResultError::EvidenceExpired,
+        ),
+        (
+            "invalid chronology",
+            "2026-09-10T12:55:00.000Z",
+            "2026-09-10T12:54:59.000Z",
+            ConformanceResultError::EvidenceChronologyInvalid,
+        ),
+    ];
+
+    for (name, observed_at, expires_at, expected) in cases {
+        let mut result = release_result();
+        result["statement"]["observedAt"] = json!(observed_at);
+        result["statement"]["expiresAt"] = json!(expires_at);
+        sign_result(&mut result, KEY_ID, &signing_key(7));
+        assert_eq!(
+            verify(&result, &trust).expect_err("invalid timing must fail"),
+            expected,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn release_requires_every_trust_policy_profile_to_pass() {
+    let mut missing = release_result();
+    remove_profile(&mut missing, "privacy");
+    remove_profile(&mut missing, "full");
+    sign_result(&mut missing, KEY_ID, &signing_key(7));
+    assert_eq!(
+        verify(
+            &missing,
+            &release_trust_policy([ConformanceProfile::Privacy])
+        )
+        .expect_err("required profile missing"),
+        ConformanceResultError::RequiredProfileMissing
+    );
+
+    let mut incomplete = release_result();
+    let privacy = profile_mut(&mut incomplete, "privacy");
+    privacy["status"] = json!("incomplete");
+    privacy["suiteResults"][0]["status"] = json!("incomplete");
+    privacy["suiteResults"][0]
+        .as_object_mut()
+        .expect("suite result")
+        .remove("evidenceDigest");
+    remove_profile(&mut incomplete, "full");
+    incomplete["statement"]["overallStatus"] = json!("incomplete");
+    sign_result(&mut incomplete, KEY_ID, &signing_key(7));
+    assert_eq!(
+        verify(
+            &incomplete,
+            &release_trust_policy([ConformanceProfile::Privacy])
+        )
+        .expect_err("required profile incomplete"),
+        ConformanceResultError::RequiredProfileNotPassed
+    );
+}
+
+#[test]
+fn release_requires_the_caller_pinned_suite_inventory() {
+    let mut attack = release_result();
+    let full = profile_mut(&mut attack, "full");
+    full["requiredSuites"] = json!(["dummy-pass"]);
+    full["suiteResults"] = json!([suite_result("dummy-pass", '7')]);
+    sign_result(&mut attack, KEY_ID, &signing_key(7));
+
+    assert_eq!(
+        verify(&attack, &release_trust_policy([ConformanceProfile::Full]))
+            .expect_err("producer-selected dummy suite must not satisfy release policy"),
+        ConformanceResultError::RequiredSuiteSetMismatch
+    );
+
+    let mut component_attack = release_result();
+    let structural = profile_mut(&mut component_attack, "structural");
+    structural["requiredSuites"] = json!(["dummy-pass"]);
+    structural["suiteResults"] = json!([suite_result("dummy-pass", '7')]);
+    sign_result(&mut component_attack, KEY_ID, &signing_key(7));
+    assert_eq!(
+        verify(
+            &component_attack,
+            &release_trust_policy([ConformanceProfile::Full])
+        )
+        .expect_err("full policy must pin every component suite inventory"),
+        ConformanceResultError::RequiredSuiteSetMismatch
+    );
+}
+
+#[test]
+fn release_policy_rejects_duplicate_profile_and_suite_requirements() {
+    let structural = profile_requirement(ConformanceProfile::Structural);
+    assert_eq!(
+        ConformanceTrustPolicy::new(
+            Some(expected_policy()),
+            [structural.clone(), structural],
+            [fixture_environment()],
+            Duration::hours(1),
+        )
+        .expect_err("duplicate profile requirements must fail"),
+        ConformanceResultError::TrustPolicyInvalid
+    );
+
+    assert_eq!(
+        ConformanceProfileRequirement::new(
+            ConformanceProfile::Structural,
+            ["schema-validation", "schema-validation"],
+        )
+        .expect_err("duplicate suite requirements must fail"),
+        ConformanceResultError::TrustPolicyInvalid
+    );
+
+    assert_eq!(
+        ConformanceTrustPolicy::new(
+            Some(expected_policy()),
+            [profile_requirement(ConformanceProfile::Full)],
+            [fixture_environment()],
+            Duration::hours(1),
+        )
+        .expect_err("full policy must pin all component profile inventories"),
+        ConformanceResultError::TrustPolicyInvalid
+    );
+}
+
+#[test]
+fn release_policy_requires_a_nonempty_exact_environment_allowlist() {
+    assert_eq!(
+        ConformanceTrustPolicy::new(
+            Some(expected_policy()),
+            [profile_requirement(ConformanceProfile::Full)],
+            [],
+            Duration::hours(1),
+        )
+        .expect_err("release environment allowlist must not be empty"),
+        ConformanceResultError::TrustPolicyInvalid
+    );
+
+    let allowed = fixture_environment();
+    let later_runtime = environment("linux", "x86_64", "rust-1.90");
+    assert!(allowed < later_runtime);
+
+    let error = ConformanceEnvironment::new("linux", "x86_64", "/private/SECRET")
+        .expect_err("environment constructor must validate every fact");
+    assert_eq!(error, ConformanceResultError::SchemaInvalid);
+    assert!(!error.to_string().contains("SECRET"));
+}
+
+#[test]
+fn release_environment_must_exactly_match_the_caller_allowlist() {
+    let mut disallowed = release_result();
+    disallowed["statement"]["environment"]["runtime"] = json!("rust-1.90");
+    sign_result(&mut disallowed, KEY_ID, &signing_key(7));
+    assert_eq!(
+        verify(
+            &disallowed,
+            &release_trust_policy([ConformanceProfile::Full])
+        )
+        .expect_err("signed evidence from a disallowed environment must fail"),
+        ConformanceResultError::EnvironmentNotAllowed
+    );
+
+    let mut allowed = release_result();
+    sign_result(&mut allowed, KEY_ID, &signing_key(7));
+    verify(&allowed, &release_trust_policy([ConformanceProfile::Full]))
+        .expect("exactly allowed environment must verify");
+}
+
+#[test]
+fn audit_only_environment_remains_informational() {
+    let mut result = audit_result();
+    result["statement"]["environment"] = json!({
+        "os": "macos",
+        "arch": "aarch64",
+        "runtime": "rust-1.90"
+    });
+    refresh_digest(&mut result);
+
+    verify(&result, &release_trust_policy([ConformanceProfile::Full]))
+        .expect("release allowlist must not constrain audit-only evidence");
+}
+
+#[test]
+fn profile_suite_semantics_fail_closed() {
+    let cases: Vec<MutationCase> = vec![
+        (
+            "missing required suite result",
+            |value| {
+                profile_mut(value, "structural")["suiteResults"] = json!([]);
+            },
+            ConformanceResultError::SuiteSetMismatch,
+        ),
+        (
+            "passed profile with failed suite",
+            |value| {
+                profile_mut(value, "structural")["suiteResults"][0]["status"] = json!("failed");
+            },
+            ConformanceResultError::ProfileStatusInconsistent,
+        ),
+        (
+            "passed profile with incomplete suite",
+            |value| {
+                let suite = &mut profile_mut(value, "structural")["suiteResults"][0];
+                suite["status"] = json!("incomplete");
+                suite
+                    .as_object_mut()
+                    .expect("suite result")
+                    .remove("evidenceDigest");
+            },
+            ConformanceResultError::ProfileStatusInconsistent,
+        ),
+        (
+            "passed profile with not-applicable suite",
+            |value| {
+                let suite = &mut profile_mut(value, "structural")["suiteResults"][0];
+                suite["status"] = json!("not_applicable");
+                suite
+                    .as_object_mut()
+                    .expect("suite result")
+                    .remove("evidenceDigest");
+            },
+            ConformanceResultError::ProfileStatusInconsistent,
+        ),
+        (
+            "passed suite without evidence",
+            |value| {
+                profile_mut(value, "structural")["suiteResults"][0]
+                    .as_object_mut()
+                    .expect("suite result")
+                    .remove("evidenceDigest");
+            },
+            ConformanceResultError::PassedSuiteEvidenceMissing,
+        ),
+        (
+            "incomplete profile hiding failed suite",
+            |value| {
+                let profile = profile_mut(value, "structural");
+                profile["status"] = json!("incomplete");
+                profile["suiteResults"][0]["status"] = json!("failed");
+                value["statement"]["overallStatus"] = json!("incomplete");
+            },
+            ConformanceResultError::ProfileStatusInconsistent,
+        ),
+        (
+            "failed profile without failed suite",
+            |value| {
+                profile_mut(value, "structural")["status"] = json!("failed");
+                value["statement"]["overallStatus"] = json!("failed");
+            },
+            ConformanceResultError::ProfileStatusInconsistent,
+        ),
+    ];
+
+    for (name, mutate, expected) in cases {
+        let mut result = release_result();
+        mutate(&mut result);
+        refresh_digest(&mut result);
+        assert_eq!(
+            verify(&result, &audit_trust_policy()).expect_err("invalid profile semantics"),
+            expected,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_profiles_and_suites_are_rejected() {
+    let mut duplicate_profile = release_result();
+    let structural = duplicate_profile["statement"]["profileResults"][0].clone();
+    duplicate_profile["statement"]["profileResults"][6] = structural;
+    refresh_digest(&mut duplicate_profile);
+    assert_eq!(
+        verify(&duplicate_profile, &audit_trust_policy()).expect_err("duplicate profile"),
+        ConformanceResultError::ProfileDuplicate
+    );
+
+    let mut duplicate_required = release_result();
+    profile_mut(&mut duplicate_required, "structural")["requiredSuites"] =
+        json!(["schema-validation", "schema-validation"]);
+    refresh_digest(&mut duplicate_required);
+    assert_eq!(
+        verify(&duplicate_required, &audit_trust_policy()).expect_err("duplicate required suite"),
+        ConformanceResultError::SuiteDuplicate
+    );
+
+    let mut duplicate_result = release_result();
+    let profile = profile_mut(&mut duplicate_result, "structural");
+    let suite = profile["suiteResults"][0].clone();
+    profile["suiteResults"]
+        .as_array_mut()
+        .expect("suite results")
+        .push(suite);
+    refresh_digest(&mut duplicate_result);
+    assert_eq!(
+        verify(&duplicate_result, &audit_trust_policy()).expect_err("duplicate suite result"),
+        ConformanceResultError::SuiteDuplicate
+    );
+}
+
+#[test]
+fn overall_and_full_profile_statuses_are_derived_not_claimed() {
+    let mut overall = release_result();
+    overall["statement"]["overallStatus"] = json!("failed");
+    refresh_digest(&mut overall);
+    assert_eq!(
+        verify(&overall, &audit_trust_policy()).expect_err("inconsistent overall status"),
+        ConformanceResultError::OverallStatusInconsistent
+    );
+
+    let mut incomplete_full = release_result();
+    remove_profile(&mut incomplete_full, "privacy");
+    refresh_digest(&mut incomplete_full);
+    assert_eq!(
+        verify(&incomplete_full, &audit_trust_policy())
+            .expect_err("full pass requires every component"),
+        ConformanceResultError::FullProfileIncomplete
+    );
+}
+
+#[test]
+fn exact_signed_release_fixture_verifies_as_release_eligibility() {
+    let mut result = release_result();
+    sign_result(&mut result, KEY_ID, &signing_key(7));
+    let verified = verify(
+        &result,
+        &release_trust_policy([
+            ConformanceProfile::Structural,
+            ConformanceProfile::SchedulerReliability,
+            ConformanceProfile::RuntimeAuthority,
+            ConformanceProfile::Continuity,
+            ConformanceProfile::Privacy,
+            ConformanceProfile::Interoperability,
+            ConformanceProfile::Full,
+        ]),
+    )
+    .expect("exact signed fixture must verify");
+
+    assert_eq!(
+        verified.classification(),
+        ConformanceVerificationClass::ReleaseEligibility
+    );
+    assert!(verified.authentication_verified());
+}
+
+#[test]
+fn verifier_errors_are_static_and_privacy_safe() {
+    let sensitive_marker = "PRIVATE_SECRET_VALUE";
+    let mut invalid_environment = audit_result();
+    invalid_environment["statement"]["environment"]["runtime"] = json!(format!(
+        "/private/{sensitive_marker}\nHOST={sensitive_marker}"
+    ));
+    refresh_digest(&mut invalid_environment);
+    let error = verify(&invalid_environment, &audit_trust_policy())
+        .expect_err("unbounded environment values must fail");
+    assert_eq!(error, ConformanceResultError::SchemaInvalid);
+    assert!(!error.to_string().contains(sensitive_marker));
+    assert!(!error.to_string().contains("/private/"));
+
+    let mut injected_environment = release_result();
+    injected_environment["statement"]["environment"]["runtime"] =
+        json!(format!("runtime-{sensitive_marker}"));
+    sign_result(&mut injected_environment, KEY_ID, &signing_key(7));
+    let error = verify(
+        &injected_environment,
+        &release_trust_policy([ConformanceProfile::Full]),
+    )
+    .expect_err("untrusted injected environment must fail");
+    assert_eq!(error, ConformanceResultError::EnvironmentNotAllowed);
+    assert!(!error.to_string().contains(sensitive_marker));
+    assert!(!error.to_string().contains("runtime-"));
+
+    let mut injected_suite = release_result();
+    let profile = profile_mut(&mut injected_suite, "full");
+    profile["requiredSuites"] = json!([format!("suite-{sensitive_marker}")]);
+    profile["suiteResults"][0]["suiteId"] = json!(format!("suite-{sensitive_marker}"));
+    sign_result(&mut injected_suite, KEY_ID, &signing_key(7));
+    let error = verify(
+        &injected_suite,
+        &release_trust_policy([ConformanceProfile::Full]),
+    )
+    .expect_err("untrusted injected suite must fail");
+    assert_eq!(error, ConformanceResultError::RequiredSuiteSetMismatch);
+    assert!(!error.to_string().contains(sensitive_marker));
+    assert!(!error.to_string().contains("suite-"));
+
+    let mut injected_key = release_result();
+    injected_key["statement"]["resultId"] = json!(format!("result-{sensitive_marker}"));
+    sign_result(
+        &mut injected_key,
+        &format!("key-{sensitive_marker}"),
+        &signing_key(7),
+    );
+    let error = verify(
+        &injected_key,
+        &release_trust_policy([ConformanceProfile::Full]),
+    )
+    .expect_err("untrusted injected key must fail");
+    assert_eq!(error, ConformanceResultError::AuthenticationKeyUntrusted);
+    assert!(!error.to_string().contains(sensitive_marker));
+    assert!(!error.to_string().contains("key-"));
+}

--- a/crates/coven-cli/src/automations/contract/conformance_tests.rs
+++ b/crates/coven-cli/src/automations/contract/conformance_tests.rs
@@ -14,7 +14,7 @@ use super::conformance::{
     ConformanceProfileRequirement, ConformanceResult, ConformanceResultError,
     ConformanceTrustPolicy, ConformanceVerificationClass, ExpectedArtifactBinding,
     ExpectedPolicyBinding, ExpectedProtocolArtifactBinding, ExpectedRunnerBinding,
-    ExpectedSourceBinding,
+    ExpectedSourceBinding, ExpectedSubjectArtifactBinding,
 };
 
 const SOURCE_REPOSITORY: &str = "https://example.invalid/OpenCoven/coven";
@@ -26,6 +26,10 @@ const RUNNER_NAME: &str = "fixture-conformance-runner";
 const RUNNER_VERSION: &str = "1.0.0-test";
 const RUNNER_SHA256: &str = "3333333333333333333333333333333333333333333333333333333333333333";
 const VECTOR_SHA256: &str = "4444444444444444444444444444444444444444444444444444444444444444";
+const SUBJECT_ARTIFACT_ID: &str = "coven-cli-macos-aarch64";
+const SUBJECT_ARTIFACT_VERSION: &str = "0.0.0-test";
+const SUBJECT_ARTIFACT_SHA256: &str =
+    "6666666666666666666666666666666666666666666666666666666666666666";
 const POLICY_ID: &str = "release-policy";
 const POLICY_VERSION: &str = "2026-09-10";
 const POLICY_DIGEST: &str = "5555555555555555555555555555555555555555555555555555555555555555";
@@ -89,6 +93,15 @@ fn base_statement(
             "version": RUNNER_VERSION,
             "artifactSha256": RUNNER_SHA256,
             "vectorSetSha256": VECTOR_SHA256
+        },
+        "subjectArtifact": {
+            "artifactId": SUBJECT_ARTIFACT_ID,
+            "artifactVersion": SUBJECT_ARTIFACT_VERSION,
+            "platform": {
+                "os": "macos",
+                "arch": "aarch64"
+            },
+            "sha256": SUBJECT_ARTIFACT_SHA256
         },
         "environment": {
             "os": "linux",
@@ -198,6 +211,14 @@ fn expected_binding_with_file_count(file_count: u64) -> ExpectedArtifactBinding 
         .expect("valid expected protocol artifact"),
         ExpectedRunnerBinding::new(RUNNER_NAME, RUNNER_VERSION, RUNNER_SHA256, VECTOR_SHA256)
             .expect("valid expected runner"),
+        ExpectedSubjectArtifactBinding::new(
+            SUBJECT_ARTIFACT_ID,
+            SUBJECT_ARTIFACT_VERSION,
+            "macos",
+            "aarch64",
+            SUBJECT_ARTIFACT_SHA256,
+        )
+        .expect("valid expected subject artifact"),
     )
 }
 
@@ -355,6 +376,16 @@ fn checked_in_schema_vectors_manifest_and_types_are_listed() {
             "missing vector case: {expected}"
         );
     }
+    for case in vectors["cases"]
+        .as_array()
+        .expect("conformance result cases")
+    {
+        assert!(
+            case["object"]["statement"]["subjectArtifact"].is_object(),
+            "vector case must bind the tested subject artifact: {}",
+            case["name"]
+        );
+    }
     assert!(manifest["schemas"]
         .as_array()
         .expect("schema list")
@@ -371,6 +402,10 @@ fn checked_in_schema_vectors_manifest_and_types_are_listed() {
         "export interface ConformanceReleaseEligibilityStatement",
         "export type ConformanceResultStatement =",
         "export type ConformanceResult =",
+        "export interface ConformanceSubjectArtifactBinding",
+        "subjectArtifact: ConformanceSubjectArtifactBinding;",
+        "status: \"passed\";",
+        "evidenceDigest: Digest;",
         "authentication: ConformanceResultAuthentication;",
         "method: \"p256-sha256\";",
     ] {
@@ -611,6 +646,13 @@ fn every_exact_source_artifact_and_runner_mismatch_is_rejected() {
                 value["statement"]["runner"]["vectorSetSha256"] = json!("d".repeat(64));
             },
             ConformanceResultError::VectorSetDigestMismatch,
+        ),
+        (
+            "subject artifact digest",
+            |value| {
+                value["statement"]["subjectArtifact"]["sha256"] = json!("7".repeat(64));
+            },
+            ConformanceResultError::SubjectArtifactMismatch,
         ),
     ];
 

--- a/crates/coven-cli/src/automations/contract/conformance_tests.rs
+++ b/crates/coven-cli/src/automations/contract/conformance_tests.rs
@@ -10,8 +10,8 @@ use serde_json::{json, Value};
 
 use super::canonical_json::{canonicalize, sha256_hex, MAX_SAFE_INTEGER};
 use super::conformance::{
-    verify_conformance_result, ConformanceEnvironment, ConformanceProfile,
-    ConformanceProfileRequirement, ConformanceResult, ConformanceResultError,
+    verify_conformance_result, ConformanceDecisionScope, ConformanceEnvironment,
+    ConformanceProfile, ConformanceProfileRequirement, ConformanceResult, ConformanceResultError,
     ConformanceTrustPolicy, ConformanceVerificationClass, ExpectedArtifactBinding,
     ExpectedPolicyBinding, ExpectedProtocolArtifactBinding, ExpectedRunnerBinding,
     ExpectedSourceBinding, ExpectedSubjectArtifactBinding,
@@ -417,6 +417,94 @@ fn checked_in_schema_vectors_manifest_and_types_are_listed() {
 }
 
 #[test]
+fn checked_in_vectors_match_the_published_json_schema() {
+    let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../spec/coven-automations/v1");
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(spec_dir.join("conformance-result.schema.json"))
+            .expect("checked-in conformance result schema"),
+    )
+    .expect("schema JSON");
+    let common_schema: Value = serde_json::from_str(
+        &fs::read_to_string(spec_dir.join("common.schema.json")).expect("checked-in common schema"),
+    )
+    .expect("common schema JSON");
+    let vectors: Value = serde_json::from_str(
+        &fs::read_to_string(spec_dir.join("conformance-result.vectors.json"))
+            .expect("checked-in conformance result vectors"),
+    )
+    .expect("vectors JSON");
+
+    assert!(
+        jsonschema::draft202012::meta::is_valid(&schema),
+        "conformance-result schema must be valid Draft 2020-12"
+    );
+    let common_schema_id = common_schema["$id"]
+        .as_str()
+        .expect("common schema $id")
+        .to_owned();
+    let registry = jsonschema::Registry::new()
+        .add(common_schema_id, common_schema)
+        .expect("register common schema")
+        .prepare()
+        .expect("prepare schema registry");
+    let validator = jsonschema::draft202012::options()
+        .with_registry(&registry)
+        .offline()
+        .build(&schema)
+        .expect("compile conformance-result schema");
+
+    for case in vectors["cases"].as_array().expect("vector cases") {
+        assert!(
+            validator.is_valid(&case["object"]),
+            "checked-in vector must satisfy the structural schema even when it is a semantic negative case: {}",
+            case["name"]
+        );
+    }
+
+    let mut valid_release = release_result();
+    sign_result(&mut valid_release, KEY_ID, &signing_key(7));
+    assert!(validator.is_valid(&valid_release));
+
+    let mut invalid_cases = Vec::new();
+
+    let mut missing_authentication = valid_release.clone();
+    missing_authentication
+        .as_object_mut()
+        .expect("result object")
+        .remove("authentication");
+    invalid_cases.push(("release authentication", missing_authentication));
+
+    let mut missing_expiry = valid_release.clone();
+    missing_expiry["statement"]
+        .as_object_mut()
+        .expect("statement object")
+        .remove("expiresAt");
+    invalid_cases.push(("release expiry", missing_expiry));
+
+    let mut unknown_member = valid_release.clone();
+    unknown_member["statement"]["unexpected"] = json!(true);
+    invalid_cases.push(("closed statement shape", unknown_member));
+
+    let mut fractional_file_count = valid_release.clone();
+    fractional_file_count["statement"]["protocolArtifact"]["fileCount"] = json!(19.5);
+    invalid_cases.push(("integral file count", fractional_file_count));
+
+    let mut missing_passed_evidence = valid_release;
+    profile_mut(&mut missing_passed_evidence, "full")["suiteResults"][0]
+        .as_object_mut()
+        .expect("suite result object")
+        .remove("evidenceDigest");
+    invalid_cases.push(("passed-suite evidence", missing_passed_evidence));
+
+    for (name, invalid) in invalid_cases {
+        assert!(
+            !validator.is_valid(&invalid),
+            "schema must reject invalid {name}"
+        );
+    }
+}
+
+#[test]
 fn checked_in_conformance_result_vectors_match_verifier_semantics() {
     let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../spec/coven-automations/v1");
     let vectors: Value = serde_json::from_str(
@@ -455,6 +543,54 @@ fn checked_in_conformance_result_vectors_match_verifier_semantics() {
             }
             _ => panic!("unknown checked-in expectation for {name}"),
         }
+    }
+}
+
+#[test]
+fn duplicate_json_members_are_rejected_as_schema_invalid() {
+    let encoded = serde_json::to_string(&audit_result()).expect("serialize audit fixture");
+    let cases = [
+        (
+            "top-level member",
+            encoded.replacen(
+                r#""schemaVersion":"coven.automations.conformance-result.v1""#,
+                r#""schemaVersion":"coven.automations.conformance-result.v1","schemaVersion":"coven.automations.conformance-result.v1""#,
+                1,
+            ),
+        ),
+        (
+            "escaped top-level member",
+            encoded.replacen(
+                r#""schemaVersion":"coven.automations.conformance-result.v1""#,
+                r#""schemaVersion":"coven.automations.conformance-result.v1","\u0073chemaVersion":"coven.automations.conformance-result.v1""#,
+                1,
+            ),
+        ),
+        (
+            "nested member",
+            encoded.replacen(
+                r#""resultId":"fixture-conformance-result""#,
+                r#""resultId":"fixture-conformance-result","resultId":"fixture-conformance-result""#,
+                1,
+            ),
+        ),
+    ];
+
+    for (name, bytes) in cases {
+        assert_ne!(
+            bytes, encoded,
+            "duplicate fixture replacement failed: {name}"
+        );
+        assert_eq!(
+            verify_conformance_result(
+                bytes.as_bytes(),
+                &expected_binding(),
+                now(),
+                &audit_trust_policy(),
+            ),
+            Err(ConformanceResultError::SchemaInvalid),
+            "{name}"
+        );
     }
 }
 
@@ -1147,6 +1283,14 @@ fn exact_signed_release_fixture_verifies_as_release_eligibility() {
         ConformanceVerificationClass::ReleaseEligibility
     );
     assert!(verified.authentication_verified());
+    let ConformanceDecisionScope::ReleaseEligibility { policy_binding } =
+        &verified.result().statement.decision_scope
+    else {
+        panic!("verified release result must expose its policy binding");
+    };
+    assert_eq!(policy_binding.policy_id.as_str(), POLICY_ID);
+    assert_eq!(policy_binding.policy_version.as_str(), POLICY_VERSION);
+    assert_eq!(policy_binding.digest.as_str(), POLICY_DIGEST);
 }
 
 #[test]

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -3,6 +3,10 @@
 // The protocol surface lands before the command router that consumes it.
 #[allow(dead_code)]
 pub mod canonical_json;
+// Conformance results are verified here; no runner or production trust root is
+// supplied by this contract slice.
+#[allow(dead_code)]
+pub mod conformance;
 // The separately advertised authority companion remains a projection and
 // validation seam until dispatch adapters land.
 #[allow(dead_code)]
@@ -31,6 +35,14 @@ pub use authority::{
 #[allow(unused_imports)]
 pub use canonical_json::{canonicalize, canonicalize_without_integrity, sha256_digest, sha256_hex};
 #[allow(unused_imports)]
+pub use conformance::{
+    verify_conformance_result, ConformanceEnvironment, ConformanceProfile,
+    ConformanceProfileRequirement, ConformanceResult, ConformanceResultError,
+    ConformanceTrustPolicy, ConformanceVerificationClass, ExpectedArtifactBinding,
+    ExpectedPolicyBinding, ExpectedProtocolArtifactBinding, ExpectedRunnerBinding,
+    ExpectedSourceBinding, VerifiedConformanceResult,
+};
+#[allow(unused_imports)]
 pub use error::{ErrorCode, ErrorEnvelope};
 #[allow(unused_imports)]
 pub use types::{
@@ -40,6 +52,9 @@ pub use types::{
 
 #[cfg(test)]
 mod authority_tests;
+
+#[cfg(test)]
+mod conformance_tests;
 
 #[cfg(test)]
 mod tests {
@@ -127,6 +142,7 @@ mod tests {
             "command-envelope.schema.json",
             "error-envelope.schema.json",
             "event-envelope.schema.json",
+            "conformance-result.schema.json",
         ] {
             let path = format!("../../../../../spec/coven-automations/v1/{artifact}");
             let schema: Value = match artifact {
@@ -156,6 +172,9 @@ mod tests {
                 )),
                 "event-envelope.schema.json" => serde_json::from_str(include_str!(
                     "../../../../../spec/coven-automations/v1/event-envelope.schema.json"
+                )),
+                "conformance-result.schema.json" => serde_json::from_str(include_str!(
+                    "../../../../../spec/coven-automations/v1/conformance-result.schema.json"
                 )),
                 _ => unreachable!("artifact list is closed"),
             }

--- a/crates/coven-cli/src/automations/contract/mod.rs
+++ b/crates/coven-cli/src/automations/contract/mod.rs
@@ -40,7 +40,7 @@ pub use conformance::{
     ConformanceProfileRequirement, ConformanceResult, ConformanceResultError,
     ConformanceTrustPolicy, ConformanceVerificationClass, ExpectedArtifactBinding,
     ExpectedPolicyBinding, ExpectedProtocolArtifactBinding, ExpectedRunnerBinding,
-    ExpectedSourceBinding, VerifiedConformanceResult,
+    ExpectedSourceBinding, ExpectedSubjectArtifactBinding, VerifiedConformanceResult,
 };
 #[allow(unused_imports)]
 pub use error::{ErrorCode, ErrorEnvelope};

--- a/scripts/package-automations-protocol.test.mjs
+++ b/scripts/package-automations-protocol.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
+  cpSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -277,6 +278,58 @@ test('reproduces the immutable historical base-v1 artifact byte for byte', () =>
     bundleSha256: '512460db71d4257d7a4d33ea306578e66d9ac499d9384eb9c2b8e2b4e2e32363',
     contractContentSha256: '3c145eb92a93426ed64631f6487a8cd12903b0a49a6e752269f594ac50a779f5',
     fileCount: 17
+  });
+});
+
+test('current protocol bundle includes the conformance-result contract artifacts', () => {
+  withScratchDir('automation-protocol-conformance-result', (scratchDir) => {
+    const repoRoot = path.join(scratchDir, 'repo');
+    const sourceSpecDir = path.join(
+      repositoryRoot,
+      'spec',
+      'coven-automations',
+      'v1'
+    );
+    const specDir = path.join(repoRoot, 'spec', 'coven-automations', 'v1');
+    mkdirSync(path.dirname(specDir), { recursive: true });
+    cpSync(sourceSpecDir, specDir, { recursive: true });
+    runGit(repoRoot, ['init']);
+    runGit(repoRoot, ['config', 'user.name', 'Protocol Test']);
+    runGit(repoRoot, ['config', 'user.email', 'protocol@example.invalid']);
+    runGit(repoRoot, ['config', 'commit.gpgSign', 'false']);
+    runGit(repoRoot, ['add', '.']);
+    runGit(repoRoot, ['commit', '-m', 'test: seed current protocol']);
+    const sourceCommit = runGit(repoRoot, ['rev-parse', 'HEAD']);
+
+    const packaged = packageAutomationsProtocol({
+      repoRoot,
+      outputDir: path.join(scratchDir, 'out'),
+      sourceCommit
+    });
+    const entries = parseTarGz(readFileSync(packaged.bundlePath));
+    const entryNames = entries.map((entry) => entry.name);
+    assert.ok(
+      entryNames.includes('coven-automations-v1/conformance-result.schema.json')
+    );
+    assert.ok(
+      entryNames.includes('coven-automations-v1/conformance-result.vectors.json')
+    );
+
+    const contractManifest = JSON.parse(
+      readFileSync(path.join(specDir, 'conformance-manifest.json'), 'utf8')
+    );
+    assert.ok(contractManifest.schemas.includes('conformance-result.schema.json'));
+    assert.equal(
+      contractManifest.conformanceResultVectors,
+      'conformance-result.vectors.json'
+    );
+
+    const bundleManifest = JSON.parse(
+      entries.find((entry) => entry.name === 'manifest.json').data.toString('utf8')
+    );
+    const bundledPaths = bundleManifest.files.map((file) => file.path);
+    assert.ok(bundledPaths.includes('conformance-result.schema.json'));
+    assert.ok(bundledPaths.includes('conformance-result.vectors.json'));
   });
 });
 

--- a/spec/coven-automations/v1/README.md
+++ b/spec/coven-automations/v1/README.md
@@ -64,16 +64,18 @@ Required test suites and canary requirements (Coven, SDK, Cave — each against 
 `conformance-result.schema.json` and `conformance-result.vectors.json` define the
 portable envelope accepted by the Rust verifier. The verifier always checks the
 JCS statement digest and exact source, protocol artifact, runner artifact, and
-vector-set bindings. An `audit_only` result remains audit-only even when it has
-a valid trusted signature. A `release_eligibility` result additionally requires
-the caller's exact policy binding, a caller-pinned suite inventory for every
-required passed profile, an exact match to one caller-allowed environment,
-bounded freshness, expiry, and a valid P-256 signature from a caller-supplied
-trusted key. The result's own `requiredSuites` values are evidence to compare
-against that policy; they are never a release trust root and are not derived
-from ambient source files. A policy requiring the `full` profile must also pin
-the exact suite inventory for all six component profiles; a producer cannot
-hide dummy component suites behind a passed `full` status.
+vector-set bindings, plus the exact implementation package, binary, archive, or
+image exercised by the suites. An `audit_only` result remains audit-only even
+when it has a valid trusted signature. A `release_eligibility` result
+additionally requires the caller's exact subject-artifact and policy bindings,
+a caller-pinned suite inventory for every required passed profile, an exact
+match to one caller-allowed environment, bounded freshness, expiry, and a valid
+P-256 signature from a caller-supplied trusted key. The result's own
+`requiredSuites` values are evidence to compare against that policy; they are
+never a release trust root and are not derived from ambient source files. A
+policy requiring the `full` profile must also pin the exact suite inventory for
+all six component profiles; a producer cannot hide dummy component suites
+behind a passed `full` status.
 
 This slice defines and verifies result envelopes only. It does **not** execute
 the vectors, certify the daemon or npm packages, provide a production signer or

--- a/spec/coven-automations/v1/README.md
+++ b/spec/coven-automations/v1/README.md
@@ -19,9 +19,11 @@ Cave, the SDK, Psyche adapters, runtimes, and future implementations consume the
 | `command-envelope.schema.json` | Every command (create, revise, activate, pause, disable, tombstone, run now, cancel, retry/recover, list/get/history/health, events read/subscribe, legacy import) + response envelope with adoption-key semantics. |
 | `error-envelope.schema.json` | Typed error codes and the frozen HTTP/control-action status mapping. |
 | `event-envelope.schema.json` | Changefeed envelope: streams, gapless sequences, event ids, causation, compaction snapshots. |
+| `conformance-result.schema.json` | Portable conformance-result envelope with a separately signed statement, exact source/protocol/runner binding, audit-only versus release-eligibility scope, per-profile suite results, freshness, and optional P-256 authentication. |
 | `state-machines.json` | Authoritative lifecycle state machines (definition, occurrence, run, attempt) plus the ten normative invariants. |
 | `compatibility-matrix.json` | Machine-readable change classes, per-field status, and explicit incompatible-profile refusal rules. |
 | `test-vectors.json` | Golden vectors: valid, invalid, unknown-field, downgrade/upgrade, unknown-variant, adoption replay/conflict, revision conflict, duplicate/out-of-order event replay — with pinned RFC 8785 digests. |
+| `conformance-result.vectors.json` | Synthetic valid and invalid result-envelope vectors. These are contract tests, not evidence that any implementation or profile passes. |
 | `coven.automations.v1.d.ts` | Pinned TypeScript projection of the schemas for SDK/Cave canaries. |
 
 ## Compatibility rules
@@ -58,6 +60,31 @@ Cave, the SDK, Psyche adapters, runtimes, and future implementations consume the
 ## Conformance
 
 Required test suites and canary requirements (Coven, SDK, Cave — each against packed/released artifacts, not source-relative imports) are listed in `conformance-manifest.json`. Golden vectors are self-contained: any draft 2020-12 validator plus the digest recipe in `test-vectors.json` suffices to run them outside the Coven crate.
+
+`conformance-result.schema.json` and `conformance-result.vectors.json` define the
+portable envelope accepted by the Rust verifier. The verifier always checks the
+JCS statement digest and exact source, protocol artifact, runner artifact, and
+vector-set bindings. An `audit_only` result remains audit-only even when it has
+a valid trusted signature. A `release_eligibility` result additionally requires
+the caller's exact policy binding, a caller-pinned suite inventory for every
+required passed profile, an exact match to one caller-allowed environment,
+bounded freshness, expiry, and a valid P-256 signature from a caller-supplied
+trusted key. The result's own `requiredSuites` values are evidence to compare
+against that policy; they are never a release trust root and are not derived
+from ambient source files. A policy requiring the `full` profile must also pin
+the exact suite inventory for all six component profiles; a producer cannot
+hide dummy component suites behind a passed `full` status.
+
+This slice defines and verifies result envelopes only. It does **not** execute
+the vectors, certify the daemon or npm packages, provide a production signer or
+trust root, or claim that any profile currently passes. JSON Schema proves only
+the closed structural shape; it does not prove signatures, digests, suite
+execution, profile semantics, caller-pinned release inventories, environment
+eligibility, freshness, or artifact equality. `fileCount` follows JSON Schema
+integer semantics, so mathematically integral forms such as `19.0` and `1.9e1`
+are accepted and normalized to `19`, while fractional, nonpositive, and
+non-JCS-safe values are rejected. Runtime Authority and full v1 certification
+remain blocked on #857's upstream signed runtime-terminal-evidence producer.
 
 ## Immutable bundle
 

--- a/spec/coven-automations/v1/conformance-manifest.json
+++ b/spec/coven-automations/v1/conformance-manifest.json
@@ -10,7 +10,8 @@
     "CommandEnvelope",
     "CommandResponse",
     "ErrorEnvelope",
-    "EventEnvelope"
+    "EventEnvelope",
+    "ConformanceResult"
   ],
   "schemas": [
     "common.schema.json",
@@ -21,11 +22,13 @@
     "automation-receipt.schema.json",
     "command-envelope.schema.json",
     "error-envelope.schema.json",
-    "event-envelope.schema.json"
+    "event-envelope.schema.json",
+    "conformance-result.schema.json"
   ],
   "stateMachines": "state-machines.json",
   "compatibilityMatrix": "compatibility-matrix.json",
   "goldenVectors": "test-vectors.json",
+  "conformanceResultVectors": "conformance-result.vectors.json",
   "requiredSuites": [
     "schema-validation",
     "rust-round-trip",
@@ -36,7 +39,8 @@
     "typed-transport-domain-error-mapping",
     "timezone-dst-and-clock-replanning",
     "golden-vectors-external-runners",
-    "packed-artifact-canaries"
+    "packed-artifact-canaries",
+    "conformance-result-envelope-verification"
   ],
   "releaseState": "proposed",
   "productionReady": false,

--- a/spec/coven-automations/v1/conformance-result.schema.json
+++ b/spec/coven-automations/v1/conformance-result.schema.json
@@ -254,6 +254,47 @@
         }
       }
     },
+    "artifactPlatform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "os",
+        "arch"
+      ],
+      "properties": {
+        "os": {
+          "$ref": "#/$defs/environmentFact"
+        },
+        "arch": {
+          "$ref": "#/$defs/environmentFact"
+        }
+      }
+    },
+    "subjectArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifactId",
+        "artifactVersion",
+        "platform",
+        "sha256"
+      ],
+      "properties": {
+        "artifactId": {
+          "$ref": "#/$defs/resultId"
+        },
+        "artifactVersion": {
+          "$ref": "#/$defs/version"
+        },
+        "platform": {
+          "$ref": "#/$defs/artifactPlatform"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      },
+      "description": "Exact implementation package, binary, archive, or image exercised by the suites. This is distinct from the protocol bundle and conformance runner artifacts."
+    },
     "environment": {
       "type": "object",
       "additionalProperties": false,
@@ -357,6 +398,7 @@
         "source",
         "protocolArtifact",
         "runner",
+        "subjectArtifact",
         "environment",
         "observedAt",
         "profileResults",
@@ -380,6 +422,9 @@
         },
         "runner": {
           "$ref": "#/$defs/runner"
+        },
+        "subjectArtifact": {
+          "$ref": "#/$defs/subjectArtifact"
         },
         "environment": {
           "$ref": "#/$defs/environment",

--- a/spec/coven-automations/v1/conformance-result.schema.json
+++ b/spec/coven-automations/v1/conformance-result.schema.json
@@ -1,0 +1,432 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencoven.ai/spec/coven-automations/v1/conformance-result.schema.json",
+  "title": "Coven Automations v1 conformance result",
+  "description": "Portable result envelope for externally produced Coven Automations v1 conformance observations. The signed statement is separated from envelope authentication so signatures cover only the RFC 8785 statement bytes. Structural validation does not prove statement digests, signatures, profile semantics, suite execution, artifact equality, freshness, caller-pinned suite inventories, allowed environments, or release eligibility; those are verifier responsibilities.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "statement",
+    "statementDigest"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "coven.automations.conformance-result.v1"
+    },
+    "statement": {
+      "$ref": "#/$defs/statement"
+    },
+    "statementDigest": {
+      "$ref": "common.schema.json#/$defs/digest",
+      "description": "SHA-256 over the RFC 8785 (JCS) canonical serialization of statement only."
+    },
+    "authentication": {
+      "$ref": "#/$defs/authentication"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "statement": {
+            "properties": {
+              "decisionScope": {
+                "properties": {
+                  "kind": {
+                    "const": "release_eligibility"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              }
+            },
+            "required": [
+              "decisionScope"
+            ]
+          }
+        },
+        "required": [
+          "statement"
+        ]
+      },
+      "then": {
+        "required": [
+          "authentication"
+        ],
+        "properties": {
+          "statement": {
+            "required": [
+              "expiresAt"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "resultId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+    },
+    "boundedIdentifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 96,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._+:-]*$"
+    },
+    "sourceCommit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "repository": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 512,
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*://[A-Za-z0-9!#$%&'()*+,./:;=?@_~-]+$",
+      "description": "Exact canonical source repository URI. Consumers compare the complete value and never include it in refusal text."
+    },
+    "environmentFact": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._+:-]*$",
+      "description": "Bounded platform/runtime identifier only. Paths, hostnames, command lines, and environment-variable dumps are outside this shape."
+    },
+    "suiteId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@-]*$"
+    },
+    "profile": {
+      "enum": [
+        "structural",
+        "scheduler_reliability",
+        "runtime_authority",
+        "continuity",
+        "privacy",
+        "interoperability",
+        "full"
+      ]
+    },
+    "status": {
+      "enum": [
+        "passed",
+        "failed",
+        "incomplete",
+        "not_applicable"
+      ]
+    },
+    "policyBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policyId",
+        "policyVersion",
+        "digest"
+      ],
+      "properties": {
+        "policyId": {
+          "$ref": "#/$defs/boundedIdentifier"
+        },
+        "policyVersion": {
+          "$ref": "#/$defs/version"
+        },
+        "digest": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "decisionScope": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "const": "audit_only"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "policyBinding"
+          ],
+          "properties": {
+            "kind": {
+              "const": "release_eligibility"
+            },
+            "policyBinding": {
+              "$ref": "#/$defs/policyBinding"
+            }
+          }
+        }
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit"
+      ],
+      "properties": {
+        "repository": {
+          "$ref": "#/$defs/repository"
+        },
+        "commit": {
+          "$ref": "#/$defs/sourceCommit"
+        }
+      }
+    },
+    "protocolArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bundleSchemaVersion",
+        "sourceCommit",
+        "bundleSha256",
+        "contractContentSha256",
+        "fileCount"
+      ],
+      "properties": {
+        "bundleSchemaVersion": {
+          "$ref": "#/$defs/version"
+        },
+        "sourceCommit": {
+          "$ref": "#/$defs/sourceCommit"
+        },
+        "bundleSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "contractContentSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "fileCount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991,
+          "description": "Positive JCS-safe file count. JSON number forms with a mathematically integral value, including 19.0 and 1.9e1, are integers and canonicalize without a fractional part."
+        }
+      }
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "artifactSha256",
+        "vectorSetSha256"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/resultId"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        },
+        "artifactSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "vectorSetSha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "os",
+        "arch",
+        "runtime"
+      ],
+      "properties": {
+        "os": {
+          "$ref": "#/$defs/environmentFact"
+        },
+        "arch": {
+          "$ref": "#/$defs/environmentFact"
+        },
+        "runtime": {
+          "$ref": "#/$defs/environmentFact"
+        }
+      }
+    },
+    "suiteResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "suiteId",
+        "status"
+      ],
+      "properties": {
+        "suiteId": {
+          "$ref": "#/$defs/suiteId"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "evidenceDigest": {
+          "$ref": "common.schema.json#/$defs/digest"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "passed"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "evidenceDigest"
+            ]
+          }
+        }
+      ]
+    },
+    "profileResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "status",
+        "requiredSuites",
+        "suiteResults"
+      ],
+      "properties": {
+        "profile": {
+          "$ref": "#/$defs/profile"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "requiredSuites": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/suiteId"
+          }
+        },
+        "suiteResults": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "$ref": "#/$defs/suiteResult"
+          }
+        }
+      },
+      "description": "JSON Schema constrains the closed shape only. The Rust verifier enforces exact internal suite-set equality, uniqueness by suiteId, and status derivation. For release eligibility it also compares requiredSuites with the caller-pinned suite inventory for that profile."
+    },
+    "statement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contractProfile",
+        "resultId",
+        "decisionScope",
+        "source",
+        "protocolArtifact",
+        "runner",
+        "environment",
+        "observedAt",
+        "profileResults",
+        "overallStatus"
+      ],
+      "properties": {
+        "contractProfile": {
+          "const": "coven.automations.v1"
+        },
+        "resultId": {
+          "$ref": "#/$defs/resultId"
+        },
+        "decisionScope": {
+          "$ref": "#/$defs/decisionScope"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "protocolArtifact": {
+          "$ref": "#/$defs/protocolArtifact"
+        },
+        "runner": {
+          "$ref": "#/$defs/runner"
+        },
+        "environment": {
+          "$ref": "#/$defs/environment",
+          "description": "Informational for audit-only results. Release eligibility requires an exact match to a nonempty caller-supplied environment allowlist."
+        },
+        "observedAt": {
+          "$ref": "common.schema.json#/$defs/timestamp"
+        },
+        "expiresAt": {
+          "$ref": "common.schema.json#/$defs/timestamp"
+        },
+        "profileResults": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 7,
+          "items": {
+            "$ref": "#/$defs/profileResult"
+          }
+        },
+        "overallStatus": {
+          "$ref": "#/$defs/status"
+        }
+      }
+    },
+    "authentication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method",
+        "keyId",
+        "signature"
+      ],
+      "properties": {
+        "method": {
+          "const": "p256-sha256"
+        },
+        "keyId": {
+          "$ref": "#/$defs/boundedIdentifier"
+        },
+        "signature": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "description": "Unpadded canonical base64url encoding of a canonical DER P-256 ECDSA signature over the RFC 8785 statement bytes."
+        }
+      }
+    }
+  }
+}

--- a/spec/coven-automations/v1/conformance-result.vectors.json
+++ b/spec/coven-automations/v1/conformance-result.vectors.json
@@ -1,0 +1,343 @@
+{
+  "schemaVersion": "coven.automations.conformance-result-vectors.v1",
+  "contractProfile": "coven.automations.v1",
+  "status": "synthetic-test-vectors",
+  "notice": "These objects exercise the result-envelope contract only. They are synthetic examples and do not claim that Coven, its daemon, any package, or any conformance profile currently passes.",
+  "cases": [
+    {
+      "name": "unsigned-audit-incomplete-valid",
+      "expectation": "accept",
+      "verificationClass": "audit_only",
+      "object": {
+        "schemaVersion": "coven.automations.conformance-result.v1",
+        "statement": {
+          "contractProfile": "coven.automations.v1",
+          "resultId": "fixture-conformance-result",
+          "decisionScope": {
+            "kind": "audit_only"
+          },
+          "source": {
+            "repository": "https://example.invalid/OpenCoven/coven",
+            "commit": "0123456789abcdef0123456789abcdef01234567"
+          },
+          "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "0123456789abcdef0123456789abcdef01234567",
+            "bundleSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+            "contractContentSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+            "fileCount": 19
+          },
+          "runner": {
+            "name": "fixture-conformance-runner",
+            "version": "1.0.0-test",
+            "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+            "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
+          },
+          "environment": {
+            "os": "linux",
+            "arch": "x86_64",
+            "runtime": "rust-1.89"
+          },
+          "observedAt": "2026-09-10T12:55:00.000Z",
+          "expiresAt": "2026-09-10T13:30:00.000Z",
+          "profileResults": [
+            {
+              "profile": "structural",
+              "status": "incomplete",
+              "requiredSuites": [
+                "schema-validation"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "schema-validation",
+                  "status": "incomplete"
+                }
+              ]
+            }
+          ],
+          "overallStatus": "incomplete"
+        },
+        "statementDigest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "e3e477f5825e3445f3c4b8453079267544df16a995257c38dadd9665252295aa"
+        }
+      }
+    },
+    {
+      "name": "statement-digest-tampered-invalid",
+      "expectation": "reject",
+      "expectedError": "statement_digest_mismatch",
+      "object": {
+        "schemaVersion": "coven.automations.conformance-result.v1",
+        "statement": {
+          "contractProfile": "coven.automations.v1",
+          "resultId": "tampered-conformance-result",
+          "decisionScope": {
+            "kind": "audit_only"
+          },
+          "source": {
+            "repository": "https://example.invalid/OpenCoven/coven",
+            "commit": "0123456789abcdef0123456789abcdef01234567"
+          },
+          "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "0123456789abcdef0123456789abcdef01234567",
+            "bundleSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+            "contractContentSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+            "fileCount": 19
+          },
+          "runner": {
+            "name": "fixture-conformance-runner",
+            "version": "1.0.0-test",
+            "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+            "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
+          },
+          "environment": {
+            "os": "linux",
+            "arch": "x86_64",
+            "runtime": "rust-1.89"
+          },
+          "observedAt": "2026-09-10T12:55:00.000Z",
+          "expiresAt": "2026-09-10T13:30:00.000Z",
+          "profileResults": [
+            {
+              "profile": "structural",
+              "status": "incomplete",
+              "requiredSuites": [
+                "schema-validation"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "schema-validation",
+                  "status": "incomplete"
+                }
+              ]
+            }
+          ],
+          "overallStatus": "incomplete"
+        },
+        "statementDigest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "e3e477f5825e3445f3c4b8453079267544df16a995257c38dadd9665252295aa"
+        }
+      }
+    },
+    {
+      "name": "all-not-applicable-cannot-pass",
+      "expectation": "reject",
+      "expectedError": "profile_status_inconsistent",
+      "object": {
+        "schemaVersion": "coven.automations.conformance-result.v1",
+        "statement": {
+          "contractProfile": "coven.automations.v1",
+          "resultId": "fixture-all-not-applicable",
+          "decisionScope": {
+            "kind": "audit_only"
+          },
+          "source": {
+            "repository": "https://example.invalid/OpenCoven/coven",
+            "commit": "0123456789abcdef0123456789abcdef01234567"
+          },
+          "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "0123456789abcdef0123456789abcdef01234567",
+            "bundleSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+            "contractContentSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+            "fileCount": 19
+          },
+          "runner": {
+            "name": "fixture-conformance-runner",
+            "version": "1.0.0-test",
+            "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+            "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
+          },
+          "environment": {
+            "os": "linux",
+            "arch": "x86_64",
+            "runtime": "rust-1.89"
+          },
+          "observedAt": "2026-09-10T12:55:00.000Z",
+          "expiresAt": "2026-09-10T13:30:00.000Z",
+          "profileResults": [
+            {
+              "profile": "structural",
+              "status": "passed",
+              "requiredSuites": [
+                "schema-validation"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "schema-validation",
+                  "status": "not_applicable"
+                }
+              ]
+            }
+          ],
+          "overallStatus": "passed"
+        },
+        "statementDigest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "f6890b88ae5f71150a9cf9407643e40ff104775464c40e457ef1460c17b0f31b"
+        }
+      }
+    },
+    {
+      "name": "full-pass-missing-component-invalid",
+      "expectation": "reject",
+      "expectedError": "full_profile_incomplete",
+      "object": {
+        "schemaVersion": "coven.automations.conformance-result.v1",
+        "statement": {
+          "contractProfile": "coven.automations.v1",
+          "resultId": "fixture-full-missing-component",
+          "decisionScope": {
+            "kind": "audit_only"
+          },
+          "source": {
+            "repository": "https://example.invalid/OpenCoven/coven",
+            "commit": "0123456789abcdef0123456789abcdef01234567"
+          },
+          "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "0123456789abcdef0123456789abcdef01234567",
+            "bundleSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+            "contractContentSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+            "fileCount": 19
+          },
+          "runner": {
+            "name": "fixture-conformance-runner",
+            "version": "1.0.0-test",
+            "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+            "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
+          },
+          "environment": {
+            "os": "linux",
+            "arch": "x86_64",
+            "runtime": "rust-1.89"
+          },
+          "observedAt": "2026-09-10T12:55:00.000Z",
+          "expiresAt": "2026-09-10T13:30:00.000Z",
+          "profileResults": [
+            {
+              "profile": "structural",
+              "status": "passed",
+              "requiredSuites": [
+                "schema-validation"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "schema-validation",
+                  "status": "passed",
+                  "evidenceDigest": {
+                    "algorithm": "sha256",
+                    "canonicalization": "jcs-rfc8785",
+                    "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  }
+                }
+              ]
+            },
+            {
+              "profile": "scheduler_reliability",
+              "status": "passed",
+              "requiredSuites": [
+                "scheduler-reliability"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "scheduler-reliability",
+                  "status": "passed",
+                  "evidenceDigest": {
+                    "algorithm": "sha256",
+                    "canonicalization": "jcs-rfc8785",
+                    "value": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  }
+                }
+              ]
+            },
+            {
+              "profile": "runtime_authority",
+              "status": "passed",
+              "requiredSuites": [
+                "runtime-authority"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "runtime-authority",
+                  "status": "passed",
+                  "evidenceDigest": {
+                    "algorithm": "sha256",
+                    "canonicalization": "jcs-rfc8785",
+                    "value": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                  }
+                }
+              ]
+            },
+            {
+              "profile": "continuity",
+              "status": "passed",
+              "requiredSuites": [
+                "continuity"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "continuity",
+                  "status": "passed",
+                  "evidenceDigest": {
+                    "algorithm": "sha256",
+                    "canonicalization": "jcs-rfc8785",
+                    "value": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                  }
+                }
+              ]
+            },
+            {
+              "profile": "interoperability",
+              "status": "passed",
+              "requiredSuites": [
+                "interoperability"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "interoperability",
+                  "status": "passed",
+                  "evidenceDigest": {
+                    "algorithm": "sha256",
+                    "canonicalization": "jcs-rfc8785",
+                    "value": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                  }
+                }
+              ]
+            },
+            {
+              "profile": "full",
+              "status": "passed",
+              "requiredSuites": [
+                "full-profile"
+              ],
+              "suiteResults": [
+                {
+                  "suiteId": "full-profile",
+                  "status": "passed",
+                  "evidenceDigest": {
+                    "algorithm": "sha256",
+                    "canonicalization": "jcs-rfc8785",
+                    "value": "6666666666666666666666666666666666666666666666666666666666666666"
+                  }
+                }
+              ]
+            }
+          ],
+          "overallStatus": "passed"
+        },
+        "statementDigest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "82c27cd09f92153fe697d77f4ed1eb538bedb229ed9e334bb32216062ee92d18"
+        }
+      }
+    }
+  ]
+}

--- a/spec/coven-automations/v1/conformance-result.vectors.json
+++ b/spec/coven-automations/v1/conformance-result.vectors.json
@@ -33,6 +33,15 @@
             "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
             "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
           },
+          "subjectArtifact": {
+            "artifactId": "coven-cli-macos-aarch64",
+            "artifactVersion": "0.0.0-test",
+            "platform": {
+              "os": "macos",
+              "arch": "aarch64"
+            },
+            "sha256": "6666666666666666666666666666666666666666666666666666666666666666"
+          },
           "environment": {
             "os": "linux",
             "arch": "x86_64",
@@ -60,7 +69,7 @@
         "statementDigest": {
           "algorithm": "sha256",
           "canonicalization": "jcs-rfc8785",
-          "value": "e3e477f5825e3445f3c4b8453079267544df16a995257c38dadd9665252295aa"
+          "value": "aa1c589956523d9b06ca76312e80090680cc935fbbb705f88a7bbd242c1cb7f1"
         }
       }
     },
@@ -92,6 +101,15 @@
             "version": "1.0.0-test",
             "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
             "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
+          },
+          "subjectArtifact": {
+            "artifactId": "coven-cli-macos-aarch64",
+            "artifactVersion": "0.0.0-test",
+            "platform": {
+              "os": "macos",
+              "arch": "aarch64"
+            },
+            "sha256": "6666666666666666666666666666666666666666666666666666666666666666"
           },
           "environment": {
             "os": "linux",
@@ -153,6 +171,15 @@
             "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
             "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
           },
+          "subjectArtifact": {
+            "artifactId": "coven-cli-macos-aarch64",
+            "artifactVersion": "0.0.0-test",
+            "platform": {
+              "os": "macos",
+              "arch": "aarch64"
+            },
+            "sha256": "6666666666666666666666666666666666666666666666666666666666666666"
+          },
           "environment": {
             "os": "linux",
             "arch": "x86_64",
@@ -180,7 +207,7 @@
         "statementDigest": {
           "algorithm": "sha256",
           "canonicalization": "jcs-rfc8785",
-          "value": "f6890b88ae5f71150a9cf9407643e40ff104775464c40e457ef1460c17b0f31b"
+          "value": "cb654ab7431aa11468187c1c3b2769067a60e3730fda7064d78bed5588f10da3"
         }
       }
     },
@@ -212,6 +239,15 @@
             "version": "1.0.0-test",
             "artifactSha256": "3333333333333333333333333333333333333333333333333333333333333333",
             "vectorSetSha256": "4444444444444444444444444444444444444444444444444444444444444444"
+          },
+          "subjectArtifact": {
+            "artifactId": "coven-cli-macos-aarch64",
+            "artifactVersion": "0.0.0-test",
+            "platform": {
+              "os": "macos",
+              "arch": "aarch64"
+            },
+            "sha256": "6666666666666666666666666666666666666666666666666666666666666666"
           },
           "environment": {
             "os": "linux",
@@ -335,7 +371,7 @@
         "statementDigest": {
           "algorithm": "sha256",
           "canonicalization": "jcs-rfc8785",
-          "value": "82c27cd09f92153fe697d77f4ed1eb538bedb229ed9e334bb32216062ee92d18"
+          "value": "3c098fe6ad42c3a3e3eda07de16683dbae0acdc477d5b5b2157fc0e2492bfcf3"
         }
       }
     }

--- a/spec/coven-automations/v1/coven.automations.v1.d.ts
+++ b/spec/coven-automations/v1/coven.automations.v1.d.ts
@@ -599,17 +599,33 @@ export interface ConformanceRunnerBinding {
   vectorSetSha256: string;
 }
 
+export interface ConformanceSubjectArtifactBinding {
+  artifactId: string;
+  artifactVersion: string;
+  platform: {
+    os: string;
+    arch: string;
+  };
+  sha256: string;
+}
+
 export interface ConformanceEnvironment {
   os: string;
   arch: string;
   runtime: string;
 }
 
-export interface ConformanceSuiteResult {
-  suiteId: string;
-  status: ConformanceStatus;
-  evidenceDigest?: Digest;
-}
+export type ConformanceSuiteResult =
+  | {
+      suiteId: string;
+      status: "passed";
+      evidenceDigest: Digest;
+    }
+  | {
+      suiteId: string;
+      status: "failed" | "incomplete" | "not_applicable";
+      evidenceDigest?: Digest;
+    };
 
 export interface ConformanceProfileResult {
   profile: ConformanceProfile;
@@ -624,6 +640,7 @@ export interface ConformanceResultStatementBase {
   source: ConformanceSourceBinding;
   protocolArtifact: ConformanceProtocolArtifactBinding;
   runner: ConformanceRunnerBinding;
+  subjectArtifact: ConformanceSubjectArtifactBinding;
   environment: ConformanceEnvironment;
   observedAt: Timestamp;
   profileResults: ConformanceProfileResult[];

--- a/spec/coven-automations/v1/coven.automations.v1.d.ts
+++ b/spec/coven-automations/v1/coven.automations.v1.d.ts
@@ -550,6 +550,125 @@ export interface CommandResponse<C extends CommandName = CommandName> {
 }
 
 // ---------------------------------------------------------------------------
+// Portable conformance result
+// ---------------------------------------------------------------------------
+
+export type ConformanceResultSchemaVersion = "coven.automations.conformance-result.v1";
+
+export type ConformanceProfile =
+  | "structural"
+  | "scheduler_reliability"
+  | "runtime_authority"
+  | "continuity"
+  | "privacy"
+  | "interoperability"
+  | "full";
+
+export type ConformanceStatus = "passed" | "failed" | "incomplete" | "not_applicable";
+
+export interface ConformancePolicyBinding {
+  policyId: string;
+  policyVersion: string;
+  digest: string;
+}
+
+export type ConformanceDecisionScope =
+  | { kind: "audit_only" }
+  | {
+      kind: "release_eligibility";
+      policyBinding: ConformancePolicyBinding;
+    };
+
+export interface ConformanceSourceBinding {
+  repository: string;
+  commit: string;
+}
+
+export interface ConformanceProtocolArtifactBinding {
+  bundleSchemaVersion: string;
+  sourceCommit: string;
+  bundleSha256: string;
+  contractContentSha256: string;
+  fileCount: number;
+}
+
+export interface ConformanceRunnerBinding {
+  name: string;
+  version: string;
+  artifactSha256: string;
+  vectorSetSha256: string;
+}
+
+export interface ConformanceEnvironment {
+  os: string;
+  arch: string;
+  runtime: string;
+}
+
+export interface ConformanceSuiteResult {
+  suiteId: string;
+  status: ConformanceStatus;
+  evidenceDigest?: Digest;
+}
+
+export interface ConformanceProfileResult {
+  profile: ConformanceProfile;
+  status: ConformanceStatus;
+  requiredSuites: string[];
+  suiteResults: ConformanceSuiteResult[];
+}
+
+export interface ConformanceResultStatementBase {
+  contractProfile: SchemaVersion;
+  resultId: string;
+  source: ConformanceSourceBinding;
+  protocolArtifact: ConformanceProtocolArtifactBinding;
+  runner: ConformanceRunnerBinding;
+  environment: ConformanceEnvironment;
+  observedAt: Timestamp;
+  profileResults: ConformanceProfileResult[];
+  overallStatus: ConformanceStatus;
+}
+
+export interface ConformanceAuditOnlyStatement extends ConformanceResultStatementBase {
+  decisionScope: { kind: "audit_only" };
+  expiresAt?: Timestamp;
+}
+
+export interface ConformanceReleaseEligibilityStatement extends ConformanceResultStatementBase {
+  decisionScope: {
+    kind: "release_eligibility";
+    policyBinding: ConformancePolicyBinding;
+  };
+  expiresAt: Timestamp;
+}
+
+export type ConformanceResultStatement =
+  | ConformanceAuditOnlyStatement
+  | ConformanceReleaseEligibilityStatement;
+
+export interface ConformanceResultAuthentication {
+  method: "p256-sha256";
+  keyId: string;
+  signature: string;
+}
+
+export interface ConformanceResultEnvelopeBase {
+  schemaVersion: ConformanceResultSchemaVersion;
+  statementDigest: Digest;
+}
+
+export type ConformanceResult =
+  | (ConformanceResultEnvelopeBase & {
+      statement: ConformanceAuditOnlyStatement;
+      authentication?: ConformanceResultAuthentication;
+    })
+  | (ConformanceResultEnvelopeBase & {
+      statement: ConformanceReleaseEligibilityStatement;
+      authentication: ConformanceResultAuthentication;
+    });
+
+// ---------------------------------------------------------------------------
 // Events / changefeed
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Context

- Summary: Add a portable, fail-closed Automations conformance-result contract and Rust verifier as a bounded #858 certification-plane slice.
- Files changed: Rust verifier/tests, JSON Schema and synthetic vectors, TypeScript declarations, protocol manifest/docs, and packaging coverage.
- Part of #858; this PR intentionally does not close the broader conformance, chaos, SLO, and diagnostics issue.

## Implementation

- Approach:
  - Define audit-only and release-eligibility result envelopes whose statement digest is SHA-256 over RFC 8785/JCS canonical statement bytes.
  - Require release decisions to match caller-pinned source, protocol bundle, runner, vector set, tested subject artifact, policy, exact suite inventory, allowed environment, freshness, expiry, and trusted P-256 authentication.
  - Validate profile/suite status semantics, duplicate rejection, `full` profile closure, passed-suite evidence, exact JSON integer forms, and timestamp syntax.
  - Keep verifier failures static and privacy-safe.
- User-visible behavior: No new runner or certification command is exposed. Consumers can parse and verify portable result envelopes without promoting audit-only evidence.
- Compatibility notes: Historical frozen protocol bundles remain unchanged. The current protocol manifest remains `proposed` and `productionReady: false`.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked -- --test-threads=1`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node --test scripts/package-automations-protocol.test.mjs`
- [x] Focused conformance verifier tests: 23 passed
- [x] Independent code review: no significant issues
- [x] Additional manual checks: exact final tree tested from short detached worktree to avoid macOS Unix-socket path limits

Default-parallel local workspace runs intermittently crossed existing strict daemon timing budgets under host load (`2.001-2.003s` against the documented `2s` contract). Both affected daemon tests pass in isolation, and the exact workspace passes serially; this PR does not alter daemon code or weaken those deadlines.

## Risk and Rollback

- Risk level: Medium. The contract is new and remains proposed, but release eligibility is intentionally fail-closed.
- Rollback plan: Revert this PR; no migration or persisted production state depends on the new result envelope.

## Agent Handoff

- Current state: Result envelope, portable projections, vectors, and verifier are complete for this bounded slice.
- Follow-ups: Build a runner that executes the published suites and emits these envelopes; establish production signer/trust-root operations; add real cross-platform evidence.
- Known gaps: This PR does not execute conformance vectors, certify Coven or npm artifacts, provide a production signer/trust root, complete Runtime Authority, or claim any profile currently passes.
