### PR TITLE
feat: add native Automations conformance runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
       - run: node --test scripts/package-github-release-test.mjs
       - run: node --test scripts/package-automations-protocol.test.mjs
       - run: node --test scripts/package-automations-authority-profile.test.mjs
+      - run: node --test conformance/automations/runner/conformance.test.mjs
       - run: node --test scripts/release-stress-test.mjs
       - run: scripts/check-workflows.sh
 

--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -1,0 +1,158 @@
+# Coven Automations audit runner
+
+This directory contains the first executable Coven Automations v1 conformance
+slice. It is deliberately limited to **audit-only** observations:
+
+- it cannot emit `release_eligibility`;
+- it cannot claim the aggregate `full` profile;
+- an unavailable target produces `not_applicable` results and a nonzero exit;
+- malformed target output produces `failed` results with static errors;
+- raw target evidence, stdout, stderr, paths, and command lines are not copied
+  into the result.
+
+The output is a
+[`coven.automations.conformance-result.v1`](../../../spec/coven-automations/v1/conformance-result.schema.json)
+envelope. Passing output is not release certification. A verifier must still
+pin the source, protocol bundle, runner, vector set, tested subject artifact,
+suite inventory, and environment. Release eligibility additionally requires
+trusted authentication and a release policy.
+
+## Run
+
+```sh
+node conformance/automations/runner/conformance.mjs \
+  --job /absolute/path/to/audit-job.json \
+  --target-command /absolute/path/to/coven
+```
+
+The target command must be the exact executable represented by
+`subjectArtifact.sha256`. Wrappers and extra target arguments are intentionally
+unsupported because they would break the binding between the reported subject
+and the implementation that actually ran. The runner reads those bytes once
+and starts every probe from a fresh private copy, so one invocation cannot
+replace the executable used by the next.
+
+Exit status `0` means every requested suite passed. Status `1` means the runner
+emitted a valid non-passing audit result. Status `2` means the job itself was
+invalid and no result was emitted.
+
+This initial standalone runner supports Linux and macOS. It fails closed on
+Windows until target processes can be contained in a kill-on-close Job Object.
+The native Coven target commands themselves remain cross-platform.
+
+## Audit job
+
+The job is a closed JSON object. Its source, protocol, runner, subject, and
+environment fields map directly into the result statement:
+
+```json
+{
+  "schemaVersion": "coven.automations.conformance-job.v1",
+  "resultId": "audit-2026-09-08T120000Z",
+  "decisionScope": { "kind": "audit_only" },
+  "source": {
+    "repository": "https://github.com/OpenCoven/coven",
+    "commit": "1111111111111111111111111111111111111111"
+  },
+  "protocolArtifact": {
+    "bundleSchemaVersion": "coven.automations.bundle.v1",
+    "sourceCommit": "1111111111111111111111111111111111111111",
+    "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "fileCount": 19
+  },
+  "runner": {
+    "name": "coven-automations-conformance-runner",
+    "version": "0.1.0",
+    "artifactSha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "vectorSetSha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "subjectArtifact": {
+    "artifactId": "coven-cli",
+    "artifactVersion": "0.1.0",
+    "platform": { "os": "linux", "arch": "x86_64" },
+    "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "environment": {
+    "os": "linux",
+    "arch": "x86_64",
+    "runtime": "node-24"
+  },
+  "observedAt": "2026-09-08T12:00:00.000Z",
+  "suites": [
+    {
+      "profile": "structural",
+      "suiteId": "capability-negotiation",
+      "vector": {
+        "schemaVersion": "coven.automations.capability-negotiation-vectors.v1",
+        "cases": [
+          {
+            "caseId": "supported-minimal",
+            "definition": {
+              "schemaVersion": 1,
+              "id": "native-supported",
+              "name": "Native supported",
+              "status": "PAUSED",
+              "rrule": "FREQ=DAILY",
+              "timezone": "local",
+              "prompt": "Run the native conformance probe",
+              "misfire": "latest",
+              "overlap": "forbid",
+              "timeoutMinutes": 30,
+              "runtime": "coven-code"
+            },
+            "expected": {
+              "outcome": "supported"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+The example values are placeholders, not evidence. Use the exact SHA-256 and
+source metadata for the files and binary under test. `source.commit` must equal
+`protocolArtifact.sourceCommit`. The runner also recomputes and requires:
+
+- `runner.artifactSha256` from `conformance.mjs`;
+- `runner.vectorSetSha256` from the JCS bytes of the job's `suites` array;
+- `subjectArtifact.sha256` from `--target-command`.
+
+The checked-in
+[`capability-negotiation.vectors.json`](capability-negotiation.vectors.json)
+contains the current nonempty vector set.
+
+## Target protocol
+
+The runner invokes the target directly without a shell.
+
+`<target> automations conformance capability` returns:
+
+```json
+{
+  "schemaVersion": "coven.automations.conformance-target-capability.v1",
+  "profiles": [
+    {
+      "profile": "structural",
+      "suites": ["capability-negotiation"]
+    }
+  ]
+}
+```
+
+For each advertised suite, the runner invokes
+`<target> automations conformance evaluate`, writes one
+`coven.automations.conformance-suite-request.v1` object to standard input, and
+expects one `coven.automations.conformance-suite-result.v1` object on standard
+output.
+
+The native Coven target currently implements only the structural
+`capability-negotiation` suite. It executes the checked-in cases against Rust's
+real definition parser and capability negotiation code. The runner computes a
+JCS SHA-256 digest of returned evidence and discards the raw evidence after
+building the result envelope. Evidence is restricted to JSON values that can
+be canonicalized consistently across the JavaScript runner and Rust verifier.
+Each target operation has a two-second deadline followed by process-tree
+termination; output is capped at one MiB.

--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -154,5 +154,7 @@ real definition parser and capability negotiation code. The runner computes a
 JCS SHA-256 digest of returned evidence and discards the raw evidence after
 building the result envelope. Evidence is restricted to JSON values that can
 be canonicalized consistently across the JavaScript runner and Rust verifier.
+The native target rejects evaluation requests larger than one MiB before JSON
+parsing.
 Each target operation has a two-second deadline followed by process-tree
 termination; output is capped at one MiB.

--- a/conformance/automations/runner/capability-negotiation.vectors.json
+++ b/conformance/automations/runner/capability-negotiation.vectors.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "coven.automations.capability-negotiation-vectors.v1",
+  "cases": [
+    {
+      "caseId": "supported-minimal",
+      "definition": {
+        "schemaVersion": 1,
+        "id": "native-supported",
+        "name": "Native supported",
+        "status": "PAUSED",
+        "rrule": "FREQ=DAILY",
+        "timezone": "local",
+        "prompt": "Run the native conformance probe",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code"
+      },
+      "expected": {
+        "outcome": "supported"
+      }
+    },
+    {
+      "caseId": "refused-trigger",
+      "definition": {
+        "schemaVersion": 1,
+        "id": "native-refused",
+        "name": "Native refused",
+        "status": "PAUSED",
+        "rrule": "FREQ=DAILY",
+        "timezone": "local",
+        "prompt": "Run the native conformance probe",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "trigger": {
+          "variant": "webhook",
+          "version": 1,
+          "webhook": {}
+        }
+      },
+      "expected": {
+        "outcome": "unsupported",
+        "variant": "trigger.webhook"
+      }
+    }
+  ]
+}

--- a/conformance/automations/runner/conformance.mjs
+++ b/conformance/automations/runner/conformance.mjs
@@ -26,6 +26,7 @@ const CONTRACT_PROFILE = "coven.automations.v1";
 const TARGET_TIMEOUT_MS = 2_000;
 const TARGET_KILL_GRACE_MS = 100;
 const TARGET_OUTPUT_LIMIT = 1024 * 1024;
+const MAX_JCS_DEPTH = 128;
 const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,159}$/;
 const SUITE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
 const VERSION = /^[A-Za-z0-9][A-Za-z0-9._+:-]{0,95}$/;
@@ -258,6 +259,9 @@ function validateJob(job) {
     }
     suiteKeys.add(key);
   }
+  if (!isPortableJcsValue(job.suites)) {
+    throw new JobError("vector set is not portable JCS");
+  }
 }
 
 function canonicalize(value) {
@@ -278,7 +282,7 @@ function hasOnlyScalarUnicode(value) {
     const unit = value.charCodeAt(index);
     if (unit >= 0xd800 && unit <= 0xdbff) {
       const next = value.charCodeAt(index + 1);
-      if (next < 0xdc00 || next > 0xdfff) return false;
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
       index += 1;
     } else if (unit >= 0xdc00 && unit <= 0xdfff) {
       return false;
@@ -288,20 +292,38 @@ function hasOnlyScalarUnicode(value) {
 }
 
 function isPortableJcsValue(value) {
-  if (value === null || typeof value === "boolean") return true;
-  if (typeof value === "string") return hasOnlyScalarUnicode(value);
-  if (typeof value === "number") {
-    return (
-      Number.isFinite(value) &&
-      (!Number.isInteger(value) || Number.isSafeInteger(value))
-    );
+  const pending = [{ value, depth: 0 }];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    const candidate = current.value;
+    if (candidate === null || typeof candidate === "boolean") continue;
+    if (typeof candidate === "string") {
+      if (!hasOnlyScalarUnicode(candidate)) return false;
+      continue;
+    }
+    if (typeof candidate === "number") {
+      if (
+        !Number.isFinite(candidate) ||
+        (Number.isInteger(candidate) && !Number.isSafeInteger(candidate))
+      ) {
+        return false;
+      }
+      continue;
+    }
+    if (current.depth >= MAX_JCS_DEPTH) return false;
+    if (Array.isArray(candidate)) {
+      for (const child of candidate) {
+        pending.push({ value: child, depth: current.depth + 1 });
+      }
+      continue;
+    }
+    if (!isObject(candidate)) return false;
+    for (const [key, child] of Object.entries(candidate)) {
+      if (!hasOnlyScalarUnicode(key)) return false;
+      pending.push({ value: child, depth: current.depth + 1 });
+    }
   }
-  if (Array.isArray(value)) return value.every(isPortableJcsValue);
-  if (!isObject(value)) return false;
-  return Object.entries(value).every(
-    ([key, child]) =>
-      hasOnlyScalarUnicode(key) && isPortableJcsValue(child),
-  );
+  return true;
 }
 
 function digestCanonical(value) {

--- a/conformance/automations/runner/conformance.mjs
+++ b/conformance/automations/runner/conformance.mjs
@@ -1,0 +1,725 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { readFile, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const JOB_SCHEMA_VERSION = "coven.automations.conformance-job.v1";
+const RESULT_SCHEMA_VERSION = "coven.automations.conformance-result.v1";
+const TARGET_CAPABILITY_SCHEMA_VERSION =
+  "coven.automations.conformance-target-capability.v1";
+const SUITE_REQUEST_SCHEMA_VERSION =
+  "coven.automations.conformance-suite-request.v1";
+const SUITE_RESULT_SCHEMA_VERSION =
+  "coven.automations.conformance-suite-result.v1";
+const CONTRACT_PROFILE = "coven.automations.v1";
+const TARGET_TIMEOUT_MS = 2_000;
+const TARGET_KILL_GRACE_MS = 100;
+const TARGET_OUTPUT_LIMIT = 1024 * 1024;
+const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,159}$/;
+const SUITE_ID = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
+const VERSION = /^[A-Za-z0-9][A-Za-z0-9._+:-]{0,95}$/;
+const ENVIRONMENT_FACT = /^[A-Za-z0-9][A-Za-z0-9._+:-]{0,127}$/;
+const SOURCE_COMMIT = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const REPOSITORY =
+  /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[A-Za-z0-9!#$%&'()*+,./:;=?@_~-]+$/;
+const COMPONENT_PROFILES = [
+  "structural",
+  "scheduler_reliability",
+  "runtime_authority",
+  "continuity",
+  "privacy",
+  "interoperability",
+];
+const STATUS_ORDER = ["passed", "failed", "incomplete", "not_applicable"];
+const RUNNER_PATH = fileURLToPath(import.meta.url);
+
+class JobError extends Error {}
+
+function hasExactKeys(value, required, optional = []) {
+  if (!isObject(value)) return false;
+  const expected = new Set([...required, ...optional]);
+  const keys = Object.keys(value);
+  return (
+    required.every((key) => Object.hasOwn(value, key)) &&
+    keys.every((key) => expected.has(key))
+  );
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringMatching(value, pattern) {
+  return typeof value === "string" && pattern.test(value);
+}
+
+function isTimestamp(value) {
+  if (typeof value !== "string") return false;
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{3})?Z$/.exec(
+      value,
+    );
+  if (match === null) return false;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText] =
+    match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  ) {
+    return false;
+  }
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return day <= daysInMonth[month - 1];
+}
+
+function isSource(value) {
+  return (
+    hasExactKeys(value, ["repository", "commit"]) &&
+    isStringMatching(value.repository, REPOSITORY) &&
+    value.repository.length <= 512 &&
+    isStringMatching(value.commit, SOURCE_COMMIT)
+  );
+}
+
+function isProtocolArtifact(value) {
+  return (
+    hasExactKeys(value, [
+      "bundleSchemaVersion",
+      "sourceCommit",
+      "bundleSha256",
+      "contractContentSha256",
+      "fileCount",
+    ]) &&
+    isStringMatching(value.bundleSchemaVersion, VERSION) &&
+    isStringMatching(value.sourceCommit, SOURCE_COMMIT) &&
+    isStringMatching(value.bundleSha256, SHA256) &&
+    isStringMatching(value.contractContentSha256, SHA256) &&
+    Number.isSafeInteger(value.fileCount) &&
+    value.fileCount > 0
+  );
+}
+
+function isRunner(value) {
+  return (
+    hasExactKeys(value, [
+      "name",
+      "version",
+      "artifactSha256",
+      "vectorSetSha256",
+    ]) &&
+    isStringMatching(value.name, IDENTIFIER) &&
+    isStringMatching(value.version, VERSION) &&
+    isStringMatching(value.artifactSha256, SHA256) &&
+    isStringMatching(value.vectorSetSha256, SHA256)
+  );
+}
+
+function isPlatform(value) {
+  return (
+    hasExactKeys(value, ["os", "arch"]) &&
+    isStringMatching(value.os, ENVIRONMENT_FACT) &&
+    isStringMatching(value.arch, ENVIRONMENT_FACT)
+  );
+}
+
+function isSubjectArtifact(value) {
+  return (
+    hasExactKeys(value, [
+      "artifactId",
+      "artifactVersion",
+      "platform",
+      "sha256",
+    ]) &&
+    isStringMatching(value.artifactId, IDENTIFIER) &&
+    isStringMatching(value.artifactVersion, VERSION) &&
+    isPlatform(value.platform) &&
+    isStringMatching(value.sha256, SHA256)
+  );
+}
+
+function isEnvironment(value) {
+  return (
+    hasExactKeys(value, ["os", "arch", "runtime"]) &&
+    isStringMatching(value.os, ENVIRONMENT_FACT) &&
+    isStringMatching(value.arch, ENVIRONMENT_FACT) &&
+    isStringMatching(value.runtime, ENVIRONMENT_FACT)
+  );
+}
+
+function validateJob(job) {
+  if (
+    !hasExactKeys(job, [
+      "schemaVersion",
+      "resultId",
+      "decisionScope",
+      "source",
+      "protocolArtifact",
+      "runner",
+      "subjectArtifact",
+      "environment",
+      "observedAt",
+      "suites",
+    ])
+  ) {
+    throw new JobError("job shape is invalid");
+  }
+  if (job.schemaVersion !== JOB_SCHEMA_VERSION) {
+    throw new JobError("schema version is unsupported");
+  }
+  if (
+    !hasExactKeys(job.decisionScope, ["kind"]) ||
+    job.decisionScope.kind !== "audit_only"
+  ) {
+    throw new JobError("decision scope is not audit-only");
+  }
+  if (!isStringMatching(job.resultId, IDENTIFIER)) {
+    throw new JobError("result id is invalid");
+  }
+  if (!isSource(job.source)) {
+    throw new JobError("source binding is invalid");
+  }
+  if (!isProtocolArtifact(job.protocolArtifact)) {
+    throw new JobError("protocol artifact is invalid");
+  }
+  if (job.protocolArtifact.sourceCommit !== job.source.commit) {
+    throw new JobError("protocol source binding is invalid");
+  }
+  if (!isRunner(job.runner)) {
+    throw new JobError("runner binding is invalid");
+  }
+  if (!isSubjectArtifact(job.subjectArtifact)) {
+    throw new JobError("subject artifact is invalid");
+  }
+  if (!isEnvironment(job.environment)) {
+    throw new JobError("environment is invalid");
+  }
+  if (!isTimestamp(job.observedAt)) {
+    throw new JobError("observed timestamp is invalid");
+  }
+  if (!Array.isArray(job.suites) || job.suites.length === 0) {
+    throw new JobError("suite inventory is invalid");
+  }
+  if (job.suites.length > 128) {
+    throw new JobError("suite inventory is invalid");
+  }
+
+  const suiteKeys = new Set();
+  for (const suite of job.suites) {
+    if (
+      !hasExactKeys(suite, ["profile", "suiteId", "vector"]) ||
+      !COMPONENT_PROFILES.includes(suite.profile) ||
+      !isStringMatching(suite.suiteId, SUITE_ID) ||
+      !isObject(suite.vector)
+    ) {
+      if (suite?.profile === "full") {
+        throw new JobError("full profile is unsupported");
+      }
+      throw new JobError("suite inventory is invalid");
+    }
+    const key = `${suite.profile}\0${suite.suiteId}`;
+    if (suiteKeys.has(key)) {
+      throw new JobError("suite inventory is invalid");
+    }
+    suiteKeys.add(key);
+  }
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(",")}]`;
+  }
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+    .join(",")}}`;
+}
+
+function hasOnlyScalarUnicode(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isPortableJcsValue(value) {
+  if (value === null || typeof value === "boolean") return true;
+  if (typeof value === "string") return hasOnlyScalarUnicode(value);
+  if (typeof value === "number") {
+    return (
+      Number.isFinite(value) &&
+      (!Number.isInteger(value) || Number.isSafeInteger(value))
+    );
+  }
+  if (Array.isArray(value)) return value.every(isPortableJcsValue);
+  if (!isObject(value)) return false;
+  return Object.entries(value).every(
+    ([key, child]) =>
+      hasOnlyScalarUnicode(key) && isPortableJcsValue(child),
+  );
+}
+
+function digestCanonical(value) {
+  return {
+    algorithm: "sha256",
+    canonicalization: "jcs-rfc8785",
+    value: createHash("sha256").update(canonicalize(value)).digest("hex"),
+  };
+}
+
+function digestBytes(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function validateArtifactBindings(job, subjectPath) {
+  let runnerBytes;
+  let subjectBytes;
+  try {
+    [runnerBytes, subjectBytes] = await Promise.all([
+      readFile(RUNNER_PATH),
+      readFile(subjectPath),
+    ]);
+  } catch {
+    throw new JobError("artifact binding input is unavailable");
+  }
+  if (job.runner.artifactSha256 !== digestBytes(runnerBytes)) {
+    throw new JobError("runner artifact binding is invalid");
+  }
+  if (job.runner.vectorSetSha256 !== digestCanonical(job.suites).value) {
+    throw new JobError("vector set binding is invalid");
+  }
+  if (job.subjectArtifact.sha256 !== digestBytes(subjectBytes)) {
+    throw new JobError("subject artifact binding is invalid");
+  }
+  return {
+    bytes: subjectBytes,
+    mode: statSync(subjectPath).mode & 0o777,
+    name: basename(subjectPath),
+  };
+}
+
+function targetExecutionSucceeded(execution) {
+  return !(
+    execution.error ||
+    execution.status !== 0 ||
+    typeof execution.stdout !== "string" ||
+    Buffer.byteLength(execution.stdout) > TARGET_OUTPUT_LIMIT
+  );
+}
+
+function parseTargetJson(execution) {
+  if (!targetExecutionSucceeded(execution)) return undefined;
+  try {
+    return JSON.parse(execution.stdout);
+  } catch {
+    return undefined;
+  }
+}
+
+async function invokeTarget(subject, operation, input) {
+  const directory = mkdtempSync(
+    join(tmpdir(), "coven-conformance-subject-"),
+  );
+  const target = join(directory, subject.name);
+  writeFileSync(target, subject.bytes, { mode: subject.mode });
+  chmodSync(target, subject.mode);
+
+  try {
+    return await new Promise((resolve) => {
+      const child = spawn(
+        target,
+        ["automations", "conformance", operation],
+        {
+          detached: process.platform !== "win32",
+          stdio: ["pipe", "pipe", "pipe"],
+          windowsHide: true,
+        },
+      );
+      const stdout = [];
+      let stdoutBytes = 0;
+      let outputExceeded = false;
+      let executionError;
+      let failureKind;
+      let killTimer;
+      let hardStopTimer;
+      let settled = false;
+      const killTree = (signal) => {
+        if (child.pid === undefined) return;
+        if (process.platform === "win32") {
+          if (signal === "SIGKILL") {
+            spawnSync(
+              "taskkill",
+              ["/PID", String(child.pid), "/T", "/F"],
+              { stdio: "ignore", windowsHide: true },
+            );
+          } else {
+            child.kill(signal);
+          }
+          return;
+        }
+        try {
+          process.kill(-child.pid, signal);
+        } catch {
+          child.kill(signal);
+        }
+      };
+      const finish = (status) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (killTimer !== undefined) clearTimeout(killTimer);
+        if (hardStopTimer !== undefined) clearTimeout(hardStopTimer);
+        let decoded = "";
+        try {
+          decoded = new TextDecoder("utf-8", { fatal: true }).decode(
+            Buffer.concat(stdout),
+          );
+        } catch (error) {
+          executionError = error;
+          failureKind = "invalid";
+        }
+        resolve({
+          error: executionError,
+          failureKind,
+          status,
+          stdout: decoded,
+        });
+      };
+      let terminating = false;
+      const terminate = (error, kind) => {
+        if (terminating) return;
+        terminating = true;
+        executionError = error;
+        failureKind = kind;
+        killTree("SIGTERM");
+        killTimer = setTimeout(() => {
+          killTree("SIGKILL");
+          hardStopTimer = setTimeout(
+            () => finish(null),
+            TARGET_KILL_GRACE_MS,
+          );
+        }, TARGET_KILL_GRACE_MS);
+      };
+      const timeout = setTimeout(
+        () => terminate(new Error("target timed out"), "unavailable"),
+        TARGET_TIMEOUT_MS,
+      );
+
+      child.stdout.on("data", (chunk) => {
+        stdoutBytes += chunk.length;
+        if (stdoutBytes <= TARGET_OUTPUT_LIMIT) {
+          stdout.push(chunk);
+        } else if (!outputExceeded) {
+          outputExceeded = true;
+          terminate(new Error("target output exceeded limit"), "invalid");
+        }
+      });
+      child.stderr.resume();
+      child.on("error", (error) => {
+        executionError = error;
+        failureKind = "unavailable";
+      });
+      child.stdin.on("error", (error) => {
+        executionError = error;
+        terminate(error, "invalid");
+      });
+      child.on("exit", () => {
+        // A target must not leave helpers behind or keep inherited pipes open.
+        killTree("SIGKILL");
+      });
+      child.on("close", (status) => {
+        finish(status);
+      });
+      if (input === undefined) {
+        child.stdin.end();
+      } else {
+        child.stdin.end(`${JSON.stringify(input)}\n`);
+      }
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function parseCapability(execution) {
+  const value = parseTargetJson(execution);
+  if (
+    !hasExactKeys(value, ["schemaVersion", "profiles"]) ||
+    value.schemaVersion !== TARGET_CAPABILITY_SCHEMA_VERSION ||
+    !Array.isArray(value.profiles)
+  ) {
+    return undefined;
+  }
+
+  const supported = new Set();
+  for (const profile of value.profiles) {
+    if (
+      !hasExactKeys(profile, ["profile", "suites"]) ||
+      !COMPONENT_PROFILES.includes(profile.profile) ||
+      !Array.isArray(profile.suites)
+    ) {
+      return undefined;
+    }
+    for (const suiteId of profile.suites) {
+      if (!isStringMatching(suiteId, SUITE_ID)) return undefined;
+      supported.add(`${profile.profile}\0${suiteId}`);
+    }
+  }
+  return supported;
+}
+
+function parseSuiteResult(execution, suiteId) {
+  const value = parseTargetJson(execution);
+  if (
+    !hasExactKeys(value, ["schemaVersion", "suiteId", "status"], [
+      "evidence",
+    ]) ||
+    value.schemaVersion !== SUITE_RESULT_SCHEMA_VERSION ||
+    value.suiteId !== suiteId ||
+    !STATUS_ORDER.includes(value.status)
+  ) {
+    return undefined;
+  }
+  if (value.status === "passed" && !Object.hasOwn(value, "evidence")) {
+    return undefined;
+  }
+  if (
+    Object.hasOwn(value, "evidence") &&
+    !isPortableJcsValue(value.evidence)
+  ) {
+    return undefined;
+  }
+
+  const result = { suiteId, status: value.status };
+  if (Object.hasOwn(value, "evidence")) {
+    result.evidenceDigest = digestCanonical(value.evidence);
+  }
+  return result;
+}
+
+function deriveStatus(statuses) {
+  if (statuses.includes("failed")) return "failed";
+  if (statuses.every((status) => status === "passed")) return "passed";
+  if (statuses.every((status) => status === "not_applicable")) {
+    return "not_applicable";
+  }
+  return "incomplete";
+}
+
+function buildReport(job, suiteResults) {
+  const byProfile = new Map();
+  for (const suite of job.suites) {
+    const entry = byProfile.get(suite.profile) ?? [];
+    entry.push(suiteResults.get(`${suite.profile}\0${suite.suiteId}`));
+    byProfile.set(suite.profile, entry);
+  }
+
+  const profileResults = COMPONENT_PROFILES.filter((profile) =>
+    byProfile.has(profile),
+  ).map((profile) => {
+    const results = byProfile
+      .get(profile)
+      .toSorted((left, right) => left.suiteId.localeCompare(right.suiteId));
+    return {
+      profile,
+      status: deriveStatus(results.map((result) => result.status)),
+      requiredSuites: results.map((result) => result.suiteId),
+      suiteResults: results,
+    };
+  });
+  const statement = {
+    contractProfile: CONTRACT_PROFILE,
+    resultId: job.resultId,
+    decisionScope: job.decisionScope,
+    source: job.source,
+    protocolArtifact: job.protocolArtifact,
+    runner: job.runner,
+    subjectArtifact: job.subjectArtifact,
+    environment: job.environment,
+    observedAt: job.observedAt,
+    profileResults,
+    overallStatus: deriveStatus(
+      profileResults.map((profile) => profile.status),
+    ),
+  };
+  return {
+    schemaVersion: RESULT_SCHEMA_VERSION,
+    statement,
+    statementDigest: digestCanonical(statement),
+  };
+}
+
+async function executeJob(job, target) {
+  const capabilityExecution = await invokeTarget(target, "capability");
+  const capability = parseCapability(capabilityExecution);
+  const suiteResults = new Map();
+
+  if (capability === undefined) {
+    const targetUnavailable =
+      capabilityExecution.failureKind === "unavailable" ||
+      (capabilityExecution.failureKind === undefined &&
+        capabilityExecution.status !== 0);
+    for (const suite of job.suites) {
+      suiteResults.set(`${suite.profile}\0${suite.suiteId}`, {
+        suiteId: suite.suiteId,
+        status: targetUnavailable ? "not_applicable" : "failed",
+      });
+    }
+    return {
+      report: buildReport(job, suiteResults),
+      message: targetUnavailable
+        ? "conformance target unavailable"
+        : "conformance target response invalid",
+    };
+  }
+
+  let invalidResponse = false;
+  for (const suite of job.suites) {
+    const key = `${suite.profile}\0${suite.suiteId}`;
+    if (!capability.has(key)) {
+      suiteResults.set(key, {
+        suiteId: suite.suiteId,
+        status: "not_applicable",
+      });
+      continue;
+    }
+
+    const request = {
+      schemaVersion: SUITE_REQUEST_SCHEMA_VERSION,
+      profile: suite.profile,
+      suiteId: suite.suiteId,
+      protocolArtifact: job.protocolArtifact,
+      subjectArtifact: job.subjectArtifact,
+      vector: suite.vector,
+    };
+    const result = parseSuiteResult(
+      await invokeTarget(target, "evaluate", request),
+      suite.suiteId,
+    );
+    if (result === undefined) {
+      invalidResponse = true;
+      suiteResults.set(key, {
+        suiteId: suite.suiteId,
+        status: "failed",
+      });
+    } else {
+      suiteResults.set(key, result);
+    }
+  }
+
+  const report = buildReport(job, suiteResults);
+  return {
+    report,
+    message: invalidResponse
+      ? "conformance target response invalid"
+      : report.statement.overallStatus === "passed"
+        ? undefined
+        : "conformance suites did not pass",
+  };
+}
+
+function parseArguments(argv) {
+  let jobPath;
+  let targetCommand;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    if (argument === "--job" && value !== undefined) {
+      jobPath = value;
+      index += 1;
+    } else if (argument === "--target-command" && value !== undefined) {
+      targetCommand = value;
+      index += 1;
+    } else {
+      throw new JobError("arguments are invalid");
+    }
+  }
+  if (jobPath === undefined || targetCommand === undefined) {
+    throw new JobError("arguments are invalid");
+  }
+  if (!isAbsolute(targetCommand)) {
+    throw new JobError("target command must be absolute");
+  }
+  return { jobPath, target: targetCommand };
+}
+
+async function main() {
+  try {
+    const { jobPath, target } = parseArguments(process.argv.slice(2));
+    if (process.platform === "win32") {
+      throw new JobError("runner platform is unsupported");
+    }
+    let job;
+    try {
+      job = JSON.parse(await readFile(jobPath, "utf8"));
+    } catch {
+      throw new JobError("job document is invalid");
+    }
+    validateJob(job);
+    let resolvedTarget;
+    try {
+      resolvedTarget = await realpath(target);
+    } catch {
+      throw new JobError("artifact binding input is unavailable");
+    }
+    const subject = await validateArtifactBindings(job, resolvedTarget);
+    const outcome = await executeJob(job, subject);
+    process.stdout.write(`${JSON.stringify(outcome.report)}\n`);
+    if (outcome.message !== undefined) {
+      process.stderr.write(`${outcome.message}\n`);
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const message =
+      error instanceof JobError ? error.message : "runner execution failed";
+    process.stderr.write(`invalid conformance job: ${message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+await main();

--- a/conformance/automations/runner/conformance.test.mjs
+++ b/conformance/automations/runner/conformance.test.mjs
@@ -1,0 +1,591 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const RUNNER = fileURLToPath(new URL("./conformance.mjs", import.meta.url));
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const SHA_C = "c".repeat(64);
+const SHA_D = "d".repeat(64);
+const SHA_E = "e".repeat(64);
+
+function canonicalize(value) {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(",")}]`;
+  }
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+    .join(",")}}`;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function validJob(overrides = {}) {
+  const job = {
+    schemaVersion: "coven.automations.conformance-job.v1",
+    resultId: "audit-2026-09-08T120000Z",
+    decisionScope: { kind: "audit_only" },
+    source: {
+      repository: "https://github.com/OpenCoven/coven",
+      commit: "1".repeat(40),
+    },
+    protocolArtifact: {
+      bundleSchemaVersion: "coven.automations.bundle.v1",
+      sourceCommit: "1".repeat(40),
+      bundleSha256: SHA_A,
+      contractContentSha256: SHA_B,
+      fileCount: 19,
+    },
+    runner: {
+      name: "coven-automations-conformance-runner",
+      version: "0.1.0",
+      artifactSha256: sha256(readFileSync(RUNNER)),
+      vectorSetSha256: SHA_D,
+    },
+    subjectArtifact: {
+      artifactId: "coven-cli",
+      artifactVersion: "0.1.0",
+      platform: { os: "linux", arch: "x86_64" },
+      sha256: SHA_E,
+    },
+    environment: {
+      os: "linux",
+      arch: "x86_64",
+      runtime: "node-22",
+    },
+    observedAt: "2026-09-08T12:00:00Z",
+    suites: [
+      {
+        profile: "structural",
+        suiteId: "schema-validation",
+        vector: {
+          schemaVersion: "coven.automations.conformance-vector.v1",
+          vectorId: "schema-valid",
+        },
+      },
+    ],
+    ...overrides,
+  };
+  job.runner.vectorSetSha256 = sha256(canonicalize(job.suites));
+  return job;
+}
+
+async function writeTarget(directory) {
+  const path = join(directory, "target.mjs");
+  await writeFile(
+    path,
+    `#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { chmodSync, writeFileSync } from "node:fs";
+const mode = process.env.COVEN_TEST_TARGET_MODE ?? "pass";
+if (mode === "unavailable") process.exit(10);
+const operation = process.argv.at(-1);
+if (operation === "capability") {
+  if (mode === "replace-source") {
+    writeFileSync(process.argv[1], \`#!/usr/bin/env node
+const operation = process.argv.at(-1);
+if (operation === "evaluate") {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+  const request = JSON.parse(input);
+  process.stdout.write(JSON.stringify({
+    schemaVersion: "coven.automations.conformance-suite-result.v1",
+    suiteId: request.suiteId,
+    status: "passed",
+    evidence: { assertion: "substituted-target-ran" }
+  }));
+}
+\`);
+    chmodSync(process.argv[1], 0o755);
+  }
+  if (mode === "ignore-timeout") {
+    process.on("SIGTERM", () => {});
+    setTimeout(() => process.exit(10), 5_000);
+    await new Promise(() => {});
+  }
+  if (mode === "descendant-timeout") {
+    spawn(process.execPath, ["-e", "setTimeout(() => {}, 5000)"], {
+      stdio: ["ignore", process.stdout, process.stderr]
+    });
+    process.on("SIGTERM", () => {});
+    await new Promise(() => {});
+  }
+  if (mode === "malformed-capability") {
+    process.stdout.write('{"credential":"SECRET-CAPABILITY-OUTPUT"');
+    process.exit(0);
+  }
+  if (mode === "invalid-utf8-capability") {
+    process.stdout.write(Buffer.from([0x7b, 0x22, 0xff, 0x22, 0x3a, 0x31, 0x7d]));
+    process.exit(0);
+  }
+  process.stdout.write(JSON.stringify({
+    schemaVersion: "coven.automations.conformance-target-capability.v1",
+    profiles: [{ profile: "structural", suites: ["schema-validation"] }]
+  }));
+  process.exit(0);
+}
+if (operation !== "evaluate") process.exit(3);
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+const request = JSON.parse(input);
+if (mode === "malformed") {
+  process.stdout.write('{"credential":"SECRET-TARGET-OUTPUT"');
+  process.exit(0);
+}
+if (mode === "early-exit") process.exit(0);
+if (mode === "invalid-utf8") {
+  const prefix = Buffer.from('{"schemaVersion":"coven.automations.conformance-suite-result.v1","suiteId":"' + request.suiteId + '","status":"passed","evidence":{"text":"');
+  const suffix = Buffer.from('"}}');
+  process.stdout.write(Buffer.concat([prefix, Buffer.from([0xff]), suffix]));
+  process.exit(0);
+}
+if (mode === "unsafe-evidence") {
+  process.stdout.write('{"schemaVersion":"coven.automations.conformance-suite-result.v1","suiteId":"' + request.suiteId + '","status":"passed","evidence":{"count":9007199254740993}}');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  schemaVersion: "coven.automations.conformance-suite-result.v1",
+  suiteId: request.suiteId,
+  status: "passed",
+  evidence: { assertion: "native-target-ran", count: 1 }
+}));
+`,
+    { mode: 0o755 },
+  );
+  await chmod(path, 0o755);
+  return path;
+}
+
+async function runRunner({
+  job = validJob(),
+  targetCommand,
+  env = {},
+}) {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-runner-"));
+  const jobPath = join(directory, "job.json");
+  const boundJob = structuredClone(job);
+  if (boundJob.subjectArtifact && "sha256" in boundJob.subjectArtifact) {
+    boundJob.subjectArtifact.sha256 = sha256(await readFile(targetCommand));
+  }
+  await writeFile(jobPath, `${JSON.stringify(boundJob)}\n`);
+  const args = [
+    RUNNER,
+    "--job",
+    jobPath,
+    "--target-command",
+    targetCommand,
+  ];
+  const result = spawnSync(process.execPath, args, {
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+      timeout: 10_000,
+  });
+  return result;
+}
+
+test("emits a valid audit-only result for an executed native target suite", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+
+  const result = await runRunner({
+    targetCommand: target,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr, "");
+  const report = JSON.parse(result.stdout);
+  assert.equal(
+    report.schemaVersion,
+    "coven.automations.conformance-result.v1",
+  );
+  assert.deepEqual(report.statement.decisionScope, { kind: "audit_only" });
+  assert.equal(report.statement.overallStatus, "passed");
+  assert.deepEqual(report.statement.profileResults, [
+    {
+      profile: "structural",
+      status: "passed",
+      requiredSuites: ["schema-validation"],
+      suiteResults: [
+        {
+          suiteId: "schema-validation",
+          status: "passed",
+          evidenceDigest: {
+            algorithm: "sha256",
+            canonicalization: "jcs-rfc8785",
+            value:
+              "afac845080050a6b189e452d960b54d5d2b493b0975d153fa9c0914ff32ff316",
+          },
+        },
+      ],
+    },
+  ]);
+  assert.deepEqual(report.statementDigest, {
+    algorithm: "sha256",
+    canonicalization: "jcs-rfc8785",
+    value: sha256(canonicalize(report.statement)),
+  });
+  assert.equal("authentication" in report, false);
+});
+
+test("records an unavailable target as not applicable and fails the gate", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "unavailable" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target unavailable\n");
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.overallStatus, "not_applicable");
+  assert.deepEqual(report.statement.profileResults[0].suiteResults, [
+    {
+      suiteId: "schema-validation",
+      status: "not_applicable",
+    },
+  ]);
+});
+
+test("turns malformed target output into a static privacy-safe failure", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "malformed" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target response invalid\n");
+  assert.equal(result.stdout.includes("SECRET-TARGET-OUTPUT"), false);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.overallStatus, "failed");
+  assert.deepEqual(report.statement.profileResults[0].suiteResults, [
+    {
+      suiteId: "schema-validation",
+      status: "failed",
+    },
+  ]);
+});
+
+test("distinguishes malformed capability output from an unavailable target", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "malformed-capability" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target response invalid\n");
+  assert.equal(result.stdout.includes("SECRET-CAPABILITY-OUTPUT"), false);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.overallStatus, "failed");
+});
+
+test("classifies non-UTF-8 capability output as invalid, not unavailable", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "invalid-utf8-capability" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target response invalid\n");
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.overallStatus, "failed");
+});
+
+test("rejects target evidence outside the portable JCS number subset", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "unsafe-evidence" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target response invalid\n");
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.overallStatus, "failed");
+  assert.equal(
+    "evidenceDigest" in
+      report.statement.profileResults[0].suiteResults[0],
+    false,
+  );
+});
+
+test("refuses release eligibility because this runner is audit only", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob({
+    decisionScope: {
+      kind: "release_eligibility",
+      policyBinding: {
+        policyId: "release",
+        policyVersion: "1",
+        digest: SHA_A,
+      },
+    },
+  });
+
+  const result = await runRunner({
+    job,
+    targetCommand: target,
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: decision scope is not audit-only\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("rejects a vector-set digest that does not bind the requested suites", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob();
+  job.runner.vectorSetSha256 = SHA_D;
+
+  const result = await runRunner({
+    job,
+    targetCommand: target,
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: vector set binding is invalid\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("rejects a runner digest that does not bind the executing script", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob();
+  job.runner.artifactSha256 = SHA_C;
+
+  const result = await runRunner({
+    job,
+    targetCommand: target,
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: runner artifact binding is invalid\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("refuses a full-profile claim in the bounded runner slice", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob({
+    suites: [
+      {
+        profile: "full",
+        suiteId: "full-profile",
+        vector: { vectorId: "unsupported-full-claim" },
+      },
+    ],
+  });
+
+  const result = await runRunner({
+    job,
+    targetCommand: target,
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: full profile is unsupported\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("requires exact subject-artifact metadata before executing", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob({
+    subjectArtifact: {
+      artifactId: "coven-cli",
+      artifactVersion: "0.1.0",
+      platform: { os: "linux", arch: "x86_64" },
+    },
+  });
+
+  const result = await runRunner({
+    job,
+    targetCommand: target,
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: subject artifact is invalid\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("rejects normalized-but-invalid calendar timestamps", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob({ observedAt: "2026-02-31T12:00:00Z" });
+
+  const result = await runRunner({
+    job,
+    targetCommand: target,
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: observed timestamp is invalid\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("requires the protocol bundle source commit to match the source binding", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob();
+  job.protocolArtifact.sourceCommit = "2".repeat(40);
+
+  const result = await runRunner({ job, targetCommand: target });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: protocol source binding is invalid\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("rejects relative target commands before artifact binding", async () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      RUNNER,
+      "--job",
+      "job.json",
+      "--target-command",
+      "relative-coven",
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: target command must be absolute\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("executes every target operation from the same staged subject bytes", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const originalDigest = sha256(await readFile(target));
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "replace-source" },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(sha256(await readFile(target)), originalDigest);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.subjectArtifact.sha256, originalDigest);
+});
+
+test("force-kills a target that ignores the graceful timeout", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const startedAt = Date.now();
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "ignore-timeout" },
+  });
+
+  const elapsedMs = Date.now() - startedAt;
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target unavailable\n");
+  assert.ok(
+    elapsedMs < 3_500,
+    `hard timeout took ${elapsedMs}ms`,
+  );
+});
+
+test("force-kills descendants that retain the target pipes", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const startedAt = Date.now();
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "descendant-timeout" },
+  });
+
+  const elapsedMs = Date.now() - startedAt;
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target unavailable\n");
+  assert.ok(
+    elapsedMs < 3_500,
+    `process-tree timeout took ${elapsedMs}ms`,
+  );
+});
+
+test("turns early target stdin closure into a static failed result", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob();
+  job.suites[0].vector.payload = "x".repeat(8 * 1024 * 1024);
+  job.runner.vectorSetSha256 = sha256(canonicalize(job.suites));
+
+  const result = await runRunner({
+    job,
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "early-exit" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target response invalid\n");
+  assert.doesNotThrow(() => JSON.parse(result.stdout));
+});
+
+test("rejects non-UTF-8 target output instead of replacement-decoding it", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "invalid-utf8" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target response invalid\n");
+  assert.equal(result.stdout.includes("\ufffd"), false);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.overallStatus, "failed");
+});

--- a/conformance/automations/runner/conformance.test.mjs
+++ b/conformance/automations/runner/conformance.test.mjs
@@ -151,6 +151,19 @@ if (mode === "invalid-utf8") {
   process.stdout.write(Buffer.concat([prefix, Buffer.from([0xff]), suffix]));
   process.exit(0);
 }
+if (mode === "deep-evidence") {
+  const depth = 20_000;
+  process.stdout.write(
+    '{"schemaVersion":"coven.automations.conformance-suite-result.v1","suiteId":"' +
+      request.suiteId +
+      '","status":"passed","evidence":' +
+      "[".repeat(depth) +
+      "0" +
+      "]".repeat(depth) +
+      "}",
+  );
+  process.exit(0);
+}
 if (mode === "unsafe-evidence") {
   process.stdout.write('{"schemaVersion":"coven.automations.conformance-suite-result.v1","suiteId":"' + request.suiteId + '","status":"passed","evidence":{"count":9007199254740993}}');
   process.exit(0);
@@ -586,6 +599,38 @@ test("rejects non-UTF-8 target output instead of replacement-decoding it", async
   assert.equal(result.status, 1);
   assert.equal(result.stderr, "conformance target response invalid\n");
   assert.equal(result.stdout.includes("\ufffd"), false);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.statement.overallStatus, "failed");
+});
+
+test("rejects vector sets that cannot be represented as portable JCS", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+  const job = validJob();
+  job.suites[0].vector.payload = "\ud800";
+  job.runner.vectorSetSha256 = sha256(canonicalize(job.suites));
+
+  const result = await runRunner({ job, targetCommand: target });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "invalid conformance job: vector set is not portable JCS\n",
+  );
+  assert.equal(result.stdout, "");
+});
+
+test("turns excessively deep target evidence into a failed result", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "coven-conformance-target-"));
+  const target = await writeTarget(directory);
+
+  const result = await runRunner({
+    targetCommand: target,
+    env: { COVEN_TEST_TARGET_MODE: "deep-evidence" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, "conformance target response invalid\n");
   const report = JSON.parse(result.stdout);
   assert.equal(report.statement.overallStatus, "failed");
 });

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -1,0 +1,173 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
+
+const TARGET_CAPABILITY_SCHEMA_VERSION: &str = "coven.automations.conformance-target-capability.v1";
+const SUITE_REQUEST_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-request.v1";
+const SUITE_RESULT_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-result.v1";
+const CAPABILITY_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.capability-negotiation-vectors.v1";
+const STRUCTURAL_PROFILE: &str = "structural";
+const MAX_CASES: usize = 128;
+
+pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetCapability {
+    schema_version: &'static str,
+    profiles: Vec<TargetProfileCapability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetProfileCapability {
+    profile: &'static str,
+    suites: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetSuiteResult {
+    schema_version: &'static str,
+    suite_id: String,
+    pub status: TargetSuiteStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetSuiteStatus {
+    Passed,
+    Failed,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct TargetSuiteRequest {
+    schema_version: String,
+    profile: String,
+    suite_id: String,
+    protocol_artifact: Value,
+    subject_artifact: Value,
+    vector: Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapabilityVectorSet {
+    schema_version: String,
+    cases: Vec<CapabilityVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapabilityVectorCase {
+    case_id: String,
+    definition: Value,
+    expected: ExpectedNegotiation,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case", deny_unknown_fields)]
+enum ExpectedNegotiation {
+    Supported,
+    Unsupported { variant: String },
+}
+
+#[must_use]
+pub fn capability() -> TargetCapability {
+    TargetCapability {
+        schema_version: TARGET_CAPABILITY_SCHEMA_VERSION,
+        profiles: vec![TargetProfileCapability {
+            profile: STRUCTURAL_PROFILE,
+            suites: vec![CAPABILITY_NEGOTIATION_SUITE],
+        }],
+    }
+}
+
+pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
+    let request: TargetSuiteRequest =
+        serde_json::from_value(request.clone()).map_err(|_| "conformance request is invalid")?;
+    if request.schema_version != SUITE_REQUEST_SCHEMA_VERSION
+        || request.profile != STRUCTURAL_PROFILE
+        || request.suite_id != CAPABILITY_NEGOTIATION_SUITE
+    {
+        return Err("conformance suite is unsupported");
+    }
+    if !request.protocol_artifact.is_object() || !request.subject_artifact.is_object() {
+        return Err("conformance request is invalid");
+    }
+
+    let vectors: CapabilityVectorSet = serde_json::from_value(request.vector.clone())
+        .map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != CAPABILITY_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    for case in &vectors.cases {
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !case.definition.is_object()
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+
+    let all_passed = vectors.cases.iter().all(case_matches);
+    let evidence = if all_passed {
+        let canonical =
+            serde_jcs::to_vec(&request.vector).map_err(|_| "conformance vector is invalid")?;
+        let vector_digest: String = Sha256::digest(canonical)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+        Some(json!({
+            "executedCases": vectors.cases.len(),
+            "passedCases": vectors.cases.len(),
+            "vectorDigest": format!("sha256:{vector_digest}")
+        }))
+    } else {
+        None
+    };
+
+    Ok(TargetSuiteResult {
+        schema_version: SUITE_RESULT_SCHEMA_VERSION,
+        suite_id: request.suite_id,
+        status: if all_passed {
+            TargetSuiteStatus::Passed
+        } else {
+            TargetSuiteStatus::Failed
+        },
+        evidence,
+    })
+}
+
+fn case_matches(case: &CapabilityVectorCase) -> bool {
+    match (negotiate_definition(&case.definition), &case.expected) {
+        (Ok(DefinitionNegotiation::Supported(_)), ExpectedNegotiation::Supported) => true,
+        (
+            Ok(DefinitionNegotiation::Unsupported(observed)),
+            ExpectedNegotiation::Unsupported { variant },
+        ) => observed.variant == *variant,
+        _ => false,
+    }
+}
+
+fn valid_case_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.bytes().enumerate().all(|(index, byte)| {
+            byte.is_ascii_alphanumeric()
+                || (index > 0 && matches!(byte, b'.' | b'_' | b':' | b'@' | b'-'))
+        })
+}

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -1,0 +1,169 @@
+use serde_json::{json, Value};
+
+use super::conformance_target::{
+    capability, evaluate, TargetSuiteStatus, CAPABILITY_NEGOTIATION_SUITE,
+};
+
+fn request(vector: Value) -> Value {
+    json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": CAPABILITY_NEGOTIATION_SUITE,
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {
+                "os": "linux",
+                "arch": "x86_64"
+            },
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vector
+    })
+}
+
+#[test]
+fn capability_advertises_only_the_native_structural_suite() {
+    assert_eq!(
+        serde_json::to_value(capability()).unwrap(),
+        json!({
+            "schemaVersion": "coven.automations.conformance-target-capability.v1",
+            "profiles": [{
+                "profile": "structural",
+                "suites": [CAPABILITY_NEGOTIATION_SUITE]
+            }]
+        })
+    );
+}
+
+#[test]
+fn capability_negotiation_suite_executes_supported_and_refused_cases() {
+    let response = evaluate(&request(json!({
+        "schemaVersion": "coven.automations.capability-negotiation-vectors.v1",
+        "cases": [
+            {
+                "caseId": "supported-minimal",
+                "definition": {
+                    "schemaVersion": 1,
+                    "id": "native-supported",
+                    "name": "Native supported",
+                    "status": "PAUSED",
+                    "rrule": "FREQ=DAILY",
+                    "timezone": "local",
+                    "prompt": "Run the native conformance probe",
+                    "misfire": "latest",
+                    "overlap": "forbid",
+                    "timeoutMinutes": 30,
+                    "runtime": "coven-code"
+                },
+                "expected": {
+                    "outcome": "supported"
+                }
+            },
+            {
+                "caseId": "refused-trigger",
+                "definition": {
+                    "schemaVersion": 1,
+                    "id": "native-refused",
+                    "name": "Native refused",
+                    "status": "PAUSED",
+                    "rrule": "FREQ=DAILY",
+                    "timezone": "local",
+                    "prompt": "Run the native conformance probe",
+                    "misfire": "latest",
+                    "overlap": "forbid",
+                    "timeoutMinutes": 30,
+                    "runtime": "coven-code",
+                    "trigger": {
+                        "variant": "webhook",
+                        "version": 1,
+                        "webhook": {}
+                    }
+                },
+                "expected": {
+                    "outcome": "unsupported",
+                    "variant": "trigger.webhook"
+                }
+            }
+        ]
+    })))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(
+        response.evidence,
+        Some(json!({
+            "executedCases": 2,
+            "passedCases": 2,
+            "vectorDigest": "sha256:fc716602d581388f683fbf9c81b588a7510b4eed308999dd89ea13f76ad5304b"
+        }))
+    );
+}
+
+#[test]
+fn capability_negotiation_suite_fails_closed_on_an_expectation_mismatch() {
+    let response = evaluate(&request(json!({
+        "schemaVersion": "coven.automations.capability-negotiation-vectors.v1",
+        "cases": [{
+            "caseId": "wrong-expectation",
+            "definition": {
+                "schemaVersion": 1,
+                "id": "native-supported",
+                "name": "Native supported",
+                "status": "PAUSED",
+                "rrule": "FREQ=DAILY",
+                "timezone": "local",
+                "prompt": "Run the native conformance probe",
+                "misfire": "latest",
+                "overlap": "forbid",
+                "timeoutMinutes": 30,
+                "runtime": "coven-code"
+            },
+            "expected": {
+                "outcome": "unsupported",
+                "variant": "webhook"
+            }
+        }]
+    })))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn evaluator_rejects_unadvertised_suites_with_a_static_error() {
+    let mut request = request(json!({
+        "schemaVersion": "coven.automations.capability-negotiation-vectors.v1",
+        "cases": []
+    }));
+    request["suiteId"] = json!("scheduler-secret-output");
+
+    assert_eq!(
+        evaluate(&request).unwrap_err(),
+        "conformance suite is unsupported"
+    );
+}
+
+#[test]
+fn evaluator_rejects_malformed_vectors_with_a_static_error() {
+    assert_eq!(
+        evaluate(&request(json!({
+            "schemaVersion": "coven.automations.capability-negotiation-vectors.v1",
+            "cases": [{
+                "caseId": "contains-secret",
+                "definition": "SECRET-DEFINITION",
+                "expected": {"outcome": "supported"}
+            }]
+        })))
+        .unwrap_err(),
+        "conformance vector is invalid"
+    );
+}

--- a/crates/coven-cli/src/automations/mod.rs
+++ b/crates/coven-cli/src/automations/mod.rs
@@ -10,6 +10,9 @@ pub mod authority_projection;
 pub mod cancellation;
 pub mod capability_negotiation;
 pub mod command_adoption;
+pub mod conformance_target;
+#[cfg(test)]
+mod conformance_target_tests;
 pub mod contract;
 pub mod daemon_tick;
 pub mod definition;

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -748,6 +748,14 @@ enum Command {
         #[command(subcommand)]
         command: SchedulerCommand,
     },
+    #[command(
+        hide = true,
+        about = "Expose machine-facing Coven Automations protocol surfaces"
+    )]
+    Automations {
+        #[command(subcommand)]
+        command: AutomationsCommand,
+    },
     #[command(about = "Inspect travel-mode handoff state (read-only)")]
     Travel {
         #[command(subcommand)]
@@ -1044,6 +1052,23 @@ enum SchedulerCommand {
         #[arg(long, help = "Print the loop state as JSON (machine-readable)")]
         json: bool,
     },
+}
+
+#[derive(Subcommand, Debug)]
+enum AutomationsCommand {
+    #[command(about = "Expose the native conformance target protocol")]
+    Conformance {
+        #[command(subcommand)]
+        command: AutomationsConformanceCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum AutomationsConformanceCommand {
+    #[command(about = "Print the native conformance suites supported by this binary")]
+    Capability,
+    #[command(about = "Evaluate one conformance suite request from standard input")]
+    Evaluate,
 }
 
 #[derive(Subcommand, Debug)]
@@ -1372,6 +1397,11 @@ fn main() -> Result<()> {
         Some(Command::Config {
             command: ConfigCommand::Paths { .. }
         })
+    ) || matches!(
+        &cli.command,
+        Some(Command::Automations {
+            command: AutomationsCommand::Conformance { .. }
+        })
     ) {
         return run_cli(cli);
     }
@@ -1646,6 +1676,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             SchedulerCommand::Decision { id, json } => observe::run_scheduler_decision(&id, json),
             SchedulerCommand::Loop { loop_id, json } => observe::run_scheduler_loop(&loop_id, json),
         },
+        Some(Command::Automations { command }) => run_automations_command(command),
         Some(Command::Travel { command }) => match command {
             TravelCommand::State {
                 client,
@@ -3637,6 +3668,30 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         &current_timestamp(),
     )?;
     Ok(record.id)
+}
+
+fn run_automations_command(command: AutomationsCommand) -> Result<()> {
+    match command {
+        AutomationsCommand::Conformance { command } => match command {
+            AutomationsConformanceCommand::Capability => {
+                println!(
+                    "{}",
+                    serde_json::to_string(&automations::conformance_target::capability())?
+                );
+                Ok(())
+            }
+            AutomationsConformanceCommand::Evaluate => {
+                let payload = io::read_to_string(io::stdin())
+                    .context("failed to read conformance request from standard input")?;
+                let request = serde_json::from_str(&payload)
+                    .map_err(|_| anyhow!("conformance request is invalid"))?;
+                let response = automations::conformance_target::evaluate(&request)
+                    .map_err(|message| anyhow!(message))?;
+                println!("{}", serde_json::to_string(&response)?);
+                Ok(())
+            }
+        },
+    }
 }
 
 fn run_logs_command(command: LogsCommand) -> Result<()> {
@@ -6232,6 +6287,26 @@ mod tests {
             other => panic!("expected scheduler loop command, got {other:?}"),
         }
         assert!(Cli::try_parse_from(["coven", "scheduler", "decision"]).is_err());
+    }
+
+    #[test]
+    fn cli_parses_automations_conformance_target_commands() {
+        assert!(matches!(
+            Cli::parse_from(["coven", "automations", "conformance", "capability"]).command,
+            Some(Command::Automations {
+                command: AutomationsCommand::Conformance {
+                    command: AutomationsConformanceCommand::Capability
+                }
+            })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "automations", "conformance", "evaluate"]).command,
+            Some(Command::Automations {
+                command: AutomationsCommand::Conformance {
+                    command: AutomationsConformanceCommand::Evaluate
+                }
+            })
+        ));
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::env::VarError;
 use std::ffi::{OsStr, OsString};
-#[cfg(unix)]
 use std::io::Read;
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -3681,8 +3680,7 @@ fn run_automations_command(command: AutomationsCommand) -> Result<()> {
                 Ok(())
             }
             AutomationsConformanceCommand::Evaluate => {
-                let payload = io::read_to_string(io::stdin())
-                    .context("failed to read conformance request from standard input")?;
+                let payload = read_conformance_request(io::stdin().lock())?;
                 let request = serde_json::from_str(&payload)
                     .map_err(|_| anyhow!("conformance request is invalid"))?;
                 let response = automations::conformance_target::evaluate(&request)
@@ -3692,6 +3690,20 @@ fn run_automations_command(command: AutomationsCommand) -> Result<()> {
             }
         },
     }
+}
+
+const MAX_CONFORMANCE_REQUEST_BYTES: usize = 1024 * 1024;
+
+fn read_conformance_request(reader: impl Read) -> Result<String> {
+    let mut payload = Vec::new();
+    reader
+        .take((MAX_CONFORMANCE_REQUEST_BYTES + 1) as u64)
+        .read_to_end(&mut payload)
+        .map_err(|_| anyhow!("conformance request is invalid"))?;
+    if payload.len() > MAX_CONFORMANCE_REQUEST_BYTES {
+        bail!("conformance request is invalid");
+    }
+    String::from_utf8(payload).map_err(|_| anyhow!("conformance request is invalid"))
 }
 
 fn run_logs_command(command: LogsCommand) -> Result<()> {
@@ -6307,6 +6319,37 @@ mod tests {
                 }
             })
         ));
+    }
+
+    #[test]
+    fn conformance_request_reader_rejects_oversized_input() {
+        let input = vec![b'x'; MAX_CONFORMANCE_REQUEST_BYTES + 1];
+
+        assert_eq!(
+            read_conformance_request(input.as_slice())
+                .unwrap_err()
+                .to_string(),
+            "conformance request is invalid"
+        );
+    }
+
+    #[test]
+    fn conformance_request_reader_accepts_bounded_input() {
+        assert_eq!(
+            read_conformance_request(br#"{"suite_id":"capability-negotiation"}"#.as_slice())
+                .unwrap(),
+            r#"{"suite_id":"capability-negotiation"}"#
+        );
+    }
+
+    #[test]
+    fn conformance_request_reader_rejects_invalid_utf8() {
+        assert_eq!(
+            read_conformance_request([0xff].as_slice())
+                .unwrap_err()
+                .to_string(),
+            "conformance request is invalid"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -1,0 +1,107 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use serde_json::{json, Value};
+
+const CAPABILITY_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/capability-negotiation.vectors.json");
+
+fn coven_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+}
+
+fn run_target(coven_home: &Path, operation: &str, input: Option<&Value>) -> anyhow::Result<Output> {
+    let mut command = Command::new(coven_bin());
+    command
+        .args(["automations", "conformance", operation])
+        .env("COVEN_HOME", coven_home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if input.is_some() {
+        command.stdin(Stdio::piped());
+    }
+    let mut child = command.spawn()?;
+    if let Some(input) = input {
+        child
+            .stdin
+            .take()
+            .expect("stdin is piped")
+            .write_all(input.to_string().as_bytes())?;
+    }
+    child.wait_with_output().map_err(Into::into)
+}
+
+#[test]
+fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+
+    let output = run_target(&coven_home, "capability", None)?;
+
+    assert!(
+        output.status.success(),
+        "capability command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout)?,
+        json!({
+            "schemaVersion": "coven.automations.conformance-target-capability.v1",
+            "profiles": [{
+                "profile": "structural",
+                "suites": ["capability-negotiation"]
+            }]
+        })
+    );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_capability_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(CAPABILITY_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "capability-negotiation",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        response["schemaVersion"],
+        "coven.automations.conformance-suite-result.v1"
+    );
+    assert_eq!(response["suiteId"], "capability-negotiation");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 2);
+    assert_eq!(response["evidence"]["passedCases"], 2);
+    assert!(response["evidence"]["vectorDigest"]
+        .as_str()
+        .is_some_and(|digest| digest.starts_with("sha256:") && digest.len() == 71));
+    assert!(!coven_home.exists());
+    Ok(())
+}

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 
 const CAPABILITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/capability-negotiation.vectors.json");
+const MAX_CONFORMANCE_REQUEST_BYTES: usize = 1024 * 1024;
 
 fn coven_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_coven"))
@@ -29,6 +30,22 @@ fn run_target(coven_home: &Path, operation: &str, input: Option<&Value>) -> anyh
             .expect("stdin is piped")
             .write_all(input.to_string().as_bytes())?;
     }
+    child.wait_with_output().map_err(Into::into)
+}
+
+fn run_target_bytes(coven_home: &Path, operation: &str, input: &[u8]) -> anyhow::Result<Output> {
+    let mut child = Command::new(coven_bin())
+        .args(["automations", "conformance", operation])
+        .env("COVEN_HOME", coven_home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(input)?;
     child.wait_with_output().map_err(Into::into)
 }
 
@@ -102,6 +119,25 @@ fn native_target_evaluates_checked_in_capability_vectors() -> anyhow::Result<()>
     assert!(response["evidence"]["vectorDigest"]
         .as_str()
         .is_some_and(|digest| digest.starts_with("sha256:") && digest.len() == 71));
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_rejects_oversized_request_without_parsing_it() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let mut request = b"{}".to_vec();
+    request.resize(MAX_CONFORMANCE_REQUEST_BYTES + 1, b' ');
+
+    let output = run_target_bytes(&coven_home, "evaluate", &request)?;
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8(output.stderr)?,
+        "Error: conformance request is invalid\n"
+    );
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add a dependency-free Automations conformance runner that emits the existing `coven.automations.conformance-result.v1` envelope
- add a stateless native Coven target for the structural `capability-negotiation` suite
- bind the exact runner, requested vector inventory, protocol source commit, and directly executed subject artifact
- fail closed on unavailable, malformed, oversized, non-UTF-8, slow, or process-spawning targets without copying raw target output into reports

## Scope

This advances #858 but does not close it.

The runner is deliberately audit-only:

- it refuses `release_eligibility`
- it refuses the aggregate `full` profile
- it does not sign results or establish a trust root
- it does not claim scheduler, Runtime Authority, continuity, privacy, or interoperability conformance
- the standalone runner currently supports Linux and macOS; it refuses Windows until target processes can be contained with a kill-on-close Job Object

The only native suite in this slice executes checked-in capability-negotiation vectors against Coven's existing Rust definition parser and capability policy. No scheduler, authority, state-transition, or receipt oracle is duplicated in JavaScript.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked -- --test-threads=1`
- `node --test conformance/automations/runner/conformance.test.mjs scripts/package-automations-protocol.test.mjs`
- `python3 scripts/check-ci-workflow-test.py`
- `python3 scripts/classify-ci-changes-test.py`
- `python scripts/check-secrets.py`
- exact-commit protocol package plus runner execution against the compiled `coven` target produced a passed structural audit result with exact source, protocol, runner, vector-set, and subject hashes
