### PR TITLE
feat: certify automation run terminal monotonicity

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -158,8 +158,9 @@ The native Coven target currently implements two structural suites.
 definition parser and capability policy. `run-terminal-monotonicity` executes
 the checked-in settlement and replay cases against the real Rust run ledger in
 an isolated in-memory store, proving that a later terminal observation cannot
-rewrite the first committed terminal state. It does not claim the complete
-occurrence or attempt state machines.
+rewrite the first committed terminal state. Each vector must use distinct first
+and replay statuses so a passing case exercises an actual conflict. It does not
+claim the complete occurrence or attempt state machines.
 
 The runner computes a JCS SHA-256 digest of returned evidence and discards the
 raw evidence after building the result envelope. Evidence is restricted to JSON

--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -122,7 +122,9 @@ source metadata for the files and binary under test. `source.commit` must equal
 
 The checked-in
 [`capability-negotiation.vectors.json`](capability-negotiation.vectors.json)
-contains the current nonempty vector set.
+and
+[`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
+files contain the current nonempty vector sets.
 
 ## Target protocol
 
@@ -136,7 +138,10 @@ The runner invokes the target directly without a shell.
   "profiles": [
     {
       "profile": "structural",
-      "suites": ["capability-negotiation"]
+      "suites": [
+        "capability-negotiation",
+        "run-terminal-monotonicity"
+      ]
     }
   ]
 }
@@ -148,13 +153,18 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements only the structural
-`capability-negotiation` suite. It executes the checked-in cases against Rust's
-real definition parser and capability negotiation code. The runner computes a
-JCS SHA-256 digest of returned evidence and discards the raw evidence after
-building the result envelope. Evidence is restricted to JSON values that can
-be canonicalized consistently across the JavaScript runner and Rust verifier.
-The native target rejects evaluation requests larger than one MiB before JSON
-parsing.
+The native Coven target currently implements two structural suites.
+`capability-negotiation` executes the checked-in cases against Rust's real
+definition parser and capability policy. `run-terminal-monotonicity` executes
+the checked-in settlement and replay cases against the real Rust run ledger in
+an isolated in-memory store, proving that a later terminal observation cannot
+rewrite the first committed terminal state. It does not claim the complete
+occurrence or attempt state machines.
+
+The runner computes a JCS SHA-256 digest of returned evidence and discards the
+raw evidence after building the result envelope. Evidence is restricted to JSON
+values that can be canonicalized consistently across the JavaScript runner and
+Rust verifier. The native target rejects evaluation requests larger than one
+MiB before JSON parsing.
 Each target operation has a two-second deadline followed by process-tree
 termination; output is capped at one MiB.

--- a/conformance/automations/runner/run-terminal-monotonicity.vectors.json
+++ b/conformance/automations/runner/run-terminal-monotonicity.vectors.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "coven.automations.run-terminal-monotonicity-vectors.v1",
+  "cases": [
+    {
+      "caseId": "succeeded-cannot-be-rewritten",
+      "firstStatus": "succeeded",
+      "replayStatus": "failed",
+      "expected": {
+        "firstCommitted": true,
+        "replayCommitted": false,
+        "finalStatus": "succeeded"
+      }
+    },
+    {
+      "caseId": "failed-cannot-be-rewritten",
+      "firstStatus": "failed",
+      "replayStatus": "succeeded",
+      "expected": {
+        "firstCommitted": true,
+        "replayCommitted": false,
+        "finalStatus": "failed"
+      }
+    },
+    {
+      "caseId": "cancelled-cannot-be-rewritten",
+      "firstStatus": "cancelled",
+      "replayStatus": "timed_out",
+      "expected": {
+        "firstCommitted": true,
+        "replayCommitted": false,
+        "finalStatus": "cancelled"
+      }
+    },
+    {
+      "caseId": "timed-out-cannot-be-rewritten",
+      "firstStatus": "timed_out",
+      "replayStatus": "succeeded",
+      "expected": {
+        "firstCommitted": true,
+        "replayCommitted": false,
+        "finalStatus": "timed_out"
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -188,6 +188,13 @@ fn evaluate_capability_negotiation(vector: &Value) -> Result<bool, &'static str>
 }
 
 fn evaluate_run_terminal_monotonicity(vector: &Value) -> Result<bool, &'static str> {
+    let (executed_cases, passed_cases) = evaluate_run_terminal_monotonicity_case_counts(vector)?;
+    Ok(passed_cases == executed_cases)
+}
+
+pub(super) fn evaluate_run_terminal_monotonicity_case_counts(
+    vector: &Value,
+) -> Result<(usize, usize), &'static str> {
     let vectors: RunTerminalVectorSet =
         serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
     if vectors.schema_version != RUN_TERMINAL_VECTOR_SCHEMA_VERSION
@@ -199,7 +206,10 @@ fn evaluate_run_terminal_monotonicity(vector: &Value) -> Result<bool, &'static s
 
     let mut case_ids = BTreeSet::new();
     for case in &vectors.cases {
-        if !valid_case_id(&case.case_id) || !case_ids.insert(&case.case_id) {
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || case.first_status == case.replay_status
+        {
             return Err("conformance vector is invalid");
         }
     }
@@ -213,12 +223,11 @@ fn evaluate_run_terminal_monotonicity(vector: &Value) -> Result<bool, &'static s
         .map_err(|_| "conformance suite execution failed")?;
     let now = DateTime::<Utc>::from_timestamp(0, 0).ok_or("conformance suite execution failed")?;
 
+    let mut passed_cases = 0;
     for (index, case) in vectors.cases.iter().enumerate() {
-        if !run_terminal_case_matches(&conn, case, index, now)? {
-            return Ok(false);
-        }
+        passed_cases += usize::from(run_terminal_case_matches(&conn, case, index, now)?);
     }
-    Ok(true)
+    Ok((vectors.cases.len(), passed_cases))
 }
 
 fn run_terminal_case_matches(

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -1,20 +1,26 @@
 use std::collections::BTreeSet;
 
+use chrono::{DateTime, Duration, Utc};
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
+use super::runs::{record_run_finish, record_run_start, RunFinish, RunStart};
 
 const TARGET_CAPABILITY_SCHEMA_VERSION: &str = "coven.automations.conformance-target-capability.v1";
 const SUITE_REQUEST_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-request.v1";
 const SUITE_RESULT_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-result.v1";
 const CAPABILITY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.capability-negotiation-vectors.v1";
+const RUN_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.run-terminal-monotonicity-vectors.v1";
 const STRUCTURAL_PROFILE: &str = "structural";
 const MAX_CASES: usize = 128;
 
 pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
+pub const RUN_TERMINAL_MONOTONICITY_SUITE: &str = "run-terminal-monotonicity";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -80,13 +86,60 @@ enum ExpectedNegotiation {
     Unsupported { variant: String },
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RunTerminalVectorSet {
+    schema_version: String,
+    cases: Vec<RunTerminalVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RunTerminalVectorCase {
+    case_id: String,
+    first_status: TerminalRunStatus,
+    replay_status: TerminalRunStatus,
+    expected: ExpectedRunTerminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TerminalRunStatus {
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+}
+
+impl TerminalRunStatus {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::TimedOut => "timed_out",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedRunTerminal {
+    first_committed: bool,
+    replay_committed: bool,
+    final_status: TerminalRunStatus,
+}
+
 #[must_use]
 pub fn capability() -> TargetCapability {
     TargetCapability {
         schema_version: TARGET_CAPABILITY_SCHEMA_VERSION,
         profiles: vec![TargetProfileCapability {
             profile: STRUCTURAL_PROFILE,
-            suites: vec![CAPABILITY_NEGOTIATION_SUITE],
+            suites: vec![
+                CAPABILITY_NEGOTIATION_SUITE,
+                RUN_TERMINAL_MONOTONICITY_SUITE,
+            ],
         }],
     }
 }
@@ -96,7 +149,6 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         serde_json::from_value(request.clone()).map_err(|_| "conformance request is invalid")?;
     if request.schema_version != SUITE_REQUEST_SCHEMA_VERSION
         || request.profile != STRUCTURAL_PROFILE
-        || request.suite_id != CAPABILITY_NEGOTIATION_SUITE
     {
         return Err("conformance suite is unsupported");
     }
@@ -104,8 +156,17 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         return Err("conformance request is invalid");
     }
 
-    let vectors: CapabilityVectorSet = serde_json::from_value(request.vector.clone())
-        .map_err(|_| "conformance vector is invalid")?;
+    let all_passed = match request.suite_id.as_str() {
+        CAPABILITY_NEGOTIATION_SUITE => evaluate_capability_negotiation(&request.vector)?,
+        RUN_TERMINAL_MONOTONICITY_SUITE => evaluate_run_terminal_monotonicity(&request.vector)?,
+        _ => return Err("conformance suite is unsupported"),
+    };
+    result_for(&request.suite_id, &request.vector, all_passed)
+}
+
+fn evaluate_capability_negotiation(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: CapabilityVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
     if vectors.schema_version != CAPABILITY_VECTOR_SCHEMA_VERSION
         || vectors.cases.is_empty()
         || vectors.cases.len() > MAX_CASES
@@ -123,17 +184,122 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         }
     }
 
-    let all_passed = vectors.cases.iter().all(case_matches);
+    Ok(vectors.cases.iter().all(capability_case_matches))
+}
+
+fn evaluate_run_terminal_monotonicity(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: RunTerminalVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != RUN_TERMINAL_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    for case in &vectors.cases {
+        if !valid_case_id(&case.case_id) || !case_ids.insert(&case.case_id) {
+            return Err("conformance vector is invalid");
+        }
+    }
+
+    let conn = Connection::open_in_memory().map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::store::AUTOMATION_DEFINITIONS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::occurrences::AUTOMATION_OCCURRENCES_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::runs::AUTOMATION_RUNS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    let now = DateTime::<Utc>::from_timestamp(0, 0).ok_or("conformance suite execution failed")?;
+
+    for (index, case) in vectors.cases.iter().enumerate() {
+        if !run_terminal_case_matches(&conn, case, index, now)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn run_terminal_case_matches(
+    conn: &Connection,
+    case: &RunTerminalVectorCase,
+    index: usize,
+    now: DateTime<Utc>,
+) -> Result<bool, &'static str> {
+    let run_id = format!("conformance-run-{index}");
+    record_run_start(
+        conn,
+        &run_id,
+        RunStart {
+            automation_id: "conformance-automation",
+            occurrence_id: None,
+            authority_profile: None,
+            session_id: None,
+            familiar_id: None,
+            runtime: "coven-code",
+            timeout_at: now + Duration::minutes(30),
+        },
+        now,
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    let first_committed = record_run_finish(
+        conn,
+        &run_id,
+        RunFinish {
+            status: case.first_status.as_str(),
+            exit_code: None,
+            session_id: None,
+            log_json: None,
+            output_commit: None,
+        },
+        now,
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    let replay_committed = record_run_finish(
+        conn,
+        &run_id,
+        RunFinish {
+            status: case.replay_status.as_str(),
+            exit_code: None,
+            session_id: None,
+            log_json: None,
+            output_commit: None,
+        },
+        now + Duration::seconds(1),
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    let final_status = conn
+        .query_row(
+            "SELECT status FROM automation_runs WHERE id = ?1",
+            [&run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|_| "conformance suite execution failed")?;
+
+    Ok(first_committed == case.expected.first_committed
+        && replay_committed == case.expected.replay_committed
+        && final_status == case.expected.final_status.as_str())
+}
+
+fn result_for(
+    suite_id: &str,
+    vector: &Value,
+    all_passed: bool,
+) -> Result<TargetSuiteResult, &'static str> {
     let evidence = if all_passed {
-        let canonical =
-            serde_jcs::to_vec(&request.vector).map_err(|_| "conformance vector is invalid")?;
+        let canonical = serde_jcs::to_vec(vector).map_err(|_| "conformance vector is invalid")?;
         let vector_digest: String = Sha256::digest(canonical)
             .iter()
             .map(|byte| format!("{byte:02x}"))
             .collect();
+        let executed_cases = vector["cases"]
+            .as_array()
+            .ok_or("conformance vector is invalid")?
+            .len();
         Some(json!({
-            "executedCases": vectors.cases.len(),
-            "passedCases": vectors.cases.len(),
+            "executedCases": executed_cases,
+            "passedCases": executed_cases,
             "vectorDigest": format!("sha256:{vector_digest}")
         }))
     } else {
@@ -142,7 +308,7 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
 
     Ok(TargetSuiteResult {
         schema_version: SUITE_RESULT_SCHEMA_VERSION,
-        suite_id: request.suite_id,
+        suite_id: suite_id.to_owned(),
         status: if all_passed {
             TargetSuiteStatus::Passed
         } else {
@@ -152,7 +318,7 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
     })
 }
 
-fn case_matches(case: &CapabilityVectorCase) -> bool {
+fn capability_case_matches(case: &CapabilityVectorCase) -> bool {
     match (negotiate_definition(&case.definition), &case.expected) {
         (Ok(DefinitionNegotiation::Supported(_)), ExpectedNegotiation::Supported) => true,
         (

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -1,8 +1,8 @@
 use serde_json::{json, Value};
 
 use super::conformance_target::{
-    capability, evaluate, TargetSuiteStatus, CAPABILITY_NEGOTIATION_SUITE,
-    RUN_TERMINAL_MONOTONICITY_SUITE,
+    capability, evaluate, evaluate_run_terminal_monotonicity_case_counts, TargetSuiteStatus,
+    CAPABILITY_NEGOTIATION_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
 fn request_for(suite_id: &str, vector: Value) -> Value {
@@ -205,6 +205,64 @@ fn run_terminal_monotonicity_suite_fails_closed_on_an_expectation_mismatch() {
 
     assert_eq!(response.status, TargetSuiteStatus::Failed);
     assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn run_terminal_monotonicity_suite_rejects_non_conflicting_replay_vectors() {
+    assert_eq!(
+        evaluate(&request_for(
+            RUN_TERMINAL_MONOTONICITY_SUITE,
+            json!({
+                "schemaVersion": "coven.automations.run-terminal-monotonicity-vectors.v1",
+                "cases": [{
+                    "caseId": "duplicate-succeeded-replay",
+                    "firstStatus": "succeeded",
+                    "replayStatus": "succeeded",
+                    "expected": {
+                        "firstCommitted": true,
+                        "replayCommitted": false,
+                        "finalStatus": "succeeded"
+                    }
+                }]
+            }),
+        ))
+        .unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn run_terminal_monotonicity_suite_continues_executing_after_a_mismatch() {
+    let vector = json!({
+        "schemaVersion": "coven.automations.run-terminal-monotonicity-vectors.v1",
+        "cases": [
+            {
+                "caseId": "rewrite-wrongly-expected",
+                "firstStatus": "failed",
+                "replayStatus": "succeeded",
+                "expected": {
+                    "firstCommitted": true,
+                    "replayCommitted": true,
+                    "finalStatus": "succeeded"
+                }
+            },
+            {
+                "caseId": "cancelled-cannot-be-rewritten",
+                "firstStatus": "cancelled",
+                "replayStatus": "timed_out",
+                "expected": {
+                    "firstCommitted": true,
+                    "replayCommitted": false,
+                    "finalStatus": "cancelled"
+                }
+            }
+        ]
+    });
+
+    assert_eq!(
+        evaluate_run_terminal_monotonicity_case_counts(&vector).unwrap(),
+        (2, 1)
+    );
 }
 
 #[test]

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -2,13 +2,14 @@ use serde_json::{json, Value};
 
 use super::conformance_target::{
     capability, evaluate, TargetSuiteStatus, CAPABILITY_NEGOTIATION_SUITE,
+    RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
-fn request(vector: Value) -> Value {
+fn request_for(suite_id: &str, vector: Value) -> Value {
     json!({
         "schemaVersion": "coven.automations.conformance-suite-request.v1",
         "profile": "structural",
-        "suiteId": CAPABILITY_NEGOTIATION_SUITE,
+        "suiteId": suite_id,
         "protocolArtifact": {
             "bundleSchemaVersion": "coven.automations.bundle.v1",
             "sourceCommit": "1111111111111111111111111111111111111111",
@@ -29,15 +30,22 @@ fn request(vector: Value) -> Value {
     })
 }
 
+fn request(vector: Value) -> Value {
+    request_for(CAPABILITY_NEGOTIATION_SUITE, vector)
+}
+
 #[test]
-fn capability_advertises_only_the_native_structural_suite() {
+fn capability_advertises_the_native_structural_suites() {
     assert_eq!(
         serde_json::to_value(capability()).unwrap(),
         json!({
             "schemaVersion": "coven.automations.conformance-target-capability.v1",
             "profiles": [{
                 "profile": "structural",
-                "suites": [CAPABILITY_NEGOTIATION_SUITE]
+                "suites": [
+                    CAPABILITY_NEGOTIATION_SUITE,
+                    RUN_TERMINAL_MONOTONICITY_SUITE
+                ]
             }]
         })
     );
@@ -132,6 +140,67 @@ fn capability_negotiation_suite_fails_closed_on_an_expectation_mismatch() {
             }
         }]
     })))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn run_terminal_monotonicity_suite_executes_the_real_run_ledger() {
+    let response = evaluate(&request_for(
+        RUN_TERMINAL_MONOTONICITY_SUITE,
+        json!({
+            "schemaVersion": "coven.automations.run-terminal-monotonicity-vectors.v1",
+            "cases": [
+                {
+                    "caseId": "succeeded-cannot-be-rewritten",
+                    "firstStatus": "succeeded",
+                    "replayStatus": "failed",
+                    "expected": {
+                        "firstCommitted": true,
+                        "replayCommitted": false,
+                        "finalStatus": "succeeded"
+                    }
+                },
+                {
+                    "caseId": "failed-cannot-be-rewritten",
+                    "firstStatus": "failed",
+                    "replayStatus": "succeeded",
+                    "expected": {
+                        "firstCommitted": true,
+                        "replayCommitted": false,
+                        "finalStatus": "failed"
+                    }
+                }
+            ]
+        }),
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 2);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 2);
+}
+
+#[test]
+fn run_terminal_monotonicity_suite_fails_closed_on_an_expectation_mismatch() {
+    let response = evaluate(&request_for(
+        RUN_TERMINAL_MONOTONICITY_SUITE,
+        json!({
+            "schemaVersion": "coven.automations.run-terminal-monotonicity-vectors.v1",
+            "cases": [{
+                "caseId": "rewrite-wrongly-expected",
+                "firstStatus": "failed",
+                "replayStatus": "succeeded",
+                "expected": {
+                    "firstCommitted": true,
+                    "replayCommitted": true,
+                    "finalStatus": "succeeded"
+                }
+            }]
+        }),
+    ))
     .unwrap();
 
     assert_eq!(response.status, TargetSuiteStatus::Failed);

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -6,6 +6,8 @@ use serde_json::{json, Value};
 
 const CAPABILITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/capability-negotiation.vectors.json");
+const RUN_TERMINAL_MONOTONICITY_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/run-terminal-monotonicity.vectors.json");
 const MAX_CONFORMANCE_REQUEST_BYTES: usize = 1024 * 1024;
 
 fn coven_bin() -> PathBuf {
@@ -67,10 +69,61 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
             "schemaVersion": "coven.automations.conformance-target-capability.v1",
             "profiles": [{
                 "profile": "structural",
-                "suites": ["capability-negotiation"]
+                "suites": [
+                    "capability-negotiation",
+                    "run-terminal-monotonicity"
+                ]
             }]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_run_terminal_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(RUN_TERMINAL_MONOTONICITY_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "run-terminal-monotonicity",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        response["schemaVersion"],
+        "coven.automations.conformance-suite-result.v1"
+    );
+    assert_eq!(response["suiteId"], "run-terminal-monotonicity");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 4);
+    assert_eq!(response["evidence"]["passedCases"], 4);
+    assert!(response["evidence"]["vectorDigest"]
+        .as_str()
+        .is_some_and(|digest| digest.starts_with("sha256:") && digest.len() == 71));
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add a checked-in `run-terminal-monotonicity` structural conformance vector set
- execute every vector through Coven's real Rust `record_run_start` and `record_run_finish` ledger operations
- prove all four supported terminal outcomes reject a conflicting replay and preserve the first committed state
- advertise the suite from the stateless native conformance target and document its bounded claim

## Scope

This advances #858 but does not close it.

The suite proves only run-ledger terminal monotonicity. It does not claim the
complete occurrence or attempt state machines, scheduler reliability, Runtime
Authority, continuity, privacy, interoperability, or release eligibility.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked -- --test-threads=1`
- `node --test conformance/automations/runner/conformance.test.mjs scripts/package-automations-protocol.test.mjs`
- `python3 scripts/check-ci-workflow-test.py`
- `python3 scripts/classify-ci-changes-test.py`
- `python scripts/check-secrets.py`
- exact-commit protocol package and external runner execution against the compiled native target passed both structural suites with exact source, protocol, runner, vector-set, and subject hashes

