### PR TITLE
fix: reserve SQLite write slot for event batches

### DIFF
--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -1007,14 +1007,24 @@ mod tests {
         contender.busy_timeout(Duration::ZERO)?;
 
         let transaction = begin_event_writer_transaction(&mut writer)?;
+        let event_count = transaction.query_row("SELECT COUNT(*) FROM events", [], |row| {
+            row.get::<_, i64>(0)
+        })?;
+        assert_eq!(event_count, 0);
         let error = contender
-            .execute_batch("BEGIN IMMEDIATE")
+            .execute("INSERT INTO events (id) VALUES (2)", [])
             .expect_err("the event writer must reserve the SQLite write slot");
         assert!(matches!(
             error.sqlite_error_code(),
             Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
         ));
-        transaction.rollback()?;
+        transaction.execute("INSERT INTO events (id) VALUES (1)", [])?;
+        transaction.commit()?;
+
+        let event_count = writer.query_row("SELECT COUNT(*) FROM events", [], |row| {
+            row.get::<_, i64>(0)
+        })?;
+        assert_eq!(event_count, 1);
         Ok(())
     }
 

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use rusqlite::{Connection, ErrorCode};
+use rusqlite::{Connection, ErrorCode, TransactionBehavior};
 use serde::Serialize;
 use serde_json::json;
 use uuid::Uuid;
@@ -687,9 +687,7 @@ fn commit_batch(
     coven_home: &std::path::Path,
     batch: &[QueuedEvent],
 ) -> Result<usize> {
-    let transaction = conn
-        .transaction()
-        .context("failed to begin event writer transaction")?;
+    let transaction = begin_event_writer_transaction(conn)?;
     let mut committed = 0;
     let mut output: Option<store::EventRecord> = None;
     for item in batch {
@@ -748,6 +746,11 @@ fn commit_batch(
         .commit()
         .context("failed to commit event writer transaction")?;
     Ok(committed)
+}
+
+fn begin_event_writer_transaction(conn: &mut Connection) -> Result<rusqlite::Transaction<'_>> {
+    conn.transaction_with_behavior(TransactionBehavior::Immediate)
+        .context("failed to begin event writer transaction")
 }
 
 fn output_record(session_id: &str, data: &str, created_at: &str) -> Result<store::EventRecord> {
@@ -987,6 +990,31 @@ mod tests {
 
         assert_eq!(inserted, 1);
         assert_eq!(attempts, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn event_writer_transaction_reserves_the_write_slot_before_reads() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let path = home.path().join("writer-transaction.sqlite");
+        let setup = Connection::open(&path)?;
+        setup.execute_batch("PRAGMA journal_mode = WAL; CREATE TABLE events (id INTEGER);")?;
+        drop(setup);
+
+        let mut writer = Connection::open(&path)?;
+        writer.busy_timeout(Duration::ZERO)?;
+        let contender = Connection::open(&path)?;
+        contender.busy_timeout(Duration::ZERO)?;
+
+        let transaction = begin_event_writer_transaction(&mut writer)?;
+        let error = contender
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect_err("the event writer must reserve the SQLite write slot");
+        assert!(matches!(
+            error.sqlite_error_code(),
+            Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+        ));
+        transaction.rollback()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- begin event-writer batches with `BEGIN IMMEDIATE` so SQLite reserves the single write slot before session-state reads
- preserve the existing bounded transient-lock retry policy and atomic batch commit behavior
- add a real WAL regression test proving a competing writer cannot slip between the event writer's read snapshot and first write

Closes #986

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- event-writer unit tests (24 passed)
- `api_prompt_delivery_failure_wins_over_successful_root_exit` repeated 100 times
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- independent code review: no findings