### PR TITLE
feat: add definition validation conformance suite

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -121,7 +121,8 @@ source metadata for the files and binary under test. `source.commit` must equal
 - `subjectArtifact.sha256` from `--target-command`.
 
 The checked-in
-[`capability-negotiation.vectors.json`](capability-negotiation.vectors.json)
+[`capability-negotiation.vectors.json`](capability-negotiation.vectors.json),
+[`definition-validation.vectors.json`](definition-validation.vectors.json),
 and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
 files contain the current nonempty vector sets.
@@ -140,6 +141,7 @@ The runner invokes the target directly without a shell.
       "profile": "structural",
       "suites": [
         "capability-negotiation",
+        "definition-validation",
         "run-terminal-monotonicity"
       ]
     }
@@ -153,14 +155,18 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements two structural suites.
+The native Coven target currently implements three structural suites.
 `capability-negotiation` executes the checked-in cases against Rust's real
-definition parser and capability policy. `run-terminal-monotonicity` executes
-the checked-in settlement and replay cases against the real Rust run ledger in
-an isolated in-memory store, proving that a later terminal observation cannot
-rewrite the first committed terminal state. Each vector must use distinct first
-and replay statuses so a passing case exercises an actual conflict. It does not
-claim the complete occurrence or attempt state machines.
+routine-definition parser and capability policy. `definition-validation`
+executes the portable v1 definition parser, integrity verification, and typed
+serialization path, accepting a canonical valid definition only when its
+normalized JCS digest matches and rejecting a tampered definition.
+`run-terminal-monotonicity` executes the checked-in settlement and replay cases
+against the real Rust run ledger in an isolated in-memory store, proving that a
+later terminal observation cannot rewrite the first committed terminal state.
+Each vector must use distinct first and replay statuses so a passing case
+exercises an actual conflict. These suites do not claim the complete definition,
+occurrence, or attempt state machines.
 
 The runner computes a JCS SHA-256 digest of returned evidence and discards the
 raw evidence after building the result envelope. Evidence is restricted to JSON

--- a/conformance/automations/runner/definition-validation.vectors.json
+++ b/conformance/automations/runner/definition-validation.vectors.json
@@ -1,0 +1,198 @@
+{
+  "schemaVersion": "coven.automations.definition-validation-vectors.v1",
+  "cases": [
+    {
+      "caseId": "canonical-definition-normalizes",
+      "definition": {
+        "schemaVersion": "coven.automations.v1",
+        "automationId": "daily-notes",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "schedule",
+          "version": 1,
+          "schedule": {
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "prompt": "Write the daily reflection.",
+          "cwd": "~/projects/notes"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        }
+      },
+      "expected": {
+        "outcome": "accepted",
+        "normalizedDigest": "sha256:05308faab35f1f918c62b8a176a2c3755bcac1380359262f3c3c187ee3347f18"
+      }
+    },
+    {
+      "caseId": "tampered-definition-is-rejected",
+      "definition": {
+        "schemaVersion": "coven.automations.v1",
+        "automationId": "daily-notes",
+        "revision": 1,
+        "lifecycleState": "active",
+        "display": {
+          "name": "Daily notes",
+          "description": "Write the daily reflection into the notes target.",
+          "tags": [
+            "notes",
+            "daily"
+          ]
+        },
+        "trigger": {
+          "variant": "schedule",
+          "version": 1,
+          "schedule": {
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc"
+          }
+        },
+        "conditions": [],
+        "action": {
+          "variant": "familiarInvocation",
+          "version": 1,
+          "prompt": "Publish the tampered prompt.",
+          "cwd": "~/projects/notes"
+        },
+        "binding": {
+          "familiarBindingPolicy": "exact",
+          "familiarId": "charm",
+          "authority": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtimeRequirements": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "policies": {
+          "timeout": {
+            "perRunMinutes": 30
+          },
+          "retry": {
+            "maxAttempts": 3,
+            "backoffPolicy": "exponential",
+            "retryableClasses": [
+              "transient_dispatch"
+            ]
+          },
+          "concurrency": {
+            "overlap": "forbid"
+          },
+          "misfire": {
+            "disposition": "latest"
+          },
+          "delivery": {
+            "outputTarget": "~/projects/notes/today.md",
+            "mode": "atomic"
+          },
+          "retention": {
+            "occurrenceHistory": {
+              "classification": "standard"
+            },
+            "runLogs": {
+              "classification": "standard"
+            },
+            "receipts": {
+              "classification": "extended"
+            }
+          }
+        },
+        "provenance": {
+          "createdBy": {
+            "principalId": "principal:tim"
+          },
+          "createdAt": "2026-08-30T09:00:00.000Z"
+        },
+        "activation": {
+          "effectiveFrom": "2026-08-30T09:00:00.000Z"
+        },
+        "extensions": {},
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        }
+      },
+      "expected": {
+        "outcome": "rejected"
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
+use super::contract::{canonicalize, sha256_hex, AutomationDefinition};
 use super::runs::{record_run_finish, record_run_start, RunFinish, RunStart};
 
 const TARGET_CAPABILITY_SCHEMA_VERSION: &str = "coven.automations.conformance-target-capability.v1";
@@ -14,12 +15,15 @@ const SUITE_REQUEST_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-
 const SUITE_RESULT_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-result.v1";
 const CAPABILITY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.capability-negotiation-vectors.v1";
+const DEFINITION_VALIDATION_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.definition-validation-vectors.v1";
 const RUN_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.run-terminal-monotonicity-vectors.v1";
 const STRUCTURAL_PROFILE: &str = "structural";
 const MAX_CASES: usize = 128;
 
 pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
+pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const RUN_TERMINAL_MONOTONICITY_SUITE: &str = "run-terminal-monotonicity";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -88,6 +92,31 @@ enum ExpectedNegotiation {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DefinitionValidationVectorSet {
+    schema_version: String,
+    cases: Vec<DefinitionValidationVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DefinitionValidationVectorCase {
+    case_id: String,
+    definition: Value,
+    expected: ExpectedDefinitionValidation,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case", deny_unknown_fields)]
+enum ExpectedDefinitionValidation {
+    Accepted {
+        #[serde(rename = "normalizedDigest")]
+        normalized_digest: String,
+    },
+    Rejected,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RunTerminalVectorSet {
     schema_version: String,
     cases: Vec<RunTerminalVectorCase>,
@@ -138,6 +167,7 @@ pub fn capability() -> TargetCapability {
             profile: STRUCTURAL_PROFILE,
             suites: vec![
                 CAPABILITY_NEGOTIATION_SUITE,
+                DEFINITION_VALIDATION_SUITE,
                 RUN_TERMINAL_MONOTONICITY_SUITE,
             ],
         }],
@@ -158,6 +188,7 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
 
     let all_passed = match request.suite_id.as_str() {
         CAPABILITY_NEGOTIATION_SUITE => evaluate_capability_negotiation(&request.vector)?,
+        DEFINITION_VALIDATION_SUITE => evaluate_definition_validation(&request.vector)?,
         RUN_TERMINAL_MONOTONICITY_SUITE => evaluate_run_terminal_monotonicity(&request.vector)?,
         _ => return Err("conformance suite is unsupported"),
     };
@@ -185,6 +216,34 @@ fn evaluate_capability_negotiation(vector: &Value) -> Result<bool, &'static str>
     }
 
     Ok(vectors.cases.iter().all(capability_case_matches))
+}
+
+fn evaluate_definition_validation(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: DefinitionValidationVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != DEFINITION_VALIDATION_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    for case in &vectors.cases {
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !case.definition.is_object()
+            || matches!(
+                &case.expected,
+                ExpectedDefinitionValidation::Accepted { normalized_digest }
+                    if !valid_sha256_digest(normalized_digest)
+            )
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+
+    Ok(vectors.cases.iter().all(definition_case_matches))
 }
 
 fn evaluate_run_terminal_monotonicity(vector: &Value) -> Result<bool, &'static str> {
@@ -338,6 +397,21 @@ fn capability_case_matches(case: &CapabilityVectorCase) -> bool {
     }
 }
 
+fn definition_case_matches(case: &DefinitionValidationVectorCase) -> bool {
+    let parsed = serde_json::from_value::<AutomationDefinition>(case.definition.clone());
+    match (&case.expected, parsed) {
+        (ExpectedDefinitionValidation::Accepted { normalized_digest }, Ok(definition)) => {
+            serde_json::to_value(definition)
+                .ok()
+                .and_then(|value| canonicalize(&value).ok())
+                .map(|canonical| format!("sha256:{}", sha256_hex(&canonical)))
+                .is_some_and(|observed| observed == *normalized_digest)
+        }
+        (ExpectedDefinitionValidation::Rejected, Err(_)) => true,
+        _ => false,
+    }
+}
+
 fn valid_case_id(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 128
@@ -345,4 +419,13 @@ fn valid_case_id(value: &str) -> bool {
             byte.is_ascii_alphanumeric()
                 || (index > 0 && matches!(byte, b'.' | b'_' | b':' | b'@' | b'-'))
         })
+}
+
+fn valid_sha256_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|digest| {
+        digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    })
 }

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -5,6 +5,9 @@ use super::conformance_target::{
     CAPABILITY_NEGOTIATION_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
+const DEFINITION_VALIDATION_VECTORS: &str =
+    include_str!("../../../../conformance/automations/runner/definition-validation.vectors.json");
+
 fn request_for(suite_id: &str, vector: Value) -> Value {
     json!({
         "schemaVersion": "coven.automations.conformance-suite-request.v1",
@@ -44,10 +47,54 @@ fn capability_advertises_the_native_structural_suites() {
                 "profile": "structural",
                 "suites": [
                     CAPABILITY_NEGOTIATION_SUITE,
+                    "definition-validation",
                     RUN_TERMINAL_MONOTONICITY_SUITE
                 ]
             }]
         })
+    );
+}
+
+#[test]
+fn definition_validation_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(DEFINITION_VALIDATION_VECTORS).unwrap();
+    let response = evaluate(&request_for("definition-validation", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 2);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 2);
+}
+
+#[test]
+fn definition_validation_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(DEFINITION_VALIDATION_VECTORS).unwrap();
+    vectors["cases"][0]["expected"] = json!({"outcome": "rejected"});
+
+    let response = evaluate(&request_for("definition-validation", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn definition_validation_suite_rejects_malformed_expected_digests() {
+    let mut vectors: Value = serde_json::from_str(DEFINITION_VALIDATION_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["normalizedDigest"] = json!("sha256:not-a-digest");
+
+    assert_eq!(
+        evaluate(&request_for("definition-validation", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn definition_validation_suite_rejects_duplicate_case_ids() {
+    let mut vectors: Value = serde_json::from_str(DEFINITION_VALIDATION_VECTORS).unwrap();
+    vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone();
+
+    assert_eq!(
+        evaluate(&request_for("definition-validation", vectors)).unwrap_err(),
+        "conformance vector is invalid"
     );
 }
 

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -6,6 +6,8 @@ use serde_json::{json, Value};
 
 const CAPABILITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/capability-negotiation.vectors.json");
+const DEFINITION_VALIDATION_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/definition-validation.vectors.json");
 const RUN_TERMINAL_MONOTONICITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/run-terminal-monotonicity.vectors.json");
 const MAX_CONFORMANCE_REQUEST_BYTES: usize = 1024 * 1024;
@@ -71,11 +73,60 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                 "profile": "structural",
                 "suites": [
                     "capability-negotiation",
+                    "definition-validation",
                     "run-terminal-monotonicity"
                 ]
             }]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_definition_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(DEFINITION_VALIDATION_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "definition-validation",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        response["schemaVersion"],
+        "coven.automations.conformance-suite-result.v1"
+    );
+    assert_eq!(response["suiteId"], "definition-validation");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 2);
+    assert_eq!(response["evidence"]["passedCases"], 2);
+    assert!(response["evidence"]["vectorDigest"]
+        .as_str()
+        .is_some_and(|digest| digest.starts_with("sha256:") && digest.len() == 71));
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add a native `definition-validation` structural conformance suite
- execute checked-in portable v1 definition vectors through Rust's canonical `AutomationDefinition` parser, integrity verifier, typed serializer, and JCS digest path
- cover a canonical accepted definition, integrity-tampered rejection, malformed expected digests, duplicate case IDs, target capability advertisement, and real-binary stateless execution

## Scope

This is a bounded audit-only slice of #858. It does not claim scheduler reliability, Runtime Authority, continuity, privacy, interoperability, the aggregate `full` profile, or release eligibility.

The standalone runner remains implementation-independent: it supplies vectors to the native target and does not introduce a JavaScript definition-validation oracle.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `node --test conformance/automations/runner/conformance.test.mjs`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- exact-artifact audit invocation against the committed `coven` binary and packaged Automations protocol, with all three advertised structural suites passing

Advances #858.
