### PR TITLE
feat: add attempt immutability conformance suite

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -121,6 +121,7 @@ source metadata for the files and binary under test. `source.commit` must equal
 - `subjectArtifact.sha256` from `--target-command`.
 
 The checked-in
+[`attempt-terminal-immutability.vectors.json`](attempt-terminal-immutability.vectors.json),
 [`capability-negotiation.vectors.json`](capability-negotiation.vectors.json),
 [`definition-validation.vectors.json`](definition-validation.vectors.json),
 and
@@ -140,6 +141,7 @@ The runner invokes the target directly without a shell.
     {
       "profile": "structural",
       "suites": [
+        "attempt-terminal-immutability",
         "capability-negotiation",
         "definition-validation",
         "run-terminal-monotonicity"
@@ -155,9 +157,11 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements three structural suites.
-`capability-negotiation` executes the checked-in cases against Rust's real
-routine-definition parser and capability policy. `definition-validation`
+The native Coven target currently implements four structural suites.
+`attempt-terminal-immutability` executes every terminal attempt state against
+the production SQLite ledger and proves that later updates and deletion are
+refused. `capability-negotiation` executes the checked-in cases against Rust's
+real routine-definition parser and capability policy. `definition-validation`
 executes the portable v1 definition parser, integrity verification, and typed
 serialization path, accepting a canonical valid definition only when its
 normalized JCS digest matches and rejecting a tampered definition.

--- a/conformance/automations/runner/attempt-terminal-immutability.vectors.json
+++ b/conformance/automations/runner/attempt-terminal-immutability.vectors.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "coven.automations.attempt-terminal-immutability-vectors.v1",
+  "cases": [
+    {
+      "caseId": "succeeded-attempt-is-immutable",
+      "firstState": "succeeded",
+      "attemptedState": "failed",
+      "expected": {
+        "updateCommitted": false,
+        "deleteCommitted": false,
+        "finalState": "succeeded"
+      }
+    },
+    {
+      "caseId": "failed-attempt-is-immutable",
+      "firstState": "failed",
+      "attemptedState": "observing",
+      "expected": {
+        "updateCommitted": false,
+        "deleteCommitted": false,
+        "finalState": "failed"
+      }
+    },
+    {
+      "caseId": "cancelled-attempt-is-immutable",
+      "firstState": "cancelled",
+      "attemptedState": "dispatching",
+      "expected": {
+        "updateCommitted": false,
+        "deleteCommitted": false,
+        "finalState": "cancelled"
+      }
+    },
+    {
+      "caseId": "timed-out-attempt-is-immutable",
+      "firstState": "timed_out",
+      "attemptedState": "started",
+      "expected": {
+        "updateCommitted": false,
+        "deleteCommitted": false,
+        "finalState": "timed_out"
+      }
+    },
+    {
+      "caseId": "ambiguous-attempt-is-immutable",
+      "firstState": "ambiguous",
+      "attemptedState": "adopted",
+      "expected": {
+        "updateCommitted": false,
+        "deleteCommitted": false,
+        "finalState": "ambiguous"
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -111,7 +111,7 @@ struct AttemptTerminalVectorCase {
     expected: ExpectedAttemptTerminal,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum AttemptLedgerState {
     Adopted,
@@ -276,6 +276,7 @@ fn evaluate_attempt_terminal_immutability(vector: &Value) -> Result<bool, &'stat
     }
 
     let mut case_ids = BTreeSet::new();
+    let mut terminal_states = BTreeSet::new();
     for case in &vectors.cases {
         if !valid_case_id(&case.case_id)
             || !case_ids.insert(&case.case_id)
@@ -284,6 +285,10 @@ fn evaluate_attempt_terminal_immutability(vector: &Value) -> Result<bool, &'stat
         {
             return Err("conformance vector is invalid");
         }
+        terminal_states.insert(case.first_state);
+    }
+    if terminal_states.len() != 5 {
+        return Err("conformance vector is invalid");
     }
 
     let conn = Connection::open_in_memory().map_err(|_| "conformance suite execution failed")?;

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -1,20 +1,24 @@
 use std::collections::BTreeSet;
 
 use chrono::{DateTime, Duration, Utc};
-use rusqlite::Connection;
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
 use super::contract::{canonicalize, sha256_hex, AutomationDefinition};
-use super::runs::{record_run_finish, record_run_start, RunFinish, RunStart};
+use super::runs::{
+    record_run_finish, record_run_start, RunFinish, RunStart, AUTOMATION_ATTEMPTS_SCHEMA_SQL,
+};
 
 const TARGET_CAPABILITY_SCHEMA_VERSION: &str = "coven.automations.conformance-target-capability.v1";
 const SUITE_REQUEST_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-request.v1";
 const SUITE_RESULT_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-result.v1";
 const CAPABILITY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.capability-negotiation-vectors.v1";
+const ATTEMPT_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.attempt-terminal-immutability-vectors.v1";
 const DEFINITION_VALIDATION_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.definition-validation-vectors.v1";
 const RUN_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
@@ -23,6 +27,7 @@ const STRUCTURAL_PROFILE: &str = "structural";
 const MAX_CASES: usize = 128;
 
 pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
+pub const ATTEMPT_TERMINAL_IMMUTABILITY_SUITE: &str = "attempt-terminal-immutability";
 pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const RUN_TERMINAL_MONOTONICITY_SUITE: &str = "run-terminal-monotonicity";
 
@@ -88,6 +93,67 @@ struct CapabilityVectorCase {
 enum ExpectedNegotiation {
     Supported,
     Unsupported { variant: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AttemptTerminalVectorSet {
+    schema_version: String,
+    cases: Vec<AttemptTerminalVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AttemptTerminalVectorCase {
+    case_id: String,
+    first_state: AttemptLedgerState,
+    attempted_state: AttemptLedgerState,
+    expected: ExpectedAttemptTerminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AttemptLedgerState {
+    Adopted,
+    Dispatching,
+    Started,
+    Observing,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Ambiguous,
+}
+
+impl AttemptLedgerState {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Adopted => "adopted",
+            Self::Dispatching => "dispatching",
+            Self::Started => "started",
+            Self::Observing => "observing",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::TimedOut => "timed_out",
+            Self::Ambiguous => "ambiguous",
+        }
+    }
+
+    const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::TimedOut | Self::Ambiguous
+        )
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedAttemptTerminal {
+    update_committed: bool,
+    delete_committed: bool,
+    final_state: AttemptLedgerState,
 }
 
 #[derive(Debug, Deserialize)]
@@ -166,6 +232,7 @@ pub fn capability() -> TargetCapability {
         profiles: vec![TargetProfileCapability {
             profile: STRUCTURAL_PROFILE,
             suites: vec![
+                ATTEMPT_TERMINAL_IMMUTABILITY_SUITE,
                 CAPABILITY_NEGOTIATION_SUITE,
                 DEFINITION_VALIDATION_SUITE,
                 RUN_TERMINAL_MONOTONICITY_SUITE,
@@ -187,12 +254,55 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
     }
 
     let all_passed = match request.suite_id.as_str() {
+        ATTEMPT_TERMINAL_IMMUTABILITY_SUITE => {
+            evaluate_attempt_terminal_immutability(&request.vector)?
+        }
         CAPABILITY_NEGOTIATION_SUITE => evaluate_capability_negotiation(&request.vector)?,
         DEFINITION_VALIDATION_SUITE => evaluate_definition_validation(&request.vector)?,
         RUN_TERMINAL_MONOTONICITY_SUITE => evaluate_run_terminal_monotonicity(&request.vector)?,
         _ => return Err("conformance suite is unsupported"),
     };
     result_for(&request.suite_id, &request.vector, all_passed)
+}
+
+fn evaluate_attempt_terminal_immutability(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: AttemptTerminalVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != ATTEMPT_TERMINAL_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    for case in &vectors.cases {
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !case.first_state.is_terminal()
+            || case.first_state == case.attempted_state
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+
+    let conn = Connection::open_in_memory().map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::store::AUTOMATION_DEFINITIONS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::occurrences::AUTOMATION_OCCURRENCES_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::runs::AUTOMATION_RUNS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch("CREATE TABLE sessions (id TEXT PRIMARY KEY NOT NULL);")
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(AUTOMATION_ATTEMPTS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+
+    let mut all_passed = true;
+    for (index, case) in vectors.cases.iter().enumerate() {
+        all_passed &= attempt_terminal_case_matches(&conn, case, index)?;
+    }
+    Ok(all_passed)
 }
 
 fn evaluate_capability_negotiation(vector: &Value) -> Result<bool, &'static str> {
@@ -348,6 +458,79 @@ fn run_terminal_case_matches(
     Ok(first_committed == case.expected.first_committed
         && replay_committed == case.expected.replay_committed
         && final_status == case.expected.final_status.as_str())
+}
+
+fn attempt_terminal_case_matches(
+    conn: &Connection,
+    case: &AttemptTerminalVectorCase,
+    index: usize,
+) -> Result<bool, &'static str> {
+    let automation_id = format!("conformance-attempt-automation-{index}");
+    let occurrence_id = format!("conformance-attempt-occurrence-{index}");
+    let run_id = format!("conformance-attempt-run-{index}");
+    let attempt_id = format!("conformance-attempt-{index}");
+    let adoption_key = format!("{run_id}:1");
+    let opened_at = "1970-01-01T00:00:00.000Z";
+    let settled_at = "1970-01-01T00:00:01.000Z";
+
+    conn.execute(
+        "INSERT INTO automation_occurrences
+            (id, automation_id, scheduled_for, state, attempt, created_at, updated_at)
+         VALUES (?1, ?2, ?3, 'failed', 1, ?3, ?4)",
+        params![occurrence_id, automation_id, opened_at, settled_at],
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    conn.execute(
+        "INSERT INTO automation_runs
+            (id, automation_id, occurrence_id, runtime, status, started_at, finished_at)
+         VALUES (?1, ?2, ?3, 'coven-code', 'failed', ?4, ?5)",
+        params![run_id, automation_id, occurrence_id, opened_at, settled_at],
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    conn.execute(
+        "INSERT INTO automation_attempts (
+            id, run_id, occurrence_id, attempt_number, adoption_key,
+            occurrence_fence_generation, dispatch_generation, state,
+            retry_classification, not_before, opened_at, settled_at
+         ) VALUES (?1, ?2, ?3, 1, ?4, 1, 1, ?5, 'initial', ?6, ?6, ?7)",
+        params![
+            attempt_id,
+            run_id,
+            occurrence_id,
+            adoption_key,
+            case.first_state.as_str(),
+            opened_at,
+            settled_at
+        ],
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+
+    let update_committed = conn
+        .execute(
+            "UPDATE automation_attempts
+             SET state = ?2, state_reason = 'conformance mutation', settled_at = ?3
+             WHERE id = ?1",
+            params![attempt_id, case.attempted_state.as_str(), opened_at],
+        )
+        .is_ok();
+    let delete_committed = conn
+        .execute(
+            "DELETE FROM automation_attempts WHERE id = ?1",
+            [&attempt_id],
+        )
+        .is_ok();
+    let final_state = conn
+        .query_row(
+            "SELECT state FROM automation_attempts WHERE id = ?1",
+            [&attempt_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|_| "conformance suite execution failed")?;
+
+    Ok(update_committed == case.expected.update_committed
+        && delete_committed == case.expected.delete_committed
+        && final_state.as_deref() == Some(case.expected.final_state.as_str()))
 }
 
 fn result_for(

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -114,6 +114,17 @@ fn attempt_terminal_immutability_suite_rejects_noop_updates() {
 }
 
 #[test]
+fn attempt_terminal_immutability_suite_requires_every_terminal_state() {
+    let mut vectors: Value = serde_json::from_str(ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS).unwrap();
+    vectors["cases"].as_array_mut().unwrap().pop();
+
+    assert_eq!(
+        evaluate(&request_for("attempt-terminal-immutability", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
 fn definition_validation_suite_executes_the_checked_in_vectors() {
     let vectors: Value = serde_json::from_str(DEFINITION_VALIDATION_VECTORS).unwrap();
     let response = evaluate(&request_for("definition-validation", vectors)).unwrap();

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -5,6 +5,9 @@ use super::conformance_target::{
     CAPABILITY_NEGOTIATION_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
+const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
+    "../../../../conformance/automations/runner/attempt-terminal-immutability.vectors.json"
+);
 const DEFINITION_VALIDATION_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/definition-validation.vectors.json");
 
@@ -46,12 +49,67 @@ fn capability_advertises_the_native_structural_suites() {
             "profiles": [{
                 "profile": "structural",
                 "suites": [
+                    "attempt-terminal-immutability",
                     CAPABILITY_NEGOTIATION_SUITE,
                     "definition-validation",
                     RUN_TERMINAL_MONOTONICITY_SUITE
                 ]
             }]
         })
+    );
+}
+
+#[test]
+fn attempt_terminal_immutability_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS).unwrap();
+    let response = evaluate(&request_for("attempt-terminal-immutability", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 5);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 5);
+}
+
+#[test]
+fn attempt_terminal_immutability_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["updateCommitted"] = json!(true);
+
+    let response = evaluate(&request_for("attempt-terminal-immutability", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn attempt_terminal_immutability_suite_rejects_duplicate_case_ids() {
+    let mut vectors: Value = serde_json::from_str(ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS).unwrap();
+    vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone();
+
+    assert_eq!(
+        evaluate(&request_for("attempt-terminal-immutability", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn attempt_terminal_immutability_suite_rejects_nonterminal_start_states() {
+    let mut vectors: Value = serde_json::from_str(ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS).unwrap();
+    vectors["cases"][0]["firstState"] = json!("observing");
+
+    assert_eq!(
+        evaluate(&request_for("attempt-terminal-immutability", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn attempt_terminal_immutability_suite_rejects_noop_updates() {
+    let mut vectors: Value = serde_json::from_str(ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS).unwrap();
+    vectors["cases"][0]["attemptedState"] = vectors["cases"][0]["firstState"].clone();
+
+    assert_eq!(
+        evaluate(&request_for("attempt-terminal-immutability", vectors)).unwrap_err(),
+        "conformance vector is invalid"
     );
 }
 

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -4,6 +4,9 @@ use std::process::{Command, Output, Stdio};
 
 use serde_json::{json, Value};
 
+const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
+    "../../../conformance/automations/runner/attempt-terminal-immutability.vectors.json"
+);
 const CAPABILITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/capability-negotiation.vectors.json");
 const DEFINITION_VALIDATION_VECTORS: &str =
@@ -72,6 +75,7 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
             "profiles": [{
                 "profile": "structural",
                 "suites": [
+                    "attempt-terminal-immutability",
                     "capability-negotiation",
                     "definition-validation",
                     "run-terminal-monotonicity"
@@ -79,6 +83,54 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
             }]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_attempt_terminal_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "attempt-terminal-immutability",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        response["schemaVersion"],
+        "coven.automations.conformance-suite-result.v1"
+    );
+    assert_eq!(response["suiteId"], "attempt-terminal-immutability");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 5);
+    assert_eq!(response["evidence"]["passedCases"], 5);
+    assert!(response["evidence"]["vectorDigest"]
+        .as_str()
+        .is_some_and(|digest| digest.starts_with("sha256:") && digest.len() == 71));
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add a native `attempt-terminal-immutability` structural conformance suite
- execute all five terminal attempt states against the production SQLite attempt ledger
- prove later state updates and deletion are refused while the original terminal state remains
- reject duplicate case IDs, nonterminal initial states, no-op mutations, and expectation mismatches

## Scope

This is another bounded audit-only slice of #858. It does not claim scheduler reliability, Runtime Authority, continuity, privacy, interoperability, the aggregate `full` profile, or release eligibility.

The suite exercises the existing native persistence invariant. It does not simulate runtime outcomes or introduce a JavaScript state-machine oracle.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked -- --test-threads=1`
- `node --test conformance/automations/runner/conformance.test.mjs`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- exact-artifact audit invocation against the committed `coven` binary and packaged Automations protocol, with all four advertised structural suites passing

Advances #858.
