### PR TITLE
feat: add event reducer conformance suite

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -124,6 +124,7 @@ The checked-in
 [`attempt-terminal-immutability.vectors.json`](attempt-terminal-immutability.vectors.json),
 [`capability-negotiation.vectors.json`](capability-negotiation.vectors.json),
 [`definition-validation.vectors.json`](definition-validation.vectors.json),
+[`event-reducer-determinism.vectors.json`](event-reducer-determinism.vectors.json),
 and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
 files contain the current nonempty vector sets.
@@ -144,6 +145,7 @@ The runner invokes the target directly without a shell.
         "attempt-terminal-immutability",
         "capability-negotiation",
         "definition-validation",
+        "event-reducer-determinism",
         "run-terminal-monotonicity"
       ]
     }
@@ -157,7 +159,7 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements four structural suites.
+The native Coven target currently implements five structural suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
 refused. `capability-negotiation` executes the checked-in cases against Rust's
@@ -165,6 +167,9 @@ real routine-definition parser and capability policy. `definition-validation`
 executes the portable v1 definition parser, integrity verification, and typed
 serialization path, accepting a canonical valid definition only when its
 normalized JCS digest matches and rejecting a tampered definition.
+`event-reducer-determinism` replays a portable event stream through the native
+Rust reducer both canonically and with an exact duplicate delivery, requiring
+the same normalized final state and expected digest.
 `run-terminal-monotonicity` executes the checked-in settlement and replay cases
 against the real Rust run ledger in an isolated in-memory store, proving that a
 later terminal observation cannot rewrite the first committed terminal state.

--- a/conformance/automations/runner/event-reducer-determinism.vectors.json
+++ b/conformance/automations/runner/event-reducer-determinism.vectors.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": "coven.automations.event-reducer-determinism-vectors.v1",
+  "cases": [
+    {
+      "caseId": "duplicate-delivery-converges",
+      "events": [
+        {
+          "schemaVersion": "coven.automations.v1",
+          "eventId": "evtocc00a7c3e9d24b6f8051",
+          "stream": {
+            "kind": "occurrence",
+            "id": "daily-notes-1756544400000"
+          },
+          "sequence": 0,
+          "recordedAt": "2026-08-30T09:00:00.000Z",
+          "observedAt": "2026-08-30T09:00:00.000Z",
+          "producer": {
+            "component": "coven-daemon",
+            "instanceId": "daemon@host-a"
+          },
+          "automationId": "daily-notes",
+          "occurrenceId": "daily-notes-1756544400000",
+          "kind": "occurrence.transitioned",
+          "summary": "occurrence occurrence none -> planned",
+          "payload": {
+            "entity": "occurrence",
+            "from": "none",
+            "to": "planned",
+            "reason": "slot_fenced",
+            "fenceGeneration": 1
+          },
+          "privacy": {
+            "classification": "operational",
+            "retention": {
+              "classification": "standard"
+            }
+          }
+        },
+        {
+          "schemaVersion": "coven.automations.v1",
+          "eventId": "evtocc01a7c3e9d24b6f8051",
+          "stream": {
+            "kind": "occurrence",
+            "id": "daily-notes-1756544400000"
+          },
+          "sequence": 1,
+          "recordedAt": "2026-08-30T09:00:01.000Z",
+          "observedAt": "2026-08-30T09:00:01.000Z",
+          "producer": {
+            "component": "coven-daemon",
+            "instanceId": "daemon@host-a"
+          },
+          "automationId": "daily-notes",
+          "occurrenceId": "daily-notes-1756544400000",
+          "kind": "occurrence.transitioned",
+          "summary": "occurrence occurrence planned -> eligible",
+          "payload": {
+            "entity": "occurrence",
+            "from": "planned",
+            "to": "eligible",
+            "reason": "eligibility_passed",
+            "fenceGeneration": 1
+          },
+          "privacy": {
+            "classification": "operational",
+            "retention": {
+              "classification": "standard"
+            }
+          }
+        },
+        {
+          "schemaVersion": "coven.automations.v1",
+          "eventId": "evtocc02a7c3e9d24b6f8051",
+          "stream": {
+            "kind": "occurrence",
+            "id": "daily-notes-1756544400000"
+          },
+          "sequence": 2,
+          "recordedAt": "2026-08-30T09:00:02.000Z",
+          "observedAt": "2026-08-30T09:00:02.000Z",
+          "producer": {
+            "component": "coven-daemon",
+            "instanceId": "daemon@host-a"
+          },
+          "automationId": "daily-notes",
+          "occurrenceId": "daily-notes-1756544400000",
+          "kind": "occurrence.transitioned",
+          "summary": "occurrence occurrence eligible -> claimed",
+          "payload": {
+            "entity": "occurrence",
+            "from": "eligible",
+            "to": "claimed",
+            "reason": "claim",
+            "fenceGeneration": 1
+          },
+          "privacy": {
+            "classification": "operational",
+            "retention": {
+              "classification": "standard"
+            }
+          }
+        }
+      ],
+      "duplicateIndex": 1,
+      "expectedStateDigest": "sha256:e91e796586ea1aed5d954073255f34f14b844c4f9920acaf4b2817408412f2ea"
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -395,10 +395,15 @@ fn evaluate_event_reducer_determinism(vector: &Value) -> Result<bool, &'static s
 
     let mut case_ids = BTreeSet::new();
     for case in &vectors.cases {
+        let mut event_ids = BTreeSet::new();
         if !valid_case_id(&case.case_id)
             || !case_ids.insert(&case.case_id)
             || case.events.is_empty()
             || case.events.len() > MAX_CASES
+            || case
+                .events
+                .iter()
+                .any(|event| !event_ids.insert(event.event_id.as_str()))
             || case.duplicate_index >= case.events.len()
             || !valid_sha256_digest(&case.expected_state_digest)
         {

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -7,7 +7,8 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
-use super::contract::{canonicalize, sha256_hex, AutomationDefinition};
+use super::contract::events::EventReducer;
+use super::contract::{canonicalize, sha256_hex, AutomationDefinition, EventEnvelope};
 use super::runs::{
     record_run_finish, record_run_start, RunFinish, RunStart, AUTOMATION_ATTEMPTS_SCHEMA_SQL,
 };
@@ -21,6 +22,8 @@ const ATTEMPT_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.attempt-terminal-immutability-vectors.v1";
 const DEFINITION_VALIDATION_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.definition-validation-vectors.v1";
+const EVENT_REDUCER_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.event-reducer-determinism-vectors.v1";
 const RUN_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.run-terminal-monotonicity-vectors.v1";
 const STRUCTURAL_PROFILE: &str = "structural";
@@ -29,6 +32,7 @@ const MAX_CASES: usize = 128;
 pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
 pub const ATTEMPT_TERMINAL_IMMUTABILITY_SUITE: &str = "attempt-terminal-immutability";
 pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
+pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
 pub const RUN_TERMINAL_MONOTONICITY_SUITE: &str = "run-terminal-monotonicity";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -183,6 +187,22 @@ enum ExpectedDefinitionValidation {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct EventReducerVectorSet {
+    schema_version: String,
+    cases: Vec<EventReducerVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct EventReducerVectorCase {
+    case_id: String,
+    events: Vec<EventEnvelope>,
+    duplicate_index: usize,
+    expected_state_digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RunTerminalVectorSet {
     schema_version: String,
     cases: Vec<RunTerminalVectorCase>,
@@ -235,6 +255,7 @@ pub fn capability() -> TargetCapability {
                 ATTEMPT_TERMINAL_IMMUTABILITY_SUITE,
                 CAPABILITY_NEGOTIATION_SUITE,
                 DEFINITION_VALIDATION_SUITE,
+                EVENT_REDUCER_DETERMINISM_SUITE,
                 RUN_TERMINAL_MONOTONICITY_SUITE,
             ],
         }],
@@ -259,6 +280,7 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         }
         CAPABILITY_NEGOTIATION_SUITE => evaluate_capability_negotiation(&request.vector)?,
         DEFINITION_VALIDATION_SUITE => evaluate_definition_validation(&request.vector)?,
+        EVENT_REDUCER_DETERMINISM_SUITE => evaluate_event_reducer_determinism(&request.vector)?,
         RUN_TERMINAL_MONOTONICITY_SUITE => evaluate_run_terminal_monotonicity(&request.vector)?,
         _ => return Err("conformance suite is unsupported"),
     };
@@ -359,6 +381,59 @@ fn evaluate_definition_validation(vector: &Value) -> Result<bool, &'static str> 
     }
 
     Ok(vectors.cases.iter().all(definition_case_matches))
+}
+
+fn evaluate_event_reducer_determinism(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: EventReducerVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != EVENT_REDUCER_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    for case in &vectors.cases {
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || case.events.is_empty()
+            || case.events.len() > MAX_CASES
+            || case.duplicate_index >= case.events.len()
+            || !valid_sha256_digest(&case.expected_state_digest)
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+
+    let mut all_passed = true;
+    for case in &vectors.cases {
+        all_passed &= event_reducer_case_matches(case)?;
+    }
+    Ok(all_passed)
+}
+
+fn event_reducer_case_matches(case: &EventReducerVectorCase) -> Result<bool, &'static str> {
+    let mut canonical = EventReducer::default();
+    for event in &case.events {
+        if canonical.apply(event).is_err() {
+            return Ok(false);
+        }
+    }
+
+    let mut duplicated = EventReducer::default();
+    for (index, event) in case.events.iter().enumerate() {
+        if duplicated.apply(event).is_err()
+            || (index == case.duplicate_index && duplicated.apply(event).is_err())
+        {
+            return Ok(false);
+        }
+    }
+
+    let canonical_state =
+        canonicalize(canonical.state()).map_err(|_| "conformance suite execution failed")?;
+    let observed_digest = format!("sha256:{}", sha256_hex(&canonical_state));
+    Ok(canonical.state() == duplicated.state() && observed_digest == case.expected_state_digest)
 }
 
 fn evaluate_run_terminal_monotonicity(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -108,6 +108,21 @@ fn event_reducer_determinism_suite_rejects_duplicate_case_ids() {
 }
 
 #[test]
+fn event_reducer_determinism_suite_rejects_duplicate_canonical_event_ids() {
+    let mut vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
+    let duplicate = vectors["cases"][0]["events"][1].clone();
+    vectors["cases"][0]["events"]
+        .as_array_mut()
+        .unwrap()
+        .push(duplicate);
+
+    assert_eq!(
+        evaluate(&request_for("event-reducer-determinism", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
 fn event_reducer_determinism_suite_rejects_malformed_expected_digests() {
     let mut vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
     vectors["cases"][0]["expectedStateDigest"] = json!("sha256:not-a-digest");

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -10,6 +10,9 @@ const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
 );
 const DEFINITION_VALIDATION_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/definition-validation.vectors.json");
+const EVENT_REDUCER_DETERMINISM_VECTORS: &str = include_str!(
+    "../../../../conformance/automations/runner/event-reducer-determinism.vectors.json"
+);
 
 fn request_for(suite_id: &str, vector: Value) -> Value {
     json!({
@@ -52,11 +55,81 @@ fn capability_advertises_the_native_structural_suites() {
                     "attempt-terminal-immutability",
                     CAPABILITY_NEGOTIATION_SUITE,
                     "definition-validation",
+                    "event-reducer-determinism",
                     RUN_TERMINAL_MONOTONICITY_SUITE
                 ]
             }]
         })
     );
+}
+
+#[test]
+fn event_reducer_determinism_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
+    let response = evaluate(&request_for("event-reducer-determinism", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 1);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 1);
+}
+
+#[test]
+fn event_reducer_determinism_suite_fails_closed_on_a_digest_mismatch() {
+    let mut vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
+    vectors["cases"][0]["expectedStateDigest"] = json!(format!("sha256:{}", "0".repeat(64)));
+
+    let response = evaluate(&request_for("event-reducer-determinism", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn event_reducer_determinism_suite_rejects_an_invalid_duplicate_index() {
+    let mut vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
+    vectors["cases"][0]["duplicateIndex"] = json!(3);
+
+    assert_eq!(
+        evaluate(&request_for("event-reducer-determinism", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn event_reducer_determinism_suite_rejects_duplicate_case_ids() {
+    let mut vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
+    let duplicate = vectors["cases"][0].clone();
+    vectors["cases"].as_array_mut().unwrap().push(duplicate);
+
+    assert_eq!(
+        evaluate(&request_for("event-reducer-determinism", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn event_reducer_determinism_suite_rejects_malformed_expected_digests() {
+    let mut vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
+    vectors["cases"][0]["expectedStateDigest"] = json!("sha256:not-a-digest");
+
+    assert_eq!(
+        evaluate(&request_for("event-reducer-determinism", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn event_reducer_determinism_suite_fails_closed_on_out_of_order_events() {
+    let mut vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS).unwrap();
+    vectors["cases"][0]["events"]
+        .as_array_mut()
+        .unwrap()
+        .swap(0, 1);
+
+    let response = evaluate(&request_for("event-reducer-determinism", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
 }
 
 #[test]

--- a/crates/coven-cli/src/automations/contract/events.rs
+++ b/crates/coven-cli/src/automations/contract/events.rs
@@ -824,6 +824,14 @@ impl EventReducer {
                     actual: event.sequence.get(),
                 });
             }
+            if let Some(cursor) = self.cursor {
+                if through <= cursor {
+                    return Err(EventStoreError::StreamOutOfOrder {
+                        expected: cursor.saturating_add(1),
+                        actual: through,
+                    });
+                }
+            }
             self.state = Value::Object(
                 snapshot
                     .state
@@ -1160,6 +1168,27 @@ mod tests {
         compacted.apply(&events[4]).unwrap();
 
         assert_eq!(compacted.state(), full.state());
+    }
+
+    #[test]
+    fn snapshot_cannot_rewind_an_existing_reduction() {
+        let events = [
+            occurrence_event("evtoccurrence0000000020", 0, "none", "planned"),
+            occurrence_event("evtoccurrence0000000021", 1, "planned", "eligible"),
+            occurrence_event("evtoccurrence0000000022", 2, "eligible", "claimed"),
+            occurrence_event("evtoccurrence0000000023", 3, "claimed", "running"),
+        ];
+        let mut reducer = EventReducer::default();
+        for event in &events {
+            reducer.apply(event).unwrap();
+        }
+
+        let stale_snapshot = snapshot_event("evtsnapshot00000000002", 2, 2);
+        let error = reducer.apply(&stale_snapshot).unwrap_err();
+
+        assert_eq!(error.code(), "STREAM_OUT_OF_ORDER");
+        assert_eq!(reducer.state()["state"], "running");
+        assert_eq!(reducer.state()["eventWindow"]["lastSequence"], 3);
     }
 
     #[test]

--- a/crates/coven-cli/src/automations/contract/events.rs
+++ b/crates/coven-cli/src/automations/contract/events.rs
@@ -1,23 +1,19 @@
 //! Durable Automations v1 event streams.
 
+use std::collections::HashSet;
 use std::fmt;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Map, Value};
 use uuid::Uuid;
 
 pub use super::types::EventRef;
-use super::types::{EventEnvelope, EventRefStream, SafeInteger, StreamKind};
-
-#[cfg(test)]
-use super::types::{EventKind, EventPayload};
-#[cfg(test)]
-use serde_json::{Map, Value};
-#[cfg(test)]
-use std::collections::HashSet;
+use super::types::{
+    EventEnvelope, EventKind, EventPayload, EventRefStream, SafeInteger, StreamKind,
+};
 
 pub const AUTOMATION_EVENTS_SCHEMA_SQL: &str = "
     CREATE TABLE IF NOT EXISTS automation_event_stream_heads (
@@ -791,7 +787,6 @@ pub fn resume_events(
     )
 }
 
-#[cfg(test)]
 #[derive(Debug, Default)]
 pub struct EventReducer {
     stream: Option<(String, String)>,
@@ -800,7 +795,6 @@ pub struct EventReducer {
     state: Value,
 }
 
-#[cfg(test)]
 impl EventReducer {
     pub fn apply(&mut self, event: &EventEnvelope) -> Result<(), EventStoreError> {
         if self.seen_event_ids.contains(event.event_id.as_str()) {

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -11,6 +11,8 @@ const CAPABILITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/capability-negotiation.vectors.json");
 const DEFINITION_VALIDATION_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/definition-validation.vectors.json");
+const EVENT_REDUCER_DETERMINISM_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/event-reducer-determinism.vectors.json");
 const RUN_TERMINAL_MONOTONICITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/run-terminal-monotonicity.vectors.json");
 const MAX_CONFORMANCE_REQUEST_BYTES: usize = 1024 * 1024;
@@ -78,11 +80,60 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                     "attempt-terminal-immutability",
                     "capability-negotiation",
                     "definition-validation",
+                    "event-reducer-determinism",
                     "run-terminal-monotonicity"
                 ]
             }]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_event_reducer_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(EVENT_REDUCER_DETERMINISM_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "event-reducer-determinism",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        response["schemaVersion"],
+        "coven.automations.conformance-suite-result.v1"
+    );
+    assert_eq!(response["suiteId"], "event-reducer-determinism");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 1);
+    assert_eq!(response["evidence"]["passedCases"], 1);
+    assert!(response["evidence"]["vectorDigest"]
+        .as_str()
+        .is_some_and(|digest| digest.starts_with("sha256:") && digest.len() == 71));
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Add a native, portable structural conformance suite for event reducer determinism under exact duplicate delivery.
- Files changed: the Rust event reducer/conformance target, unit and real-binary tests, one checked-in vector set, and runner documentation.
- Advances #858.

## Implementation

- Approach: Promote the existing Rust `EventReducer` from test-only code and exercise that same implementation through `event-reducer-determinism`.
- Vector contract: Each case embeds typed event envelopes, identifies one event to deliver twice, and pins the JCS SHA-256 digest of the expected final state.
- Evaluation: Reduce the stream canonically and with the exact duplicate, require both final states to match, and require the canonical state digest to match the vector.
- Failure behavior: Reject malformed schemas, case IDs, event envelopes, duplicate canonical event IDs, duplicate indexes, and digests; return a non-passing result for out-of-order streams or expectation mismatches.
- Reducer hardening: A new snapshot can no longer rewind an already-advanced cursor; exact duplicate snapshots remain idempotent through event-ID deduplication.
- User-visible behavior: `coven automations conformance capability` now advertises the fifth structural suite.
- Compatibility notes: Audit-only. This does not claim scheduler, runtime-authority, continuity, privacy, interoperability, or full certification.

## Evidence packet

- Objective: Prove the #858 inventory item "event reducer determinism under duplicate delivery" against native Rust code.
- Acceptance criteria: Portable vectors; exact duplicate replay; deterministic final state; pinned normalized digest; stateless real-binary execution; fail-closed malformed input.
- Non-goals: Event publication durability, scheduler duplicate-dispatch prevention, reconnect/resume scenarios, runtime callbacks, or release eligibility.
- Canonical contracts consulted: `spec/coven-automations/v1/test-vectors.json` occurrence sequence and `crates/coven-cli/src/automations/contract/events.rs`.
- Lifecycle/authority/privacy impact: Read-only reduction of synthetic operational events. No authority decision, persistent store mutation, raw evidence, prompt, credential, or path is emitted.
- Fault points exercised: Exact duplicate delivery and out-of-order delivery refusal.
- Migration and rollback: No schema or data migration. Revert this commit to remove the suite and return the reducer to test-only compilation.
- Performance/SLO delta: At most 128 cases with at most 128 in-memory events each; no persistent I/O or network access.
- Generated artifacts and provenance: Exact rebased commit `4a07253dc7f628263a43a898c994bcbba4b71c44`; exact-artifact audit retained outside the repository with statement digest `9e310687317a0e2b84ca27b0ac2c0351eb463b33224ad794e004131e0f1e8d93`.
- Cross-repository canaries: Not exercised by this structural slice.
- Unresolved uncertainty: #858 remains open for the broader profile, chaos, SLO, diagnostics, and cross-repository inventory.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked -- --test-threads=1`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node --test conformance/automations/runner/conformance.test.mjs`
- [x] Exact-artifact audit passed all five advertised structural suites.
- [x] Independent final code review reported no findings after review fixes.

The first serialized workspace run encountered the known unrelated
`restart_returns_within_deadline_when_optional_diagnostic_scan_is_slow` timing
flake. That test passed in isolation and the complete serialized workspace suite
then passed on rerun.

## Risk and Rollback

- Risk level: Low. The production delta exposes an existing reducer only to the native audit target.
- Rollback plan: Revert the commit; there is no persisted state or migration to unwind.

## Agent Handoff

- Current state: Ready for exact-head CI and merge.
- Follow-ups: Continue #858 with another independently shippable structural or diagnostic slice.
- Known gaps: The broader #858 certification plane remains intentionally incomplete.
