### PR TITLE
feat: add receipt integrity conformance suite

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -163,7 +163,7 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements six structural suites.
+The native Coven target currently implements seven structural suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
 refused. `capability-negotiation` executes the checked-in cases against Rust's

--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -126,6 +126,7 @@ The checked-in
 [`definition-validation.vectors.json`](definition-validation.vectors.json),
 [`event-reducer-determinism.vectors.json`](event-reducer-determinism.vectors.json),
 [`occurrence-fence-uniqueness.vectors.json`](occurrence-fence-uniqueness.vectors.json),
+[`receipt-integrity-validation.vectors.json`](receipt-integrity-validation.vectors.json),
 and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
 files contain the current nonempty vector sets.
@@ -148,6 +149,7 @@ The runner invokes the target directly without a shell.
         "definition-validation",
         "event-reducer-determinism",
         "occurrence-fence-uniqueness",
+        "receipt-integrity-validation",
         "run-terminal-monotonicity"
       ]
     }
@@ -176,6 +178,12 @@ the same normalized final state and expected digest.
 production SQLite occurrence schema, proving that one automation cannot claim
 the same scheduled slot twice while different automations may share a slot and
 one automation may claim distinct slots.
+`receipt-integrity-validation` parses portable receipts through the native
+typed receipt contract. It requires a canonical receipt with a matching JCS
+SHA-256 integrity value and a minimally tampered receipt whose unchanged
+integrity value must be rejected. Accepted receipts are compared by a pinned
+digest of their normalized typed representation; receipt contents are not
+returned as target evidence.
 `run-terminal-monotonicity` executes the checked-in settlement and replay cases
 against the real Rust run ledger in an isolated in-memory store, proving that a
 later terminal observation cannot rewrite the first committed terminal state.

--- a/conformance/automations/runner/receipt-integrity-validation.vectors.json
+++ b/conformance/automations/runner/receipt-integrity-validation.vectors.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": "coven.automations.receipt-integrity-validation-vectors.v1",
+  "cases": [
+    {
+      "caseId": "canonical-receipt-verifies",
+      "receipt": {
+        "schemaVersion": "coven.automations.v1",
+        "receiptId": "receipt-daily-notes-0001",
+        "automationId": "daily-notes",
+        "automationRevision": 1,
+        "definitionDigest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        },
+        "occurrenceId": "daily-notes-1756544400000",
+        "occurrenceFenceGeneration": 1,
+        "runId": "run-daily-notes-0001",
+        "attemptId": "att-daily-notes-0001-1",
+        "attemptNumber": 1,
+        "identity": {
+          "familiarId": "charm"
+        },
+        "authority": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "approval": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtime": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "exercisedCapabilities": [
+          "sessions.launch"
+        ],
+        "sideEffectClass": "local_write",
+        "outcome": {
+          "disposition": "succeeded",
+          "recoveryDisposition": "not_required"
+        },
+        "producedAt": "2026-08-30T09:00:05.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a",
+          "implementationVersion": "0.9.0"
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        },
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "3b278869178dc3a8461a0cae5a1c671e77085e468261d651460ccf6822300418",
+          "authentication": "none"
+        }
+      },
+      "expected": {
+        "outcome": "accepted",
+        "normalizedDigest": "sha256:d02ac54baca682a57cc8750f4b7e432186ec10b4e93266f92e15ee2fe485c93f"
+      }
+    },
+    {
+      "caseId": "tampered-receipt-is-rejected",
+      "receipt": {
+        "schemaVersion": "coven.automations.v1",
+        "receiptId": "receipt-daily-notes-0001",
+        "automationId": "daily-notes",
+        "automationRevision": 1,
+        "definitionDigest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "8921b840a98f0b700d0144e70b9418af2431f9863bc4e4d8529b2d9848fa4ce9"
+        },
+        "occurrenceId": "daily-notes-1756544400000",
+        "occurrenceFenceGeneration": 1,
+        "runId": "run-daily-notes-0001",
+        "attemptId": "att-daily-notes-0001-1",
+        "attemptNumber": 1,
+        "identity": {
+          "familiarId": "charm"
+        },
+        "authority": {
+          "principal": {
+            "principalId": "principal:tim"
+          },
+          "approval": {
+            "approvalPolicyRef": "policy://authority/familiars/charm"
+          }
+        },
+        "runtime": {
+          "runtimeId": "coven-code",
+          "capabilities": [
+            "sessions.launch"
+          ]
+        },
+        "exercisedCapabilities": [
+          "sessions.launch"
+        ],
+        "sideEffectClass": "local_write",
+        "outcome": {
+          "disposition": "failed",
+          "recoveryDisposition": "not_required"
+        },
+        "producedAt": "2026-08-30T09:00:05.000Z",
+        "producer": {
+          "component": "coven-daemon",
+          "instanceId": "daemon@host-a",
+          "implementationVersion": "0.9.0"
+        },
+        "privacy": {
+          "classification": "operational",
+          "retention": {
+            "classification": "standard"
+          }
+        },
+        "integrity": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785",
+          "value": "3b278869178dc3a8461a0cae5a1c671e77085e468261d651460ccf6822300418",
+          "authentication": "none"
+        }
+      },
+      "expected": {
+        "outcome": "rejected"
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -9,7 +9,9 @@ use sha2::{Digest, Sha256};
 use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
 use super::contract::events::EventReducer;
 use super::contract::types::{AutomationId, OccurrenceId};
-use super::contract::{canonicalize, sha256_hex, AutomationDefinition, EventEnvelope};
+use super::contract::{
+    canonicalize, sha256_hex, AutomationDefinition, AutomationReceipt, EventEnvelope,
+};
 use super::runs::{
     record_run_finish, record_run_start, RunFinish, RunStart, AUTOMATION_ATTEMPTS_SCHEMA_SQL,
 };
@@ -27,6 +29,8 @@ const EVENT_REDUCER_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.event-reducer-determinism-vectors.v1";
 const OCCURRENCE_FENCE_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-fence-uniqueness-vectors.v1";
+const RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.receipt-integrity-validation-vectors.v1";
 const RUN_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.run-terminal-monotonicity-vectors.v1";
 const STRUCTURAL_PROFILE: &str = "structural";
@@ -37,6 +41,7 @@ pub const ATTEMPT_TERMINAL_IMMUTABILITY_SUITE: &str = "attempt-terminal-immutabi
 pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
+pub const RECEIPT_INTEGRITY_VALIDATION_SUITE: &str = "receipt-integrity-validation";
 pub const RUN_TERMINAL_MONOTONICITY_SUITE: &str = "run-terminal-monotonicity";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -248,6 +253,31 @@ struct ExpectedOccurrenceFence {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ReceiptIntegrityVectorSet {
+    schema_version: String,
+    cases: Vec<ReceiptIntegrityVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ReceiptIntegrityVectorCase {
+    case_id: String,
+    receipt: Value,
+    expected: ExpectedReceiptIntegrity,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case", deny_unknown_fields)]
+enum ExpectedReceiptIntegrity {
+    Accepted {
+        #[serde(rename = "normalizedDigest")]
+        normalized_digest: String,
+    },
+    Rejected,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RunTerminalVectorSet {
     schema_version: String,
     cases: Vec<RunTerminalVectorCase>,
@@ -302,6 +332,7 @@ pub fn capability() -> TargetCapability {
                 DEFINITION_VALIDATION_SUITE,
                 EVENT_REDUCER_DETERMINISM_SUITE,
                 OCCURRENCE_FENCE_UNIQUENESS_SUITE,
+                RECEIPT_INTEGRITY_VALIDATION_SUITE,
                 RUN_TERMINAL_MONOTONICITY_SUITE,
             ],
         }],
@@ -328,6 +359,9 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         DEFINITION_VALIDATION_SUITE => evaluate_definition_validation(&request.vector)?,
         EVENT_REDUCER_DETERMINISM_SUITE => evaluate_event_reducer_determinism(&request.vector)?,
         OCCURRENCE_FENCE_UNIQUENESS_SUITE => evaluate_occurrence_fence_uniqueness(&request.vector)?,
+        RECEIPT_INTEGRITY_VALIDATION_SUITE => {
+            evaluate_receipt_integrity_validation(&request.vector)?
+        }
         RUN_TERMINAL_MONOTONICITY_SUITE => evaluate_run_terminal_monotonicity(&request.vector)?,
         _ => return Err("conformance suite is unsupported"),
     };
@@ -826,6 +860,58 @@ fn definition_case_matches(case: &DefinitionValidationVectorCase) -> bool {
                 .is_some_and(|observed| observed == *normalized_digest)
         }
         (ExpectedDefinitionValidation::Rejected, Err(_)) => true,
+        _ => false,
+    }
+}
+
+fn evaluate_receipt_integrity_validation(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: ReceiptIntegrityVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut has_accepted = false;
+    let mut has_rejected = false;
+    for case in &vectors.cases {
+        match &case.expected {
+            ExpectedReceiptIntegrity::Accepted { normalized_digest } => {
+                has_accepted = true;
+                if !valid_sha256_digest(normalized_digest) {
+                    return Err("conformance vector is invalid");
+                }
+            }
+            ExpectedReceiptIntegrity::Rejected => has_rejected = true,
+        }
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !case.receipt.is_object()
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+    if !has_accepted || !has_rejected {
+        return Err("conformance vector is invalid");
+    }
+
+    Ok(vectors.cases.iter().all(receipt_integrity_case_matches))
+}
+
+fn receipt_integrity_case_matches(case: &ReceiptIntegrityVectorCase) -> bool {
+    let parsed = serde_json::from_value::<AutomationReceipt>(case.receipt.clone());
+    match (&case.expected, parsed) {
+        (ExpectedReceiptIntegrity::Accepted { normalized_digest }, Ok(receipt)) => {
+            serde_json::to_value(receipt)
+                .ok()
+                .and_then(|value| canonicalize(&value).ok())
+                .map(|canonical| format!("sha256:{}", sha256_hex(&canonical)))
+                .is_some_and(|observed| observed == *normalized_digest)
+        }
+        (ExpectedReceiptIntegrity::Rejected, Err(_)) => true,
         _ => false,
     }
 }

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -10,7 +10,8 @@ use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation}
 use super::contract::events::EventReducer;
 use super::contract::types::{AutomationId, OccurrenceId};
 use super::contract::{
-    canonicalize, sha256_hex, AutomationDefinition, AutomationReceipt, EventEnvelope,
+    canonicalize, canonicalize_without_integrity, sha256_hex, AutomationDefinition,
+    AutomationReceipt, EventEnvelope,
 };
 use super::runs::{
     record_run_finish, record_run_start, RunFinish, RunStart, AUTOMATION_ATTEMPTS_SCHEMA_SQL,
@@ -885,7 +886,12 @@ fn evaluate_receipt_integrity_validation(vector: &Value) -> Result<bool, &'stati
                     return Err("conformance vector is invalid");
                 }
             }
-            ExpectedReceiptIntegrity::Rejected => has_rejected = true,
+            ExpectedReceiptIntegrity::Rejected => {
+                has_rejected = true;
+                if !structurally_valid_receipt(&case.receipt) {
+                    return Err("conformance vector is invalid");
+                }
+            }
         }
         if !valid_case_id(&case.case_id)
             || !case_ids.insert(&case.case_id)
@@ -899,6 +905,27 @@ fn evaluate_receipt_integrity_validation(vector: &Value) -> Result<bool, &'stati
     }
 
     Ok(vectors.cases.iter().all(receipt_integrity_case_matches))
+}
+
+fn structurally_valid_receipt(value: &Value) -> bool {
+    let mut candidate = value.clone();
+    if candidate
+        .get("integrity")
+        .and_then(Value::as_object)
+        .and_then(|integrity| integrity.get("value"))
+        .and_then(Value::as_str)
+        .is_none()
+    {
+        return false;
+    }
+
+    canonicalize_without_integrity(&candidate)
+        .ok()
+        .map(|canonical| {
+            candidate["integrity"]["value"] = Value::String(sha256_hex(&canonical));
+            candidate
+        })
+        .is_some_and(|candidate| serde_json::from_value::<AutomationReceipt>(candidate).is_ok())
 }
 
 fn receipt_integrity_case_matches(case: &ReceiptIntegrityVectorCase) -> bool {

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 
 use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
 use super::contract::events::EventReducer;
-use super::contract::types::{AutomationId, OccurrenceId};
+use super::contract::types::{AutomationId, OccurrenceId, Sha256Digest};
 use super::contract::{
     canonicalize, canonicalize_without_integrity, sha256_hex, AutomationDefinition,
     AutomationReceipt, EventEnvelope,
@@ -909,13 +909,15 @@ fn evaluate_receipt_integrity_validation(vector: &Value) -> Result<bool, &'stati
 
 fn structurally_valid_receipt(value: &Value) -> bool {
     let mut candidate = value.clone();
-    if candidate
+    let Some(integrity_value) = candidate
         .get("integrity")
         .and_then(Value::as_object)
         .and_then(|integrity| integrity.get("value"))
         .and_then(Value::as_str)
-        .is_none()
-    {
+    else {
+        return false;
+    };
+    if Sha256Digest::new(integrity_value.to_owned()).is_err() {
         return false;
     }
 

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -16,6 +16,9 @@ const EVENT_REDUCER_DETERMINISM_VECTORS: &str = include_str!(
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
+const RECEIPT_INTEGRITY_VALIDATION_VECTORS: &str = include_str!(
+    "../../../../conformance/automations/runner/receipt-integrity-validation.vectors.json"
+);
 
 fn request_for(suite_id: &str, vector: Value) -> Value {
     json!({
@@ -60,11 +63,34 @@ fn capability_advertises_the_native_structural_suites() {
                     "definition-validation",
                     "event-reducer-determinism",
                     "occurrence-fence-uniqueness",
+                    "receipt-integrity-validation",
                     RUN_TERMINAL_MONOTONICITY_SUITE
                 ]
             }]
         })
     );
+}
+
+#[test]
+fn receipt_integrity_validation_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(RECEIPT_INTEGRITY_VALIDATION_VECTORS).unwrap();
+    let response = evaluate(&request_for("receipt-integrity-validation", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 2);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 2);
+}
+
+#[test]
+fn receipt_integrity_validation_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(RECEIPT_INTEGRITY_VALIDATION_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["normalizedDigest"] =
+        json!("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    let response = evaluate(&request_for("receipt-integrity-validation", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
 }
 
 #[test]

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -95,7 +95,7 @@ fn receipt_integrity_validation_suite_fails_closed_on_an_expectation_mismatch() 
 
 #[test]
 fn receipt_integrity_validation_suite_rejects_invalid_vector_shapes() {
-    let invalid_mutations: [fn(&mut Value); 8] = [
+    let invalid_mutations: [fn(&mut Value); 9] = [
         |vectors| vectors["schemaVersion"] = json!("unsupported"),
         |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
         |vectors| {
@@ -104,6 +104,9 @@ fn receipt_integrity_validation_suite_rejects_invalid_vector_shapes() {
         |vectors| vectors["cases"][0]["receipt"] = json!("not-an-object"),
         |vectors| {
             vectors["cases"][1]["receipt"] = json!({ "schemaVersion": "coven.automations.v1" })
+        },
+        |vectors| {
+            vectors["cases"][1]["receipt"]["integrity"]["value"] = json!("not-a-sha256-digest")
         },
         |vectors| {
             vectors["cases"][0]["expected"]["normalizedDigest"] = json!("sha256:not-a-digest");

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -95,12 +95,16 @@ fn receipt_integrity_validation_suite_fails_closed_on_an_expectation_mismatch() 
 
 #[test]
 fn receipt_integrity_validation_suite_rejects_invalid_vector_shapes() {
-    let invalid_mutations: [fn(&mut Value); 6] = [
+    let invalid_mutations: [fn(&mut Value); 8] = [
         |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
         |vectors| {
             vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone();
         },
         |vectors| vectors["cases"][0]["receipt"] = json!("not-an-object"),
+        |vectors| {
+            vectors["cases"][1]["receipt"] = json!({ "schemaVersion": "coven.automations.v1" })
+        },
         |vectors| {
             vectors["cases"][0]["expected"]["normalizedDigest"] = json!("sha256:not-a-digest");
         },

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -94,6 +94,38 @@ fn receipt_integrity_validation_suite_fails_closed_on_an_expectation_mismatch() 
 }
 
 #[test]
+fn receipt_integrity_validation_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 6] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| {
+            vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone();
+        },
+        |vectors| vectors["cases"][0]["receipt"] = json!("not-an-object"),
+        |vectors| {
+            vectors["cases"][0]["expected"]["normalizedDigest"] = json!("sha256:not-a-digest");
+        },
+        |vectors| vectors["cases"][0]["expected"] = json!({"outcome": "rejected"}),
+        |vectors| {
+            vectors["cases"][1]["expected"] = json!({
+                "outcome": "accepted",
+                "normalizedDigest":
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            });
+        },
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value =
+            serde_json::from_str(RECEIPT_INTEGRITY_VALIDATION_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for("receipt-integrity-validation", vectors)).unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
 fn occurrence_fence_uniqueness_suite_executes_the_checked_in_vectors() {
     let vectors: Value = serde_json::from_str(OCCURRENCE_FENCE_UNIQUENESS_VECTORS).unwrap();
     let response = evaluate(&request_for("occurrence-fence-uniqueness", vectors)).unwrap();

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -16,6 +16,9 @@ const EVENT_REDUCER_DETERMINISM_VECTORS: &str =
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
+const RECEIPT_INTEGRITY_VALIDATION_VECTORS: &str = include_str!(
+    "../../../conformance/automations/runner/receipt-integrity-validation.vectors.json"
+);
 const RUN_TERMINAL_MONOTONICITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/run-terminal-monotonicity.vectors.json");
 const MAX_CONFORMANCE_REQUEST_BYTES: usize = 1024 * 1024;
@@ -85,11 +88,53 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                     "definition-validation",
                     "event-reducer-determinism",
                     "occurrence-fence-uniqueness",
+                    "receipt-integrity-validation",
                     "run-terminal-monotonicity"
                 ]
             }]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_receipt_integrity_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(RECEIPT_INTEGRITY_VALIDATION_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "receipt-integrity-validation",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "receipt-integrity-validation");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 2);
+    assert_eq!(response["evidence"]["passedCases"], 2);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Add a native structural conformance suite for receipt integrity validation.
- Files changed: the Rust conformance target, unit and real-binary tests, one checked-in portable vector set, and runner documentation.
- Advances #858.

## Implementation

- Approach: Parse portable receipts through the production typed `AutomationReceipt` deserializer, which verifies the embedded JCS SHA-256 integrity value.
- Accepted control: the canonical protocol receipt must parse and match a pinned digest of its normalized typed representation.
- Tamper case: changing the terminal disposition while retaining the original integrity value must be rejected.
- Validation rejects missing accepted/rejected controls, reused or malformed case IDs, non-object receipts, malformed expected digests, and unsupported vector schemas.
- User-visible behavior: `coven automations conformance capability` now advertises the seventh structural suite.
- Compatibility notes: Audit-only. This validates receipt parsing and integrity enforcement; it does not claim runtime receipt production, trusted authentication, or release eligibility.

## Evidence packet

- Objective: Prove #858's canonical receipt-integrity inventory item against the real Rust product contract.
- Acceptance criteria: Portable valid/tampered vectors, typed parsing, embedded integrity verification, normalized accepted digest, stateless real-binary execution, and fail-closed malformed input.
- Non-goals: Producing runtime receipts, asserting observed runtime outcomes, authentication, authority approval, delivery evidence, or release certification.
- Canonical contracts consulted: `AutomationReceipt`, its custom `Deserialize` implementation, `verify_integrity`, canonical JCS helpers, and `receipt.golden` in the v1 protocol fixtures.
- Lifecycle/authority/privacy impact: Synthetic receipt objects only; no filesystem state, credentials, prompts, raw receipt contents, or target output are emitted as evidence.
- Fault/refusal points exercised: A one-field receipt tamper with an unchanged integrity value plus expectation and vector-shape mismatches.
- Migration and rollback: No schema or data migration. Revert the commit to remove the suite.
- Performance/SLO delta: Two in-memory typed parsing cases; no persistent I/O or network access.
- Generated artifacts and provenance: Exact commit `3b7012055f250b4a28e6f8d60079318ed62bb070`; exact-artifact audit retained outside the repository with statement digest `aba407809f2b7a9611aa45e694930b58e320d45d22e04df18330ea21666926b0`.
- Cross-repository canaries: Not exercised by this structural slice.
- Unresolved uncertainty: #858 remains open for scheduler, chaos, authority, privacy, interoperability, SLO, diagnostics, and exact-release certification. #857 remains blocked on a production runtime evidence producer.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `CARGO_BUILD_JOBS=1 cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node --test conformance/automations/runner/conformance.test.mjs`
- [x] Exact-artifact audit passed all seven advertised structural suites.
- [x] Independent final code review reported no findings.

## Risk and Rollback

- Risk level: Low. The evaluator uses the existing typed receipt parser and pure canonicalization helpers.
- Rollback plan: Revert the commit; no persisted state or migration must be unwound.

## Agent Handoff

- Current state: Ready for exact-head CI and merge.
- Follow-ups: Continue #858 with another independently shippable structural or diagnostic slice.
- Known gaps: The broader #858 certification plane remains intentionally incomplete.


