### PR TITLE
test(client): exercise status sharing with explicit staging

### DIFF
--- a/crates/coven-client/src/discovery.rs
+++ b/crates/coven-client/src/discovery.rs
@@ -2182,7 +2182,7 @@ mod tests {
                     Err(error) => panic!("status replacement channel failed: {error}"),
                 };
                 writer.join().expect("status replacement thread");
-                result.expect("replace status with a delete-sharing reader");
+                result.expect("replace status after reader closes");
                 crate::status::tests::assert_status_file_is_owner_only(&status_path);
                 assert_eq!(std::fs::read(&status_path).unwrap(), b"{\"pid\":2}\n");
             } else {

--- a/crates/coven-client/src/discovery.rs
+++ b/crates/coven-client/src/discovery.rs
@@ -2174,14 +2174,17 @@ mod tests {
                 // otherwise release the reader and require bounded completion.
                 let early_result = result_rx.recv_timeout(Duration::from_millis(20));
                 drop(reader);
-                let result = match early_result {
-                    Ok(result) => result,
-                    Err(mpsc::RecvTimeoutError::Timeout) => result_rx
-                        .recv_timeout(Duration::from_secs(2))
-                        .expect("status replacement result"),
-                    Err(error) => panic!("status replacement channel failed: {error}"),
+                let received = match early_result {
+                    Ok(result) => Ok(result),
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        result_rx.recv_timeout(Duration::from_secs(2))
+                    }
+                    Err(error) => Err(error),
                 };
-                writer.join().expect("status replacement thread");
+                if let Err(panic) = writer.join() {
+                    std::panic::resume_unwind(panic);
+                }
+                let result = received.expect("status replacement result");
                 result.expect("replace status after reader closes");
                 crate::status::tests::assert_status_file_is_owner_only(&status_path);
                 assert_eq!(std::fs::read(&status_path).unwrap(), b"{\"pid\":2}\n");

--- a/crates/coven-client/src/discovery.rs
+++ b/crates/coven-client/src/discovery.rs
@@ -2041,74 +2041,146 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn status_file_reader_allows_an_atomic_status_replacement() {
+        // The protected producer supplies the same staging boundary used by the
+        // CLI. The low-level writer does not read CLI configuration itself.
+        let staging =
+            std::env::var_os("COVEN_WINDOWS_STATUS_STAGING_DIR").map(std::path::PathBuf::from);
+        if let Some(path) = &staging {
+            assert!(path.is_absolute(), "status staging must be absolute");
+            assert!(path.is_dir(), "status staging must exist");
+        }
+        assert_status_replacement_sharing(staging.as_deref());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn status_file_reader_allows_explicit_staging_replacement() {
+        let staging = StatusSharingHome::new();
+        assert_status_replacement_sharing(Some(staging.path()));
+    }
+
+    #[cfg(windows)]
+    struct StatusSharingHome(std::path::PathBuf);
+
+    #[cfg(windows)]
+    impl StatusSharingHome {
+        fn new() -> Self {
+            static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let path = std::env::temp_dir().join(format!(
+                ".coven-status-sharing-{}-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos(),
+                NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ));
+            std::fs::create_dir(&path).expect("create status replacement home");
+            Self(path)
+        }
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    #[cfg(windows)]
+    impl Drop for StatusSharingHome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[cfg(windows)]
+    fn assert_status_replacement_sharing(staging: Option<&std::path::Path>) {
         use std::{
-            ffi::OsStr,
             os::windows::{
                 ffi::OsStrExt,
                 io::{FromRawHandle, OwnedHandle},
             },
             ptr,
-            sync::mpsc,
-            time::Duration,
         };
         use windows_sys::Win32::{
             Foundation::{GENERIC_READ, INVALID_HANDLE_VALUE},
-            Storage::FileSystem::{CreateFileW, FILE_ATTRIBUTE_NORMAL, OPEN_EXISTING},
+            Storage::FileSystem::{
+                CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, OPEN_EXISTING,
+            },
         };
 
-        let home =
-            std::env::temp_dir().join(format!(".coven-client-status-share-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir(&home).expect("create status replacement home");
-        let status_path = home.join("daemon.json");
-        std::fs::write(&status_path, b"{\"pid\":1}").expect("write current status");
-        let status_path_wide: Vec<u16> = OsStr::new(&status_path)
+        let home = StatusSharingHome::new();
+        let status_path = home.path().join("daemon.json");
+        let status_path_wide: Vec<u16> = status_path
+            .as_os_str()
             .encode_wide()
-            .chain(std::iter::once(0))
+            .chain(Some(0))
             .collect();
-
-        let reader = unsafe {
-            CreateFileW(
-                status_path_wide.as_ptr(),
-                GENERIC_READ,
-                windows_status_file_share_mode(),
-                ptr::null(),
-                OPEN_EXISTING,
-                FILE_ATTRIBUTE_NORMAL,
-                ptr::null_mut(),
-            )
+        let temporary_files = || {
+            let prefix = format!(".daemon-status-{}-", std::process::id());
+            std::fs::read_dir(staging.unwrap_or(home.path()))
+                .expect("read status staging")
+                .map(|entry| entry.expect("read status staging entry").file_name())
+                .filter(|name| name.to_string_lossy().starts_with(&prefix))
+                .collect::<std::collections::BTreeSet<_>>()
         };
-        assert_ne!(reader, INVALID_HANDLE_VALUE, "open status reader");
-        // Keep the reader owned so failure paths also close the Windows handle.
-        let reader = unsafe { OwnedHandle::from_raw_handle(reader) };
-        let home_path = home.clone();
-        let (result_tx, result_rx) = mpsc::channel();
-        let writer = std::thread::spawn(move || {
-            result_tx
-                .send(crate::write_owner_only_windows_daemon_status(
-                    &home_path,
+        for allow_delete in [true, false] {
+            let before = temporary_files();
+            std::fs::write(&status_path, b"{\"pid\":1}").expect("write current status");
+            let share = if allow_delete {
+                windows_status_file_share_mode()
+            } else {
+                windows_status_file_share_mode() & !FILE_SHARE_DELETE
+            };
+            let reader = unsafe {
+                CreateFileW(
+                    status_path_wide.as_ptr(),
+                    GENERIC_READ,
+                    share,
+                    ptr::null(),
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL,
+                    ptr::null_mut(),
+                )
+            };
+            assert_ne!(reader, INVALID_HANDLE_VALUE, "open status reader");
+            let reader = unsafe { OwnedHandle::from_raw_handle(reader) };
+            // Keep the reader open throughout the bounded writer operation. Dropping
+            // it before checking the result would hide a missing delete-share flag.
+            let result = match staging {
+                Some(staging) => crate::write_owner_only_windows_daemon_status_with_staging(
+                    home.path(),
+                    staging,
                     b"{\"pid\":2}",
-                ))
-                .expect("report status replacement");
-        });
-        // Replacement may complete while a delete-sharing reader is open. Preserve
-        // an early success or error instead of requiring a minimum writer duration.
-        let early_result = result_rx.recv_timeout(Duration::from_millis(20));
-        drop(reader);
-        let result = match early_result {
-            Ok(result) => Ok(result),
-            Err(mpsc::RecvTimeoutError::Timeout) => result_rx.recv_timeout(Duration::from_secs(2)),
-            Err(error) => Err(error),
-        };
-        let result = result.expect("status replacement result");
-        let joined = writer.join();
-        result.expect("replace status after reader closes");
-        joined.expect("status replacement thread");
-        assert_eq!(
-            std::fs::read_to_string(&status_path).expect("read replaced status"),
-            "{\"pid\":2}\n"
-        );
-        std::fs::remove_dir_all(home).expect("remove status replacement home");
+                ),
+                None => crate::write_owner_only_windows_daemon_status(home.path(), b"{\"pid\":2}"),
+            };
+            if allow_delete {
+                result.expect("replace status while reader remains open");
+                crate::status::tests::assert_status_file_is_owner_only(&status_path);
+                assert_eq!(std::fs::read(&status_path).unwrap(), b"{\"pid\":2}\n");
+            } else {
+                let error =
+                    result.expect_err("reader without delete sharing must prevent replacement");
+                assert!(matches!(
+                    error,
+                    crate::ClientError::Io {
+                        operation:
+                            "failed to write owner-only Windows daemon status: replace-status-file",
+                        ..
+                    }
+                ));
+                assert_eq!(std::fs::read(&status_path).unwrap(), b"{\"pid\":1}");
+            }
+            drop(reader);
+            assert_eq!(
+                temporary_files(),
+                before,
+                "writer must clean its temporary files"
+            );
+            assert_eq!(
+                std::fs::read_dir(home.path()).unwrap().count(),
+                1,
+                "only the destination status should remain"
+            );
+        }
     }
 }
 

--- a/crates/coven-client/src/discovery.rs
+++ b/crates/coven-client/src/discovery.rs
@@ -2098,6 +2098,8 @@ mod tests {
                 io::{FromRawHandle, OwnedHandle},
             },
             ptr,
+            sync::mpsc,
+            time::Duration,
         };
         use windows_sys::Win32::{
             Foundation::{GENERIC_READ, INVALID_HANDLE_VALUE},
@@ -2106,6 +2108,11 @@ mod tests {
             },
         };
 
+        assert_eq!(
+            windows_status_file_share_mode(),
+            windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ | FILE_SHARE_DELETE,
+            "status readers must retain the exact read/delete sharing contract"
+        );
         let home = StatusSharingHome::new();
         let status_path = home.path().join("daemon.json");
         let status_path_wide: Vec<u16> = status_path
@@ -2142,21 +2149,55 @@ mod tests {
             };
             assert_ne!(reader, INVALID_HANDLE_VALUE, "open status reader");
             let reader = unsafe { OwnedHandle::from_raw_handle(reader) };
-            // Keep the reader open throughout the bounded writer operation. Dropping
-            // it before checking the result would hide a missing delete-share flag.
-            let result = match staging {
-                Some(staging) => crate::write_owner_only_windows_daemon_status_with_staging(
-                    home.path(),
-                    staging,
-                    b"{\"pid\":2}",
-                ),
-                None => crate::write_owner_only_windows_daemon_status(home.path(), b"{\"pid\":2}"),
-            };
             if allow_delete {
-                result.expect("replace status while reader remains open");
+                let home_path = home.path().to_owned();
+                let staging_path = staging.map(std::path::Path::to_owned);
+                let (result_tx, result_rx) = mpsc::channel();
+                let writer = std::thread::spawn(move || {
+                    let result = match staging_path {
+                        Some(staging) => {
+                            crate::write_owner_only_windows_daemon_status_with_staging(
+                                &home_path,
+                                &staging,
+                                b"{\"pid\":2}",
+                            )
+                        }
+                        None => crate::write_owner_only_windows_daemon_status(
+                            &home_path,
+                            b"{\"pid\":2}",
+                        ),
+                    };
+                    result_tx.send(result).expect("report status replacement");
+                });
+                // Native CI deferred MoveFileExW replacement while this reader was
+                // open. Preserve the original bounded close-and-success contract:
+                // otherwise release the reader and require bounded completion.
+                let early_result = result_rx.recv_timeout(Duration::from_millis(20));
+                drop(reader);
+                let result = match early_result {
+                    Ok(result) => result,
+                    Err(mpsc::RecvTimeoutError::Timeout) => result_rx
+                        .recv_timeout(Duration::from_secs(2))
+                        .expect("status replacement result"),
+                    Err(error) => panic!("status replacement channel failed: {error}"),
+                };
+                writer.join().expect("status replacement thread");
+                result.expect("replace status with a delete-sharing reader");
                 crate::status::tests::assert_status_file_is_owner_only(&status_path);
                 assert_eq!(std::fs::read(&status_path).unwrap(), b"{\"pid\":2}\n");
             } else {
+                // Hold the non-delete-sharing reader for the writer's complete
+                // replacement deadline so the failure cannot be hidden by close.
+                let result = match staging {
+                    Some(staging) => crate::write_owner_only_windows_daemon_status_with_staging(
+                        home.path(),
+                        staging,
+                        b"{\"pid\":2}",
+                    ),
+                    None => {
+                        crate::write_owner_only_windows_daemon_status(home.path(), b"{\"pid\":2}")
+                    }
+                };
                 let error =
                     result.expect_err("reader without delete sharing must prevent replacement");
                 assert!(matches!(
@@ -2168,8 +2209,8 @@ mod tests {
                     }
                 ));
                 assert_eq!(std::fs::read(&status_path).unwrap(), b"{\"pid\":1}");
+                drop(reader);
             }
-            drop(reader);
             assert_eq!(
                 temporary_files(),
                 before,

--- a/crates/coven-client/src/status.rs
+++ b/crates/coven-client/src/status.rs
@@ -336,7 +336,7 @@ impl Drop for LocalAllocation {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     struct TestHome(PathBuf);
@@ -355,7 +355,7 @@ mod tests {
         }
     }
 
-    fn assert_status_file_is_owner_only(path: &Path) {
+    pub(crate) fn assert_status_file_is_owner_only(path: &Path) {
         use std::os::windows::fs::OpenOptionsExt;
         use windows_sys::Win32::Storage::FileSystem::READ_CONTROL;
         let file = std::fs::OpenOptions::new()


### PR DESCRIPTION
## Context

Protected Windows run [34647484742](https://github.com/OpenCoven/chat/actions/runs/34647484742) failed in the status replacement fixture at `apply-owner-only-security.access-denied`. The fixture called the default library writer beneath restricted TEMP, while the supervised CLI uses an explicit status staging directory. Tracks #984; protected acceptance remains open.

## Implementation

The selected fixture passes configured staging explicitly to the low-level writer and retains ordinary default-path execution when staging is absent. A separate ordinary explicit-staging test covers that API. Both cases retain the original bounded reader-close-and-success behavior, preserving an early writer error. An exact read/delete share-mode assertion prevents flag drift. A reader held open without delete sharing must prevent replacement and preserve old contents. The tests inspect final owner-only security and temporary cleanup. Fixture directories are uniquely created and cleanup remains confined to owned directories.

Only Windows test code and test-helper visibility change. Production writer behavior, CLI staging validation, ACLs, privileges, limits and dependency settings are unchanged.

## Verification

- `cargo fmt --check` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `cargo test -p coven-client --locked`: 117 tests passed on macOS.
- `cargo check -p coven-client --tests --locked --target x86_64-pc-windows-gnu` passed.
- Secret scanning and staged privacy checks passed.
- Independent fixture review found no blocking issue.
- `cargo test --workspace --locked` passed.
- Native Windows CI34650170155 failed:72 client tests passed, both new positive sharing cases failed at `replace-status-file` with OS5 while the destination reader remained open. The unsupported stronger expectation was corrected at `6c52e95fb174586578e2766f69cf1adb50c8fd0a`;117 client tests, Windows cross-compilation, host lint and independent review passed again. Fresh native CI is pending; no production behavior changed.

Extra Windows cross-target clippy reports `items_after_test_module`; the same warning reproduces on unchanged base `1500f48e`. Host workspace lint passes. Cross-compilation is not native execution proof.

## Risk and Rollback

Test-only change. Revert this patch if native evidence contradicts the fixture assumptions. The separate CLI tests remain responsible for supervisor identity, containment, same-volume and reparse validation.

## Agent Handoff

Native Windows verification is required before landing. After merge, adopt the reviewed Coven observation source through frozen Chat and SDK bindings and obtain fresh protected validation. The prior SDK observation failure did not recur in run34647484742; its cause remains unclassified. Chat and active worktrees are preserved.


Current head `e5e76dfab4b3a1a8abd4f1825a147dd9db56e47b` preserves the bounded writer diagnostic label and joins the writer before reporting receive failures. Local signature and GitHub verification, formatting,117 client tests and Windows cross-compilation passed at this head. Chat’s diagnostic contract suite passed452 tests with1 skipped. Exact-head [CI34651586920](https://github.com/OpenCoven/coven/actions/runs/34651586920) is running; native acceptance remains pending.
