### PR TITLE
feat: add command adoption conformance suite

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -123,6 +123,7 @@ source metadata for the files and binary under test. `source.commit` must equal
 The checked-in
 [`attempt-terminal-immutability.vectors.json`](attempt-terminal-immutability.vectors.json),
 [`capability-negotiation.vectors.json`](capability-negotiation.vectors.json),
+[`command-adoption-idempotency.vectors.json`](command-adoption-idempotency.vectors.json),
 [`definition-validation.vectors.json`](definition-validation.vectors.json),
 [`event-reducer-determinism.vectors.json`](event-reducer-determinism.vectors.json),
 [`occurrence-fence-uniqueness.vectors.json`](occurrence-fence-uniqueness.vectors.json),
@@ -146,6 +147,7 @@ The runner invokes the target directly without a shell.
       "suites": [
         "attempt-terminal-immutability",
         "capability-negotiation",
+        "command-adoption-idempotency",
         "definition-validation",
         "event-reducer-determinism",
         "occurrence-fence-uniqueness",
@@ -163,11 +165,17 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements seven structural suites.
+The native Coven target currently implements eight structural suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
 refused. `capability-negotiation` executes the checked-in cases against Rust's
-real routine-definition parser and capability policy. `definition-validation`
+real routine-definition parser and capability policy.
+`command-adoption-idempotency` executes a valid definition create through the
+production transactional adoption path, then proves that an exact replay
+returns the committed result without duplicating the definition, adoption, or
+event while a changed request under the same adoption key is refused with
+`ADOPTION_REPLAY_MISMATCH`.
+`definition-validation`
 executes the portable v1 definition parser, integrity verification, and typed
 serialization path, accepting a canonical valid definition only when its
 normalized JCS digest matches and rejecting a tampered definition.

--- a/conformance/automations/runner/command-adoption-idempotency.vectors.json
+++ b/conformance/automations/runner/command-adoption-idempotency.vectors.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "coven.automations.command-adoption-idempotency-vectors.v1",
+  "cases": [
+    {
+      "caseId": "exact-replay-converges-and-conflict-is-refused",
+      "adoptionKey": "adopt:create:conformance:0001",
+      "definition": {
+        "schemaVersion": 1,
+        "id": "conformance-adoption",
+        "name": "Conformance adoption",
+        "status": "PAUSED",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the native adoption conformance probe."
+      },
+      "conflictingDefinition": {
+        "schemaVersion": 1,
+        "id": "conformance-adoption",
+        "name": "Conflicting conformance adoption",
+        "status": "PAUSED",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the native adoption conformance probe."
+      },
+      "expected": {
+        "firstOutcome": "committed",
+        "exactReplayOutcome": "replayed",
+        "conflictingReplayOutcome": "rejected",
+        "conflictCode": "ADOPTION_REPLAY_MISMATCH",
+        "exactReplayResultPreserved": true,
+        "exactReplayEventPreserved": true,
+        "firstCommitTimePreserved": true,
+        "originalDefinitionPreserved": true,
+        "definitionRows": 1,
+        "adoptionRows": 1,
+        "eventRows": 1
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -7,8 +7,13 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use super::capability_negotiation::{negotiate_definition, DefinitionNegotiation};
+use super::command_adoption::{
+    ensure_global_adoption_key_guards, execute_definition_command, DefinitionCommand,
+    DefinitionCommandOutcome, AUTOMATION_COMMAND_ADOPTIONS_SCHEMA_SQL,
+};
+use super::contract::error::ErrorCode;
 use super::contract::events::EventReducer;
-use super::contract::types::{AutomationId, OccurrenceId, Sha256Digest};
+use super::contract::types::{AdoptionKey, AutomationId, OccurrenceId, Sha256Digest};
 use super::contract::{
     canonicalize, canonicalize_without_integrity, sha256_hex, AutomationDefinition,
     AutomationReceipt, EventEnvelope,
@@ -22,6 +27,8 @@ const SUITE_REQUEST_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-
 const SUITE_RESULT_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-result.v1";
 const CAPABILITY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.capability-negotiation-vectors.v1";
+const COMMAND_ADOPTION_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.command-adoption-idempotency-vectors.v1";
 const ATTEMPT_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.attempt-terminal-immutability-vectors.v1";
 const DEFINITION_VALIDATION_VECTOR_SCHEMA_VERSION: &str =
@@ -39,6 +46,7 @@ const MAX_CASES: usize = 128;
 
 pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
 pub const ATTEMPT_TERMINAL_IMMUTABILITY_SUITE: &str = "attempt-terminal-immutability";
+pub const COMMAND_ADOPTION_IDEMPOTENCY_SUITE: &str = "command-adoption-idempotency";
 pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
@@ -107,6 +115,47 @@ struct CapabilityVectorCase {
 enum ExpectedNegotiation {
     Supported,
     Unsupported { variant: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CommandAdoptionVectorSet {
+    schema_version: String,
+    cases: Vec<CommandAdoptionVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CommandAdoptionVectorCase {
+    case_id: String,
+    adoption_key: String,
+    definition: Value,
+    conflicting_definition: Value,
+    expected: ExpectedCommandAdoption,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CommandAdoptionOutcome {
+    Committed,
+    Replayed,
+    Rejected,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedCommandAdoption {
+    first_outcome: CommandAdoptionOutcome,
+    exact_replay_outcome: CommandAdoptionOutcome,
+    conflicting_replay_outcome: CommandAdoptionOutcome,
+    conflict_code: ErrorCode,
+    exact_replay_result_preserved: bool,
+    exact_replay_event_preserved: bool,
+    first_commit_time_preserved: bool,
+    original_definition_preserved: bool,
+    definition_rows: usize,
+    adoption_rows: usize,
+    event_rows: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -330,6 +379,7 @@ pub fn capability() -> TargetCapability {
             suites: vec![
                 ATTEMPT_TERMINAL_IMMUTABILITY_SUITE,
                 CAPABILITY_NEGOTIATION_SUITE,
+                COMMAND_ADOPTION_IDEMPOTENCY_SUITE,
                 DEFINITION_VALIDATION_SUITE,
                 EVENT_REDUCER_DETERMINISM_SUITE,
                 OCCURRENCE_FENCE_UNIQUENESS_SUITE,
@@ -357,6 +407,9 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
             evaluate_attempt_terminal_immutability(&request.vector)?
         }
         CAPABILITY_NEGOTIATION_SUITE => evaluate_capability_negotiation(&request.vector)?,
+        COMMAND_ADOPTION_IDEMPOTENCY_SUITE => {
+            evaluate_command_adoption_idempotency(&request.vector)?
+        }
         DEFINITION_VALIDATION_SUITE => evaluate_definition_validation(&request.vector)?,
         EVENT_REDUCER_DETERMINISM_SUITE => evaluate_event_reducer_determinism(&request.vector)?,
         OCCURRENCE_FENCE_UNIQUENESS_SUITE => evaluate_occurrence_fence_uniqueness(&request.vector)?,
@@ -435,6 +488,148 @@ fn evaluate_capability_negotiation(vector: &Value) -> Result<bool, &'static str>
     }
 
     Ok(vectors.cases.iter().all(capability_case_matches))
+}
+
+fn evaluate_command_adoption_idempotency(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: CommandAdoptionVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != COMMAND_ADOPTION_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut adoption_keys = BTreeSet::new();
+    for case in &vectors.cases {
+        let definition = super::definition::RoutineDefinition::from_json(&case.definition)
+            .map_err(|_| "conformance vector is invalid")?;
+        let conflicting =
+            super::definition::RoutineDefinition::from_json(&case.conflicting_definition)
+                .map_err(|_| "conformance vector is invalid")?;
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || AdoptionKey::new(case.adoption_key.clone()).is_err()
+            || !adoption_keys.insert(&case.adoption_key)
+            || definition.id != conflicting.id
+            || definition == conflicting
+            || case.expected.first_outcome != CommandAdoptionOutcome::Committed
+            || case.expected.exact_replay_outcome != CommandAdoptionOutcome::Replayed
+            || case.expected.conflicting_replay_outcome != CommandAdoptionOutcome::Rejected
+            || case.expected.conflict_code != ErrorCode::AdoptionReplayMismatch
+            || !case.expected.exact_replay_result_preserved
+            || !case.expected.exact_replay_event_preserved
+            || !case.expected.first_commit_time_preserved
+            || !case.expected.original_definition_preserved
+            || case.expected.definition_rows != 1
+            || case.expected.adoption_rows != 1
+            || case.expected.event_rows != 1
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+
+    let mut all_passed = true;
+    for case in &vectors.cases {
+        all_passed &= command_adoption_case_matches(case)?;
+    }
+    Ok(all_passed)
+}
+
+fn command_adoption_case_matches(case: &CommandAdoptionVectorCase) -> Result<bool, &'static str> {
+    let conn = Connection::open_in_memory().map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::store::AUTOMATION_DEFINITIONS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::occurrences::AUTOMATION_OCCURRENCES_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::runs::AUTOMATION_RUNS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch("CREATE TABLE sessions (id TEXT PRIMARY KEY NOT NULL);")
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(AUTOMATION_ATTEMPTS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(AUTOMATION_COMMAND_ADOPTIONS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::contract::events::AUTOMATION_EVENTS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    ensure_global_adoption_key_guards(&conn).map_err(|_| "conformance suite execution failed")?;
+
+    let first = execute_definition_command(
+        &conn,
+        &case.adoption_key,
+        DefinitionCommand::Create {
+            definition: case.definition.clone(),
+        },
+        "2026-08-30T09:00:00.000Z",
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    let exact_replay = execute_definition_command(
+        &conn,
+        &case.adoption_key,
+        DefinitionCommand::Create {
+            definition: case.definition.clone(),
+        },
+        "2026-08-30T09:01:00.000Z",
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    let conflicting_replay = execute_definition_command(
+        &conn,
+        &case.adoption_key,
+        DefinitionCommand::Create {
+            definition: case.conflicting_definition.clone(),
+        },
+        "2026-08-30T09:02:00.000Z",
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+
+    let definition_rows = table_row_count(&conn, "SELECT COUNT(*) FROM automation_definitions")?;
+    let adoption_rows =
+        table_row_count(&conn, "SELECT COUNT(*) FROM automation_command_adoptions")?;
+    let event_rows = table_row_count(&conn, "SELECT COUNT(*) FROM automation_events")?;
+    let expected_definition = super::definition::RoutineDefinition::from_json(&case.definition)
+        .map_err(|_| "conformance vector is invalid")?;
+    let stored_definition = super::store::get_definition(&conn, &expected_definition.id)
+        .map_err(|_| "conformance suite execution failed")?
+        .and_then(|stored| {
+            serde_json::from_str::<super::definition::RoutineDefinition>(&stored.definition_json)
+                .ok()
+        });
+    let original_definition_preserved = stored_definition
+        .as_ref()
+        .is_some_and(|stored| stored == &expected_definition);
+    Ok(
+        command_outcome(first.outcome) == case.expected.first_outcome
+            && command_outcome(exact_replay.outcome) == case.expected.exact_replay_outcome
+            && command_outcome(conflicting_replay.outcome)
+                == case.expected.conflicting_replay_outcome
+            && conflicting_replay.error.as_ref().map(|error| error.code())
+                == Some(case.expected.conflict_code)
+            && (first.result == exact_replay.result) == case.expected.exact_replay_result_preserved
+            && (first.event_ref == exact_replay.event_ref)
+                == case.expected.exact_replay_event_preserved
+            && (exact_replay.replay_first_committed_at.as_deref()
+                == Some("2026-08-30T09:00:00.000Z"))
+                == case.expected.first_commit_time_preserved
+            && original_definition_preserved == case.expected.original_definition_preserved
+            && definition_rows == case.expected.definition_rows
+            && adoption_rows == case.expected.adoption_rows
+            && event_rows == case.expected.event_rows,
+    )
+}
+
+const fn command_outcome(outcome: DefinitionCommandOutcome) -> CommandAdoptionOutcome {
+    match outcome {
+        DefinitionCommandOutcome::Committed => CommandAdoptionOutcome::Committed,
+        DefinitionCommandOutcome::Replayed => CommandAdoptionOutcome::Replayed,
+        DefinitionCommandOutcome::Rejected => CommandAdoptionOutcome::Rejected,
+    }
+}
+
+fn table_row_count(conn: &Connection, query: &str) -> Result<usize, &'static str> {
+    conn.query_row(query, [], |row| row.get::<_, i64>(0))
+        .map_err(|_| "conformance suite execution failed")
+        .and_then(|count| usize::try_from(count).map_err(|_| "conformance suite execution failed"))
 }
 
 fn evaluate_definition_validation(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -8,6 +8,9 @@ use super::conformance_target::{
 const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/attempt-terminal-immutability.vectors.json"
 );
+const COMMAND_ADOPTION_IDEMPOTENCY_VECTORS: &str = include_str!(
+    "../../../../conformance/automations/runner/command-adoption-idempotency.vectors.json"
+);
 const DEFINITION_VALIDATION_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/definition-validation.vectors.json");
 const EVENT_REDUCER_DETERMINISM_VECTORS: &str = include_str!(
@@ -60,6 +63,7 @@ fn capability_advertises_the_native_structural_suites() {
                 "suites": [
                     "attempt-terminal-immutability",
                     CAPABILITY_NEGOTIATION_SUITE,
+                    "command-adoption-idempotency",
                     "definition-validation",
                     "event-reducer-determinism",
                     "occurrence-fence-uniqueness",
@@ -69,6 +73,58 @@ fn capability_advertises_the_native_structural_suites() {
             }]
         })
     );
+}
+
+#[test]
+fn command_adoption_idempotency_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(COMMAND_ADOPTION_IDEMPOTENCY_VECTORS).unwrap();
+    let response = evaluate(&request_for("command-adoption-idempotency", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 1);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 1);
+}
+
+#[test]
+fn command_adoption_idempotency_suite_rejects_impossible_expectations() {
+    let mut vectors: Value = serde_json::from_str(COMMAND_ADOPTION_IDEMPOTENCY_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["eventRows"] = json!(2);
+
+    assert_eq!(
+        evaluate(&request_for("command-adoption-idempotency", vectors)).unwrap_err(),
+        "conformance vector is invalid"
+    );
+}
+
+#[test]
+fn command_adoption_idempotency_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 7] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][0]["adoptionKey"] = json!("bad key"),
+        |vectors| vectors["cases"][0]["definition"] = json!("not-an-object"),
+        |vectors| {
+            vectors["cases"][0]["conflictingDefinition"]["id"] = json!("different-automation")
+        },
+        |vectors| {
+            vectors["cases"][0]["conflictingDefinition"] = vectors["cases"][0]["definition"].clone()
+        },
+        |vectors| {
+            let mut duplicate = vectors["cases"][0].clone();
+            duplicate["caseId"] = json!("second-case");
+            vectors["cases"].as_array_mut().unwrap().push(duplicate);
+        },
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value =
+            serde_json::from_str(COMMAND_ADOPTION_IDEMPOTENCY_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for("command-adoption-idempotency", vectors)).unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
 }
 
 #[test]

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -98,7 +98,7 @@ fn command_adoption_idempotency_suite_rejects_impossible_expectations() {
 
 #[test]
 fn command_adoption_idempotency_suite_rejects_invalid_vector_shapes() {
-    let invalid_mutations: [fn(&mut Value); 7] = [
+    let invalid_mutations: [fn(&mut Value); 8] = [
         |vectors| vectors["schemaVersion"] = json!("unsupported"),
         |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
         |vectors| vectors["cases"][0]["adoptionKey"] = json!("bad key"),
@@ -108,6 +108,11 @@ fn command_adoption_idempotency_suite_rejects_invalid_vector_shapes() {
         },
         |vectors| {
             vectors["cases"][0]["conflictingDefinition"] = vectors["cases"][0]["definition"].clone()
+        },
+        |vectors| {
+            let mut duplicate = vectors["cases"][0].clone();
+            duplicate["adoptionKey"] = json!("adopt:create:conformance:0002");
+            vectors["cases"].as_array_mut().unwrap().push(duplicate);
         },
         |vectors| {
             let mut duplicate = vectors["cases"][0].clone();

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -7,6 +7,9 @@ use serde_json::{json, Value};
 const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/attempt-terminal-immutability.vectors.json"
 );
+const COMMAND_ADOPTION_IDEMPOTENCY_VECTORS: &str = include_str!(
+    "../../../conformance/automations/runner/command-adoption-idempotency.vectors.json"
+);
 const CAPABILITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/capability-negotiation.vectors.json");
 const DEFINITION_VALIDATION_VECTORS: &str =
@@ -85,6 +88,7 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                 "suites": [
                     "attempt-terminal-immutability",
                     "capability-negotiation",
+                    "command-adoption-idempotency",
                     "definition-validation",
                     "event-reducer-determinism",
                     "occurrence-fence-uniqueness",
@@ -94,6 +98,47 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
             }]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_command_adoption_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(COMMAND_ADOPTION_IDEMPOTENCY_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "command-adoption-idempotency",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "command-adoption-idempotency");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 1);
+    assert_eq!(response["evidence"]["passedCases"], 1);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Add a native structural conformance suite for command adoption idempotency and replay conflicts.
- Files changed: the Rust conformance target, unit and real-binary tests, one checked-in portable vector set, and runner documentation.
- Advances #858.

## Implementation

- Approach: Execute a valid definition create through the production transactional `execute_definition_command` path in an isolated in-memory store initialized from production schemas.
- Exact replay: the same request under the same adoption key must return `replayed`, preserve the original result, event reference, and first commit timestamp, and add no durable rows.
- Conflicting replay: a changed valid definition under the same adoption key must be rejected with `ADOPTION_REPLAY_MISMATCH` while preserving the original typed definition.
- Durable expectations: exactly one definition row, command-adoption row, and definition event.
- Validation rejects unsupported schemas, malformed/duplicate case IDs, invalid/reused adoption keys, invalid definitions, different automation IDs, identical conflict payloads, and vacuous expectations.
- Compatibility notes: Audit-only. This covers definition-command adoption, not runtime attempt adoption, scheduler dispatch, or external side-effect idempotency.

## Evidence packet

- Objective: Prove #858's request adoption/idempotency conflict inventory item against the real Rust transactional product seam.
- Acceptance criteria: Portable exact/conflicting replay vectors, typed validation, result/event/timestamp preservation, original-definition preservation, durable row cardinality, stateless real-binary execution, and fail-closed malformed input.
- Non-goals: Runtime launch adoption, cancellation adoption, ambiguous external outcomes, authority decisions, or release certification.
- Canonical contracts consulted: `execute_definition_command`, `AUTOMATION_COMMAND_ADOPTIONS_SCHEMA_SQL`, global adoption-key guards, production definition/event schemas, and existing replay/conflict tests.
- Lifecycle/authority/privacy impact: Synthetic paused definitions only; no authority decision, credentials, private paths, prompts from users, or raw target evidence are emitted.
- Fault/refusal points exercised: Exact replay convergence and changed-request reuse of an already committed adoption key.
- Migration and rollback: No schema or data migration. Revert the commit to remove the suite.
- Performance/SLO delta: Three transactional command calls in one isolated in-memory database; no persistent I/O or network access.
- Generated artifacts and provenance: Exact commit `a8367043efc597186fa16bbdab1d649a97804e63`; exact-artifact audit retained outside the repository with statement digest `69f97b4d57f6691006c23b3c33aa7ba0b52aee6803474a020117489d85b9d2b0`.
- Cross-repository canaries: Not exercised by this structural slice.
- Unresolved uncertainty: #858 remains open for scheduler, chaos, authority, privacy, interoperability, SLO, diagnostics, and exact-release certification. #857 remains blocked on a production runtime evidence producer.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p coven-cli --locked`
- [x] `cargo test -p coven-client --lib --locked`
- [x] Workspace tests reached the pre-existing coven-client temporary-home race; every failing coven-client test passed in its package run.
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node --test conformance/automations/runner/conformance.test.mjs`
- [x] Exact-artifact audit passed all eight advertised structural suites.
- [x] Independent final code review reported no findings.

## Risk and Rollback

- Risk level: Low. The evaluator calls the existing production transactional path against isolated in-memory state.
- Rollback plan: Revert the commit; no persisted state or migration must be unwound.

## Agent Handoff

- Current state: Ready for exact-head CI and merge.
- Follow-ups: Continue #858 with another independently shippable structural or diagnostic slice.
- Known gaps: The broader #858 certification plane remains intentionally incomplete.




