### PR TITLE
fix(ci): stabilize Windows daemon lifecycle gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,10 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: windows-latest
-    timeout-minutes: 20
+    # A healthy cached run is already about 15-16 minutes. Keep enough
+    # shared-runner headroom for the suite to report failures instead of being
+    # cancelled by the job cap while tests are still progressing.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/coven-cli/tests/windows_daemon_lifecycle.rs
+++ b/crates/coven-cli/tests/windows_daemon_lifecycle.rs
@@ -4,7 +4,7 @@ use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::sync::mpsc;
+use std::sync::{mpsc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -84,6 +84,13 @@ impl Drop for DaemonGuard {
     fn drop(&mut self) {
         terminate_recorded_daemon(&self.coven_home);
     }
+}
+
+fn real_daemon_test_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 fn assert_success(label: &str, output: &Output) {
@@ -424,6 +431,7 @@ fn send_launch_request(
 
 #[test]
 fn inherited_legacy_status_with_dead_pid_does_not_wedge_lifecycle_commands() -> Result<()> {
+    let _real_daemon = real_daemon_test_lock();
     let temp = tempfile::tempdir()?;
     let coven_home = temp.path().join("coven-home");
     std::fs::create_dir_all(&coven_home)?;
@@ -574,6 +582,7 @@ fn inherited_legacy_status_rejects_cross_profile_and_arbitrary_records() -> Resu
 
 #[test]
 fn abrupt_daemon_stop_kills_child_stalled_before_per_session_job_attachment() -> Result<()> {
+    let _real_daemon = real_daemon_test_lock();
     eprintln!("[windows-daemon-lifecycle] preparing fixture");
     let temp = tempfile::tempdir()?;
     let coven_home = temp.path().join("coven-home");
@@ -644,6 +653,7 @@ fn abrupt_daemon_stop_kills_child_stalled_before_per_session_job_attachment() ->
 
 #[test]
 fn abrupt_daemon_stop_kills_live_piped_descendants() -> Result<()> {
+    let _real_daemon = real_daemon_test_lock();
     let temp = tempfile::tempdir()?;
     let coven_home = temp.path().join("coven-home");
     let project = temp.path().join("project");

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -60,6 +60,11 @@ class CheckCiWorkflowTests(unittest.TestCase):
         self.assertIn(f"actions/cache@{CACHE_SHA}", CI_TEXT)
         self.assertNotIn('actions/cache@v', CI_TEXT)
 
+    def test_windows_rust_gate_has_shared_runner_headroom(self) -> None:
+        windows = ci_job_block('rust-test-windows')
+        self.assertIn('timeout-minutes: 30', windows)
+        self.assertNotIn('timeout-minutes: 20', windows)
+
     def test_ci_runs_expected_workflow_checks(self) -> None:
         for needle in [
             'python3 scripts/classify-ci-changes-test.py',


### PR DESCRIPTION
## Summary

- serialize the three Windows integration tests that launch real background daemons so their startup health probes do not compete inside one test binary
- raise the Windows Rust job cap from 20 to 30 minutes so slow shared runners report test results instead of being canceled mid-suite
- add a workflow regression assertion for the Windows-specific timeout

The documented two-second `daemon stop` assertions remain unchanged.

Closes #1017.

## Evidence

PR #1016 exposed both failure modes on current `main`: repeated `windows_daemon_lifecycle` startup-health timeouts and a rerun canceled at the 20-minute job cap. A passing cached `main` run took about 15m35s, so the old cap had insufficient shared-runner headroom.

## Validation

- `cargo fmt --check`
- `python3 scripts/check-ci-workflow-test.py`
- `python3 scripts/check-workflows-test.py`
- `scripts/check-workflows.sh`
- `cargo test -p coven-cli --test windows_daemon_lifecycle --no-run --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- independent code review: no findings
