### PR TITLE
test(daemon): pin startup budget observation boundaries

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -12630,6 +12630,133 @@ mod tests {
     }
 
     #[test]
+    fn startup_budget_distinguishes_parent_cost_from_child_store_elapsed() {
+        let start = Instant::now();
+        let deadline = LifecycleDeadline::from_instant(start + DAEMON_LIFECYCLE_TIMEOUT);
+        // Synthetic timelines, not measurements of Windows or an E2E reproduction.
+        // The same child store duration can fit or exhaust the parent's deadline.
+        for (preparation_ms, launch_ms, expected_before, expected_after, fits) in [
+            (50, 10, 1950, 1940, true),
+            (1500, 10, 500, 490, false),
+            (50, 1460, 1950, 490, false),
+        ] {
+            let before = start + Duration::from_millis(preparation_ms);
+            let after = before + Duration::from_millis(launch_ms);
+            assert_eq!(
+                format_startup_budget(StartupSpawnPhase::Before, deadline, before),
+                format!("startup_budget phase=before-spawn remaining_ms={expected_before}")
+            );
+            assert_eq!(
+                format_startup_budget(StartupSpawnPhase::After, deadline, after),
+                format!("startup_budget phase=after-spawn remaining_ms={expected_after}")
+            );
+            // This fixture puts child store entry after launch returns. Real child
+            // execution can overlap launch; neither budget sample locates store entry.
+            let store_begin = after + Duration::from_millis(20);
+            let store_end = store_begin + Duration::from_millis(600);
+            assert_eq!(
+                store_end.duration_since(store_begin),
+                Duration::from_millis(600)
+            );
+            assert_eq!(
+                deadline
+                    .remaining_at(store_end, "waiting for Coven daemon startup health")
+                    .is_ok(),
+                fits
+            );
+        }
+    }
+
+    #[test]
+    fn startup_budget_is_not_renewed_between_launch_and_readiness() -> Result<()> {
+        struct BudgetCheckingStart {
+            expected: LifecycleDeadline,
+            launches: std::cell::Cell<usize>,
+            waits: std::cell::Cell<usize>,
+        }
+
+        impl DaemonStartController for BudgetCheckingStart {
+            fn start_background_server(
+                &self,
+                coven_home: &Path,
+                _current_exe: &Path,
+                started_at: String,
+            ) -> Result<DaemonStatus> {
+                self.launches.set(self.launches.get() + 1);
+                Ok(DaemonStatus {
+                    pid: 54321,
+                    started_at,
+                    socket: test_daemon_status_socket(coven_home),
+                    process_creation_time: None,
+                })
+            }
+
+            fn wait_for_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                deadline: LifecycleDeadline,
+            ) -> Result<Option<DaemonStatus>> {
+                self.waits.set(self.waits.get() + 1);
+                assert_eq!(deadline.instant, self.expected.instant);
+                // Advance only the observation, never sleep or renew the deadline.
+                deadline.remaining_at(
+                    self.expected.instant,
+                    "waiting for Coven daemon startup health",
+                )?;
+                anyhow::bail!("expired startup budget was accepted")
+            }
+        }
+
+        for restart in [false, true] {
+            let home = tempfile::tempdir()?;
+            // Hang guard for real filesystem preparation, not a promptness assertion.
+            // Expiry itself is exercised at an exact synthetic instant above.
+            let deadline = LifecycleDeadline::after(Duration::from_secs(3600))?;
+            let start = BudgetCheckingStart {
+                expected: deadline,
+                launches: std::cell::Cell::new(0),
+                waits: std::cell::Cell::new(0),
+            };
+            let stop = RecoveringLifecycleStopController {
+                recovered: None,
+                authenticated: false,
+                stopped: std::sync::Arc::default(),
+            };
+            let result = if restart {
+                restart_background_server_with_controllers_until(
+                    home.path(),
+                    Path::new("coven"),
+                    "synthetic-start".to_owned(),
+                    &stop,
+                    &start,
+                    deadline,
+                )
+                .map(|(_, status)| status)
+            } else {
+                ensure_background_server_with_controllers_until(
+                    home.path(),
+                    Path::new("coven"),
+                    "synthetic-start".to_owned(),
+                    &stop,
+                    &start,
+                    deadline,
+                )
+            };
+            assert_eq!(
+                result
+                    .expect_err("readiness deadline must propagate")
+                    .to_string(),
+                "timed out waiting for Coven daemon startup health"
+            );
+            assert_eq!(start.launches.get(), 1);
+            assert_eq!(start.waits.get(), 1);
+            assert_eq!(read_status(home.path())?, None);
+        }
+        Ok(())
+    }
+
+    #[test]
     fn startup_budget_observation_clamps_expired_deadlines_without_waiting() {
         let now = Instant::now();
         let deadline = LifecycleDeadline::from_instant(now + Duration::from_millis(250));


### PR DESCRIPTION
## Context

Related: OpenCoven/coven#1001; stacked on draft OpenCoven/coven#931.
Base: test/884-threads-real-daemon at 8576f41e6d622f63a3576b85bd2d3142776e59ca.
Tracking: OpenCoven/coven-threads bead threads-n74.

Objective: protect the existing startup-budget interpretation without guessing the cause of the intermittent Windows initial-start failures.
Acceptance: deterministic coverage of parent preparation versus launch costs, unchanged child store elapsed duration, and exact deadline preservation through start and restart.
Non-goals: production repair, timeout/retry changes, SQL/durability/authority changes, additional hosted diagnostic attempts, or closure of human gates.

## Source findings and implementation

Only crates/coven-cli/src/daemon.rs changes, inside its existing test module:

- A synthetic timeline table holds child store work at 600ms while independently varying parent preparation and launch costs. It checks the production budget formatter and deadline predicate. Equal child elapsed time can fit or exhaust the parent deadline.
- A controller regression executes both ensure_background_server_with_controllers_until and restart_background_server_with_controllers_until. It requires the exact supplied deadline at readiness, injects expiry using remaining_at (no sleep), checks error propagation, one launch/one wait, and no published status.

Canonical sources consulted: AGENTS.md, CONTRIBUTING.md, README.md; daemon.rs lifecycle entrypoints, LifecycleDeadline, SystemDaemonStartController, start_background_server_with_spawn, start_with_budget_observation, initialize_daemon_store, Windows serve ordering and existing controller/checkpoint tests; store.rs initialize_store_with_observer and its six initialization phases; Cargo.toml, .cargo/config.toml, and the PR template.

The real source supports a single outer budget: home resolution, locking, discovery/stop, launch, and readiness consume it. The before/after-spawn labels bracket the entire start controller, including preparation/status construction, not just the OS spawn syscall. Windows binds the pipe before initialize_daemon_store, which completes before status publication. Store checkpoints begin at child store entry, independent of the parent's deadline. Child execution can overlap launch; the two parent samples do not locate child store entry.

Therefore this rejects the proposed diagnosis as an established cause, not the possibility of budget pressure. Successful observations on issue 1001 cannot explain the earlier failed launches. No unsupported production correction is included. These are unit regressions, not real-daemon E2E or a Windows failure reproduction.

## Commands and results

Run in a NEW isolated worktree /tmp/coven-1001-startup-budget-20260911:

- cargo test --locked -p coven-cli --bin coven startup_budget -- --nocapture: 3 passed.
- cargo test --locked -p coven-cli --bin coven -- startup_ lifecycle_deadline daemon_store_initialization ensure_background_server restart_: 45 passed, including after restoring the mutation below.
- Sensitivity experiment: temporarily renewed the deadline at the ensure readiness call. cargo test --locked -p coven-cli --bin coven startup_budget_is_not_renewed_between_launch_and_readiness failed at the exact-deadline assertion as intended. Removed the mutation; final diff is test-only.
- cargo fmt --check: passed after formatting the new assertions.
- cargo clippy --locked -p coven-cli --bin coven --tests -- -D warnings: passed.
- python3 scripts/check-secrets.py: passed.
- git diff --check: passed.
- python3 scripts/check-coven-privacy.py --staged: run before commit (see publication evidence).

An initial attempt to pass multiple filters before Cargo's -- separator was rejected by Cargo; the corrected command above passed. No full-workspace suite or native Windows run was performed locally. No Threads Cargo override was used: these daemon unit tests use the locked dependency, and no current-Threads E2E claim is made.

## Risk, rollback, and handoff

Test-only change; no public API, authority, privacy, migration, audit, SQL, deadline, retry, or runtime behavior change. The one-hour test deadline is a filesystem hang guard; exact expiry is synthetic, not a widened production timeout. Rollback is reverting this commit.

No existing worktree modified. No main push, merge, protection bypass, human review impersonation, or deliberate hosted rerun. Native failing-case causation remains unresolved in OpenCoven/coven#1001. Reviewed integration, real-daemon boundary acceptance, and Nova/Val gates remain separate and open.
