### PR TITLE
feat: add native RRULE vocabulary conformance

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -128,7 +128,7 @@ The checked-in
 [`event-reducer-determinism.vectors.json`](event-reducer-determinism.vectors.json),
 [`occurrence-fence-uniqueness.vectors.json`](occurrence-fence-uniqueness.vectors.json),
 [`receipt-integrity-validation.vectors.json`](receipt-integrity-validation.vectors.json),
-and
+[`rrule-vocabulary.vectors.json`](rrule-vocabulary.vectors.json), and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
 files contain the current nonempty vector sets.
 
@@ -152,6 +152,7 @@ The runner invokes the target directly without a shell.
         "event-reducer-determinism",
         "occurrence-fence-uniqueness",
         "receipt-integrity-validation",
+        "rrule-vocabulary",
         "run-terminal-monotonicity"
       ]
     }
@@ -165,7 +166,7 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements eight structural suites.
+The native Coven target currently implements nine structural suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
 refused. `capability-negotiation` executes the checked-in cases against Rust's
@@ -192,6 +193,11 @@ SHA-256 integrity value and a minimally tampered receipt whose unchanged
 integrity value must be rejected. Accepted receipts are compared by a pinned
 digest of their normalized typed representation; receipt contents are not
 returned as target evidence.
+`rrule-vocabulary` executes a fixed portable matrix through the production
+Rust RRULE parser. It covers daily and weekly defaults, hour and weekday
+normalization, and fail-closed rejection of unsupported frequencies and keys,
+invalid combinations, duplicate parts or values, malformed parts, empty
+segments or values, and out-of-range inputs.
 `run-terminal-monotonicity` executes the checked-in settlement and replay cases
 against the real Rust run ledger in an isolated in-memory store, proving that a
 later terminal observation cannot rewrite the first committed terminal state.

--- a/conformance/automations/runner/rrule-vocabulary.vectors.json
+++ b/conformance/automations/runner/rrule-vocabulary.vectors.json
@@ -1,0 +1,193 @@
+{
+  "schemaVersion": "coven.automations.rrule-vocabulary-vectors.v1",
+  "cases": [
+    {
+      "caseId": "daily-defaults",
+      "scenario": "daily_defaults",
+      "rrule": "FREQ=DAILY",
+      "expected": {
+        "outcome": "accepted",
+        "frequency": "daily",
+        "byHour": [9],
+        "byDay": []
+      }
+    },
+    {
+      "caseId": "daily-hour-normalization",
+      "scenario": "daily_hour_normalization",
+      "rrule": "freq=daily;byhour=17,9",
+      "expected": {
+        "outcome": "accepted",
+        "frequency": "daily",
+        "byHour": [9, 17],
+        "byDay": []
+      }
+    },
+    {
+      "caseId": "weekly-defaults",
+      "scenario": "weekly_defaults",
+      "rrule": "FREQ=WEEKLY",
+      "expected": {
+        "outcome": "accepted",
+        "frequency": "weekly",
+        "byHour": [9],
+        "byDay": ["MO"]
+      }
+    },
+    {
+      "caseId": "weekly-day-normalization",
+      "scenario": "weekly_day_normalization",
+      "rrule": "freq=weekly;byday=wed,MO,fr;byhour=8",
+      "expected": {
+        "outcome": "accepted",
+        "frequency": "weekly",
+        "byHour": [8],
+        "byDay": ["FR", "MO", "WE"]
+      }
+    },
+    {
+      "caseId": "unsupported-frequency",
+      "scenario": "unsupported_frequency",
+      "rrule": "FREQ=HOURLY",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "unsupported-key",
+      "scenario": "unsupported_key",
+      "rrule": "FREQ=DAILY;COUNT=3",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "daily-byday",
+      "scenario": "daily_by_day",
+      "rrule": "FREQ=DAILY;BYDAY=MO",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "duplicate-frequency",
+      "scenario": "duplicate_frequency",
+      "rrule": "FREQ=DAILY;FREQ=WEEKLY",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "duplicate-byhour",
+      "scenario": "duplicate_by_hour",
+      "rrule": "FREQ=DAILY;BYHOUR=9;BYHOUR=17",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "duplicate-byday",
+      "scenario": "duplicate_by_day",
+      "rrule": "FREQ=WEEKLY;BYDAY=MO;BYDAY=TU",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "out-of-range-hour",
+      "scenario": "out_of_range_hour",
+      "rrule": "FREQ=DAILY;BYHOUR=24",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "duplicate-hour",
+      "scenario": "duplicate_hour",
+      "rrule": "FREQ=DAILY;BYHOUR=9,9",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "duplicate-weekday",
+      "scenario": "duplicate_weekday",
+      "rrule": "FREQ=WEEKLY;BYDAY=MO,MO",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "duplicate-weekday-alias",
+      "scenario": "duplicate_weekday_alias",
+      "rrule": "FREQ=WEEKLY;BYDAY=MO,MON",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "empty-hour-entry",
+      "scenario": "empty_hour_entry",
+      "rrule": "FREQ=DAILY;BYHOUR=9,,17",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "empty-weekday-entry",
+      "scenario": "empty_weekday_entry",
+      "rrule": "FREQ=WEEKLY;BYDAY=MO,,TU",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "unknown-weekday",
+      "scenario": "unknown_weekday",
+      "rrule": "FREQ=WEEKLY;BYDAY=XX",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "missing-frequency",
+      "scenario": "missing_frequency",
+      "rrule": "BYHOUR=9",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "malformed-part",
+      "scenario": "malformed_part",
+      "rrule": "FREQ=DAILY;BYHOUR",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "trailing-separator",
+      "scenario": "trailing_separator",
+      "rrule": "FREQ=DAILY;",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "empty-segment",
+      "scenario": "empty_segment",
+      "rrule": "FREQ=DAILY;;BYHOUR=9",
+      "expected": {
+        "outcome": "rejected"
+      }
+    },
+    {
+      "caseId": "empty-value",
+      "scenario": "empty_value",
+      "rrule": "FREQ=",
+      "expected": {
+        "outcome": "rejected"
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -18,6 +18,7 @@ use super::contract::{
     canonicalize, canonicalize_without_integrity, sha256_hex, AutomationDefinition,
     AutomationReceipt, EventEnvelope,
 };
+use super::rrule::{parse_rrule, RruleFrequency};
 use super::runs::{
     record_run_finish, record_run_start, RunFinish, RunStart, AUTOMATION_ATTEMPTS_SCHEMA_SQL,
 };
@@ -39,6 +40,8 @@ const OCCURRENCE_FENCE_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-fence-uniqueness-vectors.v1";
 const RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.receipt-integrity-validation-vectors.v1";
+const RRULE_VOCABULARY_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.rrule-vocabulary-vectors.v1";
 const RUN_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.run-terminal-monotonicity-vectors.v1";
 const STRUCTURAL_PROFILE: &str = "structural";
@@ -51,6 +54,7 @@ pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
 pub const RECEIPT_INTEGRITY_VALIDATION_SUITE: &str = "receipt-integrity-validation";
+pub const RRULE_VOCABULARY_SUITE: &str = "rrule-vocabulary";
 pub const RUN_TERMINAL_MONOTONICITY_SUITE: &str = "run-terminal-monotonicity";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -328,6 +332,100 @@ enum ExpectedReceiptIntegrity {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RruleVocabularyVectorSet {
+    schema_version: String,
+    cases: Vec<RruleVocabularyVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RruleVocabularyVectorCase {
+    case_id: String,
+    scenario: RruleVocabularyScenario,
+    rrule: String,
+    expected: ExpectedRruleVocabulary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RruleVocabularyScenario {
+    DailyDefaults,
+    DailyHourNormalization,
+    WeeklyDefaults,
+    WeeklyDayNormalization,
+    UnsupportedFrequency,
+    UnsupportedKey,
+    DailyByDay,
+    DuplicateFrequency,
+    DuplicateByHour,
+    DuplicateByDay,
+    OutOfRangeHour,
+    DuplicateHour,
+    DuplicateWeekday,
+    DuplicateWeekdayAlias,
+    EmptyHourEntry,
+    EmptyWeekdayEntry,
+    UnknownWeekday,
+    MissingFrequency,
+    MalformedPart,
+    TrailingSeparator,
+    EmptySegment,
+    EmptyValue,
+}
+
+impl RruleVocabularyScenario {
+    const COUNT: usize = 22;
+
+    const fn rule(self) -> &'static str {
+        match self {
+            Self::DailyDefaults => "FREQ=DAILY",
+            Self::DailyHourNormalization => "freq=daily;byhour=17,9",
+            Self::WeeklyDefaults => "FREQ=WEEKLY",
+            Self::WeeklyDayNormalization => "freq=weekly;byday=wed,MO,fr;byhour=8",
+            Self::UnsupportedFrequency => "FREQ=HOURLY",
+            Self::UnsupportedKey => "FREQ=DAILY;COUNT=3",
+            Self::DailyByDay => "FREQ=DAILY;BYDAY=MO",
+            Self::DuplicateFrequency => "FREQ=DAILY;FREQ=WEEKLY",
+            Self::DuplicateByHour => "FREQ=DAILY;BYHOUR=9;BYHOUR=17",
+            Self::DuplicateByDay => "FREQ=WEEKLY;BYDAY=MO;BYDAY=TU",
+            Self::OutOfRangeHour => "FREQ=DAILY;BYHOUR=24",
+            Self::DuplicateHour => "FREQ=DAILY;BYHOUR=9,9",
+            Self::DuplicateWeekday => "FREQ=WEEKLY;BYDAY=MO,MO",
+            Self::DuplicateWeekdayAlias => "FREQ=WEEKLY;BYDAY=MO,MON",
+            Self::EmptyHourEntry => "FREQ=DAILY;BYHOUR=9,,17",
+            Self::EmptyWeekdayEntry => "FREQ=WEEKLY;BYDAY=MO,,TU",
+            Self::UnknownWeekday => "FREQ=WEEKLY;BYDAY=XX",
+            Self::MissingFrequency => "BYHOUR=9",
+            Self::MalformedPart => "FREQ=DAILY;BYHOUR",
+            Self::TrailingSeparator => "FREQ=DAILY;",
+            Self::EmptySegment => "FREQ=DAILY;;BYHOUR=9",
+            Self::EmptyValue => "FREQ=",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ExpectedRruleFrequency {
+    Daily,
+    Weekly,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case", deny_unknown_fields)]
+enum ExpectedRruleVocabulary {
+    Accepted {
+        frequency: ExpectedRruleFrequency,
+        #[serde(rename = "byHour")]
+        by_hour: Vec<u8>,
+        #[serde(rename = "byDay")]
+        by_day: Vec<String>,
+    },
+    Rejected,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RunTerminalVectorSet {
     schema_version: String,
     cases: Vec<RunTerminalVectorCase>,
@@ -384,6 +482,7 @@ pub fn capability() -> TargetCapability {
                 EVENT_REDUCER_DETERMINISM_SUITE,
                 OCCURRENCE_FENCE_UNIQUENESS_SUITE,
                 RECEIPT_INTEGRITY_VALIDATION_SUITE,
+                RRULE_VOCABULARY_SUITE,
                 RUN_TERMINAL_MONOTONICITY_SUITE,
             ],
         }],
@@ -416,6 +515,7 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         RECEIPT_INTEGRITY_VALIDATION_SUITE => {
             evaluate_receipt_integrity_validation(&request.vector)?
         }
+        RRULE_VOCABULARY_SUITE => evaluate_rrule_vocabulary(&request.vector)?,
         RUN_TERMINAL_MONOTONICITY_SUITE => evaluate_run_terminal_monotonicity(&request.vector)?,
         _ => return Err("conformance suite is unsupported"),
     };
@@ -1136,6 +1236,84 @@ fn receipt_integrity_case_matches(case: &ReceiptIntegrityVectorCase) -> bool {
                 .is_some_and(|observed| observed == *normalized_digest)
         }
         (ExpectedReceiptIntegrity::Rejected, Err(_)) => true,
+        _ => false,
+    }
+}
+
+fn evaluate_rrule_vocabulary(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: RruleVocabularyVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != RRULE_VOCABULARY_VECTOR_SCHEMA_VERSION
+        || vectors.cases.len() != RruleVocabularyScenario::COUNT
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut scenarios = BTreeSet::new();
+    let mut rules = BTreeSet::new();
+    for case in &vectors.cases {
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !scenarios.insert(case.scenario)
+            || case.rrule.is_empty()
+            || case.rrule.len() > 1024
+            || !rules.insert(&case.rrule)
+            || case.rrule != case.scenario.rule()
+            || !valid_rrule_expectation(&case.expected)
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+
+    Ok(vectors.cases.iter().all(rrule_vocabulary_case_matches))
+}
+
+fn valid_rrule_expectation(expected: &ExpectedRruleVocabulary) -> bool {
+    let ExpectedRruleVocabulary::Accepted {
+        frequency,
+        by_hour,
+        by_day,
+    } = expected
+    else {
+        return true;
+    };
+    let hours_valid = !by_hour.is_empty()
+        && by_hour.iter().all(|hour| *hour <= 23)
+        && by_hour.windows(2).all(|pair| pair[0] < pair[1]);
+    let days_valid = by_day
+        .iter()
+        .all(|day| matches!(day.as_str(), "FR" | "MO" | "SA" | "SU" | "TH" | "TU" | "WE"))
+        && by_day.windows(2).all(|pair| pair[0] < pair[1]);
+    hours_valid
+        && days_valid
+        && match frequency {
+            ExpectedRruleFrequency::Daily => by_day.is_empty(),
+            ExpectedRruleFrequency::Weekly => !by_day.is_empty(),
+        }
+}
+
+fn rrule_vocabulary_case_matches(case: &RruleVocabularyVectorCase) -> bool {
+    match (&case.expected, parse_rrule(&case.rrule)) {
+        (
+            ExpectedRruleVocabulary::Accepted {
+                frequency,
+                by_hour,
+                by_day,
+            },
+            Ok(parsed),
+        ) => {
+            let frequency_matches = matches!(
+                (frequency, parsed.frequency),
+                (ExpectedRruleFrequency::Daily, RruleFrequency::Daily)
+                    | (ExpectedRruleFrequency::Weekly, RruleFrequency::Weekly)
+            );
+            frequency_matches
+                && parsed.by_hour.as_slice() == by_hour.as_slice()
+                && parsed.by_day.as_slice() == by_day.as_slice()
+        }
+        (ExpectedRruleVocabulary::Rejected, Err(_)) => true,
         _ => false,
     }
 }

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -22,6 +22,8 @@ const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
 const RECEIPT_INTEGRITY_VALIDATION_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/receipt-integrity-validation.vectors.json"
 );
+const RRULE_VOCABULARY_VECTORS: &str =
+    include_str!("../../../../conformance/automations/runner/rrule-vocabulary.vectors.json");
 
 fn request_for(suite_id: &str, vector: Value) -> Value {
     json!({
@@ -68,11 +70,93 @@ fn capability_advertises_the_native_structural_suites() {
                     "event-reducer-determinism",
                     "occurrence-fence-uniqueness",
                     "receipt-integrity-validation",
+                    "rrule-vocabulary",
                     RUN_TERMINAL_MONOTONICITY_SUITE
                 ]
             }]
         })
     );
+}
+
+#[test]
+fn rrule_vocabulary_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(RRULE_VOCABULARY_VECTORS).unwrap();
+    let response = evaluate(&request_for("rrule-vocabulary", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 22);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 22);
+}
+
+#[test]
+fn rrule_vocabulary_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(RRULE_VOCABULARY_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["byHour"] = json!([10]);
+
+    let response = evaluate(&request_for("rrule-vocabulary", vectors)).unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn rrule_vocabulary_suite_reports_outcome_mismatches() {
+    let mismatches: [fn(&mut Value); 2] = [
+        |vectors| vectors["cases"][0]["expected"] = json!({"outcome": "rejected"}),
+        |vectors| {
+            vectors["cases"][4]["expected"] = json!({
+                "outcome": "accepted",
+                "frequency": "daily",
+                "byHour": [9],
+                "byDay": []
+            })
+        },
+    ];
+
+    for mismatch in mismatches {
+        let mut vectors: Value = serde_json::from_str(RRULE_VOCABULARY_VECTORS).unwrap();
+        mismatch(&mut vectors);
+        let response = evaluate(&request_for("rrule-vocabulary", vectors)).unwrap();
+        assert_eq!(response.status, TargetSuiteStatus::Failed);
+        assert_eq!(response.evidence, None);
+    }
+}
+
+#[test]
+fn rrule_vocabulary_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 10] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][0]["rrule"] = json!(""),
+        |vectors| vectors["cases"][0]["rrule"] = json!("x".repeat(1025)),
+        |vectors| {
+            vectors["cases"][2]["rrule"] = json!("FREQ=DAILY;BYHOUR=10");
+            vectors["cases"][2]["expected"] = json!({
+                "outcome": "accepted",
+                "frequency": "daily",
+                "byHour": [10],
+                "byDay": []
+            });
+        },
+        |vectors| vectors["cases"][4]["rrule"] = json!("FREQ=DAILY;COUNT=4"),
+        |vectors| vectors["cases"][0]["expected"]["byHour"] = json!([17, 9]),
+        |vectors| vectors["cases"][2]["expected"]["byDay"] = json!([]),
+        |vectors| {
+            vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone();
+        },
+        |vectors| {
+            vectors["cases"][1]["scenario"] = vectors["cases"][0]["scenario"].clone();
+        },
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value = serde_json::from_str(RRULE_VOCABULARY_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for("rrule-vocabulary", vectors)).unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
 }
 
 #[test]

--- a/crates/coven-cli/src/automations/rrule.rs
+++ b/crates/coven-cli/src/automations/rrule.rs
@@ -53,8 +53,10 @@ fn parse_by_day(raw: &str) -> Result<Vec<String>, String> {
         if !ALLOWED.contains(&part.as_str()) {
             return Err(format!("BYDAY entry `{part}` is not a weekday"));
         }
-        // Canonicalize the two-letter form.
-        days.insert(part[..2].to_string());
+        let canonical = part[..2].to_string();
+        if !days.insert(canonical.clone()) {
+            return Err(format!("BYDAY repeats entry {canonical}"));
+        }
     }
     Ok(days.into_iter().collect())
 }
@@ -67,7 +69,7 @@ pub fn parse_rrule(text: &str) -> Result<ParsedRrule, String> {
     for part in text.split(';') {
         let part = part.trim();
         if part.is_empty() {
-            continue;
+            return Err("rrule contains an empty part".to_string());
         }
         let Some((key, value)) = part.split_once('=') else {
             return Err(format!("rrule part `{part}` is not KEY=VALUE"));
@@ -208,5 +210,27 @@ mod tests {
     fn rejects_missing_frequency() {
         let error = parse_rrule("BYHOUR=9").unwrap_err();
         assert!(error.contains("requires FREQ"), "{error}");
+    }
+
+    #[test]
+    fn rejects_empty_parts() {
+        for rule in ["FREQ=DAILY;", "FREQ=DAILY;;BYHOUR=9"] {
+            let error = parse_rrule(rule).unwrap_err();
+            assert!(error.contains("empty part"), "{rule}: {error}");
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_weekday_values_after_normalization() {
+        for rule in ["FREQ=WEEKLY;BYDAY=MO,MO", "FREQ=WEEKLY;BYDAY=MO,MON"] {
+            let error = parse_rrule(rule).unwrap_err();
+            assert!(error.contains("repeats entry MO"), "{rule}: {error}");
+        }
+    }
+
+    #[test]
+    fn rejects_empty_weekday_entries() {
+        let error = parse_rrule("FREQ=WEEKLY;BYDAY=MO,,TU").unwrap_err();
+        assert!(error.contains("is not a weekday"), "{error}");
     }
 }

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -22,6 +22,8 @@ const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
 const RECEIPT_INTEGRITY_VALIDATION_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/receipt-integrity-validation.vectors.json"
 );
+const RRULE_VOCABULARY_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/rrule-vocabulary.vectors.json");
 const RUN_TERMINAL_MONOTONICITY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/run-terminal-monotonicity.vectors.json");
 const MAX_CONFORMANCE_REQUEST_BYTES: usize = 1024 * 1024;
@@ -93,11 +95,53 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                     "event-reducer-determinism",
                     "occurrence-fence-uniqueness",
                     "receipt-integrity-validation",
+                    "rrule-vocabulary",
                     "run-terminal-monotonicity"
                 ]
             }]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_rrule_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(RRULE_VOCABULARY_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "structural",
+        "suiteId": "rrule-vocabulary",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "rrule-vocabulary");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 22);
+    assert_eq!(response["evidence"]["passedCases"], 22);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Add a native structural conformance suite for supported and rejected RRULE vocabulary.
- Files changed: the production Rust RRULE parser, native conformance target, unit and real-binary tests, one checked-in portable vector set, and runner documentation.
- Advances #858.

## Implementation

- Approach: Execute a fixed 22-case matrix through the production `parse_rrule` implementation rather than duplicating schedule authority in the conformance layer.
- Accepted behavior: Daily and weekly defaults, numeric hour sorting, two-/three-letter weekday aliases, canonical weekday sorting, default hour 9, and default weekly day Monday.
- Rejected behavior: Unsupported frequencies and keys, daily `BYDAY`, repeated parts, duplicate numeric hours, duplicate weekdays after alias normalization, empty hour or weekday entries, unknown weekdays, missing frequency, malformed parts, empty segments or values, and out-of-range hours.
- Vector integrity: Every versioned scenario is required exactly once and is bound to one exact RRULE input; case IDs, scenario labels, and rules must be unique.
- Failure semantics: Incorrect expected outcomes produce a normal failed suite result. Malformed or substituted vectors fail before execution.
- Parser hardening: Empty RRULE segments and canonical duplicate weekdays now fail closed.
- Compatibility notes: Audit-only. This covers the current parser vocabulary, not timezone/DST occurrence calculation or scheduler reliability.

## Evidence packet

- Objective: Prove #858's supported/unsupported RRULE vocabulary inventory item against the real Rust parser.
- Acceptance criteria: Portable fixed vectors, exact scenario binding, accepted normalization/defaults, rejected malformed/unsupported forms, stateless real-binary execution, and fail-closed malformed vectors.
- Non-goals: Timezone conversion, DST behavior, occurrence planning, misfire policy, scheduler wake/reconcile, or release certification.
- Canonical contracts consulted: `parse_rrule`, native target capability/evaluation schemas, and the standalone audit runner's exact-artifact binding.
- Lifecycle/authority/privacy impact: No lifecycle or authority decision. Inputs are synthetic RRULE strings; target evidence contains only counts and case IDs.
- Fault/refusal points exercised: Unsupported vocabulary, invalid combinations, duplicate parts/values, malformed and empty forms, and bounds violations.
- Migration and rollback: No schema or data migration. Revert the commit to remove the suite and parser tightening.
- Performance/SLO delta: Twenty-two in-process parser calls per audit; no persistent I/O or network access.
- Generated artifacts and provenance: Exact commit `8554e6ab0a7bcc3dda883d4f618f277316392738`; exact protocol bundle SHA-256 `c7d80b9dd14c0657f769265ec1fc8351ccce7d71253979ae7d241d8d6daf9ac8`; exact audit statement digest `c2c3c5eda6f672b0ab0bf36e138798579b18e9683423aff7c4102c310b1e6766`.
- Cross-repository canaries: Not exercised by this structural slice.
- Unresolved uncertainty: #858 remains open for virtual-time schedule semantics, scheduler/chaos/authority/privacy/interoperability/SLO profiles, diagnostics, and exact-release certification. #857 remains blocked on a production runtime evidence producer.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node --test conformance/automations/runner/*.test.mjs`
- [x] Exact-artifact audit passed all nine advertised structural suites.
- [x] Independent final code review reported no Critical or Important findings.

## Risk and Rollback

- Risk level: Low. The only production behavior change rejects RRULE forms that were previously accepted by silently discarding empty segments or deduplicating weekday values.
- Rollback plan: Revert the commit; no persisted state or migration must be unwound.

## Agent Handoff

- Current state: Ready for exact-head CI and merge.
- Follow-ups: Continue #858 with another independently shippable structural or deterministic schedule slice.
- Known gaps: The broader #858 certification plane remains intentionally incomplete.
