### PR TITLE
test(daemon): make cleanup deadline regression deterministic

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -6486,36 +6486,6 @@ mod tests {
 
     #[test]
     fn stop_cleanup_does_not_run_after_the_outer_lifecycle_deadline() -> Result<()> {
-        struct SlowVerifiedStop;
-        impl DaemonStopController for SlowVerifiedStop {
-            fn stop_verified_daemon(
-                &self,
-                _coven_home: &Path,
-                _status: &DaemonStatus,
-                deadline: LifecycleDeadline,
-            ) -> Result<VerifiedStopOutcome> {
-                let remaining = deadline.remaining("forcing the test stop deadline to expire")?;
-                std::thread::sleep(remaining.saturating_add(Duration::from_millis(10)));
-                Ok(VerifiedStopOutcome::Exited)
-            }
-
-            fn recorded_process_state(
-                &self,
-                _status: &DaemonStatus,
-            ) -> Result<RecordedProcessState> {
-                Ok(RecordedProcessState::Gone)
-            }
-
-            fn status_matches_running_daemon(
-                &self,
-                _coven_home: &Path,
-                _status: &DaemonStatus,
-                _deadline: LifecycleDeadline,
-            ) -> Result<bool> {
-                Ok(false)
-            }
-        }
-
         let temp_dir = tempfile::tempdir()?;
         let status = DaemonStatus {
             pid: 42,
@@ -6524,10 +6494,15 @@ mod tests {
             process_creation_time: None,
         };
         write_status(temp_dir.path(), &status)?;
-        let error = stop_background_server_with_controller_until(
+        let socket_path = daemon_socket_path(temp_dir.path());
+        let socket_marker = b"synthetic cleanup sentinel";
+        std::fs::write(&socket_path, socket_marker)?;
+
+        // Enter the actual cleanup phase with an expired deadline; status I/O
+        // and shared-runner scheduling must not decide which phase is tested.
+        let error = clear_status_and_socket_until(
             temp_dir.path(),
-            &SlowVerifiedStop,
-            LifecycleDeadline::after(Duration::from_millis(100))?,
+            LifecycleDeadline::from_instant(Instant::now()),
         )
         .expect_err("cleanup must not start after the original stop budget");
 
@@ -6537,6 +6512,44 @@ mod tests {
                 .contains("timed out cleaning up Coven daemon lifecycle state"),
             "unexpected timeout phase: {error:#}"
         );
+        assert_eq!(read_status(temp_dir.path())?, Some(status));
+        assert_eq!(std::fs::read(&socket_path)?, socket_marker);
+        clear_status_and_socket(temp_dir.path())?;
+        assert_eq!(read_status(temp_dir.path())?, None);
+        assert!(!socket_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn stop_with_expired_outer_deadline_preserves_status_without_signaling() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 42,
+            started_at: "2026-08-16T00:00:00Z".to_owned(),
+            socket: test_daemon_status_socket(temp_dir.path()),
+            process_creation_time: None,
+        };
+        write_status(temp_dir.path(), &status)?;
+        let signaled = std::sync::Arc::default();
+        let controller = FakeStopController {
+            pid_alive: true,
+            exited_after_signal: true,
+            signal_error: None,
+            verified_daemon: true,
+            signaled: std::sync::Arc::clone(&signaled),
+        };
+        let error = stop_background_server_with_controller_until(
+            temp_dir.path(),
+            &controller,
+            LifecycleDeadline::from_instant(Instant::now()),
+        )
+        .expect_err("an expired outer deadline must stop before reading status");
+
+        assert_eq!(
+            error.to_string(),
+            "timed out reading Coven daemon lifecycle status"
+        );
+        assert_eq!(*signaled.lock().unwrap(), 0);
         assert_eq!(read_status(temp_dir.path())?, Some(status));
         Ok(())
     }


### PR DESCRIPTION
## Objective and scope

Closes #1023. Tracks OpenCoven/coven-threads bead `threads-7ku`.

Make the cleanup-phase deadline regression independent of shared-runner jitter, without changing any production deadline or authority behavior. Fresh isolated branch from main `edf3500883e72e4239ec7151904983f61a93b83f`; only `crates/coven-cli/src/daemon.rs` unit tests change.

Ownership check before implementation: #969 is merged. The Unix publication race reported in #1001 is already implemented for #974 in #931 (private staging, chmod before no-clobber hard-link publication), and is carried by actively claimed integration #1022. This PR deliberately takes only the separately reported, unowned lifecycle-test fallback. It does not duplicate, land, or certify that socket repair.

## Root cause and change

The old test gave the entire stop path 100 ms, slept through its remaining budget in a fake controller, then demanded a cleanup-specific error. An earlier status/recovery timeout is correct production behavior but fails that assertion.

The cleanup regression now calls the actual production cleanup helper with an already-expired `LifecycleDeadline::from_instant`. It verifies the cleanup-phase error and preservation of both status and a synthetic filesystem sentinel at the socket path. An unguarded cleanup positive control proves that the fixture is removable. A separate full stop-path test proves an expired entry deadline preserves status and never signals. Existing verified-stop and concurrent-startup cleanup regressions remain unchanged.

This is lower-level deterministic lifecycle coverage, not a real-daemon startup test. It intentionally separates early-expiry and cleanup-expiry cases; it no longer claims to drive a fake stop through a wall-clock expiry into cleanup.

## Red -> correction -> green

1. Deterministic reproduction: temporarily replace the old test's 100 ms deadline with `LifecycleDeadline::from_instant(Instant::now())`. Run `cargo test --locked -p coven-cli --bin coven stop_cleanup_does_not_run_after_the_outer_lifecycle_deadline -- --nocapture`: **1 failed**, `unexpected timeout phase: timed out reading Coven daemon lifecycle status`. This models pre-phase budget exhaustion, not an independent reproduction of the exact earlier recovery timing. An initial command using `--exact` with an unqualified name selected zero tests and is not counted as evidence.
2. Test-only correction: selectors below **10 passed**.
3. Mutation check: temporarily remove the first deadline check in `clear_status_and_socket_until`, leaving the post-cleanup check. Run `cargo test --locked -p coven-cli --bin coven --quiet stop_cleanup_does_not_run_after_the_outer_lifecycle_deadline -- --nocapture`: **1 failed**, status was deleted (`None` instead of `Some`). This proves a timeout error alone cannot satisfy the regression.
4. Restore the production check completely and rerun the selectors: **10 passed, 0 failed**. Neither mutation remains.

Final local commands:

```sh
cargo test --locked -p coven-cli --bin coven --quiet -- stop_cleanup_does_not_run_after_the_outer_lifecycle_deadline stop_with_expired_outer_deadline stop_background_server_ stop_uses_one_verified_process_identity status_cleanup_cannot lifecycle_deadline
cargo fmt --check
cargo clippy --locked -p coven-cli --bin coven --tests --quiet -- -D warnings
git diff --check
python3 scripts/check-secrets.py
python3 scripts/check-coven-privacy.py --staged
```

All passed on native macOS. The targeted test result is 10 passed. Full workspace/platform coverage is delegated to normal PR CI, not claimed locally.

## Contracts, impact, and rollback

Consulted Coven AGENTS.md, CONTRIBUTING.md, README.md, `LifecycleDeadline`, stop/status recovery and cleanup implementations, existing fake controllers and related regressions; Threads agent manifest and delivery ledger; current #1001/#974/#969/#931/#1022 evidence and shared claim registry.

No production changes, public API changes, migrations, dependency changes, real familiar data, process-global umask changes, permission relaxations, retries, or ownership/symlink/inode/peer-check changes. Coven remains the runtime authority and effects owner; Threads contracts are untouched.

Rollback is a revert of this test-only commit. Remaining uncertainty: broader daemon reliability and the existing socket repair's main integration are owned elsewhere. No downstream Threads canary is warranted for a test-only change that does not alter the daemon binary or Threads dependency. No merges, deployment, human coherence approval, or freeze attestation is requested or performed.
