### PR TITLE
test(threads): own Windows admission and prove scheduled identity replay

### DIFF
--- a/crates/coven-cli/tests/fixtures/threads_admission.rs
+++ b/crates/coven-cli/tests/fixtures/threads_admission.rs
@@ -1,0 +1,400 @@
+//! Native authority-journey admission, separate from the production launcher SLA.
+
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+#[cfg(any(windows, test))]
+use coven_client::ClientError;
+#[cfg(any(windows, test))]
+use serde_json::Value;
+
+// Fixture hang guard, not the production CLI's two-second startup contract.
+pub const LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(15);
+
+pub fn start_operation(windows: bool) -> &'static str {
+    if windows {
+        "serve"
+    } else {
+        "start"
+    }
+}
+
+#[cfg(windows)]
+pub fn acquire_windows_admission() -> std::sync::MutexGuard<'static, ()> {
+    static ADMISSION: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ADMISSION
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Retain the process handle even when status publication/readiness fails.
+pub struct OwnedDaemon {
+    child: Child,
+    reaped: bool,
+    ready: bool,
+}
+
+impl OwnedDaemon {
+    pub fn spawn(command: &mut Command) -> Result<Self> {
+        Ok(Self {
+            child: command.spawn().context("spawning owned fixture daemon")?,
+            reaped: false,
+            ready: false,
+        })
+    }
+
+    pub fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.ready
+    }
+
+    #[cfg(any(windows, test))]
+    fn ensure_running(&mut self) -> Result<()> {
+        if let Some(status) = self.child.try_wait()? {
+            self.reaped = true;
+            anyhow::bail!("fixture daemon exited before readiness: {status}");
+        }
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    pub fn wait_for_health(&mut self, home: &std::path::Path) -> Result<()> {
+        let pipe = coven_client::owner_only_windows_pipe_name(home)?;
+        let pid = self.id();
+        wait_for_readiness(
+            pid,
+            &pipe,
+            || self.ensure_running(),
+            |deadline| {
+                coven_client::probe_windows_daemon_health_with_identity_until(&pipe, deadline).map(
+                    |probe| {
+                        probe.map(|probe| HealthProbe {
+                            server_pid: probe.server_pid,
+                            status: probe.status,
+                            body: probe.body,
+                        })
+                    },
+                )
+            },
+            Instant::now,
+            thread::sleep,
+        )?;
+        self.ready = true;
+        Ok(())
+    }
+
+    pub fn reap(&mut self, terminate: bool) -> Result<()> {
+        if self.reaped {
+            return Ok(());
+        }
+        if self.child.try_wait()?.is_none() && terminate {
+            self.child
+                .kill()
+                .context("terminating owned fixture daemon")?;
+        }
+        let started = Instant::now();
+        while self.child.try_wait()?.is_none() {
+            anyhow::ensure!(
+                started.elapsed() < LIFECYCLE_TIMEOUT,
+                "owned fixture daemon {} was not reaped after {:?}",
+                self.id(),
+                started.elapsed(),
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+        self.reaped = true;
+        Ok(())
+    }
+}
+
+impl Drop for OwnedDaemon {
+    fn drop(&mut self) {
+        if let Err(error) = self.reap(true) {
+            eprintln!(
+                "failed terminating/reaping owned fixture daemon {}: {error:#}",
+                self.id()
+            );
+        }
+    }
+}
+
+#[cfg(any(windows, test))]
+struct HealthProbe {
+    server_pid: u32,
+    status: u16,
+    body: Vec<u8>,
+}
+
+#[cfg(any(windows, test))]
+fn wait_for_readiness(
+    pid: u32,
+    pipe: &str,
+    mut check_child: impl FnMut() -> Result<()>,
+    mut probe: impl FnMut(Instant) -> Result<Option<HealthProbe>, ClientError>,
+    mut now: impl FnMut() -> Instant,
+    mut pause: impl FnMut(Duration),
+) -> Result<()> {
+    let started = now();
+    let deadline = started + LIFECYCLE_TIMEOUT;
+    let mut last_pending = None;
+    loop {
+        check_child()?;
+        let observed = now();
+        anyhow::ensure!(
+            observed < deadline,
+            "fixture daemon did not become healthy after {:?}: {last_pending:?}",
+            observed.saturating_duration_since(started),
+        );
+        match probe(deadline.min(observed + Duration::from_millis(250))) {
+            Ok(Some(probe)) => {
+                let body: Value = serde_json::from_slice(&probe.body)?;
+                anyhow::ensure!(
+                    probe.status == 200 && body["ok"] == true,
+                    "fixture daemon returned invalid health: HTTP {} {body}",
+                    probe.status,
+                );
+                anyhow::ensure!(
+                    probe.server_pid == pid
+                        && body["daemon"]["pid"] == pid
+                        && body["daemon"]["socket"] == pipe,
+                    "fixture health did not identify its owned process and pipe: server_pid={} {body}",
+                    probe.server_pid,
+                );
+                check_child()?;
+                let observed = now();
+                anyhow::ensure!(
+                    observed < deadline,
+                    "fixture daemon readiness exceeded its deadline after {:?}",
+                    observed.saturating_duration_since(started),
+                );
+                return Ok(());
+            }
+            Ok(None) => last_pending = Some("pipe not yet available".to_owned()),
+            Err(error) if is_pending_windows_startup_error(&error) => {
+                last_pending = Some(error.to_string());
+            }
+            Err(error) => return Err(error.into()),
+        }
+        pause(Duration::from_millis(25).min(deadline.saturating_duration_since(now())));
+    }
+}
+
+#[cfg(any(windows, test))]
+fn is_pending_windows_startup_error(error: &ClientError) -> bool {
+    match error {
+        ClientError::Io { source, .. } => source.kind() == std::io::ErrorKind::TimedOut,
+        ClientError::InvalidHttpResponse(message) => {
+            message == coven_client::EMPTY_RESPONSE_TIMEOUT_MESSAGE
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::cell::Cell;
+
+    fn healthy() -> HealthProbe {
+        HealthProbe {
+            server_pid: 42,
+            status: 200,
+            body: serde_json::to_vec(&json!({
+                "ok": true, "daemon": {"pid": 42, "socket": "fixture-pipe"}
+            }))
+            .unwrap(),
+        }
+    }
+
+    #[test]
+    fn windows_authority_admission_does_not_use_the_two_second_launcher() {
+        assert_eq!(start_operation(true), "serve");
+        assert_eq!(start_operation(false), "start");
+    }
+
+    #[test]
+    fn owned_child_cleanup_does_not_require_status_or_health() -> Result<()> {
+        #[cfg(windows)]
+        let _admission = acquire_windows_admission();
+        let home = tempfile::tempdir()?;
+        let mut command = Command::new(env!("CARGO_BIN_EXE_coven"));
+        command
+            .args(["daemon", "serve"])
+            .env("COVEN_HOME", home.path())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let mut child = OwnedDaemon::spawn(&mut command)?;
+        assert!(!child.is_ready());
+        child.reap(true)?;
+        assert!(child.child.try_wait()?.is_some());
+        assert!(child.ensure_running().is_err());
+        child.reap(true)?;
+        Ok(())
+    }
+
+    #[test]
+    fn admission_accepts_pending_cold_store_beyond_launcher_sla_without_relaunch() -> Result<()> {
+        let start = Instant::now();
+        let clock = Cell::new(start);
+        let polls = Cell::new(0);
+        wait_for_readiness(
+            42,
+            "fixture-pipe",
+            || Ok(()),
+            |deadline| {
+                polls.set(polls.get() + 1);
+                assert!(deadline <= start + LIFECYCLE_TIMEOUT);
+                if clock.get() < start + Duration::from_millis(2017) {
+                    clock.set(deadline);
+                    Err(ClientError::Io {
+                        operation: coven_client::WINDOWS_CONNECT_OPERATION,
+                        source: std::io::ErrorKind::TimedOut.into(),
+                    })
+                } else {
+                    Ok(Some(healthy()))
+                }
+            },
+            || clock.get(),
+            |delay| clock.set(clock.get() + delay),
+        )?;
+        assert!(clock.get() > start + Duration::from_secs(2));
+        assert!(polls.get() > 1);
+        Ok(())
+    }
+
+    #[test]
+    fn admission_exhausts_one_fixed_budget_and_retains_pending_reason() {
+        let start = Instant::now();
+        let clock = Cell::new(start);
+        let error = wait_for_readiness(
+            42,
+            "fixture-pipe",
+            || Ok(()),
+            |deadline| {
+                assert!(deadline <= start + LIFECYCLE_TIMEOUT);
+                clock.set(deadline);
+                Ok(None)
+            },
+            || clock.get(),
+            |delay| clock.set(clock.get() + delay),
+        )
+        .unwrap_err();
+        assert_eq!(clock.get(), start + LIFECYCLE_TIMEOUT);
+        assert!(error.to_string().contains("15s"));
+        assert!(error.to_string().contains("pipe not yet available"));
+    }
+
+    #[test]
+    fn admission_rejects_unowned_or_invalid_health_without_retry() {
+        for field in ["server_pid", "pid", "socket", "ok", "status", "json"] {
+            let mut probe = healthy();
+            match field {
+                "server_pid" => probe.server_pid = 7,
+                "status" => probe.status = 503,
+                "json" => probe.body = b"{".to_vec(),
+                _ => {
+                    let mut body: Value = serde_json::from_slice(&probe.body).unwrap();
+                    match field {
+                        "pid" => body["daemon"]["pid"] = json!(7),
+                        "socket" => body["daemon"]["socket"] = json!("another-pipe"),
+                        "ok" => body["ok"] = json!(false),
+                        _ => unreachable!(),
+                    }
+                    probe.body = serde_json::to_vec(&body).unwrap();
+                }
+            }
+            let mut probe = Some(probe);
+            assert!(
+                wait_for_readiness(
+                    42,
+                    "fixture-pipe",
+                    || Ok(()),
+                    |_| Ok(Some(probe.take().expect("must not retry invalid health"))),
+                    Instant::now,
+                    |_| panic!("invalid health is not pending"),
+                )
+                .is_err(),
+                "{field}"
+            );
+        }
+    }
+
+    #[test]
+    fn admission_rejects_child_exit_or_identity_uncertainty_even_after_health() {
+        for fail_on in [1, 2] {
+            let mut checks = 0;
+            let error = wait_for_readiness(
+                42,
+                "fixture-pipe",
+                || {
+                    checks += 1;
+                    anyhow::ensure!(checks != fail_on, "child identity unavailable");
+                    Ok(())
+                },
+                |_| Ok(Some(healthy())),
+                Instant::now,
+                |_| panic!("child uncertainty is not pending"),
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("child identity unavailable"));
+        }
+    }
+
+    #[test]
+    fn admission_rejects_health_returned_after_deadline() {
+        let start = Instant::now();
+        let clock = Cell::new(start);
+        let error = wait_for_readiness(
+            42,
+            "fixture-pipe",
+            || Ok(()),
+            |_| {
+                clock.set(start + LIFECYCLE_TIMEOUT);
+                Ok(Some(healthy()))
+            },
+            || clock.get(),
+            |_| panic!("late health must not retry"),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("exceeded its deadline"));
+    }
+
+    #[test]
+    fn startup_wait_retries_only_pending_transport_not_identity_or_protocol_errors() {
+        assert!(is_pending_windows_startup_error(&ClientError::Io {
+            operation: coven_client::WINDOWS_CONNECT_OPERATION,
+            source: std::io::ErrorKind::TimedOut.into(),
+        }));
+        assert!(is_pending_windows_startup_error(
+            &ClientError::InvalidHttpResponse(coven_client::EMPTY_RESPONSE_TIMEOUT_MESSAGE.into())
+        ));
+        for error in [
+            ClientError::DaemonInstanceChanged,
+            ClientError::Discovery("wrong owner".into()),
+            ClientError::InvalidHttpResponse("partial response timed out".into()),
+            ClientError::Io {
+                operation: coven_client::WINDOWS_CONNECT_OPERATION,
+                source: std::io::ErrorKind::PermissionDenied.into(),
+            },
+        ] {
+            assert!(!is_pending_windows_startup_error(&error), "{error}");
+            let mut error = Some(error);
+            assert!(wait_for_readiness(
+                42,
+                "fixture-pipe",
+                || Ok(()),
+                |_| Err(error.take().expect("must not retry fatal probe")),
+                Instant::now,
+                |_| panic!("fatal transport error is not pending"),
+            )
+            .is_err());
+        }
+    }
+}

--- a/crates/coven-cli/tests/fixtures/threads_daemon.rs
+++ b/crates/coven-cli/tests/fixtures/threads_daemon.rs
@@ -13,23 +13,18 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 
+#[path = "threads_admission.rs"]
+mod threads_admission;
+use threads_admission::LIFECYCLE_TIMEOUT;
+
 pub const FAMILIAR_ID: &str = "sage";
 pub const PRINCIPAL_FINGERPRINT: &str = "fpr-e2e-synthetic";
-// Hang guard, not a promptness claim; allow shared CI scheduler jitter.
-const LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(15);
-
 pub fn run_journey(journey: impl FnOnce(&mut ThreadsFixture) -> Result<()>) -> Result<()> {
     // These are authority journeys, not concurrent cold-start throughput tests.
     // Keep native Windows process admission isolated, as in
     // windows_daemon_lifecycle; transport-only tests remain concurrent.
     #[cfg(windows)]
-    let _admission = {
-        static ADMISSION: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        ADMISSION
-            .get_or_init(|| std::sync::Mutex::new(()))
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    };
+    let _admission = threads_admission::acquire_windows_admission();
     let mut fixture = ThreadsFixture::start()?;
     let result = journey(&mut fixture);
     match (result, fixture.stop_daemon()) {
@@ -49,13 +44,13 @@ pub struct HttpResponse {
 }
 
 pub struct ThreadsFixture {
+    #[cfg(windows)]
+    owned_daemon: Option<threads_admission::OwnedDaemon>,
     _temp: tempfile::TempDir,
     pub coven_home: PathBuf,
     pub workspace: PathBuf,
     daemon_pid: Option<u32>,
     stopped: bool,
-    #[cfg(windows)]
-    owned_daemon: Option<std::process::Child>,
 }
 
 impl ThreadsFixture {
@@ -139,79 +134,27 @@ forbidden = ["(?i)ignore previous"]
             .append(true)
             .open(self.coven_home.join("fixture-serve.stderr.log"))?;
         // Exercise the real server, not the separate two-second launcher SLA.
-        let child = self
-            .daemon_command_builder("serve")
+        let mut command = self.daemon_command_builder(threads_admission::start_operation(true));
+        command
             .stdin(std::process::Stdio::null())
             .stdout(stdout)
-            .stderr(stderr)
-            .spawn()?;
+            .stderr(stderr);
+        let child = threads_admission::OwnedDaemon::spawn(&mut command)?;
         let pid = child.id();
         self.owned_daemon = Some(child);
         self.daemon_pid = Some(pid);
         self.stopped = false;
-        self.wait_for_owned_windows_health(pid).with_context(|| {
-            format!(
-                "foreground fixture daemon {pid} failed readiness; stdout: {:?}; stderr: {:?}",
-                fs::read_to_string(self.coven_home.join("fixture-serve.stdout.log")),
-                fs::read_to_string(self.coven_home.join("fixture-serve.stderr.log")),
-            )
-        })
-    }
-
-    #[cfg(windows)]
-    fn wait_for_owned_windows_health(&mut self, pid: u32) -> Result<()> {
-        let started = Instant::now();
-        let deadline = started + LIFECYCLE_TIMEOUT;
-        let pipe = coven_client::owner_only_windows_pipe_name(&self.coven_home)?;
-        let mut last_pending = None;
-        loop {
-            let child = self
-                .owned_daemon
-                .as_mut()
-                .context("owned fixture process")?;
-            if let Some(status) = child.try_wait()? {
-                anyhow::bail!("fixture daemon exited before readiness: {status}");
-            }
-            anyhow::ensure!(
-                Instant::now() < deadline,
-                "fixture daemon did not become healthy after {:?}: {last_pending:?}",
-                started.elapsed(),
-            );
-            let probe_deadline = deadline.min(Instant::now() + Duration::from_millis(250));
-            match coven_client::probe_windows_daemon_health_with_identity_until(
-                &pipe,
-                probe_deadline,
-            ) {
-                Ok(Some(probe)) => {
-                    let body: Value = serde_json::from_slice(&probe.body)?;
-                    anyhow::ensure!(
-                        probe.status == 200 && body["ok"] == true,
-                        "fixture daemon returned invalid health: HTTP {} {body}",
-                        probe.status,
-                    );
-                    anyhow::ensure!(
-                        probe.server_pid == pid
-                            && body["daemon"]["pid"] == pid
-                            && body["daemon"]["socket"] == pipe,
-                        "fixture health did not identify its owned process and pipe: {body}",
-                    );
-                    anyhow::ensure!(
-                        Instant::now() < deadline,
-                        "fixture daemon readiness exceeded its deadline after {:?}",
-                        started.elapsed(),
-                    );
-                    return Ok(());
-                }
-                Ok(None) => {}
-                Err(error) if is_pending_windows_startup_error(&error) => {
-                    last_pending = Some(error.to_string());
-                }
-                Err(error) => return Err(error.into()),
-            }
-            thread::sleep(
-                Duration::from_millis(25).min(deadline.saturating_duration_since(Instant::now())),
-            );
-        }
+        self.owned_daemon
+            .as_mut()
+            .context("owned fixture process")?
+            .wait_for_health(&self.coven_home)
+            .with_context(|| {
+                format!(
+                    "foreground fixture daemon {pid} failed readiness; stdout: {:?}; stderr: {:?}",
+                    fs::read_to_string(self.coven_home.join("fixture-serve.stdout.log")),
+                    fs::read_to_string(self.coven_home.join("fixture-serve.stderr.log")),
+                )
+            })
     }
 
     #[cfg(windows)]
@@ -219,19 +162,7 @@ forbidden = ["(?i)ignore previous"]
         let Some(child) = self.owned_daemon.as_mut() else {
             return Ok(());
         };
-        if child.try_wait()?.is_none() && terminate {
-            child.kill()?;
-        }
-        let started = Instant::now();
-        while child.try_wait()?.is_none() {
-            anyhow::ensure!(
-                started.elapsed() < LIFECYCLE_TIMEOUT,
-                "owned fixture daemon {} was not reaped after {:?}",
-                child.id(),
-                started.elapsed(),
-            );
-            thread::sleep(Duration::from_millis(25));
-        }
+        child.reap(terminate)?;
         self.owned_daemon = None;
         Ok(())
     }
@@ -431,6 +362,17 @@ forbidden = ["(?i)ignore previous"]
 
 impl Drop for ThreadsFixture {
     fn drop(&mut self) {
+        #[cfg(windows)]
+        if self
+            .owned_daemon
+            .as_ref()
+            .is_some_and(|child| !child.is_ready())
+        {
+            if let Err(error) = self.reap_owned_daemon(true) {
+                eprintln!("failed terminating unready owned fixture daemon: {error:#}");
+            }
+            return;
+        }
         if self.stopped {
             return;
         }
@@ -451,17 +393,6 @@ impl Drop for ThreadsFixture {
                 eprintln!("failed terminating fixture daemon pid {pid}: {error:#}");
             }
         }
-    }
-}
-
-#[cfg(any(windows, test))]
-fn is_pending_windows_startup_error(error: &coven_client::ClientError) -> bool {
-    match error {
-        coven_client::ClientError::Io { source, .. } => source.kind() == io::ErrorKind::TimedOut,
-        coven_client::ClientError::InvalidHttpResponse(message) => {
-            message == coven_client::EMPTY_RESPONSE_TIMEOUT_MESSAGE
-        }
-        _ => false,
     }
 }
 
@@ -701,28 +632,6 @@ fn windows_pipe_connected(stream: &WindowsPipe) -> io::Result<()> {
 mod transport_tests {
     use super::*;
 
-    #[test]
-    fn startup_wait_retries_only_pending_transport_not_identity_or_protocol_errors() {
-        use coven_client::ClientError;
-        assert!(is_pending_windows_startup_error(&ClientError::Io {
-            operation: coven_client::WINDOWS_CONNECT_OPERATION,
-            source: io::ErrorKind::TimedOut.into(),
-        }));
-        assert!(is_pending_windows_startup_error(
-            &ClientError::InvalidHttpResponse(coven_client::EMPTY_RESPONSE_TIMEOUT_MESSAGE.into())
-        ));
-        for error in [
-            ClientError::DaemonInstanceChanged,
-            ClientError::Discovery("wrong owner".into()),
-            ClientError::InvalidHttpResponse("partial response timed out".into()),
-            ClientError::Io {
-                operation: coven_client::WINDOWS_CONNECT_OPERATION,
-                source: io::ErrorKind::PermissionDenied.into(),
-            },
-        ] {
-            assert!(!is_pending_windows_startup_error(&error), "{error}");
-        }
-    }
     use std::collections::VecDeque;
 
     struct ScriptedStream(VecDeque<&'static [u8]>);

--- a/crates/coven-cli/tests/support/threads_identity_replay_cases.rs
+++ b/crates/coven-cli/tests/support/threads_identity_replay_cases.rs
@@ -1,0 +1,280 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+enum IdentityDrift {
+    IdentityBytes,
+    SoulBytes,
+    RosterMetadata,
+    ActivePolicy,
+}
+
+impl IdentityDrift {
+    fn name(self) -> &'static str {
+        match self {
+            Self::IdentityBytes => "identity-bytes",
+            Self::SoulBytes => "soul-bytes",
+            Self::RosterMetadata => "roster-metadata",
+            Self::ActivePolicy => "active-policy",
+        }
+    }
+
+    fn apply(self, fixture: &ThreadsFixture, case: &Value) -> Result<()> {
+        match self {
+            Self::IdentityBytes | Self::SoulBytes => {
+                let source = if matches!(self, Self::IdentityBytes) {
+                    "IDENTITY.md"
+                } else {
+                    "SOUL.md"
+                };
+                let path = fixture.workspace.join(source);
+                let original = fs::read_to_string(&path)?;
+                fs::write(
+                    path,
+                    format!("{original}\n<!-- Synthetic source revision; identity facts unchanged. -->\n"),
+                )?;
+            }
+            Self::RosterMetadata => {
+                let path = fixture.coven_home.join("familiars.toml");
+                let mut roster: toml::Value = toml::from_str(&fs::read_to_string(&path)?)?;
+                let familiar = roster["familiar"]
+                    .as_array_mut()
+                    .context("fixture familiar roster")?
+                    .iter_mut()
+                    .find(|entry| entry["id"].as_str() == Some(FAMILIAR_ID))
+                    .context("fixture familiar entry")?;
+                familiar["description"] =
+                    toml::Value::String("Synthetic revised roster metadata.".to_owned());
+                fs::write(path, toml::to_string(&roster)?)?;
+            }
+            Self::ActivePolicy => {
+                let path = fixture.workspace.join("ward.toml");
+                let mut ward: toml::Value = toml::from_str(&fs::read_to_string(&path)?)?;
+                let purpose = ward
+                    .get_mut("identity_invariant")
+                    .and_then(toml::Value::as_array_mut)
+                    .context("active identity declarations")?
+                    .iter_mut()
+                    .find(|declaration| declaration["fact"].as_str() == Some("purpose"))
+                    .context("active purpose declaration")?;
+                anyhow::ensure!(
+                    purpose["operator"].as_str() == Some("includes"),
+                    "fixture purpose must use the includes predicate"
+                );
+                let full_purpose = case["candidate_facts"]
+                    .as_array()
+                    .context("corpus candidate facts")?
+                    .iter()
+                    .find(|fact| fact["fact"] == "purpose")
+                    .and_then(|fact| fact["value"].as_str())
+                    .context("corpus purpose")?;
+                let original = purpose["expected"].as_str().context("expected purpose")?;
+                anyhow::ensure!(
+                    full_purpose.contains(original) && full_purpose != original,
+                    "policy change must strengthen a still-satisfied purpose predicate"
+                );
+                purpose["expected"] = toml::Value::String(full_purpose.to_owned());
+                fs::write(path, toml::to_string(&ward)?)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn scheduled_valid_identity_bytes_reject_at_deadline_and_after_restart() -> Result<()> {
+    assert_scheduled_valid_identity_drift(IdentityDrift::IdentityBytes)
+}
+
+#[test]
+fn scheduled_valid_soul_bytes_reject_at_deadline_and_after_restart() -> Result<()> {
+    assert_scheduled_valid_identity_drift(IdentityDrift::SoulBytes)
+}
+
+#[test]
+fn scheduled_valid_roster_metadata_rejects_at_deadline_and_after_restart() -> Result<()> {
+    assert_scheduled_valid_identity_drift(IdentityDrift::RosterMetadata)
+}
+
+#[test]
+fn scheduled_valid_active_policy_rejects_at_deadline_and_after_restart() -> Result<()> {
+    assert_scheduled_valid_identity_drift(IdentityDrift::ActivePolicy)
+}
+
+fn assert_scheduled_valid_identity_drift(drift: IdentityDrift) -> Result<()> {
+    let corpus = retired_ward_corpus()?;
+    let case = retired_review_case(&corpus)?;
+    let duration = case["approval"]["veto"]["duration_seconds"]
+        .as_i64()
+        .context("corpus veto duration")?;
+    for restart in [false, true] {
+        let route = if restart { "restart" } else { "live" };
+        run_clocked_journey(
+            &format!("scheduled-valid-{}-{route}", drift.name()),
+            |home, workspace| seed_retired_review_case(home, workspace, case),
+            |fixture, capability| {
+                let staged = submit_retired_case(fixture, case)?;
+                let id = staged["proposalId"].as_str().context("proposal id")?;
+                let pending_path =
+                    Path::new(staged["pendingPath"].as_str().context("pending path")?);
+                let pending: Value = serde_json::from_slice(&fs::read(pending_path)?)?;
+                tick_scheduler(fixture, capability)?;
+                let opened = identity_proposal_audit(fixture, id)?;
+                anyhow::ensure!(
+                    opened.len() == 2
+                        && opened[0]["event_type"] == "proposal_submitted"
+                        && opened[1]["event_type"] == "proposal_window_opened"
+                        && opened[0]["detail"]["classification"] == pending["classification"],
+                    "supported intake/opening did not bind one auditable proposal: {opened:?}"
+                );
+                if restart {
+                    fixture.stop_daemon()?;
+                }
+                drift.apply(fixture, case)?;
+                let soul_after_drift = fs::read(fixture.workspace.join("SOUL.md"))?;
+                let identity_after_drift = fs::read(fixture.workspace.join("IDENTITY.md"))?;
+                if restart {
+                    fixture.start_daemon()?;
+                }
+                advance_clock_to_offset(fixture, capability, duration)?;
+                tick_scheduler(fixture, capability)?;
+                assert_window_terminal(
+                    fixture,
+                    id,
+                    "proposal_rejected",
+                    "evidence_diverged",
+                    json!(false),
+                )?;
+                anyhow::ensure!(
+                    pending["identityEvidence"]
+                        .as_array()
+                        .is_some_and(|binding| binding.len() == 32),
+                    "supported scheduled intake did not persist its identity commitment"
+                );
+                assert_corpus_bytes(fixture, case, "before")?;
+                anyhow::ensure!(!pending_path.exists(), "rejected proposal remains on disk");
+                let applied: i64 = fixture.store()?.query_row(
+                    "SELECT COUNT(*) FROM ward_audit
+                     WHERE event_type IN ('proposal_approved', 'apply_audit')",
+                    [],
+                    |row| row.get(0),
+                )?;
+                anyhow::ensure!(applied == 0, "stale identity evidence authorized a write");
+                let terminal = identity_proposal_audit(fixture, id)?;
+                anyhow::ensure!(
+                    terminal.len() == 3 && terminal[..2] == opened,
+                    "terminal audit lost or rewrote submission/opening correspondence"
+                );
+
+                fixture.restart_daemon()?;
+                tick_scheduler(fixture, capability)?;
+                anyhow::ensure!(
+                    identity_proposal_audit(fixture, id)? == terminal,
+                    "restart changed or duplicated the terminal audit chain"
+                );
+                assert_corpus_bytes(fixture, case, "before")?;
+
+                // A fresh proposal under the changed authority must still pass.
+                // This distinguishes evidence drift from an invalid predicate.
+                let fresh = submit_retired_case(fixture, case)?;
+                let fresh_id = fresh["proposalId"].as_str().context("fresh proposal id")?;
+                let fresh_pending: Value = serde_json::from_slice(&fs::read(
+                    fresh["pendingPath"]
+                        .as_str()
+                        .context("fresh pending path")?,
+                )?)?;
+                anyhow::ensure!(
+                    fresh_id != id
+                        && fresh_pending["identityEvidence"] != pending["identityEvidence"],
+                    "fresh intake did not bind the changed identity evidence"
+                );
+                for field in [
+                    "familiar_id",
+                    "channel",
+                    "affected_surfaces",
+                    "affected_regions",
+                    "path_tier_floor",
+                    "approval_path",
+                    "evidence_replay_hash",
+                ] {
+                    anyhow::ensure!(
+                        fresh_pending["classification"][field] == pending["classification"][field],
+                        "fresh intake changed {field}, not just identity evidence"
+                    );
+                }
+                tick_scheduler(fixture, capability)?;
+                let deadline: time::OffsetDateTime =
+                    serde_json::from_value(fresh_pending["veto_deadline"].clone())?;
+                advance_clock(
+                    fixture,
+                    capability,
+                    &deadline.format(&time::format_description::well_known::Rfc3339)?,
+                )?;
+                tick_scheduler(fixture, capability)?;
+                assert_window_terminal(
+                    fixture,
+                    fresh_id,
+                    "proposal_approved",
+                    "applied",
+                    json!(true),
+                )?;
+                assert_corpus_bytes(fixture, case, "after")?;
+                anyhow::ensure!(
+                    fs::read(fixture.workspace.join("SOUL.md"))? == soul_after_drift
+                        && fs::read(fixture.workspace.join("IDENTITY.md"))? == identity_after_drift,
+                    "proposal processing rewrote authoritative identity sources"
+                );
+                anyhow::ensure!(
+                    identity_proposal_audit(fixture, id)? == terminal,
+                    "fresh approval altered the stale proposal's terminal record"
+                );
+                let remaining = fixture.request("GET", "/api/v1/threads/proposals", None)?;
+                anyhow::ensure!(
+                    remaining.status == 200 && remaining.body["proposals"] == json!([]),
+                    "completed identity replay journey left pending authority: {remaining:?}"
+                );
+                fs::create_dir_all(&fixture.artifact_dir)?;
+                fs::write(
+                    fixture.artifact_dir.join("identity-replay-proof.json"),
+                    serde_json::to_vec_pretty(&json!({
+                        "scenario": fixture.scenario,
+                        "original_intake": pending,
+                        "original_audit": terminal,
+                        "fresh_intake": fresh_pending,
+                        "fresh_audit": identity_proposal_audit(fixture, fresh_id)?,
+                        "stale_proposal_applied_rows": applied,
+                        "changed_predicates_still_satisfied": true,
+                    }))?,
+                )?;
+                Ok(())
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn identity_proposal_audit(fixture: &ThreadsFixture, id: &str) -> Result<Vec<Value>> {
+    let conn = fixture.store()?;
+    let mut statement = conn.prepare(
+        "SELECT event_type, decision, detail FROM ward_audit WHERE proposal_id = ?1
+         AND event_type IN ('proposal_submitted', 'proposal_window_opened',
+                            'proposal_approved', 'proposal_rejected', 'proposal_vetoed')
+         ORDER BY rowid",
+    )?;
+    let rows = statement
+        .query_map([id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    rows.into_iter()
+        .map(|(event, decision, detail)| {
+            let detail = detail
+                .map(|value| serde_json::from_str::<Value>(&value))
+                .transpose()?;
+            Ok(json!({"event_type": event, "decision": decision, "detail": detail}))
+        })
+        .collect()
+}

--- a/crates/coven-cli/tests/threads_e2e.rs
+++ b/crates/coven-cli/tests/threads_e2e.rs
@@ -17,6 +17,9 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+#[path = "fixtures/threads_admission.rs"]
+mod threads_admission;
+
 const FAMILIAR_ID: &str = "sage";
 const PRINCIPAL_FINGERPRINT: &str = "fpr-e2e-synthetic";
 const REQUIRE_OVERRIDE_ENV: &str = "COVEN_THREADS_E2E_REQUIRE_LOCAL_OVERRIDE";
@@ -30,6 +33,11 @@ const REPRODUCTION_COMMAND: &str = if cfg!(feature = "threads-test-clock") {
 #[cfg(feature = "threads-test-clock")]
 mod final_commit_cases {
     include!("support/threads_final_commit_cases.rs");
+}
+
+#[cfg(feature = "threads-test-clock")]
+mod identity_replay_cases {
+    include!("support/threads_identity_replay_cases.rs");
 }
 
 #[test]
@@ -994,19 +1002,34 @@ fn same_home_daemon_lifecycle_helpers_survive_restart_and_crash() -> Result<()> 
                     .context("daemon lifecycle entry is missing operation")
             })
             .collect::<Result<Vec<_>>>()?;
+        let expected = if cfg!(windows) {
+            vec![
+                "daemon serve",
+                "daemon stop",
+                "daemon serve",
+                "daemon stop",
+                "daemon serve",
+                "daemon stop",
+                "daemon serve",
+                "daemon crash",
+                "daemon serve",
+                "daemon stop",
+            ]
+        } else {
+            vec![
+                "daemon start",
+                "daemon restart",
+                "daemon stop",
+                "daemon start",
+                "daemon stop",
+                "daemon restart",
+                "daemon crash",
+                "daemon start",
+                "daemon stop",
+            ]
+        };
         anyhow::ensure!(
-            operations
-                == [
-                    "daemon start",
-                    "daemon restart",
-                    "daemon stop",
-                    "daemon start",
-                    "daemon stop",
-                    "daemon restart",
-                    "daemon crash",
-                    "daemon start",
-                    "daemon stop",
-                ],
+            operations == expected,
             "unexpected lifecycle sequence in success provenance: {operations:?}"
         );
 
@@ -1115,6 +1138,52 @@ fn startup_failure_retains_partial_fixture_evidence_before_cleanup() -> Result<(
         )?)?["pid"],
         0
     );
+    Ok(())
+}
+
+#[test]
+fn owned_serve_failure_retains_provenance_and_reaps_before_home_cleanup() -> Result<()> {
+    let artifacts = tempfile::tempdir()?;
+    let mut evidence = EvidenceContext::new("owned-serve-startup-retention");
+    evidence.artifact_dir = artifacts.path().to_path_buf();
+    let mut owned_pid = None;
+    let mut fixture_home = None;
+    let result = ThreadsFixture::start_with_setup_and_start(
+        &evidence,
+        |_, _| Ok(()),
+        |fixture| {
+            fixture_home = Some(fixture.coven_home.clone());
+            fixture.start_owned_daemon_with_readiness(|child, home| {
+                owned_pid = Some(child.id());
+                fs::write(
+                    home.join("fixture-serve.stderr.log"),
+                    format!("synthetic admission failure at {}\n", home.display()),
+                )?;
+                anyhow::bail!("synthetic owned readiness failure before status publication")
+            })
+        },
+    );
+    let error = result.err().context("owned admission must fail")?;
+    assert!(format!("{error:#}").contains("synthetic owned readiness failure"));
+    assert!(!pid_is_alive(owned_pid.context("owned pid")?));
+    assert!(!fixture_home.as_ref().context("fixture home")?.exists());
+    evidence.write_setup_failure(&error)?;
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(artifacts.path().join("manifest.json"))?)?;
+    assert_eq!(manifest["result"], "failed");
+    assert_eq!(manifest["setup_completed"], false);
+    assert!(manifest["coven_commit"].is_string());
+    assert_eq!(manifest["daemon_lifecycle"][0]["operation"], "daemon serve");
+    assert_eq!(
+        manifest["daemon_lifecycle"][0]["pid_after"],
+        owned_pid.unwrap()
+    );
+    assert!(manifest["daemon_lifecycle"][0]["command_status"].is_null());
+    let log = fs::read_to_string(artifacts.path().join("logs/daemon.log"))?;
+    assert!(log.contains("synthetic owned readiness failure"));
+    assert!(log.contains("synthetic admission failure at <coven-home>"));
+    assert!(!log.contains(&fixture_home.unwrap().display().to_string()));
+    assert!(artifacts.path().join("state/daemon-status.json").exists());
     Ok(())
 }
 
@@ -1641,6 +1710,7 @@ impl DaemonLifecycleEvent {
 }
 
 struct ThreadsFixture {
+    owned_daemon: Option<threads_admission::OwnedDaemon>,
     _temp: tempfile::TempDir,
     coven: PathBuf,
     coven_home: PathBuf,
@@ -1662,6 +1732,8 @@ struct ThreadsFixture {
     daemon_events: Vec<DaemonLifecycleEvent>,
     daemon_pid: Option<u32>,
     stopped: bool,
+    #[cfg(windows)]
+    _admission: std::sync::MutexGuard<'static, ()>,
 }
 
 impl ThreadsFixture {
@@ -1681,6 +1753,9 @@ impl ThreadsFixture {
         prepare: impl FnOnce(&Path, &Path) -> Result<()>,
         start: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<Self> {
+        // Serialize whole native authority journeys, including restart and cleanup.
+        #[cfg(windows)]
+        let admission = threads_admission::acquire_windows_admission();
         let workspace_root = workspace_root();
         let dependency = threads_dependency(&workspace_root)?;
         if std::env::var_os(REQUIRE_OVERRIDE_ENV).is_some() {
@@ -1715,6 +1790,7 @@ impl ThreadsFixture {
         let coven = PathBuf::from(env!("CARGO_BIN_EXE_coven"));
         let path = std::env::var_os("PATH").unwrap_or_default();
         let mut fixture = Self {
+            owned_daemon: None,
             _temp: temp,
             coven,
             coven_home,
@@ -1735,7 +1811,9 @@ impl ThreadsFixture {
             last_response: None,
             daemon_events: Vec::new(),
             daemon_pid: None,
-            stopped: false,
+            stopped: true,
+            #[cfg(windows)]
+            _admission: admission,
         };
         if let Err(error) = start(&mut fixture) {
             let capture = (|| {
@@ -1786,6 +1864,9 @@ impl ThreadsFixture {
     }
 
     fn current_daemon_pid(&self) -> Option<u32> {
+        if let Some(child) = &self.owned_daemon {
+            return Some(child.id()).filter(|pid| pid_is_alive(*pid));
+        }
         self.daemon_pid
             .filter(|pid| pid_is_alive(*pid))
             .or_else(|| {
@@ -1800,10 +1881,83 @@ impl ThreadsFixture {
     }
 
     fn start_daemon(&mut self) -> Result<()> {
-        let pid_before = self.current_daemon_pid();
-        self.stopped = false;
-        let output = self.daemon_command(&["daemon", "start"])?;
-        self.complete_daemon_start(pid_before, output)
+        #[cfg(windows)]
+        {
+            self.start_owned_daemon_with_readiness(|child, home| child.wait_for_health(home))
+        }
+        #[cfg(unix)]
+        {
+            let pid_before = self.current_daemon_pid();
+            self.stopped = false;
+            let output = self
+                .daemon_command(&["daemon", threads_admission::start_operation(cfg!(windows))])?;
+            self.complete_daemon_start(pid_before, output)
+        }
+    }
+
+    fn start_owned_daemon_with_readiness(
+        &mut self,
+        readiness: impl FnOnce(&mut threads_admission::OwnedDaemon, &Path) -> Result<()>,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            self.owned_daemon.is_none() && self.current_daemon_pid().is_none(),
+            "owned fixture daemon must be stopped before start"
+        );
+        #[cfg(windows)]
+        let endpoint = coven_client::owner_only_windows_pipe_name(&self.coven_home)?;
+        #[cfg(unix)]
+        let endpoint = self.coven_home.join("coven.sock").display().to_string();
+        self.daemon_events.push(DaemonLifecycleEvent::note(
+            "daemon serve",
+            None,
+            format!(
+                "owned authority fixture admission at {endpoint} (15-second readiness hang guard; not CLI start)"
+            ),
+        ));
+        let result = (|| {
+            let stdout = fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(self.coven_home.join("fixture-serve.stdout.log"))?;
+            let stderr = fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(self.coven_home.join("fixture-serve.stderr.log"))?;
+            let mut command = Command::new(&self.coven);
+            command
+                .args(["daemon", threads_admission::start_operation(true)])
+                .env("COVEN_HOME", &self.coven_home)
+                .env("PATH", &self.path)
+                .stdin(std::process::Stdio::null())
+                .stdout(stdout)
+                .stderr(stderr);
+            let child = threads_admission::OwnedDaemon::spawn(&mut command)?;
+            let pid = child.id();
+            self.owned_daemon = Some(child);
+            self.daemon_pid = Some(pid);
+            self.stopped = false;
+            self.daemon_events
+                .last_mut()
+                .context("serve event")?
+                .pid_after = Some(pid);
+            readiness(
+                self.owned_daemon.as_mut().context("owned fixture daemon")?,
+                &self.coven_home,
+            )
+        })();
+        if let Err(error) = &result {
+            self.daemon_events.last_mut().context("serve event")?.note =
+                Some(format!("owned daemon serve admission failed: {error:#}"));
+        }
+        result
+    }
+
+    fn reap_owned_daemon(&mut self, terminate: bool) -> Result<()> {
+        if let Some(child) = &mut self.owned_daemon {
+            child.reap(terminate)?;
+            self.owned_daemon = None;
+        }
+        Ok(())
     }
 
     fn complete_daemon_start(&mut self, pid_before: Option<u32>, output: Output) -> Result<()> {
@@ -1859,6 +2013,7 @@ impl ThreadsFixture {
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        self.reap_owned_daemon(false)?;
         wait_for_daemon_shutdown(&self.coven_home, pid_before)?;
         self.daemon_pid = None;
         self.stopped = true;
@@ -1867,43 +2022,65 @@ impl ThreadsFixture {
 
     fn restart_daemon(&mut self) -> Result<()> {
         let pid_before = self.current_daemon_pid();
-        self.stopped = false;
-        let output = self.daemon_command(&["daemon", "restart"])?;
-        anyhow::ensure!(
-            output.status.success(),
-            "daemon restart failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-
-        let health_result = wait_for_daemon_health(&self.coven_home);
-        let pid_after = daemon_pid(&self.coven_home).ok();
-        self.daemon_events.push(DaemonLifecycleEvent::from_output(
-            "daemon restart",
-            pid_before,
-            pid_after,
-            &output,
-            health_result
+        #[cfg(windows)]
+        {
+            // This proves a real daemon replacement, not the CLI restart SLA.
+            self.stop_daemon()?;
+            self.start_daemon()?;
+            anyhow::ensure!(
+                pid_before.is_none() || pid_before != self.daemon_pid,
+                "fixture restart did not replace the running process {pid_before:?}"
+            );
+            Ok(())
+        }
+        #[cfg(unix)]
+        {
+            self.stopped = false;
+            let output = self.daemon_command(&["daemon", "restart"])?;
+            let pid_after = daemon_pid(&self.coven_home).ok();
+            self.daemon_events.push(DaemonLifecycleEvent::from_output(
+                "daemon restart",
+                pid_before,
+                pid_after,
+                &output,
+                (!output.status.success())
+                    .then(|| "CLI restart failed before fixture health check".to_owned()),
+            ));
+            anyhow::ensure!(
+                output.status.success(),
+                "daemon restart failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let health_result = wait_for_daemon_health(&self.coven_home);
+            let pid_after = daemon_pid(&self.coven_home).ok();
+            let event = self.daemon_events.last_mut().context("restart event")?;
+            event.pid_after = pid_after;
+            event.note = health_result
                 .as_ref()
                 .err()
-                .map(|error| format!("daemon health check failed after restart: {error:#}")),
-        ));
-        health_result?;
+                .map(|error| format!("daemon health check failed after restart: {error:#}"));
+            health_result?;
 
-        let pid_after = pid_after.context("daemon status is missing pid after restart")?;
-        self.daemon_pid = Some(pid_after);
-        anyhow::ensure!(
-            pid_before != Some(pid_after),
-            "daemon restart did not replace the running process {pid_after}"
-        );
-        Ok(())
+            let pid_after = pid_after.context("daemon status is missing pid after restart")?;
+            self.daemon_pid = Some(pid_after);
+            anyhow::ensure!(
+                pid_before != Some(pid_after),
+                "daemon restart did not replace the running process {pid_after}"
+            );
+            Ok(())
+        }
     }
 
     fn crash_daemon(&mut self) -> Result<()> {
         let pid = self
             .current_daemon_pid()
             .context("daemon crash requires a running daemon")?;
-        terminate_daemon_process(&self.coven_home, pid)?;
+        if self.owned_daemon.is_some() {
+            self.reap_owned_daemon(true)?;
+        } else {
+            terminate_daemon_process(&self.coven_home, pid)?;
+        }
         wait_for_process_exit(pid, "crashed daemon", Duration::from_secs(3))?;
         self.daemon_events.push(DaemonLifecycleEvent::note(
             "daemon crash",
@@ -2006,6 +2183,15 @@ impl ThreadsFixture {
         }
         daemon_log.push_str("daemon recovery log:\n");
         daemon_log.push_str(&String::from_utf8_lossy(&recovery_log));
+        for name in ["fixture-serve.stdout.log", "fixture-serve.stderr.log"] {
+            match fs::read_to_string(self.coven_home.join(name)) {
+                Ok(log) => {
+                    daemon_log.push_str(&format!("\n{name}:\n{log}"));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => daemon_log.push_str(&format!("\n{name}: <capture-error: {error}>\n")),
+            }
+        }
         fs::write(
             logs.join("daemon.log"),
             self.sanitize_fixture_text(&daemon_log),
@@ -2076,6 +2262,21 @@ impl ThreadsFixture {
 
 impl Drop for ThreadsFixture {
     fn drop(&mut self) {
+        if self.owned_daemon.is_some() {
+            if self
+                .owned_daemon
+                .as_ref()
+                .is_some_and(|child| child.is_ready())
+            {
+                if let Err(error) = self.stop_daemon() {
+                    eprintln!("threads E2E owned daemon graceful shutdown failed: {error:#}");
+                }
+            }
+            if let Err(error) = self.reap_owned_daemon(true) {
+                eprintln!("threads E2E owned daemon cleanup failed: {error:#}");
+            }
+            return;
+        }
         if self.stopped {
             return;
         }

--- a/crates/coven-client/src/lifecycle.rs
+++ b/crates/coven-client/src/lifecycle.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
@@ -502,16 +502,16 @@ fn canonicalize_profile_binding(
     let reported = Path::new(&status.socket);
     let socket_identity = peer.map(|peer| (peer.socket_device, peer.socket_inode));
     let matches_selected = if reported.is_absolute() {
-        same_filesystem_object(endpoint.socket(), reported, socket_identity)
+        same_socket_binding(endpoint.socket(), reported, socket_identity)
     } else {
-        same_filesystem_object(endpoint.socket(), reported, socket_identity)
+        same_socket_binding(endpoint.socket(), reported, socket_identity)
             || endpoint
                 .socket()
                 .parent()
                 .into_iter()
                 .flat_map(Path::ancestors)
                 .any(|base| {
-                    same_filesystem_object(endpoint.socket(), &base.join(reported), socket_identity)
+                    same_socket_binding(endpoint.socket(), &base.join(reported), socket_identity)
                 })
     };
     if !matches_selected {
@@ -533,16 +533,28 @@ fn canonicalize_profile_binding(
     Ok(())
 }
 
-fn same_filesystem_object(
+fn canonicalize_socket_path(path: &Path) -> Option<PathBuf> {
+    let name = path.file_name()?;
+    let parent = path.parent()?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    // Darwin can resolve a hard-linked socket leaf to a stale staging name.
+    Some(std::fs::canonicalize(parent).ok()?.join(name))
+}
+
+fn same_socket_binding(
     selected: &Path,
     candidate: &Path,
     expected_identity: Option<(u64, u64)>,
 ) -> bool {
-    use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
 
-    let (Ok(selected_path), Ok(candidate_path)) = (
-        std::fs::canonicalize(selected),
-        std::fs::canonicalize(candidate),
+    let (Some(selected_path), Some(candidate_path)) = (
+        canonicalize_socket_path(selected),
+        canonicalize_socket_path(candidate),
     ) else {
         return false;
     };
@@ -550,12 +562,14 @@ fn same_filesystem_object(
         return false;
     }
     let (Ok(selected), Ok(candidate)) = (
-        std::fs::metadata(selected_path),
-        std::fs::metadata(candidate_path),
+        std::fs::symlink_metadata(selected),
+        std::fs::symlink_metadata(candidate),
     ) else {
         return false;
     };
-    selected.dev() == candidate.dev()
+    selected.file_type().is_socket()
+        && candidate.file_type().is_socket()
+        && selected.dev() == candidate.dev()
         && selected.ino() == candidate.ino()
         && expected_identity
             .is_none_or(|(device, inode)| selected.dev() == device && selected.ino() == inode)
@@ -754,11 +768,15 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn macos_tmp_spellings_have_the_same_canonical_filesystem_identity() {
-        assert!(super::same_filesystem_object(
-            std::path::Path::new("/private/tmp"),
-            std::path::Path::new("/tmp"),
-            None,
-        ));
+    fn macos_tmp_spellings_have_the_same_canonical_socket_path() {
+        let expected = Some(std::path::PathBuf::from("/private/tmp/coven.sock"));
+        assert_eq!(
+            super::canonicalize_socket_path(std::path::Path::new("/private/tmp/coven.sock")),
+            expected,
+        );
+        assert_eq!(
+            super::canonicalize_socket_path(std::path::Path::new("/tmp/coven.sock")),
+            expected,
+        );
     }
 }

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -107,15 +107,21 @@ fn serve_responses(
     home: &Path,
     responses: Vec<(String, u16, String)>,
 ) -> std::thread::JoinHandle<()> {
-    use std::{
-        io::{Read, Write},
-        os::unix::{fs::PermissionsExt, net::UnixListener},
-    };
+    use std::os::unix::{fs::PermissionsExt, net::UnixListener};
 
     let socket = home.join("coven.sock");
     let listener = UnixListener::bind(&socket).expect("bind test daemon socket");
     fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
         .expect("make test daemon socket owner-only");
+    serve_bound_responses(listener, responses)
+}
+
+fn serve_bound_responses(
+    listener: std::os::unix::net::UnixListener,
+    responses: Vec<(String, u16, String)>,
+) -> std::thread::JoinHandle<()> {
+    use std::io::{Read, Write};
+
     std::thread::spawn(move || {
         for (expected_path, status, body) in responses {
             let (mut stream, _) = listener.accept().expect("accept client request");
@@ -1607,6 +1613,58 @@ fn lifecycle_probe_returns_the_profile_bound_daemon_identity() {
 
     assert_eq!(actual, expected);
     server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_probe_accepts_private_staged_hardlink_publication() {
+    assert_staged_lifecycle_binding(false);
+}
+
+#[test]
+fn lifecycle_probe_rejects_another_hardlink_name_for_the_same_inode() {
+    assert_staged_lifecycle_binding(true);
+}
+
+fn assert_staged_lifecycle_binding(report_staged_name: bool) {
+    use std::{
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::Duration,
+    };
+
+    let home = TestHome::new();
+    let staging = home.path.join(".private");
+    fs::create_dir(&staging).expect("create private socket staging directory");
+    fs::set_permissions(&staging, fs::Permissions::from_mode(0o700))
+        .expect("protect socket staging directory");
+    let staged = staging.join("s");
+    let published = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&staged).expect("bind private staged socket");
+    fs::set_permissions(&staged, fs::Permissions::from_mode(0o600)).expect("protect staged socket");
+    fs::hard_link(&staged, &published).expect("publish owner-local socket");
+    let expected = lifecycle_status(&home.path);
+    let mut reported = expected.clone();
+    if report_staged_name {
+        reported.socket = staged.to_string_lossy().into_owned();
+    }
+    let server = serve_bound_responses(
+        listener,
+        vec![("/health".to_owned(), 200, lifecycle_health(&reported))],
+    );
+    let actual = probe_unix_daemon_health(&home.path, Duration::from_secs(1));
+    server.join().expect("server thread");
+    if report_staged_name {
+        assert!(
+            matches!(actual, Err(ClientError::Discovery(_))),
+            "same inode must not authorize a different reported profile path: {actual:?}"
+        );
+    } else {
+        assert_eq!(
+            actual
+                .expect("probe privately published socket")
+                .expect("health included daemon identity"),
+            expected
+        );
+    }
 }
 
 #[test]

--- a/docs/reference/threads-e2e.md
+++ b/docs/reference/threads-e2e.md
@@ -32,6 +32,16 @@ The final-commit journey pauses after authority validation, changes the
 authoritative identity bytes, and requires a typed rejection without applying
 the candidate writes.
 
+Four additional identity-replay cases each exercise a live deadline and a
+restart: changed `IDENTITY.md` bytes, changed `SOUL.md` bytes, changed roster
+metadata, and a strengthened but still-satisfied active purpose predicate.
+They use supported scheduled intake, not injected proposal envelopes. The
+original proposal must close once with `EvidenceDiverged` at the logical
+deadline without applying; its submission/opening/terminal chain must survive
+another restart unchanged. A fresh proposal under the changed authority must
+then apply successfully, distinguishing valid evidence drift from a failed
+identity predicate.
+
 These tests use owner-local IPC, the strongest current supported authorization
 path. A supplied fingerprint does not grant protected-write authority. The
 suite does not certify a signed principal-authorization profile, changed runtime
@@ -44,19 +54,34 @@ fixture in each disposable home and explicit real-scheduler ticks, not sleeps
 or a mock scheduler. See [Threads test clock](../design/threads-test-clock.md).
 Without the feature, Cargo runs only the smaller smoke/lifecycle subset. CI
 executes the feature-enabled target on Linux, Windows, and the existing macOS
-push lane. All platforms run the same 15 daemon journeys through `coven-client`
+push lane. All platforms run the same feature-enabled journeys through `coven-client`
 discovery and authenticated transport; Windows uses the owner-only named pipe.
-Three additional artifact regressions exercise startup-evidence retention;
-they are not extra daemon journeys.
-Two further regressions cover artifact-root isolation and the local default.
+Additional regressions cover startup-evidence retention, artifact-root
+isolation, launch selection, readiness, and owned-child cleanup; these are not
+extra authority journeys or native Windows execution evidence.
 HTTP framing regressions belong to the shared client's tests, not a separate
 harness parser. A cross-target compilation or Windows workspace run alone is
 not evidence that these journeys executed on Windows.
 
-Lifecycle commands still use the production CLI and its existing deadlines.
-Windows crash injection binds the process handle to the authenticated pipe
-server PID and creation time before termination. Requests are never retried
-automatically; a response timeout does not prove a mutation did not commit.
+Windows authority journeys serialize admission and retain an owned
+`coven daemon serve` child, using the same native helper as the smaller Threads
+fixtures. Their fixed 15-second readiness budget is a fixture hang guard for
+cold-store initialization, not a change to the production two-second launcher
+SLA. Only pending transport observations are polled; invalid health, changed
+identity, and child-exit/inspection errors fail admission immediately. Readiness
+requires the authenticated pipe server PID, health PID, and owner-local pipe to
+match the owned child. The child is reaped on shutdown, crash, or setup failure,
+even if it never published status.
+
+Windows fixture restart means checked CLI stop followed by a new owned
+`daemon serve`; provenance records those operations, not `daemon restart`.
+Unix fixture lifecycle commands and the dedicated native
+`windows_daemon_lifecycle` CLI start/stop/restart deadline tests are unchanged.
+Crash injection terminates the retained owned handle on Windows. The shared
+admission regressions inject time, pending probes, and child/health identity;
+they do not use wall-clock sleeps as authority evidence. Requests are never
+retried automatically; a response timeout does not prove a mutation did not
+commit.
 
 ## Testing a local Threads checkout
 
@@ -111,13 +136,21 @@ test log, and early setup failures can still lack revision metadata.
 On failure, the same directory also contains the synthetic request and
 response, daemon recovery log, Ward audit rows, hashed pending/workspace
 inventories, SQLite schema, and a bounded, sanitized status snapshot. Startup
-failures retain the failed CLI event and available fixture evidence before
+failures retain the failed CLI or owned-serve event and available fixture evidence before
 cleanup; fallback markers do not overwrite captured files. A capture error in
 one state source is reported without discarding the others.
+Owned-serve stdout/stderr are included in the sanitized daemon log, including
+admission failures before status publication.
+
+Successful valid-identity-drift scenarios also retain
+`identity-replay-proof.json`: original and fresh intake documents, queried
+submission/opening/terminal audit projections, and the stale proposal's
+zero-apply observation before the positive control. These packets supplement
+the scenario manifest; they do not replace its source/override provenance.
 
 For a constructed fixture, `manifest.json` includes exact Coven and Threads
 revisions and `local_threads_override_active`, even if daemon startup fails;
-earlier failures can record those fields as null. Windows readiness errors
+earlier failures can record those fields as null. Production CLI Windows readiness errors
 include a bounded last-probe category and observation of the retained child
 handle, without changing the startup deadline or identity checks.
 The existing recovery log also records fixed-category remaining-budget samples

--- a/docs/reference/threads-e2e.md
+++ b/docs/reference/threads-e2e.md
@@ -77,6 +77,10 @@ Windows fixture restart means checked CLI stop followed by a new owned
 `daemon serve`; provenance records those operations, not `daemon restart`.
 Unix fixture lifecycle commands and the dedicated native
 `windows_daemon_lifecycle` CLI start/stop/restart deadline tests are unchanged.
+Unix lifecycle health compares the canonical profile directory and socket
+basename, then checks non-symlink socket metadata against the authenticated
+endpoint's device/inode. This supports retained private staging hard links
+without accepting another reported socket name for the same inode.
 Crash injection terminates the retained owned handle on Windows. The shared
 admission regressions inject time, pending probes, and child/health identity;
 they do not use wall-clock sleeps as authority evidence. Requests are never


### PR DESCRIPTION
## Context

Incremental contribution to OpenCoven/coven#1022, tracked by
OpenCoven/coven#1025, OpenCoven/coven#1028 and
`threads-vpp.1` / `threads-vpp.2`.
This does not replace the integration or publication owners.

- Resolve the native Windows authority-fixture admission failure retained in
  [CI 34684041348](https://github.com/OpenCoven/coven/actions/runs/34684041348).
- Supply supported scheduled valid-to-valid identity replay evidence missing
  from the previous acceptance packet.
- Non-goals: changing production lifecycle budgets, optimizing all
  daemon startup paths, adding auto approval, changing protected floors or
  migration policy, or closing the Phase-5 coherence/freeze gates.

## Implementation

- Extract the existing owned Windows `daemon serve` admission helper and reuse
  it in the main E2E target and smaller Threads fixtures. One fixed fixture
  readiness budget, authenticated child/pipe/health matching, fatal-error
  refusal, cleanup and sanitized evidence are retained.
- Windows authority-fixture restart is honestly recorded as checked stop plus
  a new owned serve process. Dedicated CLI lifecycle tests remain unchanged.
- Add four identity drift classes, each with live-deadline and restart
  scenarios: identity bytes, soul bytes, roster metadata and a strengthened
  still-satisfied active purpose predicate.
- Require the stale proposal's immutable submission/opening/rejection chain,
  one `EvidenceDiverged` terminal and no stale write. Then require a fresh
  proposal under the changed authority to apply, proving predicates still hold.
- Retain `identity-replay-proof.json` for each successful scenario.
- Repair the incoming integration base's macOS hard-link profile-binding
  regression in a separate client commit. Canonicalize the parent directory,
  preserve the socket basename, and require exact profile path plus
  non-symlink socket metadata matching the authenticated device/inode.
  Different hardlink names for the same inode remain rejected.

Files: `tests/fixtures/threads_admission.rs`,
`tests/fixtures/threads_daemon.rs`, `tests/threads_e2e.rs`,
`tests/support/threads_identity_replay_cases.rs` under `crates/coven-cli`,
and `docs/reference/threads-e2e.md`; the companion repair also changes
`crates/coven-client/src/lifecycle.rs` and `crates/coven-client/tests/health.rs`.

Consulted contracts: Coven `AGENTS.md`, `CONTRIBUTING.md`, existing native
authority fixtures and lifecycle tests; Threads `agent/manifest.yaml`,
Phase-5 approval semantics, public approval/identity/audit contracts and
`docs/testing/e2e-contract.md`.

## Verification

All local daemon commands used Rust 1.95.0 and disposable, short private
`TMPDIR` roots. No real Coven home or familiar data was used.

### Original contribution and immutable hosted observation

The following evidence belongs to original contribution
`a34c64a28c5e90b3e378a53822dcaabaa58f32cf` and its pre-publication source state,
not to later integration heads:

- `cargo fmt --check`: passed.
- Current clean Threads `8a2f7fb4229e783368b7d3f2fdced43d4891a02d`
  was proven to be the actual `coven-cli` dependency through Cargo metadata.
  The ephemeral overlay lock hash was unchanged during execution:
  `fd90e9f44d2b9db9593128c6374422366f948ee9574457e8d833602ccdebf6e8`.
- `cargo test --locked -p coven-cli --test threads_e2e --test threads_protected_intake --test threads_identity_invariants --test threads_terminal_recovery --features threads-test-clock --quiet`:
  E2E 33, identity invariants 31, protected intake 25, and terminal recovery
  20 passed; no ignored or filtered tests in these four target runs.
  Cargo reports targets in its own order. Shared helper tests occur in
  multiple targets.
- Equivalent scoped `cargo clippy ... -- -D warnings`: passed.
- The four new identity cases also passed against the unchanged committed
  Threads pin `c3bd46bcadb6396db8436c47411a4d0eac17192b`.
- Equivalent four-target Clippy with
  `--target x86_64-pc-windows-gnu`: passed; this is not native Windows execution.
- `python3 scripts/check-secrets.py`: passed.
- `python3 scripts/check-coven-privacy.py --staged`: passed for all five changed
  files; read-only code review reported no significant issues.
- Published-head observation
  [34686742995](https://github.com/OpenCoven/coven-threads/actions/runs/34686742995)
  passed against clean Threads `8a2f7fb4`. Independently parsed the wrapper,
  all 31 distinct passing journey manifests, and all eight identity proof
  packets with stale `EvidenceDiverged` and fresh `Applied` chains. Artifact
  `10295667950` SHA-256:
  `7c67ee98256ada7663eb368461e183c8b151d940e0f4d52c8f7d9abc2b386732`.

### Reconciled contribution

Head `1294a8935a5831015598d316b222859f4298457b` includes owner base
`6aa885570f4987bc0fa342a1ec7125eaefb66a57` and the separate client binding fix.
The merge alone failed 19 daemon journeys during setup; 14 helper tests passed.
Raw health reported the correct public socket, but Rust canonicalized the
retained hard-linked socket leaf to a nonexistent sibling `home/s` on macOS.
The client correctly refused that unresolvable binding.

- New retained-private-hardlink health regression failed with the same
  discovery error before the fix; full health target passes 49/49 afterward.
  A negative case rejects a different reported hardlink path with the same inode.
- The existing macOS canonical-parent alias regression passes.
- The same four targets pass E2E 33 / identity 31 / protected 25 / recovery 20 with the committed
  Threads pin. This is not relabeled as a current-Threads override run.
- Scoped client/daemon Clippy, repository formatting and staged privacy guards
  pass.
- Fresh exact-head current-Threads observation
  [34687875506](https://github.com/OpenCoven/coven-threads/actions/runs/34687875506)
  passed for `1294a893` / clean `8a2f7fb4`. Independently verified the wrapper,
  all 31 passing manifests and all eight persisted identity proof packets.
  Artifact `10295909244` SHA-256:
  `c8d2864cc177c12799634fa8a18db6e658ad8c77cc3cf4d50619a63fb2bc4574`.
- Native Windows acceptance passed in
  [CI 34687832909](https://github.com/OpenCoven/coven/actions/runs/34687832909).
  The actual compiled revision was synthetic merge
  `63a496886d1851a2518519692d55f2c59096d9b9`, with parents `f54a1158` and
  `1294a893`, using the committed Threads `c3bd46bc` pin (not a local override).
  Windows `threads_e2e` passed 19 without the clock feature and 33 with it;
  the unchanged dedicated `windows_daemon_lifecycle` target passed all 6.
  Independently parsed all 36 passing manifests: 5 workspace smoke journeys
  plus 31 feature journeys, not 36 distinct scenarios. All eight identity
  proof packets and owned-serve/stop/replacement-PID provenance were checked.
  Artifact `10297115458` SHA-256:
  `f02f2c30968f159a9040c9beee7266478443fb518530ae08b029fff6bd14c9f4`.
  Its dependency dirty flag is true: state fingerprint
  `e3f9ad050974054ecfbdbb5d8c67e4959c96a39b4e05e8458bf90ef53385c93b`
  matches the inspected `c3bd46bc` cache with only Cargo's empty, untracked
  `.cargo-ok` marker and no tracked/staged changes. No flag was suppressed.
- The identical native-tested daemon `63a4968` then passed current clean
  Threads `8a2f7fb4` in observation
  [34688911843](https://github.com/OpenCoven/coven-threads/actions/runs/34688911843).
  Independently parsed its exact wrapper, 31 passing manifests and eight
  identity packets. Artifact `10297310050` SHA-256:
  `318351a53346d99153cdd46dac2402dc1b559d22bcdd5514d427649114f63bb1`.
- The owner merged this PR at `1294a893` via `cacb6470`, not at the branch's
  later tip. Subsequent fixture/failure-evidence reconciliation is published
  separately as `976218d5` and is being consolidated with the auto follow-up
  under OpenCoven/coven#1026. It is not part of this PR's merged source or
  native acceptance receipt. No result here is transferred to that follow-up.

### Retained red and production-fix attribution

The original native Windows target was 19 passed / 1 failed. Its failure
manifest identifies `scheduled-window-approval-policy-changed`, with setup
incomplete: the child store initialized in 2,017 ms while the launcher had
1,987 ms remaining after spawn. Failure artifact `10294773022` has SHA-256
`1d523c33e8c2690471c2cb0bcd6c73a3abcfa2220f9ea09532d16e0c7e4c8179`.
The fixture patch does not reclassify that run as green.

A separate real-daemon red used production Coven
`65766b89b4c945d325853cefdd05f364ee87cbac`, only the new test transplanted,
and the clean current Threads override above. The supported scheduled
identity-byte case incorrectly produced `proposal_approved` / `applied` with
`replay_hash_matched=true` after still-valid identity drift. Exit 101 was the
expected regression failure, with successful setup and retained audit rows.
The final published test module was rerun against that pre-fix daemon with
the same result; module SHA-256:
`c7a65fb668e9fccf4cdebf1ba4d03aec6a02f31dc1328bf6ad86c429217c03f0`.
The current-Threads overlay and its unchanged lock hash were checked again.

The production identity-intake binding fix is already in
`7622de7ce318fd8f0c7b823186672476df0f46fd`, integrating
OpenCoven/coven#969. This contribution supplies its missing black-box proof,
not a second identity implementation. All eight current-Threads scenario
manifests and proof packets were independently parsed and matched to one
stable local source state.

Native Windows and immutable hosted evidence now establish the original
startup and scheduled-identity subtasks at `63a4968`. Newer owner integration,
the separate auto route and reserved human/root gates remain outstanding.
No local, cross-compiled or older-head result substitutes for a new head's
native acceptance.

## Risk and Rollback

R4 boundary-fixture and narrowly scoped client binding change; no SQL schema,
public Rust exhaustive type, dependency pin or deployment policy changes.
No migration or deployment is performed. The fixture contribution can be
reverted independently. The client repair is coupled to the incoming private
hardlink publisher: reverting it requires restoring a compatible publisher,
not reintroducing the known macOS discovery failure. Retain all failure
evidence and keep acceptance blocked if rolling back.

Fixtures and evidence are synthetic. The strongest current owner-local
authorization path is used; this does not certify signed principal authority,
all crash interleavings or human review.

## Agent Handoff

Keep the existing integration/publication owners and Phase-5 root issues open.
The separate bounded auto-route work is OpenCoven/coven#1026 and
OpenCoven/coven-threads#55. No merge, stable-pin rollout or human freeze is
authorized by this PR's local results.
