### PR TITLE
feat: certify automation misfire planning

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -127,6 +127,7 @@ The checked-in
 [`definition-lifecycle-transitions.vectors.json`](definition-lifecycle-transitions.vectors.json),
 [`definition-validation.vectors.json`](definition-validation.vectors.json),
 [`event-reducer-determinism.vectors.json`](event-reducer-determinism.vectors.json),
+[`misfire-latest-planning.vectors.json`](misfire-latest-planning.vectors.json),
 [`occurrence-fence-uniqueness.vectors.json`](occurrence-fence-uniqueness.vectors.json),
 [`receipt-integrity-validation.vectors.json`](receipt-integrity-validation.vectors.json),
 [`rrule-vocabulary.vectors.json`](rrule-vocabulary.vectors.json), and
@@ -157,6 +158,12 @@ The runner invokes the target directly without a shell.
         "rrule-vocabulary",
         "run-terminal-monotonicity"
       ]
+    },
+    {
+      "profile": "scheduler_reliability",
+      "suites": [
+        "misfire-latest-planning"
+      ]
     }
   ]
 }
@@ -168,7 +175,8 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements ten structural suites.
+The native Coven target currently implements ten structural suites and one
+scheduler-reliability suite.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
 refused. `capability-negotiation` executes the checked-in cases against Rust's
@@ -189,6 +197,10 @@ normalized JCS digest matches and rejecting a tampered definition.
 `event-reducer-determinism` replays a portable event stream through the native
 Rust reducer both canonically and with an exact duplicate delivery, requiring
 the same normalized final state and expected digest.
+`misfire-latest-planning` executes fixed virtual-time cases through the
+production occurrence planner. It proves that downtime collapses daily work to
+the latest due slot, exact replay is idempotent, a clock rollback does not add
+an older fence, and paused definitions do not plan.
 `occurrence-fence-uniqueness` executes a portable three-case matrix against the
 production SQLite occurrence schema, proving that one automation cannot claim
 the same scheduled slot twice while different automations may share a slot and

--- a/conformance/automations/runner/misfire-latest-planning.vectors.json
+++ b/conformance/automations/runner/misfire-latest-planning.vectors.json
@@ -1,0 +1,113 @@
+{
+  "schemaVersion": "coven.automations.misfire-latest-planning-vectors.v1",
+  "cases": [
+    {
+      "caseId": "restart-collapses-to-latest-due-slot",
+      "scenario": "restart_collapse_latest",
+      "definition": {
+        "schemaVersion": 1,
+        "id": "restart-collapse",
+        "name": "Restart collapse",
+        "status": "ACTIVE",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the restart collapse probe.",
+        "tags": []
+      },
+      "createdAt": "2026-09-01T08:00:00.000Z",
+      "observedAt": "2026-09-04T12:00:00.000Z",
+      "expected": {
+        "firstOutcome": "planned",
+        "secondOutcome": "already_fenced",
+        "scheduledSlots": [
+          "2026-09-04T09:00:00.000Z"
+        ]
+      }
+    },
+    {
+      "caseId": "existing-latest-fence-replays-idempotently",
+      "scenario": "existing_fence_replay",
+      "definition": {
+        "schemaVersion": 1,
+        "id": "existing-fence",
+        "name": "Existing fence",
+        "status": "ACTIVE",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the existing fence probe.",
+        "tags": []
+      },
+      "createdAt": "2026-09-01T08:00:00.000Z",
+      "observedAt": "2026-09-04T12:00:00.000Z",
+      "existingScheduledFor": "2026-09-04T09:00:00.000Z",
+      "expected": {
+        "firstOutcome": "already_fenced",
+        "secondOutcome": "already_fenced",
+        "scheduledSlots": [
+          "2026-09-04T09:00:00.000Z"
+        ]
+      }
+    },
+    {
+      "caseId": "clock-rollback-adds-no-older-fence",
+      "scenario": "clock_rollback_no_older_fence",
+      "definition": {
+        "schemaVersion": 1,
+        "id": "clock-rollback",
+        "name": "Clock rollback",
+        "status": "ACTIVE",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the clock rollback probe.",
+        "tags": []
+      },
+      "createdAt": "2026-09-01T08:00:00.000Z",
+      "observedAt": "2026-09-03T12:00:00.000Z",
+      "existingScheduledFor": "2026-09-04T09:00:00.000Z",
+      "expected": {
+        "firstOutcome": "not_due",
+        "secondOutcome": "not_due",
+        "scheduledSlots": [
+          "2026-09-04T09:00:00.000Z"
+        ]
+      }
+    },
+    {
+      "caseId": "paused-definition-never-plans",
+      "scenario": "paused_definition",
+      "definition": {
+        "schemaVersion": 1,
+        "id": "paused-definition",
+        "name": "Paused definition",
+        "status": "PAUSED",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the paused definition probe.",
+        "tags": []
+      },
+      "createdAt": "2026-09-01T08:00:00.000Z",
+      "observedAt": "2026-09-04T12:00:00.000Z",
+      "expected": {
+        "firstOutcome": "not_due",
+        "secondOutcome": "not_due",
+        "scheduledSlots": []
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -38,6 +38,8 @@ const DEFINITION_VALIDATION_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.definition-validation-vectors.v1";
 const EVENT_REDUCER_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.event-reducer-determinism-vectors.v1";
+const MISFIRE_LATEST_PLANNING_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.misfire-latest-planning-vectors.v1";
 const OCCURRENCE_FENCE_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-fence-uniqueness-vectors.v1";
 const RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION: &str =
@@ -47,6 +49,7 @@ const RRULE_VOCABULARY_VECTOR_SCHEMA_VERSION: &str =
 const RUN_TERMINAL_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.run-terminal-monotonicity-vectors.v1";
 const STRUCTURAL_PROFILE: &str = "structural";
+const SCHEDULER_RELIABILITY_PROFILE: &str = "scheduler_reliability";
 const MAX_CASES: usize = 128;
 
 pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
@@ -55,6 +58,7 @@ pub const COMMAND_ADOPTION_IDEMPOTENCY_SUITE: &str = "command-adoption-idempoten
 pub const DEFINITION_LIFECYCLE_TRANSITIONS_SUITE: &str = "definition-lifecycle-transitions";
 pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
+pub const MISFIRE_LATEST_PLANNING_SUITE: &str = "misfire-latest-planning";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
 pub const RECEIPT_INTEGRITY_VALIDATION_SUITE: &str = "receipt-integrity-validation";
 pub const RRULE_VOCABULARY_SUITE: &str = "rrule-vocabulary";
@@ -430,6 +434,55 @@ struct OccurrenceFenceVectorSet {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct MisfireLatestPlanningVectorSet {
+    schema_version: String,
+    cases: Vec<MisfireLatestPlanningVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct MisfireLatestPlanningVectorCase {
+    case_id: String,
+    scenario: MisfireLatestPlanningScenario,
+    definition: Value,
+    created_at: String,
+    observed_at: String,
+    #[serde(default)]
+    existing_scheduled_for: Option<String>,
+    expected: ExpectedMisfireLatestPlanning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MisfireLatestPlanningScenario {
+    RestartCollapseLatest,
+    ExistingFenceReplay,
+    ClockRollbackNoOlderFence,
+    PausedDefinition,
+}
+
+impl MisfireLatestPlanningScenario {
+    const COUNT: usize = 4;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ExpectedPlanOutcome {
+    Planned,
+    NotDue,
+    AlreadyFenced,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedMisfireLatestPlanning {
+    first_outcome: ExpectedPlanOutcome,
+    second_outcome: ExpectedPlanOutcome,
+    scheduled_slots: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct OccurrenceFenceVectorCase {
     case_id: String,
     scenario: OccurrenceFenceScenario,
@@ -629,55 +682,72 @@ struct ExpectedRunTerminal {
 pub fn capability() -> TargetCapability {
     TargetCapability {
         schema_version: TARGET_CAPABILITY_SCHEMA_VERSION,
-        profiles: vec![TargetProfileCapability {
-            profile: STRUCTURAL_PROFILE,
-            suites: vec![
-                ATTEMPT_TERMINAL_IMMUTABILITY_SUITE,
-                CAPABILITY_NEGOTIATION_SUITE,
-                COMMAND_ADOPTION_IDEMPOTENCY_SUITE,
-                DEFINITION_LIFECYCLE_TRANSITIONS_SUITE,
-                DEFINITION_VALIDATION_SUITE,
-                EVENT_REDUCER_DETERMINISM_SUITE,
-                OCCURRENCE_FENCE_UNIQUENESS_SUITE,
-                RECEIPT_INTEGRITY_VALIDATION_SUITE,
-                RRULE_VOCABULARY_SUITE,
-                RUN_TERMINAL_MONOTONICITY_SUITE,
-            ],
-        }],
+        profiles: vec![
+            TargetProfileCapability {
+                profile: STRUCTURAL_PROFILE,
+                suites: vec![
+                    ATTEMPT_TERMINAL_IMMUTABILITY_SUITE,
+                    CAPABILITY_NEGOTIATION_SUITE,
+                    COMMAND_ADOPTION_IDEMPOTENCY_SUITE,
+                    DEFINITION_LIFECYCLE_TRANSITIONS_SUITE,
+                    DEFINITION_VALIDATION_SUITE,
+                    EVENT_REDUCER_DETERMINISM_SUITE,
+                    OCCURRENCE_FENCE_UNIQUENESS_SUITE,
+                    RECEIPT_INTEGRITY_VALIDATION_SUITE,
+                    RRULE_VOCABULARY_SUITE,
+                    RUN_TERMINAL_MONOTONICITY_SUITE,
+                ],
+            },
+            TargetProfileCapability {
+                profile: SCHEDULER_RELIABILITY_PROFILE,
+                suites: vec![MISFIRE_LATEST_PLANNING_SUITE],
+            },
+        ],
     }
 }
 
 pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
     let request: TargetSuiteRequest =
         serde_json::from_value(request.clone()).map_err(|_| "conformance request is invalid")?;
-    if request.schema_version != SUITE_REQUEST_SCHEMA_VERSION
-        || request.profile != STRUCTURAL_PROFILE
-    {
+    if request.schema_version != SUITE_REQUEST_SCHEMA_VERSION {
         return Err("conformance suite is unsupported");
     }
     if !request.protocol_artifact.is_object() || !request.subject_artifact.is_object() {
         return Err("conformance request is invalid");
     }
 
-    let all_passed = match request.suite_id.as_str() {
-        ATTEMPT_TERMINAL_IMMUTABILITY_SUITE => {
+    let all_passed = match (request.profile.as_str(), request.suite_id.as_str()) {
+        (STRUCTURAL_PROFILE, ATTEMPT_TERMINAL_IMMUTABILITY_SUITE) => {
             evaluate_attempt_terminal_immutability(&request.vector)?
         }
-        CAPABILITY_NEGOTIATION_SUITE => evaluate_capability_negotiation(&request.vector)?,
-        COMMAND_ADOPTION_IDEMPOTENCY_SUITE => {
+        (STRUCTURAL_PROFILE, CAPABILITY_NEGOTIATION_SUITE) => {
+            evaluate_capability_negotiation(&request.vector)?
+        }
+        (STRUCTURAL_PROFILE, COMMAND_ADOPTION_IDEMPOTENCY_SUITE) => {
             evaluate_command_adoption_idempotency(&request.vector)?
         }
-        DEFINITION_LIFECYCLE_TRANSITIONS_SUITE => {
+        (STRUCTURAL_PROFILE, DEFINITION_LIFECYCLE_TRANSITIONS_SUITE) => {
             evaluate_definition_lifecycle_transitions(&request.vector)?
         }
-        DEFINITION_VALIDATION_SUITE => evaluate_definition_validation(&request.vector)?,
-        EVENT_REDUCER_DETERMINISM_SUITE => evaluate_event_reducer_determinism(&request.vector)?,
-        OCCURRENCE_FENCE_UNIQUENESS_SUITE => evaluate_occurrence_fence_uniqueness(&request.vector)?,
-        RECEIPT_INTEGRITY_VALIDATION_SUITE => {
+        (STRUCTURAL_PROFILE, DEFINITION_VALIDATION_SUITE) => {
+            evaluate_definition_validation(&request.vector)?
+        }
+        (STRUCTURAL_PROFILE, EVENT_REDUCER_DETERMINISM_SUITE) => {
+            evaluate_event_reducer_determinism(&request.vector)?
+        }
+        (STRUCTURAL_PROFILE, OCCURRENCE_FENCE_UNIQUENESS_SUITE) => {
+            evaluate_occurrence_fence_uniqueness(&request.vector)?
+        }
+        (STRUCTURAL_PROFILE, RECEIPT_INTEGRITY_VALIDATION_SUITE) => {
             evaluate_receipt_integrity_validation(&request.vector)?
         }
-        RRULE_VOCABULARY_SUITE => evaluate_rrule_vocabulary(&request.vector)?,
-        RUN_TERMINAL_MONOTONICITY_SUITE => evaluate_run_terminal_monotonicity(&request.vector)?,
+        (STRUCTURAL_PROFILE, RRULE_VOCABULARY_SUITE) => evaluate_rrule_vocabulary(&request.vector)?,
+        (STRUCTURAL_PROFILE, RUN_TERMINAL_MONOTONICITY_SUITE) => {
+            evaluate_run_terminal_monotonicity(&request.vector)?
+        }
+        (SCHEDULER_RELIABILITY_PROFILE, MISFIRE_LATEST_PLANNING_SUITE) => {
+            evaluate_misfire_latest_planning(&request.vector)?
+        }
         _ => return Err("conformance suite is unsupported"),
     };
     result_for(&request.suite_id, &request.vector, all_passed)
@@ -1203,6 +1273,247 @@ fn event_reducer_case_matches(case: &EventReducerVectorCase) -> Result<bool, &'s
         canonicalize(canonical.state()).map_err(|_| "conformance suite execution failed")?;
     let observed_digest = format!("sha256:{}", sha256_hex(&canonical_state));
     Ok(canonical.state() == duplicated.state() && observed_digest == case.expected_state_digest)
+}
+
+fn evaluate_misfire_latest_planning(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: MisfireLatestPlanningVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != MISFIRE_LATEST_PLANNING_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut scenarios = BTreeSet::new();
+    for case in &vectors.cases {
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !scenarios.insert(case.scenario)
+            || !misfire_latest_planning_case_is_valid(case)
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+    if scenarios.len() != MisfireLatestPlanningScenario::COUNT {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut all_passed = true;
+    for case in &vectors.cases {
+        all_passed &= misfire_latest_planning_case_matches(case)?;
+    }
+    Ok(all_passed)
+}
+
+fn misfire_latest_planning_case_is_valid(case: &MisfireLatestPlanningVectorCase) -> bool {
+    let Ok(definition) = super::definition::RoutineDefinition::from_json(&case.definition) else {
+        return false;
+    };
+    let Some(created_at) = canonical_timestamp(&case.created_at) else {
+        return false;
+    };
+    let Some(observed_at) = canonical_timestamp(&case.observed_at) else {
+        return false;
+    };
+    let existing = match case.existing_scheduled_for.as_deref() {
+        Some(value) => {
+            let Some(timestamp) = canonical_timestamp(value) else {
+                return false;
+            };
+            Some(timestamp)
+        }
+        None => None,
+    };
+    let scheduled_slots = case
+        .expected
+        .scheduled_slots
+        .iter()
+        .map(|slot| canonical_timestamp(slot))
+        .collect::<Option<Vec<_>>>();
+    let Some(scheduled_slots) = scheduled_slots else {
+        return false;
+    };
+    if scheduled_slots.windows(2).any(|slots| slots[0] >= slots[1])
+        || definition.rrule != "FREQ=DAILY;BYHOUR=9"
+        || definition.timezone != super::definition::RoutineTimezone::Utc
+        || definition.misfire != super::definition::RoutineMisfire::Latest
+        || definition.overlap != super::definition::RoutineOverlap::Forbid
+    {
+        return false;
+    }
+
+    let first_due = scheduled_after(&definition, created_at);
+    let second_due = first_due.and_then(|slot| scheduled_after(&definition, slot));
+    let latest_due = latest_scheduled_at_or_before(&definition, created_at, observed_at);
+    let next_after_observation = scheduled_after(&definition, observed_at);
+
+    match case.scenario {
+        MisfireLatestPlanningScenario::RestartCollapseLatest => {
+            definition.status == super::definition::RoutineStatus::Active
+                && created_at < observed_at
+                && second_due.is_some_and(|slot| slot <= observed_at)
+                && existing.is_none()
+                && case.expected.first_outcome == ExpectedPlanOutcome::Planned
+                && case.expected.second_outcome == ExpectedPlanOutcome::AlreadyFenced
+                && scheduled_slots.len() == 1
+        }
+        MisfireLatestPlanningScenario::ExistingFenceReplay => {
+            definition.status == super::definition::RoutineStatus::Active
+                && created_at < observed_at
+                && existing.is_some_and(|slot| {
+                    latest_due == Some(slot) && scheduled_slots.as_slice() == [slot]
+                })
+                && case.expected.first_outcome == ExpectedPlanOutcome::AlreadyFenced
+                && case.expected.second_outcome == ExpectedPlanOutcome::AlreadyFenced
+        }
+        MisfireLatestPlanningScenario::ClockRollbackNoOlderFence => {
+            definition.status == super::definition::RoutineStatus::Active
+                && created_at < observed_at
+                && first_due.is_some_and(|slot| slot <= observed_at)
+                && existing.is_some_and(|slot| {
+                    next_after_observation == Some(slot) && scheduled_slots.as_slice() == [slot]
+                })
+                && case.expected.first_outcome == ExpectedPlanOutcome::NotDue
+                && case.expected.second_outcome == ExpectedPlanOutcome::NotDue
+        }
+        MisfireLatestPlanningScenario::PausedDefinition => {
+            definition.status == super::definition::RoutineStatus::Paused
+                && created_at < observed_at
+                && first_due.is_some_and(|slot| slot <= observed_at)
+                && existing.is_none()
+                && case.expected.first_outcome == ExpectedPlanOutcome::NotDue
+                && case.expected.second_outcome == ExpectedPlanOutcome::NotDue
+                && scheduled_slots.is_empty()
+        }
+    }
+}
+
+fn scheduled_after(
+    definition: &super::definition::RoutineDefinition,
+    instant: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    super::schedule::next_due(&definition.rrule, definition.timezone, instant)
+        .ok()
+        .flatten()
+}
+
+fn latest_scheduled_at_or_before(
+    definition: &super::definition::RoutineDefinition,
+    created_at: DateTime<Utc>,
+    observed_at: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    let bounded_start = observed_at.checked_sub_signed(Duration::days(15))?;
+    let mut cursor = created_at.max(bounded_start);
+    let mut latest = None;
+
+    for _ in 0..=16 {
+        let next = scheduled_after(definition, cursor)?;
+        if next > observed_at {
+            return latest;
+        }
+        latest = Some(next);
+        cursor = next;
+    }
+
+    None
+}
+
+fn misfire_latest_planning_case_matches(
+    case: &MisfireLatestPlanningVectorCase,
+) -> Result<bool, &'static str> {
+    let definition = super::definition::RoutineDefinition::from_json(&case.definition)
+        .map_err(|_| "conformance vector is invalid")?;
+    let created_at =
+        canonical_timestamp(&case.created_at).ok_or("conformance vector is invalid")?;
+    let observed_at =
+        canonical_timestamp(&case.observed_at).ok_or("conformance vector is invalid")?;
+    let conn = Connection::open_in_memory().map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::store::AUTOMATION_DEFINITIONS_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute_batch(super::occurrences::AUTOMATION_OCCURRENCES_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    let record = super::store::insert_definition(&conn, &definition)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute(
+        "UPDATE automation_definitions
+         SET created_at = ?2, updated_at = ?2
+         WHERE id = ?1",
+        params![definition.id, case.created_at],
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+
+    if let Some(existing) = case.existing_scheduled_for.as_deref() {
+        let scheduled_at = canonical_timestamp(existing).ok_or("conformance vector is invalid")?;
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, automation_revision, definition_digest, scheduled_for, kind,
+                 state, attempt, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, 'scheduled', 'planned', 0, ?6, ?6)",
+            params![
+                format!("{}-{}", definition.id, scheduled_at.timestamp_millis()),
+                definition.id,
+                i64::try_from(record.revision).map_err(|_| "conformance suite execution failed")?,
+                record
+                    .definition_digest
+                    .as_deref()
+                    .ok_or("conformance suite execution failed")?,
+                existing,
+                case.created_at,
+            ],
+        )
+        .map_err(|_| "conformance suite execution failed")?;
+    }
+
+    let first =
+        super::occurrences::plan_latest_due_occurrence(&conn, &definition, created_at, observed_at)
+            .map_err(|_| "conformance suite execution failed")?;
+    let second =
+        super::occurrences::plan_latest_due_occurrence(&conn, &definition, created_at, observed_at)
+            .map_err(|_| "conformance suite execution failed")?;
+    let scheduled_slots = conn
+        .prepare(
+            "SELECT scheduled_for
+             FROM automation_occurrences
+             WHERE automation_id = ?1
+             ORDER BY scheduled_for ASC",
+        )
+        .map_err(|_| "conformance suite execution failed")?
+        .query_map([&definition.id], |row| row.get::<_, String>(0))
+        .map_err(|_| "conformance suite execution failed")?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|_| "conformance suite execution failed")?;
+
+    Ok(plan_outcome_matches(&first, case.expected.first_outcome)
+        && plan_outcome_matches(&second, case.expected.second_outcome)
+        && scheduled_slots == case.expected.scheduled_slots)
+}
+
+fn plan_outcome_matches(
+    observed: &super::occurrences::PlanOutcome,
+    expected: ExpectedPlanOutcome,
+) -> bool {
+    matches!(
+        (observed, expected),
+        (
+            super::occurrences::PlanOutcome::Planned(_),
+            ExpectedPlanOutcome::Planned
+        ) | (
+            super::occurrences::PlanOutcome::NotDue,
+            ExpectedPlanOutcome::NotDue
+        ) | (
+            super::occurrences::PlanOutcome::AlreadyFenced,
+            ExpectedPlanOutcome::AlreadyFenced
+        )
+    )
+}
+
+fn canonical_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .filter(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Millis, true) == value)
 }
 
 fn evaluate_occurrence_fence_uniqueness(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 
 use super::conformance_target::{
     capability, evaluate, evaluate_run_terminal_monotonicity_case_counts, TargetSuiteStatus,
-    CAPABILITY_NEGOTIATION_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
+    CAPABILITY_NEGOTIATION_SUITE, MISFIRE_LATEST_PLANNING_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
 const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
@@ -19,6 +19,8 @@ const DEFINITION_VALIDATION_VECTORS: &str =
 const EVENT_REDUCER_DETERMINISM_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/event-reducer-determinism.vectors.json"
 );
+const MISFIRE_LATEST_PLANNING_VECTORS: &str =
+    include_str!("../../../../conformance/automations/runner/misfire-latest-planning.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -28,10 +30,10 @@ const RECEIPT_INTEGRITY_VALIDATION_VECTORS: &str = include_str!(
 const RRULE_VOCABULARY_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/rrule-vocabulary.vectors.json");
 
-fn request_for(suite_id: &str, vector: Value) -> Value {
+fn request_for_profile(profile: &str, suite_id: &str, vector: Value) -> Value {
     json!({
         "schemaVersion": "coven.automations.conformance-suite-request.v1",
-        "profile": "structural",
+        "profile": profile,
         "suiteId": suite_id,
         "protocolArtifact": {
             "bundleSchemaVersion": "coven.automations.bundle.v1",
@@ -53,6 +55,10 @@ fn request_for(suite_id: &str, vector: Value) -> Value {
     })
 }
 
+fn request_for(suite_id: &str, vector: Value) -> Value {
+    request_for_profile("structural", suite_id, vector)
+}
+
 fn request(vector: Value) -> Value {
     request_for(CAPABILITY_NEGOTIATION_SUITE, vector)
 }
@@ -63,22 +69,126 @@ fn capability_advertises_the_native_structural_suites() {
         serde_json::to_value(capability()).unwrap(),
         json!({
             "schemaVersion": "coven.automations.conformance-target-capability.v1",
-            "profiles": [{
-                "profile": "structural",
-                "suites": [
-                    "attempt-terminal-immutability",
-                    CAPABILITY_NEGOTIATION_SUITE,
-                    "command-adoption-idempotency",
-                    "definition-lifecycle-transitions",
-                    "definition-validation",
-                    "event-reducer-determinism",
-                    "occurrence-fence-uniqueness",
-                    "receipt-integrity-validation",
-                    "rrule-vocabulary",
-                    RUN_TERMINAL_MONOTONICITY_SUITE
-                ]
-            }]
+            "profiles": [
+                {
+                    "profile": "structural",
+                    "suites": [
+                        "attempt-terminal-immutability",
+                        CAPABILITY_NEGOTIATION_SUITE,
+                        "command-adoption-idempotency",
+                        "definition-lifecycle-transitions",
+                        "definition-validation",
+                        "event-reducer-determinism",
+                        "occurrence-fence-uniqueness",
+                        "receipt-integrity-validation",
+                        "rrule-vocabulary",
+                        RUN_TERMINAL_MONOTONICITY_SUITE
+                    ]
+                },
+                {
+                    "profile": "scheduler_reliability",
+                    "suites": [MISFIRE_LATEST_PLANNING_SUITE]
+                }
+            ]
         })
+    );
+}
+
+#[test]
+fn misfire_latest_planning_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(MISFIRE_LATEST_PLANNING_VECTORS).unwrap();
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        MISFIRE_LATEST_PLANNING_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 4);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 4);
+}
+
+#[test]
+fn misfire_latest_planning_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(MISFIRE_LATEST_PLANNING_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["scheduledSlots"] = json!(["2026-09-03T09:00:00.000Z"]);
+
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        MISFIRE_LATEST_PLANNING_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn misfire_latest_planning_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 8] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone(),
+        |vectors| vectors["cases"][1]["scenario"] = vectors["cases"][0]["scenario"].clone(),
+        |vectors| vectors["cases"][0]["createdAt"] = json!("not-a-time"),
+        |vectors| vectors["cases"][0]["definition"]["status"] = json!("PAUSED"),
+        |vectors| vectors["cases"][1]["existingScheduledFor"] = Value::Null,
+        |vectors| vectors["cases"][2]["expected"]["firstOutcome"] = json!("planned"),
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value = serde_json::from_str(MISFIRE_LATEST_PLANNING_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for_profile(
+                "scheduler_reliability",
+                MISFIRE_LATEST_PLANNING_SUITE,
+                vectors,
+            ))
+            .unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
+fn misfire_latest_planning_suite_rejects_vacuous_timing_scenarios() {
+    let invalid_mutations: [fn(&mut Value); 5] = [
+        |vectors| vectors["cases"][0]["createdAt"] = json!("2026-09-03T10:00:00.000Z"),
+        |vectors| vectors["cases"][1]["observedAt"] = json!("2026-09-04T08:00:00.000Z"),
+        |vectors| vectors["cases"][2]["createdAt"] = json!("2026-09-03T13:00:00.000Z"),
+        |vectors| {
+            vectors["cases"][2]["createdAt"] = json!("2026-09-03T08:00:00.000Z");
+            vectors["cases"][2]["observedAt"] = json!("2026-09-03T08:30:00.000Z");
+            vectors["cases"][2]["existingScheduledFor"] = json!("2026-09-03T09:00:00.000Z");
+            vectors["cases"][2]["expected"]["scheduledSlots"] = json!(["2026-09-03T09:00:00.000Z"]);
+        },
+        |vectors| vectors["cases"][3]["observedAt"] = json!("2026-09-01T08:30:00.000Z"),
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value = serde_json::from_str(MISFIRE_LATEST_PLANNING_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for_profile(
+                "scheduler_reliability",
+                MISFIRE_LATEST_PLANNING_SUITE,
+                vectors,
+            ))
+            .unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
+fn misfire_latest_planning_suite_requires_scheduler_profile() {
+    let vectors: Value = serde_json::from_str(MISFIRE_LATEST_PLANNING_VECTORS).unwrap();
+    assert_eq!(
+        evaluate(&request_for(MISFIRE_LATEST_PLANNING_SUITE, vectors)).unwrap_err(),
+        "conformance suite is unsupported"
     );
 }
 

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -19,6 +19,8 @@ const DEFINITION_VALIDATION_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/definition-validation.vectors.json");
 const EVENT_REDUCER_DETERMINISM_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/event-reducer-determinism.vectors.json");
+const MISFIRE_LATEST_PLANNING_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/misfire-latest-planning.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -88,23 +90,70 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
         serde_json::from_slice::<Value>(&output.stdout)?,
         json!({
             "schemaVersion": "coven.automations.conformance-target-capability.v1",
-            "profiles": [{
-                "profile": "structural",
-                "suites": [
-                    "attempt-terminal-immutability",
-                    "capability-negotiation",
-                    "command-adoption-idempotency",
-                    "definition-lifecycle-transitions",
-                    "definition-validation",
-                    "event-reducer-determinism",
-                    "occurrence-fence-uniqueness",
-                    "receipt-integrity-validation",
-                    "rrule-vocabulary",
-                    "run-terminal-monotonicity"
-                ]
-            }]
+            "profiles": [
+                {
+                    "profile": "structural",
+                    "suites": [
+                        "attempt-terminal-immutability",
+                        "capability-negotiation",
+                        "command-adoption-idempotency",
+                        "definition-lifecycle-transitions",
+                        "definition-validation",
+                        "event-reducer-determinism",
+                        "occurrence-fence-uniqueness",
+                        "receipt-integrity-validation",
+                        "rrule-vocabulary",
+                        "run-terminal-monotonicity"
+                    ]
+                },
+                {
+                    "profile": "scheduler_reliability",
+                    "suites": ["misfire-latest-planning"]
+                }
+            ]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_misfire_latest_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(MISFIRE_LATEST_PLANNING_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "scheduler_reliability",
+        "suiteId": "misfire-latest-planning",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "misfire-latest-planning");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 4);
+    assert_eq!(response["evidence"]["passedCases"], 4);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Adds the first production-backed `scheduler_reliability` conformance suite for native Coven Automations.
- Files changed: Portable misfire vectors and runner documentation; native target capability/evaluator; target unit and real-binary integration coverage.
- Refs #858

## Implementation

- Approach: Advertise `scheduler_reliability` separately from `structural`, then execute four deterministic UTC cases through production definition persistence, occurrence schema, schedule math, and `plan_latest_due_occurrence`.
- User-visible behavior: `coven automations conformance-target capability` now reports `misfire-latest-planning`; suite execution emits machine-readable evidence for restart collapse, replay idempotency, clock rollback, and paused definitions.
- Compatibility notes: Audit-only. This does not claim aggregate `full` conformance or release eligibility, and existing structural suites remain unchanged.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (3,740 passed; 5 ignored)
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: 21 standalone runner tests; 11 protocol packaging tests; staged/range privacy guard; clean exact-head worktree.

## Risk and Rollback

- Risk level: Low. The new profile and suite are additive; strict vector validation rejects malformed or semantically vacuous scenarios.
- Rollback plan: Revert `31548a29c0c227de1926ab96f7c44d9961373db5`.

## Agent Handoff

- Current state: Exact-head local gates pass; independent review found no Critical, Important, or Medium issues after the vacuous-scenario regression was fixed test-first.
- Follow-ups: Continue #858 with additional scheduler reliability, chaos, SLO, diagnostics, authority, continuity, privacy, and interoperability slices.
- Known gaps: This scoped PR certifies only misfire-latest planning and intentionally leaves broader #858 acceptance open.
