### PR TITLE
feat(agents): add revisioned invocation events

### DIFF
--- a/crates/coven-agents/README.md
+++ b/crates/coven-agents/README.md
@@ -12,6 +12,8 @@ applications, and familiar runtimes can share:
 - persistent loop journals that can be rediscovered after process or machine restart
 - explicit offline reconciliation before ambiguous work resumes
 - metadata-only lifecycle observation
+- validated logical agent references with optional immutable revisions
+- versioned, serializable invocation lifecycle events
 
 Input guardrails apply to the starting agent, and output guardrails apply to the
 agent that produces the final output. A `SessionStore` must serialize writers
@@ -29,6 +31,26 @@ individual event variants. `Runner::run_with_invocation` accepts an explicit
 context, including an optional parent invocation ID for caller-managed nested
 work. These IDs provide correlation only: they do not authorize execution or
 promise durable adoption, idempotency, deduplication, or safe retries.
+
+`AgentRef` pairs a validated logical agent ID with an optional immutable
+`AgentRevision`. Agent IDs and revisions are non-empty, at most 127 bytes, and
+contain no whitespace or control characters. `Runner::new` rejects agents whose
+legacy `AgentId` cannot form a valid reference. Callers can register a revision
+with `Agent::with_revision`; an explicit `InvocationRequest` must then name that
+exact revision or the run fails before model execution. The compatibility
+`Runner::run` and `Runner::run_with_invocation` entry points resolve the
+currently registered revision automatically.
+
+`InvocationObserver` receives a separate canonical metadata stream without
+changing the existing `RunObserver` event shapes. Every admitted request emits
+one versioned `started` event and one terminal `completed` or `failed` event.
+Legacy handoffs inside the same run are emitted as `control_transferred`, not as
+durable delegation. Every event carries the original requested target and
+source; failures separately identify `failed_at`, so a target-resolution
+failure is not mislabeled as execution by that target. The
+`coven.agent-invocation-event.v1` wire schema rejects unknown fields. Attempt
+and executor bindings remain absent until Coven has an executor contract that
+can supply them truthfully.
 
 This pre-1.0 API adds an `invocation` field to event and outcome shapes.
 `RunFailure::invocation` is boxed, and `RunFailure::new_items` is an owned boxed

--- a/crates/coven-agents/src/agent.rs
+++ b/crates/coven-agents/src/agent.rs
@@ -2,7 +2,10 @@ use std::{fmt, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{InputGuardrail, Model, OutputGuardrail, Tool, ToolDefinition};
+use crate::{
+    AgentRef, AgentRefError, AgentRevision, InputGuardrail, Model, OutputGuardrail, Tool,
+    ToolDefinition,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -70,6 +73,7 @@ where
     C: Sync,
 {
     pub(crate) id: AgentId,
+    pub(crate) revision: Option<AgentRevision>,
     pub(crate) name: String,
     pub(crate) instructions: String,
     pub(crate) model: Arc<dyn Model<C>>,
@@ -91,6 +95,7 @@ where
     ) -> Self {
         Self {
             id: id.into(),
+            revision: None,
             name: name.into(),
             instructions: instructions.into(),
             model,
@@ -105,6 +110,17 @@ where
         &self.id
     }
 
+    pub fn revision(&self) -> Option<&AgentRevision> {
+        self.revision.as_ref()
+    }
+
+    pub fn agent_ref(&self) -> Result<AgentRef, AgentRefError> {
+        match &self.revision {
+            Some(revision) => AgentRef::with_revision(self.id.as_str(), revision.as_str()),
+            None => AgentRef::new(self.id.as_str()),
+        }
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -116,6 +132,11 @@ where
     pub fn with_tool(mut self, tool: Arc<dyn Tool<C>>) -> Self {
         let definition = tool.definition();
         self.tools.push(AgentTool { tool, definition });
+        self
+    }
+
+    pub fn with_revision(mut self, revision: AgentRevision) -> Self {
+        self.revision = Some(revision);
         self
     }
 

--- a/crates/coven-agents/src/error.rs
+++ b/crates/coven-agents/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{AgentId, InvocationContext, RunItem};
+use crate::{AgentId, AgentRef, AgentRefError, InvocationContext, RunItem};
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -23,6 +23,12 @@ impl std::fmt::Display for GuardrailStage {
 pub enum ConfigError {
     #[error("at least one agent is required")]
     NoAgents,
+    #[error("agent `{agent}` does not form a valid agent reference")]
+    InvalidAgentRef {
+        agent: AgentId,
+        #[source]
+        source: AgentRefError,
+    },
     #[error("agent id `{0}` is registered more than once")]
     DuplicateAgent(AgentId),
     #[error("agent `{agent}` registers tool `{tool}` more than once")]
@@ -41,6 +47,19 @@ pub enum ConfigError {
 pub enum RunError {
     #[error("starting agent `{0}` is not registered")]
     UnknownStartingAgent(AgentId),
+    #[error("starting agent reference `{requested}` does not match registered `{registered}`")]
+    AgentRevisionMismatch {
+        requested: Box<AgentRef>,
+        registered: Box<AgentRef>,
+    },
+    #[error("explicit invocation target `{agent}` requires an immutable registered revision")]
+    AgentRevisionRequired { agent: AgentId },
+    #[error("starting agent `{agent}` does not form a valid agent reference")]
+    InvalidAgentRef {
+        agent: AgentId,
+        #[source]
+        source: AgentRefError,
+    },
     #[error("runner configuration became invalid: {reason}")]
     InvalidConfiguration { reason: String },
     #[error("session id was provided but no session store is configured")]

--- a/crates/coven-agents/src/invocation.rs
+++ b/crates/coven-agents/src/invocation.rs
@@ -1,7 +1,244 @@
 use std::{fmt, str::FromStr};
 
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
+use thiserror::Error;
 use uuid::Uuid;
+
+use crate::AgentId;
+
+const MAX_AGENT_REF_COMPONENT_BYTES: usize = 127;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AgentRefError {
+    #[error("agent {field} must not be empty")]
+    Empty { field: &'static str },
+    #[error("agent {field} exceeds {MAX_AGENT_REF_COMPONENT_BYTES} bytes")]
+    TooLong { field: &'static str },
+    #[error("agent {field} must not contain whitespace or control characters")]
+    InvalidCharacter { field: &'static str },
+}
+
+fn validate_agent_ref_component(value: &str, field: &'static str) -> Result<(), AgentRefError> {
+    if value.is_empty() {
+        return Err(AgentRefError::Empty { field });
+    }
+    if value.len() > MAX_AGENT_REF_COMPONENT_BYTES {
+        return Err(AgentRefError::TooLong { field });
+    }
+    if value
+        .chars()
+        .any(|character| character.is_whitespace() || character.is_control())
+    {
+        return Err(AgentRefError::InvalidCharacter { field });
+    }
+    Ok(())
+}
+
+/// Immutable revision identifier for a registered agent implementation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct AgentRevision(String);
+
+impl AgentRevision {
+    pub fn new(value: impl Into<String>) -> Result<Self, AgentRefError> {
+        let value = value.into();
+        validate_agent_ref_component(&value, "revision")?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for AgentRevision {
+    type Err = AgentRefError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentRevision {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(de::Error::custom)
+    }
+}
+
+/// Validated logical identity and optional immutable revision of an agent.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct AgentRef {
+    id: AgentId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    revision: Option<AgentRevision>,
+}
+
+impl AgentRef {
+    pub fn new(id: impl Into<String>) -> Result<Self, AgentRefError> {
+        Self::from_parts(id.into(), None)
+    }
+
+    pub fn with_revision(
+        id: impl Into<String>,
+        revision: impl Into<String>,
+    ) -> Result<Self, AgentRefError> {
+        Self::from_parts(id.into(), Some(AgentRevision::new(revision)?))
+    }
+
+    fn from_parts(id: String, revision: Option<AgentRevision>) -> Result<Self, AgentRefError> {
+        validate_agent_ref_component(&id, "id")?;
+        Ok(Self {
+            id: AgentId::new(id),
+            revision,
+        })
+    }
+
+    pub fn id(&self) -> &AgentId {
+        &self.id
+    }
+
+    pub fn revision(&self) -> Option<&AgentRevision> {
+        self.revision.as_ref()
+    }
+}
+
+impl fmt::Display for AgentRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.id.fmt(formatter)?;
+        if let Some(revision) = &self.revision {
+            write!(formatter, "@{}", revision.as_str())?;
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawAgentRef {
+            id: String,
+            #[serde(default)]
+            revision: Option<AgentRevision>,
+        }
+
+        let raw = RawAgentRef::deserialize(deserializer)?;
+        Self::from_parts(raw.id, raw.revision).map_err(de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InvocationEventVersion {
+    #[serde(rename = "coven.agent-invocation-event.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum InvocationSource {
+    Caller,
+    Agent { agent: AgentRef },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum InvocationEventKind {
+    Started {},
+    ControlTransferred {
+        from: AgentRef,
+        to: AgentRef,
+        name: String,
+    },
+    Completed {
+        final_agent: AgentRef,
+        turns: usize,
+        control_transfers: usize,
+    },
+    Failed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        failed_at: Option<AgentRef>,
+        kind: InvocationFailureKind,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum InvocationFailureKind {
+    Configuration,
+    Session,
+    InputGuardrail,
+    OutputGuardrail,
+    Model,
+    Tool,
+    ControlTransfer,
+    InvalidResponse,
+    Limit,
+}
+
+/// Versioned metadata-only event for one provider-neutral agent invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InvocationEvent {
+    contract: InvocationEventVersion,
+    pub invocation: InvocationContext,
+    pub source: InvocationSource,
+    pub requested_target: AgentRef,
+    pub event: InvocationEventKind,
+}
+
+impl InvocationEvent {
+    pub const fn new(
+        invocation: InvocationContext,
+        source: InvocationSource,
+        requested_target: AgentRef,
+        event: InvocationEventKind,
+    ) -> Self {
+        Self {
+            contract: InvocationEventVersion::V1,
+            invocation,
+            source,
+            requested_target,
+            event,
+        }
+    }
+
+    pub const fn contract(&self) -> InvocationEventVersion {
+        self.contract
+    }
+}
+
+/// Validated request metadata for the canonical invocation event stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InvocationRequest {
+    pub invocation: InvocationContext,
+    pub source: InvocationSource,
+    pub requested_target: AgentRef,
+}
+
+impl InvocationRequest {
+    pub const fn new(
+        invocation: InvocationContext,
+        source: InvocationSource,
+        requested_target: AgentRef,
+    ) -> Self {
+        Self {
+            invocation,
+            source,
+            requested_target,
+        }
+    }
+}
 
 /// Stable correlation identity for one runner invocation.
 ///
@@ -47,6 +284,7 @@ impl FromStr for InvocationId {
 
 /// Correlation carried unchanged through one invocation and its events.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InvocationContext {
     pub id: InvocationId,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/coven-agents/src/lib.rs
+++ b/crates/coven-agents/src/lib.rs
@@ -18,7 +18,11 @@ mod tool;
 pub use agent::{Agent, AgentId, Handoff};
 pub use error::{BoxError, ConfigError, GuardrailStage, RunError, RunFailure};
 pub use guardrail::{GuardrailVerdict, InputGuardrail, OutputGuardrail};
-pub use invocation::{InvocationContext, InvocationId};
+pub use invocation::{
+    AgentRef, AgentRefError, AgentRevision, InvocationContext, InvocationEvent,
+    InvocationEventKind, InvocationEventVersion, InvocationFailureKind, InvocationId,
+    InvocationRequest, InvocationSource,
+};
 pub use loop_journal::FileLoopJournal;
 pub use loop_runner::{
     GoalLoopRunner, InMemoryLoopJournal, LoopAttempt, LoopCheckpoint, LoopCheckpointStatus,
@@ -29,7 +33,9 @@ pub use model::{
     HandoffCall, HandoffDefinition, Model, ModelAction, ModelRequest, ModelResponse, RunItem,
     ToolCall,
 };
-pub use observer::{NoopObserver, RunEvent, RunFailureKind, RunObserver};
+pub use observer::{
+    InvocationObserver, NoopInvocationObserver, NoopObserver, RunEvent, RunFailureKind, RunObserver,
+};
 pub use runner::{RunOptions, RunResult, Runner};
 pub use session::{InMemorySession, SessionStore};
 pub use tool::{Tool, ToolDefinition};

--- a/crates/coven-agents/src/observer.rs
+++ b/crates/coven-agents/src/observer.rs
@@ -1,4 +1,4 @@
-use crate::{AgentId, GuardrailStage, InvocationContext};
+use crate::{AgentId, GuardrailStage, InvocationContext, InvocationEvent};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunFailureKind {
@@ -86,4 +86,15 @@ pub struct NoopObserver;
 
 impl RunObserver for NoopObserver {
     fn on_event(&self, _event: &RunEvent) {}
+}
+
+pub trait InvocationObserver: Send + Sync {
+    fn on_event(&self, event: &InvocationEvent);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopInvocationObserver;
+
+impl InvocationObserver for NoopInvocationObserver {
+    fn on_event(&self, _event: &InvocationEvent) {}
 }

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -4,9 +4,11 @@ use std::{
 };
 
 use crate::{
-    Agent, AgentId, ConfigError, GuardrailStage, GuardrailVerdict, HandoffDefinition,
-    InvocationContext, InvocationId, ModelAction, ModelRequest, NoopObserver, RunError, RunEvent,
-    RunFailure, RunFailureKind, RunItem, RunObserver, SessionStore,
+    Agent, AgentId, AgentRef, ConfigError, GuardrailStage, GuardrailVerdict, HandoffDefinition,
+    InvocationContext, InvocationEvent, InvocationEventKind, InvocationFailureKind, InvocationId,
+    InvocationObserver, InvocationRequest, InvocationSource, ModelAction, ModelRequest,
+    NoopInvocationObserver, NoopObserver, RunError, RunEvent, RunFailure, RunFailureKind, RunItem,
+    RunObserver, SessionStore,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,6 +49,20 @@ struct RunProgress {
     handoffs: usize,
 }
 
+const fn invocation_failure_kind(kind: RunFailureKind) -> InvocationFailureKind {
+    match kind {
+        RunFailureKind::Configuration => InvocationFailureKind::Configuration,
+        RunFailureKind::Session => InvocationFailureKind::Session,
+        RunFailureKind::InputGuardrail => InvocationFailureKind::InputGuardrail,
+        RunFailureKind::OutputGuardrail => InvocationFailureKind::OutputGuardrail,
+        RunFailureKind::Model => InvocationFailureKind::Model,
+        RunFailureKind::Tool => InvocationFailureKind::Tool,
+        RunFailureKind::Handoff => InvocationFailureKind::ControlTransfer,
+        RunFailureKind::InvalidResponse => InvocationFailureKind::InvalidResponse,
+        RunFailureKind::Limit => InvocationFailureKind::Limit,
+    }
+}
+
 pub struct Runner<C>
 where
     C: Sync,
@@ -54,6 +70,7 @@ where
     agents: BTreeMap<AgentId, Arc<Agent<C>>>,
     session: Option<Arc<dyn SessionStore>>,
     observer: Arc<dyn RunObserver>,
+    invocation_observer: Arc<dyn InvocationObserver>,
 }
 
 impl<C> Runner<C>
@@ -65,6 +82,12 @@ where
 
         for agent in agents {
             let id = agent.id.clone();
+            agent
+                .agent_ref()
+                .map_err(|source| ConfigError::InvalidAgentRef {
+                    agent: id.clone(),
+                    source,
+                })?;
             if registered.insert(id.clone(), Arc::new(agent)).is_some() {
                 return Err(ConfigError::DuplicateAgent(id));
             }
@@ -108,6 +131,7 @@ where
             agents: registered,
             session: None,
             observer: Arc::new(NoopObserver),
+            invocation_observer: Arc::new(NoopInvocationObserver),
         })
     }
 
@@ -121,7 +145,76 @@ where
         self
     }
 
+    pub fn with_invocation_observer(mut self, observer: Arc<dyn InvocationObserver>) -> Self {
+        self.invocation_observer = observer;
+        self
+    }
+
+    fn registered_agent_ref(&self, id: &AgentId) -> Option<AgentRef> {
+        self.agents
+            .get(id)
+            .map(|agent| agent.agent_ref().expect("runner validates agent refs"))
+    }
+
+    fn observe_invocation(&self, request: &InvocationRequest, event: InvocationEventKind) {
+        self.invocation_observer.on_event(&InvocationEvent::new(
+            request.invocation.clone(),
+            request.source.clone(),
+            request.requested_target.clone(),
+            event,
+        ));
+    }
+
     fn fail(
+        &self,
+        request: &InvocationRequest,
+        agent: &AgentId,
+        kind: RunFailureKind,
+        error: RunError,
+    ) -> RunError {
+        self.fail_with_location(
+            request,
+            agent,
+            self.registered_agent_ref(agent),
+            kind,
+            error,
+        )
+    }
+
+    fn fail_before_execution(
+        &self,
+        request: &InvocationRequest,
+        agent: &AgentId,
+        kind: RunFailureKind,
+        error: RunError,
+    ) -> RunError {
+        self.fail_with_location(request, agent, None, kind, error)
+    }
+
+    fn fail_with_location(
+        &self,
+        request: &InvocationRequest,
+        agent: &AgentId,
+        failed_at: Option<AgentRef>,
+        kind: RunFailureKind,
+        error: RunError,
+    ) -> RunError {
+        self.observer.on_event(&RunEvent::RunFailed {
+            invocation: request.invocation.clone(),
+            agent: agent.clone(),
+            kind,
+        });
+        self.observe_invocation(
+            request,
+            InvocationEventKind::Failed {
+                failed_at,
+                kind: invocation_failure_kind(kind),
+            },
+        );
+        error
+    }
+
+    fn fail_legacy(
         &self,
         invocation: &InvocationContext,
         agent: &AgentId,
@@ -149,7 +242,7 @@ where
     /// or tool execution.
     async fn check_input_guardrails(
         &self,
-        invocation: &InvocationContext,
+        request: &InvocationRequest,
         agent: &Agent<C>,
         input: &str,
         context: &C,
@@ -157,7 +250,7 @@ where
         for guardrail in &agent.input_guardrails {
             let verdict = guardrail.check(input, context).await.map_err(|source| {
                 self.fail(
-                    invocation,
+                    request,
                     &agent.id,
                     RunFailureKind::InputGuardrail,
                     RunError::GuardrailFailed {
@@ -170,7 +263,7 @@ where
             })?;
             let allowed = verdict == GuardrailVerdict::Allow;
             self.observer.on_event(&RunEvent::GuardrailChecked {
-                invocation: invocation.clone(),
+                invocation: request.invocation.clone(),
                 agent: agent.id.clone(),
                 guardrail: guardrail.name().to_owned(),
                 stage: GuardrailStage::Input,
@@ -178,7 +271,7 @@ where
             });
             if let GuardrailVerdict::Reject { reason } = verdict {
                 return Err(self.fail(
-                    invocation,
+                    request,
                     &agent.id,
                     RunFailureKind::InputGuardrail,
                     RunError::GuardrailRejected {
@@ -241,19 +334,83 @@ where
         options: RunOptions,
         invocation: InvocationContext,
     ) -> Result<RunResult, RunFailure> {
+        let starting_agent = starting_agent.into();
+        let requested_target = match AgentRef::new(starting_agent.as_str()) {
+            Ok(requested_target) => requested_target,
+            Err(source) => {
+                let mut progress = RunProgress::default();
+                progress.items.push(RunItem::UserMessage {
+                    content: input.into(),
+                });
+                self.observer.on_event(&RunEvent::RunStarted {
+                    invocation: invocation.clone(),
+                    starting_agent: starting_agent.clone(),
+                });
+                let error = self.fail_legacy(
+                    &invocation,
+                    &starting_agent,
+                    RunFailureKind::Configuration,
+                    RunError::InvalidAgentRef {
+                        agent: starting_agent.clone(),
+                        source,
+                    },
+                );
+                return Err(RunFailure {
+                    invocation: Box::new(invocation),
+                    error,
+                    new_items: progress.items.into_boxed_slice(),
+                    turns: 0,
+                    handoffs: 0,
+                });
+            }
+        };
+        let requested_target = self
+            .registered_agent_ref(requested_target.id())
+            .unwrap_or(requested_target);
+        self.run_invocation_inner(
+            InvocationRequest::new(invocation, InvocationSource::Caller, requested_target),
+            input,
+            context,
+            options,
+            false,
+        )
+        .await
+    }
+
+    /// Runs one validated invocation request and emits its versioned metadata
+    /// event stream alongside the compatibility [`RunEvent`] stream.
+    pub async fn run_invocation(
+        &self,
+        request: InvocationRequest,
+        input: impl Into<String>,
+        context: &C,
+        options: RunOptions,
+    ) -> Result<RunResult, RunFailure> {
+        self.run_invocation_inner(request, input, context, options, true)
+            .await
+    }
+
+    async fn run_invocation_inner(
+        &self,
+        request: InvocationRequest,
+        input: impl Into<String>,
+        context: &C,
+        options: RunOptions,
+        require_revision: bool,
+    ) -> Result<RunResult, RunFailure> {
         let mut progress = RunProgress::default();
 
         self.run_loop(
-            &invocation,
-            starting_agent.into(),
+            &request,
             input.into(),
             context,
             options,
+            require_revision,
             &mut progress,
         )
         .await
         .map_err(|error| RunFailure {
-            invocation: Box::new(invocation.clone()),
+            invocation: Box::new(request.invocation.clone()),
             error,
             new_items: progress.items.into_boxed_slice(),
             turns: progress.turns,
@@ -263,39 +420,67 @@ where
 
     async fn run_loop(
         &self,
-        invocation: &InvocationContext,
-        starting_agent: AgentId,
+        request: &InvocationRequest,
         input: String,
         context: &C,
         options: RunOptions,
+        require_revision: bool,
         progress: &mut RunProgress,
     ) -> Result<RunResult, RunError> {
+        let starting_agent = request.requested_target.id().clone();
         self.observer.on_event(&RunEvent::RunStarted {
-            invocation: invocation.clone(),
+            invocation: request.invocation.clone(),
             starting_agent: starting_agent.clone(),
         });
+        self.observe_invocation(request, InvocationEventKind::Started {});
 
         progress.items.push(RunItem::UserMessage {
             content: input.clone(),
         });
 
         let mut current = self.agents.get(&starting_agent).cloned().ok_or_else(|| {
-            self.fail(
-                invocation,
+            self.fail_before_execution(
+                request,
                 &starting_agent,
                 RunFailureKind::Configuration,
                 RunError::UnknownStartingAgent(starting_agent.clone()),
             )
         })?;
 
-        self.check_input_guardrails(invocation, &current, &input, context)
+        let registered_target = current.agent_ref().expect("runner validates agent refs");
+        if require_revision
+            && (request.requested_target.revision().is_none()
+                || registered_target.revision().is_none())
+        {
+            return Err(self.fail_before_execution(
+                request,
+                &starting_agent,
+                RunFailureKind::Configuration,
+                RunError::AgentRevisionRequired {
+                    agent: starting_agent.clone(),
+                },
+            ));
+        }
+        if request.requested_target != registered_target {
+            return Err(self.fail_before_execution(
+                request,
+                &starting_agent,
+                RunFailureKind::Configuration,
+                RunError::AgentRevisionMismatch {
+                    requested: Box::new(request.requested_target.clone()),
+                    registered: Box::new(registered_target),
+                },
+            ));
+        }
+
+        self.check_input_guardrails(request, &current, &input, context)
             .await?;
 
         let mut model_items = match (&options.session_id, &self.session) {
             (Some(session_id), Some(session)) => {
                 let mut items = session.load(session_id).await.map_err(|source| {
                     self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::Session,
                         RunError::SessionFailed {
@@ -309,7 +494,7 @@ where
             }
             (Some(_), None) => {
                 return Err(self.fail(
-                    invocation,
+                    request,
                     &current.id,
                     RunFailureKind::Session,
                     RunError::SessionUnavailable,
@@ -330,12 +515,12 @@ where
             progress.turns = turn;
 
             self.observer.on_event(&RunEvent::ModelRequested {
-                invocation: invocation.clone(),
+                invocation: request.invocation.clone(),
                 agent: current.id.clone(),
                 turn,
             });
 
-            let request = ModelRequest {
+            let model_request = ModelRequest {
                 agent_id: current.id.clone(),
                 agent_name: current.name.clone(),
                 instructions: current.instructions.clone(),
@@ -357,11 +542,11 @@ where
             };
             let response = current
                 .model
-                .generate(request, context)
+                .generate(model_request, context)
                 .await
                 .map_err(|source| {
                     self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::Model,
                         RunError::ModelFailed {
@@ -383,7 +568,7 @@ where
             if response.actions.is_empty() {
                 let output = response.assistant_message.ok_or_else(|| {
                     self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -397,7 +582,7 @@ where
                 for guardrail in &current.output_guardrails {
                     let verdict = guardrail.check(&output, context).await.map_err(|source| {
                         self.fail(
-                            invocation,
+                            request,
                             &current.id,
                             RunFailureKind::OutputGuardrail,
                             RunError::GuardrailFailed {
@@ -410,7 +595,7 @@ where
                     })?;
                     let allowed = verdict == GuardrailVerdict::Allow;
                     self.observer.on_event(&RunEvent::GuardrailChecked {
-                        invocation: invocation.clone(),
+                        invocation: request.invocation.clone(),
                         agent: current.id.clone(),
                         guardrail: guardrail.name().to_owned(),
                         stage: GuardrailStage::Output,
@@ -418,7 +603,7 @@ where
                     });
                     if let GuardrailVerdict::Reject { reason } = verdict {
                         return Err(self.fail(
-                            invocation,
+                            request,
                             &current.id,
                             RunFailureKind::OutputGuardrail,
                             RunError::GuardrailRejected {
@@ -437,7 +622,7 @@ where
                         .await
                         .map_err(|source| {
                             self.fail(
-                                invocation,
+                                request,
                                 &current.id,
                                 RunFailureKind::Session,
                                 RunError::SessionFailed {
@@ -449,13 +634,21 @@ where
                 }
 
                 self.observer.on_event(&RunEvent::RunCompleted {
-                    invocation: invocation.clone(),
+                    invocation: request.invocation.clone(),
                     final_agent: current.id.clone(),
                     turns: turn,
                     handoffs: progress.handoffs,
                 });
+                self.observe_invocation(
+                    request,
+                    InvocationEventKind::Completed {
+                        final_agent: current.agent_ref().expect("runner validates agent refs"),
+                        turns: turn,
+                        control_transfers: progress.handoffs,
+                    },
+                );
                 return Ok(RunResult {
-                    invocation: invocation.clone(),
+                    invocation: request.invocation.clone(),
                     final_output: output,
                     final_agent: current.id.clone(),
                     new_items: std::mem::take(&mut progress.items),
@@ -472,7 +665,7 @@ where
             if handoff_actions > 0 {
                 if response.actions.len() != 1 {
                     return Err(self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -484,7 +677,7 @@ where
                 progress.handoffs += 1;
                 if progress.handoffs > options.max_handoffs {
                     return Err(self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::Limit,
                         RunError::MaxHandoffsExceeded {
@@ -495,7 +688,7 @@ where
 
                 let [ModelAction::Handoff(call)] = response.actions.as_slice() else {
                     return Err(self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -510,7 +703,7 @@ where
                     .find(|handoff| handoff.name == call.name)
                     .ok_or_else(|| {
                         self.fail(
-                            invocation,
+                            request,
                             &current.id,
                             RunFailureKind::Handoff,
                             RunError::UnknownHandoff {
@@ -521,7 +714,7 @@ where
                     })?;
                 let target = self.agents.get(&handoff.target).cloned().ok_or_else(|| {
                     self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::Configuration,
                         RunError::InvalidConfiguration {
@@ -540,17 +733,25 @@ where
                 progress.items.push(item.clone());
                 model_items.push(item);
                 self.observer.on_event(&RunEvent::Handoff {
-                    invocation: invocation.clone(),
+                    invocation: request.invocation.clone(),
                     from: current.id.clone(),
                     to: target.id.clone(),
                     name: handoff.name.clone(),
                 });
+                self.observe_invocation(
+                    request,
+                    InvocationEventKind::ControlTransferred {
+                        from: current.agent_ref().expect("runner validates agent refs"),
+                        to: target.agent_ref().expect("runner validates agent refs"),
+                        name: handoff.name.clone(),
+                    },
+                );
                 current = target;
                 // Ingress parity: the handoff target enforces the same input
                 // policy it would enforce as the starting agent, checked
                 // against the original user input, before its first model turn
                 // or tool execution.
-                self.check_input_guardrails(invocation, &current, &input, context)
+                self.check_input_guardrails(request, &current, &input, context)
                     .await?;
                 continue;
             }
@@ -564,7 +765,7 @@ where
                 };
                 if !seen_call_ids.insert(call.id.clone()) {
                     return Err(self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::DuplicateToolCallId {
@@ -578,7 +779,7 @@ where
             for action in response.actions {
                 let ModelAction::ToolCall(call) = action else {
                     return Err(self.fail(
-                        invocation,
+                        request,
                         &current.id,
                         RunFailureKind::InvalidResponse,
                         RunError::InvalidModelResponse {
@@ -593,7 +794,7 @@ where
                     .find(|tool| tool.definition.name == call.name)
                     .ok_or_else(|| {
                         self.fail(
-                            invocation,
+                            request,
                             &current.id,
                             RunFailureKind::Tool,
                             RunError::UnknownTool {
@@ -609,7 +810,7 @@ where
                 progress.items.push(call_item.clone());
                 model_items.push(call_item);
                 self.observer.on_event(&RunEvent::ToolStarted {
-                    invocation: invocation.clone(),
+                    invocation: request.invocation.clone(),
                     agent: current.id.clone(),
                     tool: call.name.clone(),
                     call_id: call.id.clone(),
@@ -620,7 +821,7 @@ where
                         .await
                         .map_err(|source| {
                             self.fail(
-                                invocation,
+                                request,
                                 &current.id,
                                 RunFailureKind::Tool,
                                 RunError::ToolFailed {
@@ -639,7 +840,7 @@ where
                 progress.items.push(result_item.clone());
                 model_items.push(result_item);
                 self.observer.on_event(&RunEvent::ToolCompleted {
-                    invocation: invocation.clone(),
+                    invocation: request.invocation.clone(),
                     agent: current.id.clone(),
                     tool: call.name,
                     call_id: call.id,
@@ -648,7 +849,7 @@ where
         }
 
         Err(self.fail(
-            invocation,
+            request,
             &current.id,
             RunFailureKind::Limit,
             RunError::MaxTurnsExceeded {

--- a/crates/coven-agents/tests/invocation_contract.rs
+++ b/crates/coven-agents/tests/invocation_contract.rs
@@ -1,0 +1,428 @@
+use std::{
+    collections::VecDeque,
+    io,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use coven_agents::{
+    Agent, AgentRef, AgentRevision, BoxError, Handoff, HandoffCall, InvocationContext,
+    InvocationEvent, InvocationEventKind, InvocationEventVersion, InvocationFailureKind,
+    InvocationId, InvocationObserver, InvocationRequest, InvocationSource, Model, ModelAction,
+    ModelRequest, ModelResponse, RunError, RunOptions, Runner,
+};
+use serde_json::json;
+
+struct QueueModel {
+    responses: Mutex<VecDeque<ModelResponse>>,
+}
+
+impl QueueModel {
+    fn new(responses: impl IntoIterator<Item = ModelResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses.into_iter().collect()),
+        }
+    }
+}
+
+#[async_trait]
+impl Model<()> for QueueModel {
+    async fn generate(
+        &self,
+        _request: ModelRequest,
+        _context: &(),
+    ) -> Result<ModelResponse, BoxError> {
+        self.responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| Box::new(io::Error::other("no queued response")) as BoxError)
+    }
+}
+
+#[derive(Default)]
+struct RecordingInvocationObserver {
+    events: Mutex<Vec<InvocationEvent>>,
+}
+
+impl RecordingInvocationObserver {
+    fn events(&self) -> Vec<InvocationEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl InvocationObserver for RecordingInvocationObserver {
+    fn on_event(&self, event: &InvocationEvent) {
+        self.events.lock().unwrap().push(event.clone());
+    }
+}
+
+#[test]
+fn agent_ref_round_trips_with_an_optional_revision() {
+    let agent = AgentRef::with_revision("triage", "sha256:abc123").unwrap();
+
+    assert_eq!(agent.id().as_str(), "triage");
+    assert_eq!(
+        agent.revision().map(AgentRevision::as_str),
+        Some("sha256:abc123")
+    );
+    assert_eq!(
+        serde_json::to_value(&agent).unwrap(),
+        json!({
+            "id": "triage",
+            "revision": "sha256:abc123"
+        })
+    );
+    assert_eq!(
+        serde_json::from_value::<AgentRef>(serde_json::to_value(&agent).unwrap()).unwrap(),
+        agent
+    );
+
+    let unrevisioned = AgentRef::new("triage").unwrap();
+    assert_eq!(
+        serde_json::to_value(&unrevisioned).unwrap(),
+        json!({ "id": "triage" })
+    );
+}
+
+#[test]
+fn agent_ref_rejects_ambiguous_or_open_ended_wire_values() {
+    for invalid_id in ["", " triage", "triage ", "tri age", "triage\nworker"] {
+        assert!(
+            AgentRef::new(invalid_id).is_err(),
+            "accepted invalid agent id {invalid_id:?}"
+        );
+    }
+    assert!(AgentRef::new("a".repeat(128)).is_err());
+
+    for invalid_revision in ["", " latest", "latest ", "latest stable", "v1\nv2"] {
+        assert!(
+            AgentRef::with_revision("triage", invalid_revision).is_err(),
+            "accepted invalid agent revision {invalid_revision:?}"
+        );
+    }
+    assert!(AgentRef::with_revision("triage", "r".repeat(128)).is_err());
+
+    assert!(serde_json::from_value::<AgentRef>(json!({
+        "id": "triage",
+        "unexpected": true
+    }))
+    .is_err());
+    assert!(serde_json::from_value::<AgentRef>(json!({
+        "id": "tri age"
+    }))
+    .is_err());
+    assert!(serde_json::from_value::<AgentRef>(json!({
+        "id": "triage",
+        "revision": ""
+    }))
+    .is_err());
+}
+
+#[test]
+fn canonical_invocation_event_has_a_closed_versioned_wire_shape() {
+    let invocation = InvocationContext::root(
+        "11111111-1111-4111-8111-111111111111"
+            .parse::<InvocationId>()
+            .unwrap(),
+    );
+    let source = AgentRef::with_revision("planner", "rev-planner").unwrap();
+    let target = AgentRef::with_revision("worker", "rev-worker").unwrap();
+    let event = InvocationEvent::new(
+        invocation,
+        InvocationSource::Agent { agent: source },
+        target,
+        InvocationEventKind::Started {},
+    );
+
+    let encoded = serde_json::to_value(&event).unwrap();
+    assert_eq!(
+        encoded,
+        json!({
+            "contract": "coven.agent-invocation-event.v1",
+            "invocation": {
+                "id": "11111111-1111-4111-8111-111111111111"
+            },
+            "source": {
+                "type": "agent",
+                "agent": {
+                    "id": "planner",
+                    "revision": "rev-planner"
+                }
+            },
+            "requested_target": {
+                "id": "worker",
+                "revision": "rev-worker"
+            },
+            "event": {
+                "type": "started"
+            }
+        })
+    );
+    assert_eq!(
+        serde_json::from_value::<InvocationEvent>(encoded).unwrap(),
+        event
+    );
+    assert_eq!(event.contract(), InvocationEventVersion::V1);
+
+    assert!(serde_json::from_value::<InvocationEvent>(json!({
+        "contract": "coven.agent-invocation-event.v1",
+        "invocation": {
+            "id": "11111111-1111-4111-8111-111111111111"
+        },
+        "source": { "type": "caller" },
+        "requested_target": { "id": "worker" },
+        "event": { "type": "started", "unexpected": true }
+    }))
+    .is_err());
+    assert!(serde_json::from_value::<InvocationEvent>(json!({
+        "contract": "coven.agent-invocation-event.v1",
+        "invocation": {
+            "id": "11111111-1111-4111-8111-111111111111",
+            "unexpected": true
+        },
+        "source": { "type": "caller" },
+        "requested_target": { "id": "worker" },
+        "event": { "type": "started" }
+    }))
+    .is_err());
+}
+
+#[tokio::test]
+async fn runner_emits_revisioned_canonical_lifecycle_and_control_transfer_events() {
+    let triage = Agent::new(
+        "triage",
+        "Triage",
+        "Route.",
+        Arc::new(QueueModel::new([ModelResponse::actions(vec![
+            ModelAction::Handoff(HandoffCall::new("to-worker")),
+        ])])),
+    )
+    .with_revision("rev-triage".parse().unwrap())
+    .with_handoff(Handoff::new("to-worker", "Route to worker", "worker"));
+    let worker = Agent::new(
+        "worker",
+        "Worker",
+        "Answer.",
+        Arc::new(QueueModel::new([ModelResponse::final_output("Done.")])),
+    )
+    .with_revision("rev-worker".parse().unwrap());
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let runner = Runner::new([triage, worker])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+    let invocation = InvocationContext::child(
+        "22222222-2222-4222-8222-222222222222".parse().unwrap(),
+        "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+    );
+    let source = AgentRef::with_revision("planner", "rev-planner").unwrap();
+    let target = AgentRef::with_revision("triage", "rev-triage").unwrap();
+
+    let result = runner
+        .run_invocation(
+            InvocationRequest::new(
+                invocation.clone(),
+                InvocationSource::Agent {
+                    agent: source.clone(),
+                },
+                target.clone(),
+            ),
+            "Route this.",
+            &(),
+            RunOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.final_output, "Done.");
+    let events = observer.events();
+    assert_eq!(events.len(), 3, "expected start, transfer, terminal");
+    assert!(events.iter().all(|event| {
+        event.invocation == invocation
+            && event.requested_target == target
+            && event.source
+                == InvocationSource::Agent {
+                    agent: source.clone(),
+                }
+    }));
+    assert!(matches!(&events[0].event, InvocationEventKind::Started {}));
+    assert!(matches!(
+        &events[1].event,
+        InvocationEventKind::ControlTransferred { from, to, name }
+            if from == &AgentRef::with_revision("triage", "rev-triage").unwrap()
+                && to == &AgentRef::with_revision("worker", "rev-worker").unwrap()
+                && name == "to-worker"
+    ));
+    assert!(matches!(
+        &events[2].event,
+        InvocationEventKind::Completed {
+            final_agent,
+            turns: 2,
+            control_transfers: 1
+        } if final_agent == &AgentRef::with_revision("worker", "rev-worker").unwrap()
+    ));
+    for event in events {
+        let encoded = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            serde_json::from_value::<InvocationEvent>(encoded).unwrap(),
+            event
+        );
+    }
+}
+
+#[tokio::test]
+async fn revision_mismatch_fails_before_execution_with_unambiguous_event_fields() {
+    let agent = Agent::new(
+        "worker",
+        "Worker",
+        "Answer.",
+        Arc::new(QueueModel::new([ModelResponse::final_output("unused")])),
+    )
+    .with_revision("rev-current".parse().unwrap());
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let runner = Runner::new([agent])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+    let target = AgentRef::with_revision("worker", "rev-stale").unwrap();
+
+    let failure = runner
+        .run_invocation(
+            InvocationRequest::new(
+                InvocationContext::root("33333333-3333-4333-8333-333333333333".parse().unwrap()),
+                InvocationSource::Caller,
+                target.clone(),
+            ),
+            "Do not execute.",
+            &(),
+            RunOptions::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::AgentRevisionMismatch { .. }
+    ));
+    let events = observer.events();
+    assert_eq!(events.len(), 2, "expected start and terminal failure");
+    assert_eq!(events[0].requested_target, target);
+    assert!(matches!(
+        &events[1].event,
+        InvocationEventKind::Failed {
+            failed_at: None,
+            kind: InvocationFailureKind::Configuration
+        }
+    ));
+}
+
+#[tokio::test]
+async fn explicit_invocation_requires_the_registered_revision_when_one_exists() {
+    let agent = Agent::new(
+        "worker",
+        "Worker",
+        "Answer.",
+        Arc::new(QueueModel::new([ModelResponse::final_output("unused")])),
+    )
+    .with_revision("rev-current".parse().unwrap());
+    let runner = Runner::new([agent]).unwrap();
+
+    let failure = runner
+        .run_invocation(
+            InvocationRequest::new(
+                InvocationContext::root("44444444-4444-4444-8444-444444444444".parse().unwrap()),
+                InvocationSource::Caller,
+                AgentRef::new("worker").unwrap(),
+            ),
+            "Do not execute.",
+            &(),
+            RunOptions::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::AgentRevisionRequired { .. }
+    ));
+}
+
+#[tokio::test]
+async fn explicit_invocation_rejects_an_unrevisioned_registration() {
+    let agent = Agent::new(
+        "worker",
+        "Worker",
+        "Answer.",
+        Arc::new(QueueModel::new([ModelResponse::final_output("unused")])),
+    );
+    let runner = Runner::new([agent]).unwrap();
+
+    let failure = runner
+        .run_invocation(
+            InvocationRequest::new(
+                InvocationContext::root("55555555-5555-4555-8555-555555555555".parse().unwrap()),
+                InvocationSource::Caller,
+                AgentRef::new("worker").unwrap(),
+            ),
+            "Do not execute.",
+            &(),
+            RunOptions::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::AgentRevisionRequired { ref agent } if agent.as_str() == "worker"
+    ));
+}
+
+#[tokio::test]
+async fn compatibility_run_resolves_the_registered_revision_for_canonical_events() {
+    let agent = Agent::new(
+        "worker",
+        "Worker",
+        "Answer.",
+        Arc::new(QueueModel::new([ModelResponse::final_output("Done.")])),
+    )
+    .with_revision("rev-current".parse().unwrap());
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let runner = Runner::new([agent])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+
+    runner
+        .run("worker", "Execute.", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    let expected = AgentRef::with_revision("worker", "rev-current").unwrap();
+    let events = observer.events();
+    assert!(events
+        .iter()
+        .all(|event| event.requested_target == expected));
+}
+
+#[tokio::test]
+async fn execution_failure_reports_the_exact_agent_revision_where_it_failed() {
+    let agent = Agent::new("worker", "Worker", "Answer.", Arc::new(QueueModel::new([])))
+        .with_revision("rev-current".parse().unwrap());
+    let observer = Arc::new(RecordingInvocationObserver::default());
+    let runner = Runner::new([agent])
+        .unwrap()
+        .with_invocation_observer(observer.clone());
+
+    let failure = runner
+        .run("worker", "Fail.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(failure.error, RunError::ModelFailed { .. }));
+    let events = observer.events();
+    assert!(matches!(
+        &events.last().unwrap().event,
+        InvocationEventKind::Failed {
+            failed_at: Some(agent),
+            kind: InvocationFailureKind::Model
+        } if agent == &AgentRef::with_revision("worker", "rev-current").unwrap()
+    ));
+}

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -591,6 +591,19 @@ fn rejects_handoffs_to_unregistered_agents() {
     );
 }
 
+#[test]
+fn rejects_registered_agents_without_valid_identity_refs() {
+    let model = Arc::new(QueueModel::default());
+    let agent = Agent::new("invalid agent", "Invalid", "Answer.", model);
+
+    let error = Runner::new([agent]).err().unwrap();
+
+    assert!(matches!(
+        error,
+        ConfigError::InvalidAgentRef { ref agent, .. } if agent.as_str() == "invalid agent"
+    ));
+}
+
 #[tokio::test]
 async fn unknown_starting_agent_reports_a_paired_run_lifecycle() {
     let model = Arc::new(QueueModel::new([ModelResponse::final_output("unused")]));


### PR DESCRIPTION
## Context

- Adds the next bounded contract slice for #804 after the merged invocation-correlation checkpoint in #956.
- Introduces validated revision-aware agent references and a separate canonical invocation event stream without turning `coven-agents` into a durable or distributed runtime.
- Refs #804; the broader delegation, authority, persistence, executor, and legacy-removal stages remain open.

## Implementation

- Add `AgentRef` and `AgentRevision` with closed serde decoding and validation for empty, oversized, whitespace-bearing, and control-bearing values.
- Validate every registered legacy `AgentId` in `Runner::new`; optional immutable revisions are attached with `Agent::with_revision`.
- Add `InvocationRequest`, `InvocationSource`, `InvocationObserver`, and the versioned `coven.agent-invocation-event.v1` wire contract.
- Emit one canonical start and one terminal event, plus explicit `control_transferred` events for legacy in-run handoffs. Events retain the original source/requested target and distinguish terminal `failed_at` from the requested target.
- Require exact revision binding on the explicit `run_invocation` API. Existing `run`, `run_with_invocation`, `RunEvent`, result, failure, model, tool, session, and loop behavior remain compatible; legacy entry points resolve the registered revision automatically.
- Keep attempt/executor, authority, adoption, retry, persistence, transport, and durable delegation semantics out of this slice.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked --quiet`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `git diff --cached --check`
- [x] Focused `coven-agents` tests, including 9 new contract tests
- [x] Independent code review; explicit unrevisioned invocation gap fixed and re-reviewed with no significant findings

## Risk and Rollback

- Risk: Medium. The new wire/API surface is additive, but `Runner::new` now rejects malformed legacy agent IDs and `ConfigError`/`RunError` gain explicit validation variants. Existing valid callers retain their call shapes and behavior.
- Rollback: Revert commit `45fa0efd3ce41df8e7bff364ed160bede22f8955`; no data migration is involved.

## Agent Handoff

- Current state: Exact local workspace gates pass on `45fa0efd3ce41df8e7bff364ed160bede22f8955` based on `8bab50f6bedd35550d893e229fb799b7a52c05c4`.
- Follow-up: Continue #804 with a separately reviewed bounded `DelegationSpec` and context/authority contract. Do not add retries or remote execution before durable adoption semantics exist.
- Known gaps: Canonical events intentionally do not claim durable storage, idempotency, authority, attempt/executor binding, cancellation, recovery, or transport semantics.
