### PR TITLE
feat: add calendar scheduler conformance

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -123,6 +123,7 @@ source metadata for the files and binary under test. `source.commit` must equal
 The checked-in
 [`attempt-terminal-immutability.vectors.json`](attempt-terminal-immutability.vectors.json),
 [`capability-negotiation.vectors.json`](capability-negotiation.vectors.json),
+[`calendar-schedule-resolution.vectors.json`](calendar-schedule-resolution.vectors.json),
 [`command-adoption-idempotency.vectors.json`](command-adoption-idempotency.vectors.json),
 [`definition-lifecycle-transitions.vectors.json`](definition-lifecycle-transitions.vectors.json),
 [`definition-validation.vectors.json`](definition-validation.vectors.json),
@@ -162,6 +163,7 @@ The runner invokes the target directly without a shell.
     {
       "profile": "scheduler_reliability",
       "suites": [
+        "calendar-schedule-resolution",
         "misfire-latest-planning"
       ]
     }
@@ -175,8 +177,8 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements ten structural suites and one
-scheduler-reliability suite.
+The native Coven target currently implements ten structural suites and two
+scheduler-reliability suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
 refused. `capability-negotiation` executes the checked-in cases against Rust's
@@ -197,6 +199,12 @@ normalized JCS digest matches and rejecting a tampered definition.
 `event-reducer-determinism` replays a portable event stream through the native
 Rust reducer both canonically and with an exact duplicate delivery, requiring
 the same normalized final state and expected digest.
+`calendar-schedule-resolution` executes fixed UTC and IANA-timezone cases
+through the production scheduler. It covers same-day and multi-hour daily
+schedules, weekly weekday selection, winter and summer offsets, skipped DST
+gaps, deterministic selection of the first DST-fold occurrence, leap-day,
+month, and year boundaries, and fail-closed refusal of unresolved `local`
+timezones.
 `misfire-latest-planning` executes fixed virtual-time cases through the
 production occurrence planner. It proves that downtime collapses daily work to
 the latest due slot, exact replay is idempotent, a clock rollback does not add

--- a/conformance/automations/runner/calendar-schedule-resolution.vectors.json
+++ b/conformance/automations/runner/calendar-schedule-resolution.vectors.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": "coven.automations.calendar-schedule-resolution-vectors.v1",
+  "cases": [
+    {
+      "caseId": "daily-same-day",
+      "scenario": "daily_same_day",
+      "rrule": "FREQ=DAILY;BYHOUR=9",
+      "timezone": "utc",
+      "from": "2026-08-28T08:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-08-28T09:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "multiple-daily-hours",
+      "scenario": "multiple_daily_hours",
+      "rrule": "FREQ=DAILY;BYHOUR=9,17",
+      "timezone": "utc",
+      "from": "2026-08-28T12:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-08-28T17:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "weekly-weekday",
+      "scenario": "weekly_weekday",
+      "rrule": "FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=8",
+      "timezone": "utc",
+      "from": "2026-08-28T09:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-08-31T08:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "iana-winter-offset",
+      "scenario": "iana_winter_offset",
+      "rrule": "FREQ=DAILY;BYHOUR=9",
+      "timezone": "America/New_York",
+      "from": "2026-01-15T13:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-01-15T14:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "iana-summer-offset",
+      "scenario": "iana_summer_offset",
+      "rrule": "FREQ=DAILY;BYHOUR=9",
+      "timezone": "America/New_York",
+      "from": "2026-07-15T12:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-07-15T13:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "dst-spring-gap",
+      "scenario": "dst_spring_gap",
+      "rrule": "FREQ=DAILY;BYHOUR=2",
+      "timezone": "America/New_York",
+      "from": "2026-03-07T08:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-03-09T06:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "dst-fall-fold",
+      "scenario": "dst_fall_fold",
+      "rrule": "FREQ=DAILY;BYHOUR=1",
+      "timezone": "America/New_York",
+      "from": "2026-11-01T04:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-11-01T05:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "leap-day-boundary",
+      "scenario": "leap_day_boundary",
+      "rrule": "FREQ=DAILY;BYHOUR=9",
+      "timezone": "utc",
+      "from": "2028-02-28T10:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2028-02-29T09:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "month-boundary",
+      "scenario": "month_boundary",
+      "rrule": "FREQ=DAILY;BYHOUR=9",
+      "timezone": "utc",
+      "from": "2026-08-31T10:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2026-09-01T09:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "year-boundary",
+      "scenario": "year_boundary",
+      "rrule": "FREQ=WEEKLY;BYDAY=FR;BYHOUR=8",
+      "timezone": "utc",
+      "from": "2026-12-31T12:00:00.000Z",
+      "expected": {
+        "outcome": "scheduled",
+        "nextDueAt": "2027-01-01T08:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "local-timezone-refused",
+      "scenario": "local_timezone_refused",
+      "rrule": "FREQ=DAILY;BYHOUR=9",
+      "timezone": "local",
+      "from": "2026-08-28T08:00:00.000Z",
+      "expected": {
+        "outcome": "rejected",
+        "reason": "local_timezone_unresolved"
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -28,6 +28,8 @@ const SUITE_REQUEST_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-
 const SUITE_RESULT_SCHEMA_VERSION: &str = "coven.automations.conformance-suite-result.v1";
 const CAPABILITY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.capability-negotiation-vectors.v1";
+const CALENDAR_SCHEDULE_RESOLUTION_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.calendar-schedule-resolution-vectors.v1";
 const COMMAND_ADOPTION_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.command-adoption-idempotency-vectors.v1";
 const DEFINITION_LIFECYCLE_VECTOR_SCHEMA_VERSION: &str =
@@ -53,6 +55,7 @@ const SCHEDULER_RELIABILITY_PROFILE: &str = "scheduler_reliability";
 const MAX_CASES: usize = 128;
 
 pub const CAPABILITY_NEGOTIATION_SUITE: &str = "capability-negotiation";
+pub const CALENDAR_SCHEDULE_RESOLUTION_SUITE: &str = "calendar-schedule-resolution";
 pub const ATTEMPT_TERMINAL_IMMUTABILITY_SUITE: &str = "attempt-terminal-immutability";
 pub const COMMAND_ADOPTION_IDEMPOTENCY_SUITE: &str = "command-adoption-idempotency";
 pub const DEFINITION_LIFECYCLE_TRANSITIONS_SUITE: &str = "definition-lifecycle-transitions";
@@ -434,6 +437,106 @@ struct OccurrenceFenceVectorSet {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CalendarScheduleResolutionVectorSet {
+    schema_version: String,
+    cases: Vec<CalendarScheduleResolutionVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CalendarScheduleResolutionVectorCase {
+    case_id: String,
+    scenario: CalendarScheduleResolutionScenario,
+    rrule: String,
+    timezone: String,
+    from: String,
+    expected: ExpectedCalendarScheduleResolution,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CalendarScheduleResolutionScenario {
+    DailySameDay,
+    MultipleDailyHours,
+    WeeklyWeekday,
+    IanaWinterOffset,
+    IanaSummerOffset,
+    DstSpringGap,
+    DstFallFold,
+    LeapDayBoundary,
+    MonthBoundary,
+    YearBoundary,
+    LocalTimezoneRefused,
+}
+
+impl CalendarScheduleResolutionScenario {
+    const COUNT: usize = 11;
+
+    const fn input(self) -> (&'static str, &'static str, &'static str) {
+        match self {
+            Self::DailySameDay => ("FREQ=DAILY;BYHOUR=9", "utc", "2026-08-28T08:00:00.000Z"),
+            Self::MultipleDailyHours => {
+                ("FREQ=DAILY;BYHOUR=9,17", "utc", "2026-08-28T12:00:00.000Z")
+            }
+            Self::WeeklyWeekday => (
+                "FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=8",
+                "utc",
+                "2026-08-28T09:00:00.000Z",
+            ),
+            Self::IanaWinterOffset => (
+                "FREQ=DAILY;BYHOUR=9",
+                "America/New_York",
+                "2026-01-15T13:00:00.000Z",
+            ),
+            Self::IanaSummerOffset => (
+                "FREQ=DAILY;BYHOUR=9",
+                "America/New_York",
+                "2026-07-15T12:00:00.000Z",
+            ),
+            Self::DstSpringGap => (
+                "FREQ=DAILY;BYHOUR=2",
+                "America/New_York",
+                "2026-03-07T08:00:00.000Z",
+            ),
+            Self::DstFallFold => (
+                "FREQ=DAILY;BYHOUR=1",
+                "America/New_York",
+                "2026-11-01T04:00:00.000Z",
+            ),
+            Self::LeapDayBoundary => ("FREQ=DAILY;BYHOUR=9", "utc", "2028-02-28T10:00:00.000Z"),
+            Self::MonthBoundary => ("FREQ=DAILY;BYHOUR=9", "utc", "2026-08-31T10:00:00.000Z"),
+            Self::YearBoundary => (
+                "FREQ=WEEKLY;BYDAY=FR;BYHOUR=8",
+                "utc",
+                "2026-12-31T12:00:00.000Z",
+            ),
+            Self::LocalTimezoneRefused => {
+                ("FREQ=DAILY;BYHOUR=9", "local", "2026-08-28T08:00:00.000Z")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case", deny_unknown_fields)]
+enum ExpectedCalendarScheduleResolution {
+    Scheduled {
+        #[serde(rename = "nextDueAt")]
+        next_due_at: String,
+    },
+    Rejected {
+        reason: CalendarScheduleRejection,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CalendarScheduleRejection {
+    LocalTimezoneUnresolved,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct MisfireLatestPlanningVectorSet {
     schema_version: String,
     cases: Vec<MisfireLatestPlanningVectorCase>,
@@ -700,7 +803,10 @@ pub fn capability() -> TargetCapability {
             },
             TargetProfileCapability {
                 profile: SCHEDULER_RELIABILITY_PROFILE,
-                suites: vec![MISFIRE_LATEST_PLANNING_SUITE],
+                suites: vec![
+                    CALENDAR_SCHEDULE_RESOLUTION_SUITE,
+                    MISFIRE_LATEST_PLANNING_SUITE,
+                ],
             },
         ],
     }
@@ -744,6 +850,9 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         (STRUCTURAL_PROFILE, RRULE_VOCABULARY_SUITE) => evaluate_rrule_vocabulary(&request.vector)?,
         (STRUCTURAL_PROFILE, RUN_TERMINAL_MONOTONICITY_SUITE) => {
             evaluate_run_terminal_monotonicity(&request.vector)?
+        }
+        (SCHEDULER_RELIABILITY_PROFILE, CALENDAR_SCHEDULE_RESOLUTION_SUITE) => {
+            evaluate_calendar_schedule_resolution(&request.vector)?
         }
         (SCHEDULER_RELIABILITY_PROFILE, MISFIRE_LATEST_PLANNING_SUITE) => {
             evaluate_misfire_latest_planning(&request.vector)?
@@ -1273,6 +1382,101 @@ fn event_reducer_case_matches(case: &EventReducerVectorCase) -> Result<bool, &'s
         canonicalize(canonical.state()).map_err(|_| "conformance suite execution failed")?;
     let observed_digest = format!("sha256:{}", sha256_hex(&canonical_state));
     Ok(canonical.state() == duplicated.state() && observed_digest == case.expected_state_digest)
+}
+
+fn evaluate_calendar_schedule_resolution(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: CalendarScheduleResolutionVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != CALENDAR_SCHEDULE_RESOLUTION_VECTOR_SCHEMA_VERSION
+        || vectors.cases.is_empty()
+        || vectors.cases.len() > MAX_CASES
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut scenarios = BTreeSet::new();
+    for case in &vectors.cases {
+        let (rrule, timezone, from) = case.scenario.input();
+        let expected_shape_matches = match (&case.scenario, &case.expected) {
+            (
+                CalendarScheduleResolutionScenario::LocalTimezoneRefused,
+                ExpectedCalendarScheduleResolution::Rejected {
+                    reason: CalendarScheduleRejection::LocalTimezoneUnresolved,
+                },
+            ) => true,
+            (
+                CalendarScheduleResolutionScenario::LocalTimezoneRefused,
+                ExpectedCalendarScheduleResolution::Scheduled { .. },
+            )
+            | (
+                _,
+                ExpectedCalendarScheduleResolution::Rejected {
+                    reason: CalendarScheduleRejection::LocalTimezoneUnresolved,
+                },
+            ) => false,
+            (_, ExpectedCalendarScheduleResolution::Scheduled { next_due_at }) => {
+                canonical_timestamp(next_due_at).is_some()
+            }
+        };
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !scenarios.insert(case.scenario)
+            || case.rrule != rrule
+            || case.timezone != timezone
+            || case.from != from
+            || canonical_timestamp(&case.from).is_none()
+            || !expected_shape_matches
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+    if scenarios.len() != CalendarScheduleResolutionScenario::COUNT {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut all_passed = true;
+    for case in &vectors.cases {
+        all_passed &= calendar_schedule_resolution_case_matches(case)?;
+    }
+    Ok(all_passed)
+}
+
+fn calendar_schedule_resolution_case_matches(
+    case: &CalendarScheduleResolutionVectorCase,
+) -> Result<bool, &'static str> {
+    let definition = super::definition::RoutineDefinition::from_json(&json!({
+        "schemaVersion": 1,
+        "id": case.case_id,
+        "name": "Calendar schedule conformance",
+        "status": "ACTIVE",
+        "rrule": case.rrule,
+        "timezone": case.timezone,
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the calendar schedule conformance probe.",
+        "tags": []
+    }))
+    .map_err(|_| "conformance vector is invalid")?;
+    let from = canonical_timestamp(&case.from).ok_or("conformance vector is invalid")?;
+    let observed = super::schedule::next_due(&definition.rrule, definition.timezone, from);
+
+    Ok(match (&case.expected, observed) {
+        (ExpectedCalendarScheduleResolution::Scheduled { next_due_at }, Ok(Some(observed))) => {
+            canonical_timestamp(next_due_at).is_some_and(|expected| expected == observed)
+        }
+        (
+            ExpectedCalendarScheduleResolution::Rejected {
+                reason: CalendarScheduleRejection::LocalTimezoneUnresolved,
+            },
+            Err(error),
+        ) => {
+            error == "timezone `local` must be resolved to an exact IANA timezone before scheduling"
+        }
+        _ => false,
+    })
 }
 
 fn evaluate_misfire_latest_planning(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -2,7 +2,8 @@ use serde_json::{json, Value};
 
 use super::conformance_target::{
     capability, evaluate, evaluate_run_terminal_monotonicity_case_counts, TargetSuiteStatus,
-    CAPABILITY_NEGOTIATION_SUITE, MISFIRE_LATEST_PLANNING_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
+    CALENDAR_SCHEDULE_RESOLUTION_SUITE, CAPABILITY_NEGOTIATION_SUITE,
+    MISFIRE_LATEST_PLANNING_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
 const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
@@ -10,6 +11,9 @@ const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
 );
 const COMMAND_ADOPTION_IDEMPOTENCY_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/command-adoption-idempotency.vectors.json"
+);
+const CALENDAR_SCHEDULE_RESOLUTION_VECTORS: &str = include_str!(
+    "../../../../conformance/automations/runner/calendar-schedule-resolution.vectors.json"
 );
 const DEFINITION_LIFECYCLE_TRANSITIONS_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/definition-lifecycle-transitions.vectors.json"
@@ -87,10 +91,86 @@ fn capability_advertises_the_native_structural_suites() {
                 },
                 {
                     "profile": "scheduler_reliability",
-                    "suites": [MISFIRE_LATEST_PLANNING_SUITE]
+                    "suites": [
+                        CALENDAR_SCHEDULE_RESOLUTION_SUITE,
+                        MISFIRE_LATEST_PLANNING_SUITE
+                    ]
                 }
             ]
         })
+    );
+}
+
+#[test]
+fn calendar_schedule_resolution_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(CALENDAR_SCHEDULE_RESOLUTION_VECTORS).unwrap();
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        CALENDAR_SCHEDULE_RESOLUTION_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 11);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 11);
+}
+
+#[test]
+fn calendar_schedule_resolution_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(CALENDAR_SCHEDULE_RESOLUTION_VECTORS).unwrap();
+    vectors["cases"][5]["expected"]["nextDueAt"] = json!("2026-03-08T07:00:00.000Z");
+
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        CALENDAR_SCHEDULE_RESOLUTION_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn calendar_schedule_resolution_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 7] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone(),
+        |vectors| vectors["cases"][1]["scenario"] = vectors["cases"][0]["scenario"].clone(),
+        |vectors| vectors["cases"][0]["from"] = json!("not-a-time"),
+        |vectors| vectors["cases"][5]["timezone"] = json!("utc"),
+        |vectors| {
+            vectors["cases"][10]["expected"] = json!({
+                "outcome": "scheduled",
+                "nextDueAt": "2026-08-28T09:00:00.000Z"
+            })
+        },
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value =
+            serde_json::from_str(CALENDAR_SCHEDULE_RESOLUTION_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for_profile(
+                "scheduler_reliability",
+                CALENDAR_SCHEDULE_RESOLUTION_SUITE,
+                vectors,
+            ))
+            .unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
+fn calendar_schedule_resolution_suite_requires_scheduler_profile() {
+    let vectors: Value = serde_json::from_str(CALENDAR_SCHEDULE_RESOLUTION_VECTORS).unwrap();
+    assert_eq!(
+        evaluate(&request_for(CALENDAR_SCHEDULE_RESOLUTION_SUITE, vectors)).unwrap_err(),
+        "conformance suite is unsupported"
     );
 }
 

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -10,6 +10,9 @@ const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
 const COMMAND_ADOPTION_IDEMPOTENCY_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/command-adoption-idempotency.vectors.json"
 );
+const CALENDAR_SCHEDULE_RESOLUTION_VECTORS: &str = include_str!(
+    "../../../conformance/automations/runner/calendar-schedule-resolution.vectors.json"
+);
 const DEFINITION_LIFECYCLE_TRANSITIONS_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/definition-lifecycle-transitions.vectors.json"
 );
@@ -108,11 +111,55 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                 },
                 {
                     "profile": "scheduler_reliability",
-                    "suites": ["misfire-latest-planning"]
+                    "suites": [
+                        "calendar-schedule-resolution",
+                        "misfire-latest-planning"
+                    ]
                 }
             ]
         })
     );
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_calendar_schedule_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(CALENDAR_SCHEDULE_RESOLUTION_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "scheduler_reliability",
+        "suiteId": "calendar-schedule-resolution",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "calendar-schedule-resolution");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 11);
+    assert_eq!(response["evidence"]["passedCases"], 11);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Adds a deterministic, portable calendar schedule resolution suite to the native Coven Automations conformance target.
- Files changed: native target validation/execution, 11 checked-in vectors, target/unit integration tests, and runner documentation.
- Refs #858

## Implementation

- Approach: Advertise `calendar-schedule-resolution` under `scheduler_reliability`, validate a closed 11-scenario vector inventory, parse each schedule through `RoutineDefinition::from_json`, and execute production `schedule::next_due`.
- User-visible behavior: Conformance consumers can now verify daily and weekly UTC scheduling, multiple daily hours, IANA winter/summer offsets, DST gaps/folds, leap/month/year boundaries, and fail-closed unresolved `local` timezones.
- Compatibility notes: Additive target capability only. The runner remains audit-only, raw target evidence remains discarded, and no release-eligibility or aggregate `full` claim is added.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `cargo test -p coven-cli automations::conformance_target_tests --locked`
- [x] `cargo test -p coven-cli --test automations_conformance --locked`
- [x] Independent code review found no significant issues.

## Risk and Rollback

- Risk level: Low. The change is additive and isolated to the audit-only conformance target.
- Rollback plan: Revert this commit to remove the advertised suite, vectors, tests, and documentation.

## Agent Handoff

- Current state: Complete and locally verified against the exact committed tree.
- Follow-ups: Continue the remaining scheduler reliability, chaos, SLO, diagnostics, authority, privacy, and interoperability inventory tracked by #858.
- Known gaps: This slice does not claim complete Scheduler Reliability or release eligibility.
