### PR TITLE
feat: add occurrence lease recovery conformance

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -130,6 +130,7 @@ The checked-in
 [`event-reducer-determinism.vectors.json`](event-reducer-determinism.vectors.json),
 [`misfire-latest-planning.vectors.json`](misfire-latest-planning.vectors.json),
 [`occurrence-fence-uniqueness.vectors.json`](occurrence-fence-uniqueness.vectors.json),
+[`occurrence-lease-recovery.vectors.json`](occurrence-lease-recovery.vectors.json),
 [`receipt-integrity-validation.vectors.json`](receipt-integrity-validation.vectors.json),
 [`rrule-vocabulary.vectors.json`](rrule-vocabulary.vectors.json), and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
@@ -164,7 +165,8 @@ The runner invokes the target directly without a shell.
       "profile": "scheduler_reliability",
       "suites": [
         "calendar-schedule-resolution",
-        "misfire-latest-planning"
+        "misfire-latest-planning",
+        "occurrence-lease-recovery"
       ]
     }
   ]
@@ -177,7 +179,7 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements ten structural suites and two
+The native Coven target currently implements ten structural suites and three
 scheduler-reliability suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
@@ -209,6 +211,11 @@ timezones.
 production occurrence planner. It proves that downtime collapses daily work to
 the latest due slot, exact replay is idempotent, a clock rollback does not add
 an older fence, and paused definitions do not plan.
+`occurrence-lease-recovery` executes fixed virtual-time cases through the
+production expired-lease recovery path. It proves that pre-dispatch claims are
+recovered after and exactly at lease expiry, unexpired claims remain owned, and
+runtime-owned or runtime-evidenced work is never treated as safe to fail from a
+lease timeout alone.
 `occurrence-fence-uniqueness` executes a portable three-case matrix against the
 production SQLite occurrence schema, proving that one automation cannot claim
 the same scheduled slot twice while different automations may share a slot and

--- a/conformance/automations/runner/occurrence-lease-recovery.vectors.json
+++ b/conformance/automations/runner/occurrence-lease-recovery.vectors.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": "coven.automations.occurrence-lease-recovery-vectors.v1",
+  "cases": [
+    {
+      "caseId": "expired-before-dispatch",
+      "scenario": "expired_before_dispatch",
+      "now": "2026-09-01T10:00:00.000Z",
+      "initial": {
+        "state": "claimed",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T09:59:59.999Z",
+        "runningRun": false
+      },
+      "expected": {
+        "recoveredCount": 1,
+        "state": "failed",
+        "leaseOwner": null,
+        "leaseExpiresAt": null,
+        "failureReason": "lease expired"
+      }
+    },
+    {
+      "caseId": "exact-lease-deadline",
+      "scenario": "exact_lease_deadline",
+      "now": "2026-09-01T10:00:00.000Z",
+      "initial": {
+        "state": "claimed",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T10:00:00.000Z",
+        "runningRun": false
+      },
+      "expected": {
+        "recoveredCount": 1,
+        "state": "failed",
+        "leaseOwner": null,
+        "leaseExpiresAt": null,
+        "failureReason": "lease expired"
+      }
+    },
+    {
+      "caseId": "unexpired-claim",
+      "scenario": "unexpired_claim",
+      "now": "2026-09-01T10:00:00.000Z",
+      "initial": {
+        "state": "claimed",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T10:00:00.001Z",
+        "runningRun": false
+      },
+      "expected": {
+        "recoveredCount": 0,
+        "state": "claimed",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T10:00:00.001Z",
+        "failureReason": null
+      }
+    },
+    {
+      "caseId": "runtime-owned-occurrence",
+      "scenario": "runtime_owned_occurrence",
+      "now": "2026-09-01T10:00:00.000Z",
+      "initial": {
+        "state": "running",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T09:59:59.999Z",
+        "runningRun": false
+      },
+      "expected": {
+        "recoveredCount": 0,
+        "state": "running",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T09:59:59.999Z",
+        "failureReason": null
+      }
+    },
+    {
+      "caseId": "claimed-with-runtime-evidence",
+      "scenario": "claimed_with_runtime_evidence",
+      "now": "2026-09-01T10:00:00.000Z",
+      "initial": {
+        "state": "claimed",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T09:59:59.999Z",
+        "runningRun": true
+      },
+      "expected": {
+        "recoveredCount": 0,
+        "state": "claimed",
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T09:59:59.999Z",
+        "failureReason": null
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -42,6 +42,8 @@ const EVENT_REDUCER_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.event-reducer-determinism-vectors.v1";
 const MISFIRE_LATEST_PLANNING_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.misfire-latest-planning-vectors.v1";
+const OCCURRENCE_LEASE_RECOVERY_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.occurrence-lease-recovery-vectors.v1";
 const OCCURRENCE_FENCE_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-fence-uniqueness-vectors.v1";
 const RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION: &str =
@@ -62,6 +64,7 @@ pub const DEFINITION_LIFECYCLE_TRANSITIONS_SUITE: &str = "definition-lifecycle-t
 pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
 pub const MISFIRE_LATEST_PLANNING_SUITE: &str = "misfire-latest-planning";
+pub const OCCURRENCE_LEASE_RECOVERY_SUITE: &str = "occurrence-lease-recovery";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
 pub const RECEIPT_INTEGRITY_VALIDATION_SUITE: &str = "receipt-integrity-validation";
 pub const RRULE_VOCABULARY_SUITE: &str = "rrule-vocabulary";
@@ -537,6 +540,109 @@ enum CalendarScheduleRejection {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct OccurrenceLeaseRecoveryVectorSet {
+    schema_version: String,
+    cases: Vec<OccurrenceLeaseRecoveryVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct OccurrenceLeaseRecoveryVectorCase {
+    case_id: String,
+    scenario: OccurrenceLeaseRecoveryScenario,
+    now: String,
+    initial: InitialOccurrenceLease,
+    expected: ExpectedOccurrenceLeaseRecovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum OccurrenceLeaseRecoveryScenario {
+    ExpiredBeforeDispatch,
+    ExactLeaseDeadline,
+    UnexpiredClaim,
+    RuntimeOwnedOccurrence,
+    ClaimedWithRuntimeEvidence,
+}
+
+impl OccurrenceLeaseRecoveryScenario {
+    const COUNT: usize = 5;
+
+    const fn input(self) -> (&'static str, LeaseOccurrenceState, &'static str, bool) {
+        match self {
+            Self::ExpiredBeforeDispatch => (
+                "2026-09-01T10:00:00.000Z",
+                LeaseOccurrenceState::Claimed,
+                "2026-09-01T09:59:59.999Z",
+                false,
+            ),
+            Self::ExactLeaseDeadline => (
+                "2026-09-01T10:00:00.000Z",
+                LeaseOccurrenceState::Claimed,
+                "2026-09-01T10:00:00.000Z",
+                false,
+            ),
+            Self::UnexpiredClaim => (
+                "2026-09-01T10:00:00.000Z",
+                LeaseOccurrenceState::Claimed,
+                "2026-09-01T10:00:00.001Z",
+                false,
+            ),
+            Self::RuntimeOwnedOccurrence => (
+                "2026-09-01T10:00:00.000Z",
+                LeaseOccurrenceState::Running,
+                "2026-09-01T09:59:59.999Z",
+                false,
+            ),
+            Self::ClaimedWithRuntimeEvidence => (
+                "2026-09-01T10:00:00.000Z",
+                LeaseOccurrenceState::Claimed,
+                "2026-09-01T09:59:59.999Z",
+                true,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct InitialOccurrenceLease {
+    state: LeaseOccurrenceState,
+    lease_owner: String,
+    lease_expires_at: String,
+    running_run: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LeaseOccurrenceState {
+    Claimed,
+    Running,
+    Failed,
+}
+
+impl LeaseOccurrenceState {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Claimed => "claimed",
+            Self::Running => "running",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedOccurrenceLeaseRecovery {
+    recovered_count: usize,
+    state: LeaseOccurrenceState,
+    lease_owner: Option<String>,
+    lease_expires_at: Option<String>,
+    failure_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct MisfireLatestPlanningVectorSet {
     schema_version: String,
     cases: Vec<MisfireLatestPlanningVectorCase>,
@@ -806,6 +912,7 @@ pub fn capability() -> TargetCapability {
                 suites: vec![
                     CALENDAR_SCHEDULE_RESOLUTION_SUITE,
                     MISFIRE_LATEST_PLANNING_SUITE,
+                    OCCURRENCE_LEASE_RECOVERY_SUITE,
                 ],
             },
         ],
@@ -856,6 +963,9 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         }
         (SCHEDULER_RELIABILITY_PROFILE, MISFIRE_LATEST_PLANNING_SUITE) => {
             evaluate_misfire_latest_planning(&request.vector)?
+        }
+        (SCHEDULER_RELIABILITY_PROFILE, OCCURRENCE_LEASE_RECOVERY_SUITE) => {
+            evaluate_occurrence_lease_recovery(&request.vector)?
         }
         _ => return Err("conformance suite is unsupported"),
     };
@@ -1477,6 +1587,150 @@ fn calendar_schedule_resolution_case_matches(
         }
         _ => false,
     })
+}
+
+fn evaluate_occurrence_lease_recovery(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: OccurrenceLeaseRecoveryVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != OCCURRENCE_LEASE_RECOVERY_VECTOR_SCHEMA_VERSION
+        || vectors.cases.len() != OccurrenceLeaseRecoveryScenario::COUNT
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut scenarios = BTreeSet::new();
+    for case in &vectors.cases {
+        let (now, state, lease_expires_at, running_run) = case.scenario.input();
+        let expected_is_coherent = match case.expected.state {
+            LeaseOccurrenceState::Failed => {
+                case.expected.lease_owner.is_none()
+                    && case.expected.lease_expires_at.is_none()
+                    && case.expected.failure_reason.as_deref() == Some("lease expired")
+            }
+            LeaseOccurrenceState::Claimed | LeaseOccurrenceState::Running => {
+                case.expected
+                    .lease_owner
+                    .as_deref()
+                    .is_some_and(|owner| !owner.is_empty())
+                    && case
+                        .expected
+                        .lease_expires_at
+                        .as_deref()
+                        .and_then(canonical_timestamp)
+                        .is_some()
+                    && case.expected.failure_reason.is_none()
+            }
+        };
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !scenarios.insert(case.scenario)
+            || case.now != now
+            || case.initial.state != state
+            || case.initial.lease_owner != "daemon-a"
+            || case.initial.lease_expires_at != lease_expires_at
+            || case.initial.running_run != running_run
+            || canonical_timestamp(&case.now).is_none()
+            || canonical_timestamp(&case.initial.lease_expires_at).is_none()
+            || case.expected.recovered_count > 1
+            || !expected_is_coherent
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+    if scenarios.len() != OccurrenceLeaseRecoveryScenario::COUNT {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut all_passed = true;
+    for (case_index, case) in vectors.cases.iter().enumerate() {
+        all_passed &= occurrence_lease_recovery_case_matches(case_index, case)?;
+    }
+    Ok(all_passed)
+}
+
+fn occurrence_lease_recovery_case_matches(
+    case_index: usize,
+    case: &OccurrenceLeaseRecoveryVectorCase,
+) -> Result<bool, &'static str> {
+    let conn = command_conformance_connection()?;
+    let automation_id = format!("lease-conformance-{case_index}");
+    let definition = super::definition::RoutineDefinition::from_json(&json!({
+        "schemaVersion": 1,
+        "id": automation_id,
+        "name": "Lease recovery conformance",
+        "status": "ACTIVE",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the occurrence lease recovery conformance probe.",
+        "tags": []
+    }))
+    .map_err(|_| "conformance suite execution failed")?;
+    super::store::insert_definition(&conn, &definition)
+        .map_err(|_| "conformance suite execution failed")?;
+    let occurrence_id = format!("lease-occurrence-{case_index}");
+    conn.execute(
+        "INSERT INTO automation_occurrences
+            (id, automation_id, automation_revision, definition_digest, scheduled_for,
+             kind, state, lease_owner, lease_expires_at, attempt, created_at, updated_at)
+         SELECT ?1, id, revision, definition_digest, '2026-09-01T09:00:00.000Z',
+                'scheduled', ?2, ?3, ?4, 1,
+                '2026-09-01T09:00:00.000Z', '2026-09-01T09:00:00.000Z'
+         FROM automation_definitions
+         WHERE id = ?5",
+        rusqlite::params![
+            occurrence_id,
+            case.initial.state.as_str(),
+            case.initial.lease_owner,
+            case.initial.lease_expires_at,
+            automation_id,
+        ],
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+    if case.initial.running_run {
+        conn.execute(
+            "INSERT INTO automation_runs
+                (id, automation_id, occurrence_id, status, started_at, timeout_at)
+             VALUES (?1, ?2, ?3, 'running',
+                     '2026-09-01T09:30:00.000Z', '2026-09-01T10:30:00.000Z')",
+            rusqlite::params![
+                format!("lease-run-{case_index}"),
+                automation_id,
+                occurrence_id,
+            ],
+        )
+        .map_err(|_| "conformance suite execution failed")?;
+    }
+
+    let now = canonical_timestamp(&case.now).ok_or("conformance vector is invalid")?;
+    let recovered = super::occurrences::recover_expired_leases(&conn, now)
+        .map_err(|_| "conformance suite execution failed")?;
+    let observed = conn
+        .query_row(
+            "SELECT state, lease_owner, lease_expires_at, failure_reason
+             FROM automation_occurrences
+             WHERE id = ?1",
+            [&occurrence_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            },
+        )
+        .map_err(|_| "conformance suite execution failed")?;
+
+    Ok(recovered == case.expected.recovered_count
+        && observed.0 == case.expected.state.as_str()
+        && observed.1 == case.expected.lease_owner
+        && observed.2 == case.expected.lease_expires_at
+        && observed.3 == case.expected.failure_reason)
 }
 
 fn evaluate_misfire_latest_planning(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -3,7 +3,8 @@ use serde_json::{json, Value};
 use super::conformance_target::{
     capability, evaluate, evaluate_run_terminal_monotonicity_case_counts, TargetSuiteStatus,
     CALENDAR_SCHEDULE_RESOLUTION_SUITE, CAPABILITY_NEGOTIATION_SUITE,
-    MISFIRE_LATEST_PLANNING_SUITE, RUN_TERMINAL_MONOTONICITY_SUITE,
+    MISFIRE_LATEST_PLANNING_SUITE, OCCURRENCE_LEASE_RECOVERY_SUITE,
+    RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
 const ATTEMPT_TERMINAL_IMMUTABILITY_VECTORS: &str = include_str!(
@@ -25,6 +26,9 @@ const EVENT_REDUCER_DETERMINISM_VECTORS: &str = include_str!(
 );
 const MISFIRE_LATEST_PLANNING_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/misfire-latest-planning.vectors.json");
+const OCCURRENCE_LEASE_RECOVERY_VECTORS: &str = include_str!(
+    "../../../../conformance/automations/runner/occurrence-lease-recovery.vectors.json"
+);
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -93,7 +97,8 @@ fn capability_advertises_the_native_structural_suites() {
                     "profile": "scheduler_reliability",
                     "suites": [
                         CALENDAR_SCHEDULE_RESOLUTION_SUITE,
-                        MISFIRE_LATEST_PLANNING_SUITE
+                        MISFIRE_LATEST_PLANNING_SUITE,
+                        OCCURRENCE_LEASE_RECOVERY_SUITE
                     ]
                 }
             ]
@@ -170,6 +175,89 @@ fn calendar_schedule_resolution_suite_requires_scheduler_profile() {
     let vectors: Value = serde_json::from_str(CALENDAR_SCHEDULE_RESOLUTION_VECTORS).unwrap();
     assert_eq!(
         evaluate(&request_for(CALENDAR_SCHEDULE_RESOLUTION_SUITE, vectors)).unwrap_err(),
+        "conformance suite is unsupported"
+    );
+}
+
+#[test]
+fn occurrence_lease_recovery_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(OCCURRENCE_LEASE_RECOVERY_VECTORS).unwrap();
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        OCCURRENCE_LEASE_RECOVERY_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 5);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 5);
+}
+
+#[test]
+fn occurrence_lease_recovery_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(OCCURRENCE_LEASE_RECOVERY_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["recoveredCount"] = json!(0);
+
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        OCCURRENCE_LEASE_RECOVERY_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn occurrence_lease_recovery_suite_accepts_portable_case_ids() {
+    let mut vectors: Value = serde_json::from_str(OCCURRENCE_LEASE_RECOVERY_VECTORS).unwrap();
+    vectors["cases"][0]["caseId"] = json!(format!("case:{}", "a".repeat(120)));
+
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        OCCURRENCE_LEASE_RECOVERY_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+}
+
+#[test]
+fn occurrence_lease_recovery_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 8] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone(),
+        |vectors| vectors["cases"][1]["scenario"] = vectors["cases"][0]["scenario"].clone(),
+        |vectors| vectors["cases"][0]["now"] = json!("not-a-time"),
+        |vectors| vectors["cases"][0]["initial"]["leaseExpiresAt"] = json!("not-a-time"),
+        |vectors| vectors["cases"][0]["initial"]["runningRun"] = json!(true),
+        |vectors| vectors["cases"][4]["expected"]["state"] = json!("failed"),
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value = serde_json::from_str(OCCURRENCE_LEASE_RECOVERY_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for_profile(
+                "scheduler_reliability",
+                OCCURRENCE_LEASE_RECOVERY_SUITE,
+                vectors,
+            ))
+            .unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
+fn occurrence_lease_recovery_suite_requires_scheduler_profile() {
+    let vectors: Value = serde_json::from_str(OCCURRENCE_LEASE_RECOVERY_VECTORS).unwrap();
+    assert_eq!(
+        evaluate(&request_for(OCCURRENCE_LEASE_RECOVERY_SUITE, vectors)).unwrap_err(),
         "conformance suite is unsupported"
     );
 }

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -24,6 +24,8 @@ const EVENT_REDUCER_DETERMINISM_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/event-reducer-determinism.vectors.json");
 const MISFIRE_LATEST_PLANNING_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/misfire-latest-planning.vectors.json");
+const OCCURRENCE_LEASE_RECOVERY_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/occurrence-lease-recovery.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -113,7 +115,8 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                     "profile": "scheduler_reliability",
                     "suites": [
                         "calendar-schedule-resolution",
-                        "misfire-latest-planning"
+                        "misfire-latest-planning",
+                        "occurrence-lease-recovery"
                     ]
                 }
             ]
@@ -201,6 +204,47 @@ fn native_target_evaluates_checked_in_misfire_latest_vectors() -> anyhow::Result
     assert_eq!(response["status"], "passed");
     assert_eq!(response["evidence"]["executedCases"], 4);
     assert_eq!(response["evidence"]["passedCases"], 4);
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_occurrence_lease_recovery_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(OCCURRENCE_LEASE_RECOVERY_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "scheduler_reliability",
+        "suiteId": "occurrence-lease-recovery",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "occurrence-lease-recovery");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 5);
+    assert_eq!(response["evidence"]["passedCases"], 5);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Adds deterministic occurrence lease recovery coverage to the native Coven Automations conformance target.
- Files changed: native target validation/execution, five checked-in vectors, target/unit integration tests, and runner documentation.
- Refs #858

## Implementation

- Approach: Advertise `occurrence-lease-recovery` under `scheduler_reliability`, validate a closed five-scenario vector inventory, create isolated production-schema state, and execute `recover_expired_leases`.
- User-visible behavior: Conformance consumers can verify recovery after and exactly at lease expiry, preservation before expiry, and preservation of runtime-owned or runtime-evidenced work.
- Compatibility notes: Additive target capability only. Portable case IDs remain labels and are never reused as stricter internal automation IDs. The runner remains audit-only and returns only aggregate evidence.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `cargo test -p coven-cli automations::conformance_target_tests --locked`
- [x] `cargo test -p coven-cli --test automations_conformance --locked`
- [x] Independent review findings fixed; final re-review found no significant issues.

## Risk and Rollback

- Risk level: Low. The change is additive and isolated to the audit-only conformance target.
- Rollback plan: Revert this commit to remove the advertised suite, vectors, tests, and documentation.

## Agent Handoff

- Current state: Complete and locally verified against the exact committed tree.
- Follow-ups: Continue scheduler overlap, retry/backoff, cancellation, fencing, crash/fault injection, SLO, diagnostics, authority, privacy, and interoperability coverage tracked by #858.
- Known gaps: This slice does not claim complete Scheduler Reliability or release eligibility.
