### PR TITLE
fix(ci): keep Windows cache packing outside acceptance gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,9 @@ jobs:
           COVEN_THREADS_E2E_ARTIFACT_ROOT: ${{ runner.temp }}/threads-e2e-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           "COVEN_THREADS_E2E_ARTIFACT_ROOT=$env:COVEN_THREADS_E2E_ARTIFACT_ROOT" >> $env:GITHUB_ENV
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # The manual Windows release-stress job owns cache writes. Post-job
+      # packing must not consume this acceptance job's remaining test budget.
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release-stress.yml
+++ b/.github/workflows/release-stress.yml
@@ -69,14 +69,17 @@ jobs:
         with:
           node-version: 24
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-05-20
+      # This manually dispatched job populates the shared Windows test cache;
+      # required CI only restores it, so packing cannot cancel acceptance.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-release-stress-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-rust-test-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-rust-test-
             ${{ runner.os }}-release-stress-
       # See the unix job: the per-command timeout must bound the test, not a
       # cold compile. Windows is where this actually bit -- the first surface

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -65,6 +65,38 @@ class CheckCiWorkflowTests(unittest.TestCase):
         self.assertIn('timeout-minutes: 30', windows)
         self.assertNotIn('timeout-minutes: 20', windows)
 
+    def test_windows_rust_gate_restores_without_post_job_cache_packing(self) -> None:
+        windows = ci_job_block('rust-test-windows')
+        self.assertIn(f"uses: actions/cache/restore@{CACHE_SHA}", windows)
+        self.assertNotIn("uses: actions/cache@", windows)
+        self.assertNotIn("uses: actions/cache/save@", windows)
+        self.assertIn(
+            "key: ${{ runner.os }}-rust-test-${{ hashFiles('Cargo.lock') }}",
+            windows,
+        )
+        self.assertIn("${{ runner.os }}-rust-test-", windows)
+        self.assertIn("cargo test --workspace --locked", windows)
+        self.assertIn("timeout-minutes: 30", windows)
+        self.assertNotIn("continue-on-error:", windows)
+
+    def test_manual_windows_release_stress_owns_shared_test_cache_writes(self) -> None:
+        stress = RELEASE_STRESS_WORKFLOW.read_text(encoding='utf-8')
+        triggers = stress.split("\non:\n", 1)[1].split("\npermissions:", 1)[0]
+        self.assertEqual(triggers.strip(), "workflow_dispatch:")
+        windows = stress.split("\n  windows:\n", 1)[1]
+        cache = windows.split(f"- uses: actions/cache@{CACHE_SHA}", 1)[1].split(
+            "\n      - name:", 1
+        )[0]
+        self.assertIn(
+            "key: ${{ runner.os }}-rust-test-${{ hashFiles('Cargo.lock') }}",
+            cache,
+        )
+        self.assertIn("${{ runner.os }}-rust-test-", cache)
+        self.assertIn("${{ runner.os }}-release-stress-", cache)
+        self.assertIn("timeout-minutes: 45", windows)
+        self.assertIn("cargo test --workspace --locked --no-run", windows)
+        self.assertNotIn("continue-on-error:", windows)
+
     def test_ci_runs_expected_workflow_checks(self) -> None:
         for needle in [
             'python3 scripts/classify-ci-changes-test.py',
@@ -152,7 +184,7 @@ class CheckCiWorkflowTests(unittest.TestCase):
         )
         self.assertLess(
             steps.index("- name: Configure Threads evidence directory"),
-            steps.index("- uses: actions/cache@"),
+            steps.index("- uses: actions/cache/restore@"),
         )
         self.assertEqual(steps.count("COVEN_THREADS_E2E_ARTIFACT_ROOT:"), 1)
         self.assertNotIn("runner.", job_config)


### PR DESCRIPTION
## Context

Closes #1037. Dependency of #1029 and #1033.

**Consolidated tracking PR; draft, standalone auto-merge disabled.** Exact source commit `2b592013` is preserved by the normal merge **5bae1413863f08cb62161275b955fe20bbc034b0** in #1029. Its runtime is unchanged from validated `4cd61462`; the combined runtime/cache candidate receives current-base acceptance together. This PR and its branch remain retained until the commit actually reaches main.

Standalone run **34728045108** is cancelled, not accepted: workspace **3,607 passed / five ignored**, then **64 of 210 clock-unit tests** completed before the 30-minute job deadline. Clock compilation had finished; no assertion failure, panic or compiler error was recorded. Clock-native execution was skipped. The six complete default manifests remain preserved. This is distinct from post-job packing: restore-only worked and no cache-save post-action existed. Broader elapsed-time pressure was observed, but its underlying cause is unknown; it is not attributed speculatively to runtime or cache changes.

Windows run [34724682607](https://github.com/OpenCoven/coven/actions/runs/34724682607) finished every test step and uploaded evidence, then exceeded its unchanged 30-minute job limit during post-job `actions/cache` packing. The job remains cancelled, not accepted green CI. Its complete execution receipts were 3,663 workspace passes / five ignored, 212 clock-unit passes, 78 clock-native passes and 90 complete passing manifests.

The upload completed at 23:37:42Z, `tar`/`zstd` started at 23:37:43Z, and the job deadline cancelled packing at 23:40:11Z. GitHub explicitly annotated the 30-minute limit. The evidence establishes the cancellation mechanism, not whether packing was slow or blocked.

## Implementation

- The required Windows Rust job uses the pinned `actions/cache/restore` sub-action on both PR and main runs. It has no automatic cache-save post-action.
- The existing, manually dispatched Windows Release stress job owns writes to the shared Windows test-cache key. It retains its old stress-cache fallback, existing successful-job save behavior and unchanged stress commands.
- Cache misses still build normally. Linux/macOS cache policies, all required jobs and test commands, every budget, failure behavior, and run/attempt-isolated always-upload evidence are unchanged.

No new workflow, runner, permission, dependency, runtime change, timeout increase, test skip or gate exception is introduced.

## Verification

The two new policy assertions failed before correction. Existing workflow-policy and script modules now pass 27 tests; CI classification passes 19 tests. The repository's pinned actionlint, staged privacy and secret guards pass. The pinned restore action's metadata was inspected: it runs the restore-only entry point and declares no post-action.

This is a three-file workflow/policy-test change; no Rust source was changed. Current-head hosted CI must pass before merge. The successful test execution of the old cancelled run is not substituted for that gate.

## Risk and rollback

The shared Windows cache is now populated by the already-manual Release stress workflow rather than acceptance jobs. Cache availability remains an optimization, not authority or a passing-test signal. A missing/stale cache may require more compilation, but must not change which tests execute.

Reverting restores automatic packing inside the required job and therefore restores the demonstrated cancellation risk. Do not compensate by weakening budgets or acceptance.

## Agent handoff

Source commit **2b5920137976c49ce9d9646d4dc2d44d0514bead**, tree **f8934bd2477218f0ba24fa7818f7457d159360e0**, based on main **c09945ef**. Isolated under claim `issue-1037`; the frozen #1029 acceptance lane was not edited or rebuilt.

Finish the composed #1029 current-base gate, resolve any genuine review findings, and land the preserved histories normally. Do not merge this old-runtime lane separately or treat its cancelled run as passing. Remove the completed owned worktree/branch only after actual main ancestry is established. Keep all cancellation artifacts and the separate historical POST-timeout uncertainty.
