### PR TITLE
feat: add overlap claim conformance

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -131,6 +131,7 @@ The checked-in
 [`misfire-latest-planning.vectors.json`](misfire-latest-planning.vectors.json),
 [`occurrence-fence-uniqueness.vectors.json`](occurrence-fence-uniqueness.vectors.json),
 [`occurrence-lease-recovery.vectors.json`](occurrence-lease-recovery.vectors.json),
+[`overlap-forbid-claiming.vectors.json`](overlap-forbid-claiming.vectors.json),
 [`receipt-integrity-validation.vectors.json`](receipt-integrity-validation.vectors.json),
 [`rrule-vocabulary.vectors.json`](rrule-vocabulary.vectors.json), and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
@@ -166,7 +167,8 @@ The runner invokes the target directly without a shell.
       "suites": [
         "calendar-schedule-resolution",
         "misfire-latest-planning",
-        "occurrence-lease-recovery"
+        "occurrence-lease-recovery",
+        "overlap-forbid-claiming"
       ]
     }
   ]
@@ -179,7 +181,7 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements ten structural suites and three
+The native Coven target currently implements ten structural suites and four
 scheduler-reliability suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
@@ -216,6 +218,10 @@ production expired-lease recovery path. It proves that pre-dispatch claims are
 recovered after and exactly at lease expiry, unexpired claims remain owned, and
 runtime-owned or runtime-evidenced work is never treated as safe to fail from a
 lease timeout alone.
+`overlap-forbid-claiming` executes fixed virtual-time cases through the
+production atomic occurrence claim path. It proves that claimed or running
+occurrences and an independently running run block new work, while succeeded,
+failed, and cancelled occurrences release overlap capacity.
 `occurrence-fence-uniqueness` executes a portable three-case matrix against the
 production SQLite occurrence schema, proving that one automation cannot claim
 the same scheduled slot twice while different automations may share a slot and

--- a/conformance/automations/runner/overlap-forbid-claiming.vectors.json
+++ b/conformance/automations/runner/overlap-forbid-claiming.vectors.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "coven.automations.overlap-forbid-claiming-vectors.v1",
+  "cases": [
+    {
+      "caseId": "no-overlap-claims",
+      "scenario": "no_overlap",
+      "now": "2026-09-01T10:00:00.000Z",
+      "blocker": "none",
+      "expected": {
+        "claimed": true,
+        "targetState": "claimed",
+        "targetAttempt": 1,
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T11:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "claimed-occurrence-blocks",
+      "scenario": "claimed_occurrence",
+      "now": "2026-09-01T10:00:00.000Z",
+      "blocker": "claimed_occurrence",
+      "expected": {
+        "claimed": false,
+        "targetState": "planned",
+        "targetAttempt": 0,
+        "leaseOwner": null,
+        "leaseExpiresAt": null
+      }
+    },
+    {
+      "caseId": "running-occurrence-blocks",
+      "scenario": "running_occurrence",
+      "now": "2026-09-01T10:00:00.000Z",
+      "blocker": "running_occurrence",
+      "expected": {
+        "claimed": false,
+        "targetState": "planned",
+        "targetAttempt": 0,
+        "leaseOwner": null,
+        "leaseExpiresAt": null
+      }
+    },
+    {
+      "caseId": "running-run-blocks",
+      "scenario": "running_run",
+      "now": "2026-09-01T10:00:00.000Z",
+      "blocker": "running_run",
+      "expected": {
+        "claimed": false,
+        "targetState": "planned",
+        "targetAttempt": 0,
+        "leaseOwner": null,
+        "leaseExpiresAt": null
+      }
+    },
+    {
+      "caseId": "succeeded-occurrence-allows",
+      "scenario": "succeeded_occurrence",
+      "now": "2026-09-01T10:00:00.000Z",
+      "blocker": "succeeded_occurrence",
+      "expected": {
+        "claimed": true,
+        "targetState": "claimed",
+        "targetAttempt": 1,
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T11:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "failed-occurrence-allows",
+      "scenario": "failed_occurrence",
+      "now": "2026-09-01T10:00:00.000Z",
+      "blocker": "failed_occurrence",
+      "expected": {
+        "claimed": true,
+        "targetState": "claimed",
+        "targetAttempt": 1,
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T11:00:00.000Z"
+      }
+    },
+    {
+      "caseId": "cancelled-occurrence-allows",
+      "scenario": "cancelled_occurrence",
+      "now": "2026-09-01T10:00:00.000Z",
+      "blocker": "cancelled_occurrence",
+      "expected": {
+        "claimed": true,
+        "targetState": "claimed",
+        "targetAttempt": 1,
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T11:00:00.000Z"
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -44,6 +44,8 @@ const MISFIRE_LATEST_PLANNING_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.misfire-latest-planning-vectors.v1";
 const OCCURRENCE_LEASE_RECOVERY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-lease-recovery-vectors.v1";
+const OVERLAP_FORBID_CLAIMING_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.overlap-forbid-claiming-vectors.v1";
 const OCCURRENCE_FENCE_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-fence-uniqueness-vectors.v1";
 const RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION: &str =
@@ -65,6 +67,7 @@ pub const DEFINITION_VALIDATION_SUITE: &str = "definition-validation";
 pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
 pub const MISFIRE_LATEST_PLANNING_SUITE: &str = "misfire-latest-planning";
 pub const OCCURRENCE_LEASE_RECOVERY_SUITE: &str = "occurrence-lease-recovery";
+pub const OVERLAP_FORBID_CLAIMING_SUITE: &str = "overlap-forbid-claiming";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
 pub const RECEIPT_INTEGRITY_VALIDATION_SUITE: &str = "receipt-integrity-validation";
 pub const RRULE_VOCABULARY_SUITE: &str = "rrule-vocabulary";
@@ -643,6 +646,89 @@ struct ExpectedOccurrenceLeaseRecovery {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct OverlapForbidClaimingVectorSet {
+    schema_version: String,
+    cases: Vec<OverlapForbidClaimingVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct OverlapForbidClaimingVectorCase {
+    case_id: String,
+    scenario: OverlapForbidClaimingScenario,
+    now: String,
+    blocker: OverlapBlocker,
+    expected: ExpectedOverlapForbidClaim,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum OverlapForbidClaimingScenario {
+    NoOverlap,
+    ClaimedOccurrence,
+    RunningOccurrence,
+    RunningRun,
+    SucceededOccurrence,
+    FailedOccurrence,
+    CancelledOccurrence,
+}
+
+impl OverlapForbidClaimingScenario {
+    const COUNT: usize = 7;
+
+    const fn blocker(self) -> OverlapBlocker {
+        match self {
+            Self::NoOverlap => OverlapBlocker::None,
+            Self::ClaimedOccurrence => OverlapBlocker::ClaimedOccurrence,
+            Self::RunningOccurrence => OverlapBlocker::RunningOccurrence,
+            Self::RunningRun => OverlapBlocker::RunningRun,
+            Self::SucceededOccurrence => OverlapBlocker::SucceededOccurrence,
+            Self::FailedOccurrence => OverlapBlocker::FailedOccurrence,
+            Self::CancelledOccurrence => OverlapBlocker::CancelledOccurrence,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum OverlapBlocker {
+    None,
+    ClaimedOccurrence,
+    RunningOccurrence,
+    RunningRun,
+    SucceededOccurrence,
+    FailedOccurrence,
+    CancelledOccurrence,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedOverlapForbidClaim {
+    claimed: bool,
+    target_state: OverlapTargetState,
+    target_attempt: u8,
+    lease_owner: Option<String>,
+    lease_expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum OverlapTargetState {
+    Planned,
+    Claimed,
+}
+
+impl OverlapTargetState {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Planned => "planned",
+            Self::Claimed => "claimed",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct MisfireLatestPlanningVectorSet {
     schema_version: String,
     cases: Vec<MisfireLatestPlanningVectorCase>,
@@ -913,6 +999,7 @@ pub fn capability() -> TargetCapability {
                     CALENDAR_SCHEDULE_RESOLUTION_SUITE,
                     MISFIRE_LATEST_PLANNING_SUITE,
                     OCCURRENCE_LEASE_RECOVERY_SUITE,
+                    OVERLAP_FORBID_CLAIMING_SUITE,
                 ],
             },
         ],
@@ -966,6 +1053,9 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         }
         (SCHEDULER_RELIABILITY_PROFILE, OCCURRENCE_LEASE_RECOVERY_SUITE) => {
             evaluate_occurrence_lease_recovery(&request.vector)?
+        }
+        (SCHEDULER_RELIABILITY_PROFILE, OVERLAP_FORBID_CLAIMING_SUITE) => {
+            evaluate_overlap_forbid_claiming(&request.vector)?
         }
         _ => return Err("conformance suite is unsupported"),
     };
@@ -1731,6 +1821,177 @@ fn occurrence_lease_recovery_case_matches(
         && observed.1 == case.expected.lease_owner
         && observed.2 == case.expected.lease_expires_at
         && observed.3 == case.expected.failure_reason)
+}
+
+fn evaluate_overlap_forbid_claiming(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: OverlapForbidClaimingVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != OVERLAP_FORBID_CLAIMING_VECTOR_SCHEMA_VERSION
+        || vectors.cases.len() != OverlapForbidClaimingScenario::COUNT
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut scenarios = BTreeSet::new();
+    for case in &vectors.cases {
+        let expected_is_coherent = if case.expected.claimed {
+            case.expected.target_state == OverlapTargetState::Claimed
+                && case.expected.target_attempt == 1
+                && case.expected.lease_owner.as_deref() == Some("daemon-a")
+                && case
+                    .expected
+                    .lease_expires_at
+                    .as_deref()
+                    .and_then(canonical_timestamp)
+                    .is_some()
+        } else {
+            case.expected.target_state == OverlapTargetState::Planned
+                && case.expected.target_attempt == 0
+                && case.expected.lease_owner.is_none()
+                && case.expected.lease_expires_at.is_none()
+        };
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !scenarios.insert(case.scenario)
+            || case.now != "2026-09-01T10:00:00.000Z"
+            || case.blocker != case.scenario.blocker()
+            || canonical_timestamp(&case.now).is_none()
+            || !expected_is_coherent
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+    if scenarios.len() != OverlapForbidClaimingScenario::COUNT {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut all_passed = true;
+    for (case_index, case) in vectors.cases.iter().enumerate() {
+        all_passed &= overlap_forbid_claiming_case_matches(case_index, case)?;
+    }
+    Ok(all_passed)
+}
+
+fn overlap_forbid_claiming_case_matches(
+    case_index: usize,
+    case: &OverlapForbidClaimingVectorCase,
+) -> Result<bool, &'static str> {
+    let conn = command_conformance_connection()?;
+    conn.execute_batch(super::leadership::AUTOMATION_SCHEDULER_AUTHORITY_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    let automation_id = format!("overlap-conformance-{case_index}");
+    let definition = super::definition::RoutineDefinition::from_json(&json!({
+        "schemaVersion": 1,
+        "id": automation_id,
+        "name": "Overlap claim conformance",
+        "status": "ACTIVE",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "prompt": "Run the overlap claim conformance probe.",
+        "tags": []
+    }))
+    .map_err(|_| "conformance suite execution failed")?;
+    super::store::insert_definition(&conn, &definition)
+        .map_err(|_| "conformance suite execution failed")?;
+    let target_id = format!("overlap-target-{case_index}");
+    conn.execute(
+        "INSERT INTO automation_occurrences
+            (id, automation_id, automation_revision, definition_digest, scheduled_for,
+             kind, state, attempt, created_at, updated_at)
+         SELECT ?1, id, revision, definition_digest, '2026-09-01T09:00:00.000Z',
+                'scheduled', 'planned', 0,
+                '2026-09-01T09:00:00.000Z', '2026-09-01T09:00:00.000Z'
+         FROM automation_definitions
+         WHERE id = ?2",
+        rusqlite::params![target_id, automation_id],
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+
+    if case.blocker != OverlapBlocker::None {
+        let blocker_id = format!("overlap-blocker-{case_index}");
+        let (state, lease_owner, lease_expires_at) = match case.blocker {
+            OverlapBlocker::ClaimedOccurrence => (
+                "claimed",
+                Some("daemon-b"),
+                Some("2026-09-01T12:00:00.000Z"),
+            ),
+            OverlapBlocker::RunningOccurrence => (
+                "running",
+                Some("daemon-b"),
+                Some("2026-09-01T12:00:00.000Z"),
+            ),
+            OverlapBlocker::RunningRun | OverlapBlocker::FailedOccurrence => ("failed", None, None),
+            OverlapBlocker::SucceededOccurrence => ("succeeded", None, None),
+            OverlapBlocker::CancelledOccurrence => ("cancelled", None, None),
+            OverlapBlocker::None => unreachable!(),
+        };
+        conn.execute(
+            "INSERT INTO automation_occurrences
+                (id, automation_id, automation_revision, definition_digest, scheduled_for,
+                 kind, state, lease_owner, lease_expires_at, attempt, created_at, updated_at)
+             SELECT ?1, id, revision, definition_digest, '2026-09-01T08:00:00.000Z',
+                    'scheduled', ?2, ?3, ?4, 1,
+                    '2026-09-01T08:00:00.000Z', '2026-09-01T08:00:00.000Z'
+             FROM automation_definitions
+             WHERE id = ?5",
+            rusqlite::params![
+                blocker_id,
+                state,
+                lease_owner,
+                lease_expires_at,
+                automation_id,
+            ],
+        )
+        .map_err(|_| "conformance suite execution failed")?;
+        if case.blocker == OverlapBlocker::RunningRun {
+            conn.execute(
+                "INSERT INTO automation_runs
+                    (id, automation_id, occurrence_id, status, started_at, timeout_at)
+                 VALUES (?1, ?2, ?3, 'running',
+                         '2026-09-01T08:00:00.000Z', '2026-09-01T10:30:00.000Z')",
+                rusqlite::params![
+                    format!("overlap-run-{case_index}"),
+                    automation_id,
+                    blocker_id,
+                ],
+            )
+            .map_err(|_| "conformance suite execution failed")?;
+        }
+    }
+
+    let now = canonical_timestamp(&case.now).ok_or("conformance vector is invalid")?;
+    let claimed =
+        super::occurrences::claim_due_occurrence(&conn, &automation_id, "daemon-a", 60, now)
+            .map_err(|_| "conformance suite execution failed")?;
+    let observed = conn
+        .query_row(
+            "SELECT state, attempt, lease_owner, lease_expires_at
+             FROM automation_occurrences
+             WHERE id = ?1",
+            [&target_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, u8>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            },
+        )
+        .map_err(|_| "conformance suite execution failed")?;
+
+    Ok(
+        claimed.as_deref() == case.expected.claimed.then_some(target_id.as_str())
+            && observed.0 == case.expected.target_state.as_str()
+            && observed.1 == case.expected.target_attempt
+            && observed.2 == case.expected.lease_owner
+            && observed.3 == case.expected.lease_expires_at,
+    )
 }
 
 fn evaluate_misfire_latest_planning(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -1912,52 +1912,51 @@ fn overlap_forbid_claiming_case_matches(
     )
     .map_err(|_| "conformance suite execution failed")?;
 
-    if case.blocker != OverlapBlocker::None {
-        let blocker_id = format!("overlap-blocker-{case_index}");
-        let (state, lease_owner, lease_expires_at) = match case.blocker {
-            OverlapBlocker::ClaimedOccurrence => (
-                "claimed",
-                Some("daemon-b"),
-                Some("2026-09-01T12:00:00.000Z"),
-            ),
-            OverlapBlocker::RunningOccurrence => (
-                "running",
-                Some("daemon-b"),
-                Some("2026-09-01T12:00:00.000Z"),
-            ),
-            OverlapBlocker::RunningRun | OverlapBlocker::FailedOccurrence => ("failed", None, None),
-            OverlapBlocker::SucceededOccurrence => ("succeeded", None, None),
-            OverlapBlocker::CancelledOccurrence => ("cancelled", None, None),
-            OverlapBlocker::None => unreachable!(),
-        };
-        conn.execute(
-            "INSERT INTO automation_occurrences
-                (id, automation_id, automation_revision, definition_digest, scheduled_for,
-                 kind, state, lease_owner, lease_expires_at, attempt, created_at, updated_at)
-             SELECT ?1, id, revision, definition_digest, '2026-09-01T08:00:00.000Z',
-                    'scheduled', ?2, ?3, ?4, 1,
-                    '2026-09-01T08:00:00.000Z', '2026-09-01T08:00:00.000Z'
-             FROM automation_definitions
-             WHERE id = ?5",
-            rusqlite::params![
-                blocker_id,
-                state,
-                lease_owner,
-                lease_expires_at,
-                automation_id,
-            ],
-        )
-        .map_err(|_| "conformance suite execution failed")?;
-        if case.blocker == OverlapBlocker::RunningRun {
+    match case.blocker {
+        OverlapBlocker::None => {}
+        OverlapBlocker::RunningRun => {
             conn.execute(
                 "INSERT INTO automation_runs
-                    (id, automation_id, occurrence_id, status, started_at, timeout_at)
-                 VALUES (?1, ?2, ?3, 'running',
+                    (id, automation_id, status, started_at, timeout_at)
+                 VALUES (?1, ?2, 'running',
                          '2026-09-01T08:00:00.000Z', '2026-09-01T10:30:00.000Z')",
+                rusqlite::params![format!("overlap-run-{case_index}"), automation_id],
+            )
+            .map_err(|_| "conformance suite execution failed")?;
+        }
+        blocker => {
+            let blocker_id = format!("overlap-blocker-{case_index}");
+            let (state, lease_owner, lease_expires_at) = match blocker {
+                OverlapBlocker::ClaimedOccurrence => (
+                    "claimed",
+                    Some("daemon-b"),
+                    Some("2026-09-01T12:00:00.000Z"),
+                ),
+                OverlapBlocker::RunningOccurrence => (
+                    "running",
+                    Some("daemon-b"),
+                    Some("2026-09-01T12:00:00.000Z"),
+                ),
+                OverlapBlocker::SucceededOccurrence => ("succeeded", None, None),
+                OverlapBlocker::FailedOccurrence => ("failed", None, None),
+                OverlapBlocker::CancelledOccurrence => ("cancelled", None, None),
+                OverlapBlocker::None | OverlapBlocker::RunningRun => unreachable!(),
+            };
+            conn.execute(
+                "INSERT INTO automation_occurrences
+                    (id, automation_id, automation_revision, definition_digest, scheduled_for,
+                     kind, state, lease_owner, lease_expires_at, attempt, created_at, updated_at)
+                 SELECT ?1, id, revision, definition_digest, '2026-09-01T08:00:00.000Z',
+                        'scheduled', ?2, ?3, ?4, 1,
+                        '2026-09-01T08:00:00.000Z', '2026-09-01T08:00:00.000Z'
+                 FROM automation_definitions
+                 WHERE id = ?5",
                 rusqlite::params![
-                    format!("overlap-run-{case_index}"),
-                    automation_id,
                     blocker_id,
+                    state,
+                    lease_owner,
+                    lease_expires_at,
+                    automation_id,
                 ],
             )
             .map_err(|_| "conformance suite execution failed")?;

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 use super::conformance_target::{
     capability, evaluate, evaluate_run_terminal_monotonicity_case_counts, TargetSuiteStatus,
     CALENDAR_SCHEDULE_RESOLUTION_SUITE, CAPABILITY_NEGOTIATION_SUITE,
-    MISFIRE_LATEST_PLANNING_SUITE, OCCURRENCE_LEASE_RECOVERY_SUITE,
+    MISFIRE_LATEST_PLANNING_SUITE, OCCURRENCE_LEASE_RECOVERY_SUITE, OVERLAP_FORBID_CLAIMING_SUITE,
     RUN_TERMINAL_MONOTONICITY_SUITE,
 };
 
@@ -29,6 +29,8 @@ const MISFIRE_LATEST_PLANNING_VECTORS: &str =
 const OCCURRENCE_LEASE_RECOVERY_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/occurrence-lease-recovery.vectors.json"
 );
+const OVERLAP_FORBID_CLAIMING_VECTORS: &str =
+    include_str!("../../../../conformance/automations/runner/overlap-forbid-claiming.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -98,7 +100,8 @@ fn capability_advertises_the_native_structural_suites() {
                     "suites": [
                         CALENDAR_SCHEDULE_RESOLUTION_SUITE,
                         MISFIRE_LATEST_PLANNING_SUITE,
-                        OCCURRENCE_LEASE_RECOVERY_SUITE
+                        OCCURRENCE_LEASE_RECOVERY_SUITE,
+                        OVERLAP_FORBID_CLAIMING_SUITE
                     ]
                 }
             ]
@@ -258,6 +261,80 @@ fn occurrence_lease_recovery_suite_requires_scheduler_profile() {
     let vectors: Value = serde_json::from_str(OCCURRENCE_LEASE_RECOVERY_VECTORS).unwrap();
     assert_eq!(
         evaluate(&request_for(OCCURRENCE_LEASE_RECOVERY_SUITE, vectors)).unwrap_err(),
+        "conformance suite is unsupported"
+    );
+}
+
+#[test]
+fn overlap_forbid_claiming_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(OVERLAP_FORBID_CLAIMING_VECTORS).unwrap();
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        OVERLAP_FORBID_CLAIMING_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 7);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 7);
+}
+
+#[test]
+fn overlap_forbid_claiming_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(OVERLAP_FORBID_CLAIMING_VECTORS).unwrap();
+    vectors["cases"][1]["expected"] = json!({
+        "claimed": true,
+        "targetState": "claimed",
+        "targetAttempt": 1,
+        "leaseOwner": "daemon-a",
+        "leaseExpiresAt": "2026-09-01T11:00:00.000Z"
+    });
+
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        OVERLAP_FORBID_CLAIMING_SUITE,
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn overlap_forbid_claiming_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 8] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone(),
+        |vectors| vectors["cases"][1]["scenario"] = vectors["cases"][0]["scenario"].clone(),
+        |vectors| vectors["cases"][0]["now"] = json!("not-a-time"),
+        |vectors| vectors["cases"][2]["blocker"] = json!("claimed_occurrence"),
+        |vectors| vectors["cases"][0]["expected"]["leaseExpiresAt"] = Value::Null,
+        |vectors| vectors["cases"][1]["expected"]["targetAttempt"] = json!(1),
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value = serde_json::from_str(OVERLAP_FORBID_CLAIMING_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for_profile(
+                "scheduler_reliability",
+                OVERLAP_FORBID_CLAIMING_SUITE,
+                vectors,
+            ))
+            .unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
+fn overlap_forbid_claiming_suite_requires_scheduler_profile() {
+    let vectors: Value = serde_json::from_str(OVERLAP_FORBID_CLAIMING_VECTORS).unwrap();
+    assert_eq!(
+        evaluate(&request_for(OVERLAP_FORBID_CLAIMING_SUITE, vectors)).unwrap_err(),
         "conformance suite is unsupported"
     );
 }

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -26,6 +26,8 @@ const MISFIRE_LATEST_PLANNING_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/misfire-latest-planning.vectors.json");
 const OCCURRENCE_LEASE_RECOVERY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/occurrence-lease-recovery.vectors.json");
+const OVERLAP_FORBID_CLAIMING_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/overlap-forbid-claiming.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -116,7 +118,8 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                     "suites": [
                         "calendar-schedule-resolution",
                         "misfire-latest-planning",
-                        "occurrence-lease-recovery"
+                        "occurrence-lease-recovery",
+                        "overlap-forbid-claiming"
                     ]
                 }
             ]
@@ -245,6 +248,47 @@ fn native_target_evaluates_checked_in_occurrence_lease_recovery_vectors() -> any
     assert_eq!(response["status"], "passed");
     assert_eq!(response["evidence"]["executedCases"], 5);
     assert_eq!(response["evidence"]["passedCases"], 5);
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_overlap_forbid_claiming_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(OVERLAP_FORBID_CLAIMING_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "scheduler_reliability",
+        "suiteId": "overlap-forbid-claiming",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "overlap-forbid-claiming");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 7);
+    assert_eq!(response["evidence"]["passedCases"], 7);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: Adds deterministic overlap-forbid claiming coverage to the native Coven Automations conformance target.
- Files changed: native target validation/execution, seven checked-in vectors, target/unit integration tests, and runner documentation.
- Refs #858

## Implementation

- Approach: Advertise `overlap-forbid-claiming` under `scheduler_reliability`, validate a closed seven-scenario vector inventory, create isolated production-schema state, and execute `claim_due_occurrence`.
- User-visible behavior: Conformance consumers can verify that claimed/running occurrences and an independent running run block new work, while succeeded, failed, and cancelled occurrences release capacity.
- Compatibility notes: Additive target capability only. Internal database identifiers are independent of portable case labels. The runner remains audit-only and returns only aggregate evidence.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `cargo test -p coven-cli automations::conformance_target_tests --locked`
- [x] `cargo test -p coven-cli --test automations_conformance --locked`
- [x] Independent review found no significant issues.

## Risk and Rollback

- Risk level: Low. The change is additive and isolated to the audit-only conformance target.
- Rollback plan: Revert this commit to remove the advertised suite, vectors, tests, and documentation.

## Agent Handoff

- Current state: Complete and locally verified against the exact committed tree.
- Follow-ups: Continue retry/backoff, cancellation, scheduler fencing, crash/fault injection, SLO, diagnostics, authority, privacy, and interoperability coverage tracked by #858.
- Known gaps: This slice does not claim complete Scheduler Reliability or release eligibility.
