### PR TITLE
feat: certify automation retry timing

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -132,6 +132,7 @@ The checked-in
 [`occurrence-fence-uniqueness.vectors.json`](occurrence-fence-uniqueness.vectors.json),
 [`occurrence-lease-recovery.vectors.json`](occurrence-lease-recovery.vectors.json),
 [`overlap-forbid-claiming.vectors.json`](overlap-forbid-claiming.vectors.json),
+[`retry-backoff-timing.vectors.json`](retry-backoff-timing.vectors.json),
 [`receipt-integrity-validation.vectors.json`](receipt-integrity-validation.vectors.json),
 [`rrule-vocabulary.vectors.json`](rrule-vocabulary.vectors.json), and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
@@ -168,7 +169,8 @@ The runner invokes the target directly without a shell.
         "calendar-schedule-resolution",
         "misfire-latest-planning",
         "occurrence-lease-recovery",
-        "overlap-forbid-claiming"
+        "overlap-forbid-claiming",
+        "retry-backoff-timing"
       ]
     }
   ]
@@ -181,7 +183,7 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements ten structural suites and four
+The native Coven target currently implements ten structural suites and five
 scheduler-reliability suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
@@ -222,6 +224,14 @@ lease timeout alone.
 production atomic occurrence claim path. It proves that claimed or running
 occurrences and an independently running run block new work, while succeeded,
 failed, and cancelled occurrences release overlap capacity.
+`retry-backoff-timing` executes fixed virtual-time cases through the production
+retry timing primitive used by rejected-launch and lease-expiry recovery. It
+proves immediate and fixed delays are measured from failure observation,
+exponential full-jitter ceilings grow by attempt, deterministic replay is
+stable for one run and attempt, and the ceiling is capped at one day.
+Exponential vectors pin the scheduled delay derived from the first eight bytes
+of `BLAKE3("<runId>:<nextAttemptNumber>")`, interpreted as an unsigned
+big-endian integer and mapped to `1..=ceiling` with modulo arithmetic.
 `occurrence-fence-uniqueness` executes a portable three-case matrix against the
 production SQLite occurrence schema, proving that one automation cannot claim
 the same scheduled slot twice while different automations may share a slot and

--- a/conformance/automations/runner/retry-backoff-timing.vectors.json
+++ b/conformance/automations/runner/retry-backoff-timing.vectors.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": "coven.automations.retry-backoff-timing-vectors.v1",
+  "cases": [
+    {
+      "caseId": "no-backoff-is-immediate",
+      "scenario": "none_immediate",
+      "policy": {
+        "maxAttempts": 2,
+        "backoffPolicy": "none",
+        "retryableClasses": ["runtime_unavailable"]
+      },
+      "runId": "retry-none",
+      "nextAttemptNumber": 2,
+      "observedAt": "2026-09-01T10:00:00.000Z",
+      "expected": {
+        "delaySeconds": 0,
+        "minimumDelaySeconds": 0,
+        "maximumDelaySeconds": 0,
+        "ceilingSeconds": 0,
+        "notBefore": "2026-09-01T10:00:00.000Z",
+        "deterministic": true
+      }
+    },
+    {
+      "caseId": "fixed-backoff-starts-at-observation",
+      "scenario": "fixed_from_observation",
+      "policy": {
+        "maxAttempts": 2,
+        "backoffPolicy": "fixed",
+        "backoffSeconds": 60,
+        "retryableClasses": ["transient_dispatch"]
+      },
+      "runId": "retry-fixed",
+      "nextAttemptNumber": 2,
+      "observedAt": "2026-09-01T10:00:50.000Z",
+      "expected": {
+        "delaySeconds": 60,
+        "minimumDelaySeconds": 60,
+        "maximumDelaySeconds": 60,
+        "ceilingSeconds": 60,
+        "notBefore": "2026-09-01T10:01:50.000Z",
+        "deterministic": true
+      }
+    },
+    {
+      "caseId": "exponential-second-attempt-uses-base-ceiling",
+      "scenario": "exponential_attempt_two",
+      "policy": {
+        "maxAttempts": 4,
+        "backoffPolicy": "exponential",
+        "backoffSeconds": 10,
+        "retryableClasses": ["runtime_unavailable"]
+      },
+      "runId": "retry-exponential-two",
+      "nextAttemptNumber": 2,
+      "observedAt": "2026-09-01T10:00:00.000Z",
+      "expected": {
+        "delaySeconds": 8,
+        "minimumDelaySeconds": 1,
+        "maximumDelaySeconds": 10,
+        "ceilingSeconds": 10,
+        "notBefore": "2026-09-01T10:00:08.000Z",
+        "deterministic": true
+      }
+    },
+    {
+      "caseId": "exponential-fourth-attempt-grows-ceiling",
+      "scenario": "exponential_attempt_four",
+      "policy": {
+        "maxAttempts": 4,
+        "backoffPolicy": "exponential",
+        "backoffSeconds": 10,
+        "retryableClasses": ["runtime_unavailable"]
+      },
+      "runId": "retry-exponential-four",
+      "nextAttemptNumber": 4,
+      "observedAt": "2026-09-01T10:00:00.000Z",
+      "expected": {
+        "delaySeconds": 17,
+        "minimumDelaySeconds": 1,
+        "maximumDelaySeconds": 40,
+        "ceilingSeconds": 40,
+        "notBefore": "2026-09-01T10:00:17.000Z",
+        "deterministic": true
+      }
+    },
+    {
+      "caseId": "exponential-backoff-caps-at-one-day",
+      "scenario": "exponential_one_day_cap",
+      "policy": {
+        "maxAttempts": 3,
+        "backoffPolicy": "exponential",
+        "backoffSeconds": 50000,
+        "retryableClasses": ["lease_expired"]
+      },
+      "runId": "retry-exponential-cap",
+      "nextAttemptNumber": 3,
+      "observedAt": "2026-09-01T10:00:00.000Z",
+      "expected": {
+        "delaySeconds": 61621,
+        "minimumDelaySeconds": 1,
+        "maximumDelaySeconds": 86400,
+        "ceilingSeconds": 86400,
+        "notBefore": "2026-09-02T03:07:01.000Z",
+        "deterministic": true
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -46,6 +46,8 @@ const OCCURRENCE_LEASE_RECOVERY_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-lease-recovery-vectors.v1";
 const OVERLAP_FORBID_CLAIMING_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.overlap-forbid-claiming-vectors.v1";
+const RETRY_BACKOFF_TIMING_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.retry-backoff-timing-vectors.v1";
 const OCCURRENCE_FENCE_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-fence-uniqueness-vectors.v1";
 const RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION: &str =
@@ -68,6 +70,7 @@ pub const EVENT_REDUCER_DETERMINISM_SUITE: &str = "event-reducer-determinism";
 pub const MISFIRE_LATEST_PLANNING_SUITE: &str = "misfire-latest-planning";
 pub const OCCURRENCE_LEASE_RECOVERY_SUITE: &str = "occurrence-lease-recovery";
 pub const OVERLAP_FORBID_CLAIMING_SUITE: &str = "overlap-forbid-claiming";
+pub const RETRY_BACKOFF_TIMING_SUITE: &str = "retry-backoff-timing";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
 pub const RECEIPT_INTEGRITY_VALIDATION_SUITE: &str = "receipt-integrity-validation";
 pub const RRULE_VOCABULARY_SUITE: &str = "rrule-vocabulary";
@@ -711,6 +714,88 @@ struct ExpectedOverlapForbidClaim {
     lease_expires_at: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RetryBackoffTimingVectorSet {
+    schema_version: String,
+    cases: Vec<RetryBackoffTimingVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RetryBackoffTimingVectorCase {
+    case_id: String,
+    scenario: RetryBackoffTimingScenario,
+    policy: Value,
+    run_id: String,
+    next_attempt_number: u8,
+    observed_at: String,
+    expected: ExpectedRetryBackoffTiming,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RetryBackoffTimingScenario {
+    NoneImmediate,
+    FixedFromObservation,
+    ExponentialAttemptTwo,
+    ExponentialAttemptFour,
+    ExponentialOneDayCap,
+}
+
+impl RetryBackoffTimingScenario {
+    const COUNT: usize = 5;
+
+    fn matches_input(
+        self,
+        policy: &super::definition::RoutineRetryPolicy,
+        next_attempt_number: u8,
+    ) -> bool {
+        use super::contract::types::BackoffPolicy;
+
+        match self {
+            Self::NoneImmediate => {
+                policy.backoff_policy == BackoffPolicy::None
+                    && policy.backoff_seconds.is_none()
+                    && next_attempt_number == 2
+            }
+            Self::FixedFromObservation => {
+                policy.backoff_policy == BackoffPolicy::Fixed
+                    && policy.backoff_seconds.is_some()
+                    && next_attempt_number == 2
+            }
+            Self::ExponentialAttemptTwo => {
+                policy.backoff_policy == BackoffPolicy::Exponential
+                    && policy.backoff_seconds.is_some()
+                    && next_attempt_number == 2
+            }
+            Self::ExponentialAttemptFour => {
+                policy.backoff_policy == BackoffPolicy::Exponential
+                    && policy.backoff_seconds.is_some()
+                    && next_attempt_number == 4
+            }
+            Self::ExponentialOneDayCap => {
+                policy.backoff_policy == BackoffPolicy::Exponential
+                    && policy
+                        .backoff_seconds
+                        .is_some_and(|seconds| seconds > 43_200)
+                    && next_attempt_number == 3
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedRetryBackoffTiming {
+    delay_seconds: u32,
+    minimum_delay_seconds: u32,
+    maximum_delay_seconds: u32,
+    ceiling_seconds: u32,
+    not_before: String,
+    deterministic: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum OverlapTargetState {
@@ -1000,6 +1085,7 @@ pub fn capability() -> TargetCapability {
                     MISFIRE_LATEST_PLANNING_SUITE,
                     OCCURRENCE_LEASE_RECOVERY_SUITE,
                     OVERLAP_FORBID_CLAIMING_SUITE,
+                    RETRY_BACKOFF_TIMING_SUITE,
                 ],
             },
         ],
@@ -1056,6 +1142,9 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         }
         (SCHEDULER_RELIABILITY_PROFILE, OVERLAP_FORBID_CLAIMING_SUITE) => {
             evaluate_overlap_forbid_claiming(&request.vector)?
+        }
+        (SCHEDULER_RELIABILITY_PROFILE, RETRY_BACKOFF_TIMING_SUITE) => {
+            evaluate_retry_backoff_timing(&request.vector)?
         }
         _ => return Err("conformance suite is unsupported"),
     };
@@ -1991,6 +2080,91 @@ fn overlap_forbid_claiming_case_matches(
             && observed.2 == case.expected.lease_owner
             && observed.3 == case.expected.lease_expires_at,
     )
+}
+
+fn evaluate_retry_backoff_timing(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: RetryBackoffTimingVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != RETRY_BACKOFF_TIMING_VECTOR_SCHEMA_VERSION
+        || vectors.cases.len() != RetryBackoffTimingScenario::COUNT
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut scenarios = BTreeSet::new();
+    let mut validated = Vec::with_capacity(vectors.cases.len());
+    for (case_index, case) in vectors.cases.iter().enumerate() {
+        let definition = super::definition::RoutineDefinition::from_json(&json!({
+            "schemaVersion": 1,
+            "id": format!("retry-conformance-{case_index}"),
+            "name": "Retry backoff timing conformance",
+            "status": "PAUSED",
+            "rrule": "FREQ=DAILY;BYHOUR=9",
+            "timezone": "utc",
+            "misfire": "latest",
+            "overlap": "forbid",
+            "timeoutMinutes": 30,
+            "retry": case.policy,
+            "runtime": "coven-code",
+            "prompt": "Run the retry backoff timing conformance probe.",
+            "tags": []
+        }))
+        .map_err(|_| "conformance vector is invalid")?;
+        let observed_at =
+            canonical_timestamp(&case.observed_at).ok_or("conformance vector is invalid")?;
+        let expected_not_before = canonical_timestamp(&case.expected.not_before)
+            .ok_or("conformance vector is invalid")?;
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !scenarios.insert(case.scenario)
+            || !valid_case_id(&case.run_id)
+            || case.next_attempt_number < 2
+            || case.next_attempt_number > definition.retry.max_attempts
+            || definition.retry.retryable_classes.is_empty()
+            || !case
+                .scenario
+                .matches_input(&definition.retry, case.next_attempt_number)
+            || case.expected.minimum_delay_seconds > case.expected.maximum_delay_seconds
+            || case.expected.delay_seconds < case.expected.minimum_delay_seconds
+            || case.expected.delay_seconds > case.expected.maximum_delay_seconds
+            || case.expected.maximum_delay_seconds > 86_400
+        {
+            return Err("conformance vector is invalid");
+        }
+        validated.push((definition.retry, observed_at, expected_not_before));
+    }
+    if scenarios.len() != RetryBackoffTimingScenario::COUNT {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut passed_cases = 0;
+    for (case, (policy, observed_at, expected_not_before)) in vectors.cases.iter().zip(validated) {
+        let first = super::runner::retry_backoff_timing(
+            &policy,
+            &case.run_id,
+            case.next_attempt_number,
+            observed_at,
+        );
+        let replay = super::runner::retry_backoff_timing(
+            &policy,
+            &case.run_id,
+            case.next_attempt_number,
+            observed_at,
+        );
+        let deterministic = first == replay;
+        passed_cases += usize::from(
+            first.delay_seconds == case.expected.delay_seconds
+                && first.delay_seconds >= case.expected.minimum_delay_seconds
+                && first.delay_seconds <= case.expected.maximum_delay_seconds
+                && first.ceiling_seconds == case.expected.ceiling_seconds
+                && first.not_before
+                    == observed_at + Duration::seconds(i64::from(first.delay_seconds))
+                && first.not_before == expected_not_before
+                && deterministic == case.expected.deterministic,
+        );
+    }
+    Ok(passed_cases == vectors.cases.len())
 }
 
 fn evaluate_misfire_latest_planning(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -31,6 +31,8 @@ const OCCURRENCE_LEASE_RECOVERY_VECTORS: &str = include_str!(
 );
 const OVERLAP_FORBID_CLAIMING_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/overlap-forbid-claiming.vectors.json");
+const RETRY_BACKOFF_TIMING_VECTORS: &str =
+    include_str!("../../../../conformance/automations/runner/retry-backoff-timing.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -101,7 +103,8 @@ fn capability_advertises_the_native_structural_suites() {
                         CALENDAR_SCHEDULE_RESOLUTION_SUITE,
                         MISFIRE_LATEST_PLANNING_SUITE,
                         OCCURRENCE_LEASE_RECOVERY_SUITE,
-                        OVERLAP_FORBID_CLAIMING_SUITE
+                        OVERLAP_FORBID_CLAIMING_SUITE,
+                        "retry-backoff-timing"
                     ]
                 }
             ]
@@ -335,6 +338,75 @@ fn overlap_forbid_claiming_suite_requires_scheduler_profile() {
     let vectors: Value = serde_json::from_str(OVERLAP_FORBID_CLAIMING_VECTORS).unwrap();
     assert_eq!(
         evaluate(&request_for(OVERLAP_FORBID_CLAIMING_SUITE, vectors)).unwrap_err(),
+        "conformance suite is unsupported"
+    );
+}
+
+#[test]
+fn retry_backoff_timing_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(RETRY_BACKOFF_TIMING_VECTORS).unwrap();
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        "retry-backoff-timing",
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 5);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 5);
+}
+
+#[test]
+fn retry_backoff_timing_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(RETRY_BACKOFF_TIMING_VECTORS).unwrap();
+    vectors["cases"][2]["expected"]["delaySeconds"] = json!(1);
+
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        "retry-backoff-timing",
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn retry_backoff_timing_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 9] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone(),
+        |vectors| vectors["cases"][1]["scenario"] = vectors["cases"][0]["scenario"].clone(),
+        |vectors| vectors["cases"][0]["observedAt"] = json!("not-a-time"),
+        |vectors| vectors["cases"][0]["nextAttemptNumber"] = json!(1),
+        |vectors| vectors["cases"][1]["policy"]["backoffSeconds"] = Value::Null,
+        |vectors| vectors["cases"][2]["policy"]["backoffPolicy"] = json!("fixed"),
+        |vectors| vectors["cases"][4]["expected"]["minimumDelaySeconds"] = json!(90000),
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value = serde_json::from_str(RETRY_BACKOFF_TIMING_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for_profile(
+                "scheduler_reliability",
+                "retry-backoff-timing",
+                vectors,
+            ))
+            .unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
+fn retry_backoff_timing_suite_requires_scheduler_profile() {
+    let vectors: Value = serde_json::from_str(RETRY_BACKOFF_TIMING_VECTORS).unwrap();
+    assert_eq!(
+        evaluate(&request_for("retry-backoff-timing", vectors)).unwrap_err(),
         "conformance suite is unsupported"
     );
 }

--- a/crates/coven-cli/src/automations/runner.rs
+++ b/crates/coven-cli/src/automations/runner.rs
@@ -1003,12 +1003,8 @@ fn settle_rejected_launch(
         .map_err(|error| format!("failed to inspect retry run deadline: {error}"))?;
     if retryable && attempt_number < definition.retry.max_attempts && retry_deadline_open {
         let next_attempt_number = attempt_number + 1;
-        let retry_at = now
-            + chrono::Duration::seconds(i64::from(retry_delay_seconds(
-                &definition.retry,
-                run_id,
-                next_attempt_number,
-            )));
+        let retry_at =
+            retry_backoff_timing(&definition.retry, run_id, next_attempt_number, now).not_before;
         let retry_at_iso = retry_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         transaction
             .execute(
@@ -1498,14 +1494,31 @@ fn attempt_has_authority(
     .map_err(|error| format!("failed to inspect automation attempt authority: {error}"))
 }
 
-fn retry_delay_seconds(policy: &RoutineRetryPolicy, run_id: &str, next_attempt_number: u8) -> u32 {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RetryBackoffTiming {
+    pub delay_seconds: u32,
+    pub ceiling_seconds: u32,
+    pub not_before: DateTime<Utc>,
+}
+
+fn retry_delay_ceiling_seconds(policy: &RoutineRetryPolicy, next_attempt_number: u8) -> u32 {
     match policy.backoff_policy {
         BackoffPolicy::None => 0,
         BackoffPolicy::Fixed => policy.backoff_seconds.unwrap_or(1),
         BackoffPolicy::Exponential => {
             let base = policy.backoff_seconds.unwrap_or(1);
             let exponent = u32::from(next_attempt_number.saturating_sub(2)).min(16);
-            let ceiling = base.saturating_mul(1_u32 << exponent).min(86_400);
+            base.saturating_mul(1_u32 << exponent).min(86_400)
+        }
+    }
+}
+
+fn retry_delay_seconds(policy: &RoutineRetryPolicy, run_id: &str, next_attempt_number: u8) -> u32 {
+    let ceiling = retry_delay_ceiling_seconds(policy, next_attempt_number);
+    match policy.backoff_policy {
+        BackoffPolicy::None => 0,
+        BackoffPolicy::Fixed => ceiling,
+        BackoffPolicy::Exponential => {
             let digest = blake3::hash(format!("{run_id}:{next_attempt_number}").as_bytes());
             let sample = u64::from_be_bytes(
                 digest.as_bytes()[..8]
@@ -1515,6 +1528,21 @@ fn retry_delay_seconds(policy: &RoutineRetryPolicy, run_id: &str, next_attempt_n
             u32::try_from(sample % u64::from(ceiling) + 1)
                 .expect("retry delay is bounded to one day")
         }
+    }
+}
+
+pub(super) fn retry_backoff_timing(
+    policy: &RoutineRetryPolicy,
+    run_id: &str,
+    next_attempt_number: u8,
+    observed_at: DateTime<Utc>,
+) -> RetryBackoffTiming {
+    let ceiling_seconds = retry_delay_ceiling_seconds(policy, next_attempt_number);
+    let delay_seconds = retry_delay_seconds(policy, run_id, next_attempt_number);
+    RetryBackoffTiming {
+        delay_seconds,
+        ceiling_seconds,
+        not_before: observed_at + chrono::Duration::seconds(i64::from(delay_seconds)),
     }
 }
 
@@ -1776,12 +1804,8 @@ fn retry_proven_preownership_lease_expiry_in(
     }
     if retries_lease_expiry && attempt_number < definition.retry.max_attempts {
         let next_attempt_number = attempt_number + 1;
-        let retry_at = now
-            + chrono::Duration::seconds(i64::from(retry_delay_seconds(
-                &definition.retry,
-                run_id,
-                next_attempt_number,
-            )));
+        let retry_at =
+            retry_backoff_timing(&definition.retry, run_id, next_attempt_number, now).not_before;
         let retry_at_iso = retry_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         conn.execute(
             "INSERT INTO automation_attempts

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -28,6 +28,8 @@ const OCCURRENCE_LEASE_RECOVERY_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/occurrence-lease-recovery.vectors.json");
 const OVERLAP_FORBID_CLAIMING_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/overlap-forbid-claiming.vectors.json");
+const RETRY_BACKOFF_TIMING_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/retry-backoff-timing.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -119,7 +121,8 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                         "calendar-schedule-resolution",
                         "misfire-latest-planning",
                         "occurrence-lease-recovery",
-                        "overlap-forbid-claiming"
+                        "overlap-forbid-claiming",
+                        "retry-backoff-timing"
                     ]
                 }
             ]
@@ -289,6 +292,47 @@ fn native_target_evaluates_checked_in_overlap_forbid_claiming_vectors() -> anyho
     assert_eq!(response["status"], "passed");
     assert_eq!(response["evidence"]["executedCases"], 7);
     assert_eq!(response["evidence"]["passedCases"], 7);
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_retry_backoff_timing_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(RETRY_BACKOFF_TIMING_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "scheduler_reliability",
+        "suiteId": "retry-backoff-timing",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "retry-backoff-timing");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 5);
+    assert_eq!(response["evidence"]["passedCases"], 5);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Context

- Summary: add native Scheduler Reliability conformance for retry backoff timing.
- Files changed: portable vectors, native conformance target/tests, shared production retry timing primitive, and runner documentation.
- Refs #858

## Implementation

- Approach: execute five fixed virtual-time vectors through the same `retry_backoff_timing` primitive used by rejected-launch and lease-expiry retry scheduling.
- User-visible behavior: the native target now advertises and evaluates `retry-backoff-timing`, covering immediate and fixed delays, deterministic exponential full jitter, attempt-based ceiling growth, and the one-day cap.
- Compatibility notes: the conformance target remains audit-only and emits aggregate evidence only. Existing retry scheduling is behavior-preserving; its two call sites now share the independently testable timing primitive.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: `python3 scripts/check-coven-privacy.py --staged`; `node --test conformance/automations/runner/conformance.test.mjs`; focused native target unit and CLI integration tests; independent code review with exact-jitter remediation and clean re-review.

## Risk and Rollback

- Risk level: low. The production change extracts existing deterministic timing behavior without changing policy inputs or persistence shape.
- Rollback plan: revert this PR to remove the suite and restore the inline retry-time calculation.

## Agent Handoff

- Current state: complete and locally green at `fee3886`.
- Follow-ups: continue #858 with retry exhaustion/quarantine recovery and cancellation/fencing scenarios.
- Known gaps: this slice certifies timing only; it does not claim the broader Scheduler Reliability or Full profiles.
