### PR TITLE
feat: certify retry quarantine recovery

### DIFF
--- a/conformance/automations/runner/README.md
+++ b/conformance/automations/runner/README.md
@@ -133,6 +133,7 @@ The checked-in
 [`occurrence-lease-recovery.vectors.json`](occurrence-lease-recovery.vectors.json),
 [`overlap-forbid-claiming.vectors.json`](overlap-forbid-claiming.vectors.json),
 [`retry-backoff-timing.vectors.json`](retry-backoff-timing.vectors.json),
+[`retry-quarantine-recovery.vectors.json`](retry-quarantine-recovery.vectors.json),
 [`receipt-integrity-validation.vectors.json`](receipt-integrity-validation.vectors.json),
 [`rrule-vocabulary.vectors.json`](rrule-vocabulary.vectors.json), and
 [`run-terminal-monotonicity.vectors.json`](run-terminal-monotonicity.vectors.json)
@@ -170,7 +171,8 @@ The runner invokes the target directly without a shell.
         "misfire-latest-planning",
         "occurrence-lease-recovery",
         "overlap-forbid-claiming",
-        "retry-backoff-timing"
+        "retry-backoff-timing",
+        "retry-quarantine-recovery"
       ]
     }
   ]
@@ -183,7 +185,7 @@ For each advertised suite, the runner invokes
 expects one `coven.automations.conformance-suite-result.v1` object on standard
 output.
 
-The native Coven target currently implements ten structural suites and five
+The native Coven target currently implements ten structural suites and six
 scheduler-reliability suites.
 `attempt-terminal-immutability` executes every terminal attempt state against
 the production SQLite ledger and proves that later updates and deletion are
@@ -232,6 +234,11 @@ stable for one run and attempt, and the ceiling is capped at one day.
 Exponential vectors pin the scheduled delay derived from the first eight bytes
 of `BLAKE3("<runId>:<nextAttemptNumber>")`, interpreted as an unsigned
 big-endian integer and mapped to `1..=ceiling` with modulo arithmetic.
+`retry-quarantine-recovery` executes fixed virtual-time cases through the
+production retry-state ledger and scheduler tick. It proves first and repeated
+exhaustions quarantine a routine with current failure evidence, quarantine
+blocks occurrence planning, explicit release clears the state and restores
+scheduling, and release without an existing quarantine is an idempotent no-op.
 `occurrence-fence-uniqueness` executes a portable three-case matrix against the
 production SQLite occurrence schema, proving that one automation cannot claim
 the same scheduled slot twice while different automations may share a slot and

--- a/conformance/automations/runner/retry-quarantine-recovery.vectors.json
+++ b/conformance/automations/runner/retry-quarantine-recovery.vectors.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": "coven.automations.retry-quarantine-recovery-vectors.v1",
+  "cases": [
+    {
+      "caseId": "first-exhaustion-quarantines-and-blocks",
+      "scenario": "first_exhaustion",
+      "exhaustions": [
+        {
+          "at": "2026-09-02T08:30:00.000Z",
+          "failureClass": "runtime_unavailable",
+          "reason": "runtime unavailable"
+        }
+      ],
+      "observeAt": "2026-09-02T10:00:00.000Z",
+      "expected": {
+        "rowExists": true,
+        "consecutiveExhaustions": 1,
+        "quarantined": true,
+        "quarantinedAt": "2026-09-02T08:30:00.000Z",
+        "failureClass": "runtime_unavailable",
+        "reason": "runtime unavailable",
+        "releaseChanged": false,
+        "plannedCount": 0,
+        "claimedCount": 0
+      }
+    },
+    {
+      "caseId": "repeated-exhaustion-updates-latest-evidence",
+      "scenario": "repeated_exhaustion",
+      "exhaustions": [
+        {
+          "at": "2026-09-02T08:30:00.000Z",
+          "failureClass": "runtime_unavailable",
+          "reason": "runtime unavailable"
+        },
+        {
+          "at": "2026-09-02T08:45:00.000Z",
+          "failureClass": "lease_expired",
+          "reason": "lease expired"
+        }
+      ],
+      "observeAt": "2026-09-02T10:00:00.000Z",
+      "expected": {
+        "rowExists": true,
+        "consecutiveExhaustions": 2,
+        "quarantined": true,
+        "quarantinedAt": "2026-09-02T08:45:00.000Z",
+        "failureClass": "lease_expired",
+        "reason": "lease expired",
+        "releaseChanged": false,
+        "plannedCount": 0,
+        "claimedCount": 0
+      }
+    },
+    {
+      "caseId": "explicit-release-restores-scheduling",
+      "scenario": "explicit_release",
+      "exhaustions": [
+        {
+          "at": "2026-09-02T08:30:00.000Z",
+          "failureClass": "runtime_unavailable",
+          "reason": "runtime unavailable"
+        }
+      ],
+      "releaseAt": "2026-09-02T08:45:00.000Z",
+      "observeAt": "2026-09-02T10:00:00.000Z",
+      "expected": {
+        "rowExists": true,
+        "consecutiveExhaustions": 0,
+        "quarantined": false,
+        "quarantinedAt": null,
+        "failureClass": null,
+        "reason": null,
+        "releaseChanged": true,
+        "plannedCount": 1,
+        "claimedCount": 1
+      }
+    },
+    {
+      "caseId": "release-without-quarantine-is-noop",
+      "scenario": "release_without_quarantine",
+      "exhaustions": [],
+      "releaseAt": "2026-09-02T08:45:00.000Z",
+      "observeAt": "2026-09-02T10:00:00.000Z",
+      "expected": {
+        "rowExists": false,
+        "consecutiveExhaustions": 0,
+        "quarantined": false,
+        "quarantinedAt": null,
+        "failureClass": null,
+        "reason": null,
+        "releaseChanged": false,
+        "plannedCount": 1,
+        "claimedCount": 1
+      }
+    }
+  ]
+}

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -74,11 +74,11 @@ textwrap = "0.16"
 unicode-casefold = "0.2.0"
 chrono-tz = "0.10.4"
 iana-time-zone = "0.1.65"
+tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 rustix = { version = "1", features = ["fs"] }
-tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 interprocess = "2"
@@ -87,4 +87,3 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Securit
 
 [dev-dependencies]
 jsonschema = { version = "0.56.0", default-features = false, features = ["arbitrary-precision"] }
-tempfile = "3"

--- a/crates/coven-cli/src/automations/conformance_target.rs
+++ b/crates/coven-cli/src/automations/conformance_target.rs
@@ -48,6 +48,10 @@ const OVERLAP_FORBID_CLAIMING_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.overlap-forbid-claiming-vectors.v1";
 const RETRY_BACKOFF_TIMING_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.retry-backoff-timing-vectors.v1";
+const RETRY_QUARANTINE_RECOVERY_VECTOR_SCHEMA_VERSION: &str =
+    "coven.automations.retry-quarantine-recovery-vectors.v1";
+const RETRY_QUARANTINE_FIXTURE_CREATED_AT: &str = "2026-09-01T08:00:00.000Z";
+const RETRY_QUARANTINE_OBSERVE_AT: &str = "2026-09-02T10:00:00.000Z";
 const OCCURRENCE_FENCE_VECTOR_SCHEMA_VERSION: &str =
     "coven.automations.occurrence-fence-uniqueness-vectors.v1";
 const RECEIPT_INTEGRITY_VECTOR_SCHEMA_VERSION: &str =
@@ -71,6 +75,7 @@ pub const MISFIRE_LATEST_PLANNING_SUITE: &str = "misfire-latest-planning";
 pub const OCCURRENCE_LEASE_RECOVERY_SUITE: &str = "occurrence-lease-recovery";
 pub const OVERLAP_FORBID_CLAIMING_SUITE: &str = "overlap-forbid-claiming";
 pub const RETRY_BACKOFF_TIMING_SUITE: &str = "retry-backoff-timing";
+pub const RETRY_QUARANTINE_RECOVERY_SUITE: &str = "retry-quarantine-recovery";
 pub const OCCURRENCE_FENCE_UNIQUENESS_SUITE: &str = "occurrence-fence-uniqueness";
 pub const RECEIPT_INTEGRITY_VALIDATION_SUITE: &str = "receipt-integrity-validation";
 pub const RRULE_VOCABULARY_SUITE: &str = "rrule-vocabulary";
@@ -796,6 +801,87 @@ struct ExpectedRetryBackoffTiming {
     deterministic: bool,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RetryQuarantineRecoveryVectorSet {
+    schema_version: String,
+    cases: Vec<RetryQuarantineRecoveryVectorCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RetryQuarantineRecoveryVectorCase {
+    case_id: String,
+    scenario: RetryQuarantineRecoveryScenario,
+    exhaustions: Vec<RetryExhaustionInput>,
+    #[serde(default)]
+    release_at: Option<String>,
+    observe_at: String,
+    expected: ExpectedRetryQuarantineRecovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RetryQuarantineRecoveryScenario {
+    FirstExhaustion,
+    RepeatedExhaustion,
+    ExplicitRelease,
+    ReleaseWithoutQuarantine,
+}
+
+impl RetryQuarantineRecoveryScenario {
+    const COUNT: usize = 4;
+
+    fn matches_input(self, exhaustion_count: usize, has_release: bool) -> bool {
+        match self {
+            Self::FirstExhaustion => exhaustion_count == 1 && !has_release,
+            Self::RepeatedExhaustion => exhaustion_count == 2 && !has_release,
+            Self::ExplicitRelease => exhaustion_count == 1 && has_release,
+            Self::ReleaseWithoutQuarantine => exhaustion_count == 0 && has_release,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RetryExhaustionInput {
+    at: String,
+    failure_class: RetryExhaustionClass,
+    reason: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RetryExhaustionClass {
+    TransientDispatch,
+    LeaseExpired,
+    RuntimeUnavailable,
+}
+
+impl RetryExhaustionClass {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::TransientDispatch => "transient_dispatch",
+            Self::LeaseExpired => "lease_expired",
+            Self::RuntimeUnavailable => "runtime_unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedRetryQuarantineRecovery {
+    row_exists: bool,
+    consecutive_exhaustions: u32,
+    quarantined: bool,
+    quarantined_at: Option<String>,
+    failure_class: Option<String>,
+    reason: Option<String>,
+    release_changed: bool,
+    planned_count: usize,
+    claimed_count: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum OverlapTargetState {
@@ -1086,6 +1172,7 @@ pub fn capability() -> TargetCapability {
                     OCCURRENCE_LEASE_RECOVERY_SUITE,
                     OVERLAP_FORBID_CLAIMING_SUITE,
                     RETRY_BACKOFF_TIMING_SUITE,
+                    RETRY_QUARANTINE_RECOVERY_SUITE,
                 ],
             },
         ],
@@ -1145,6 +1232,9 @@ pub fn evaluate(request: &Value) -> Result<TargetSuiteResult, &'static str> {
         }
         (SCHEDULER_RELIABILITY_PROFILE, RETRY_BACKOFF_TIMING_SUITE) => {
             evaluate_retry_backoff_timing(&request.vector)?
+        }
+        (SCHEDULER_RELIABILITY_PROFILE, RETRY_QUARANTINE_RECOVERY_SUITE) => {
+            evaluate_retry_quarantine_recovery(&request.vector)?
         }
         _ => return Err("conformance suite is unsupported"),
     };
@@ -2165,6 +2255,206 @@ fn evaluate_retry_backoff_timing(vector: &Value) -> Result<bool, &'static str> {
         );
     }
     Ok(passed_cases == vectors.cases.len())
+}
+
+fn evaluate_retry_quarantine_recovery(vector: &Value) -> Result<bool, &'static str> {
+    let vectors: RetryQuarantineRecoveryVectorSet =
+        serde_json::from_value(vector.clone()).map_err(|_| "conformance vector is invalid")?;
+    if vectors.schema_version != RETRY_QUARANTINE_RECOVERY_VECTOR_SCHEMA_VERSION
+        || vectors.cases.len() != RetryQuarantineRecoveryScenario::COUNT
+    {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut case_ids = BTreeSet::new();
+    let mut scenarios = BTreeSet::new();
+    let fixture_created_at = canonical_timestamp(RETRY_QUARANTINE_FIXTURE_CREATED_AT)
+        .ok_or("conformance vector is invalid")?;
+    let expected_observe_at =
+        canonical_timestamp(RETRY_QUARANTINE_OBSERVE_AT).ok_or("conformance vector is invalid")?;
+    for case in &vectors.cases {
+        let observe_at =
+            canonical_timestamp(&case.observe_at).ok_or("conformance vector is invalid")?;
+        let release_at = match case.release_at.as_deref() {
+            Some(value) => Some(canonical_timestamp(value).ok_or("conformance vector is invalid")?),
+            None => None,
+        };
+        let mut previous_at = None;
+        for exhaustion in &case.exhaustions {
+            let at = canonical_timestamp(&exhaustion.at).ok_or("conformance vector is invalid")?;
+            if exhaustion.reason.trim().is_empty()
+                || exhaustion.reason.len() > 256
+                || previous_at.is_some_and(|previous| at <= previous)
+                || at <= fixture_created_at
+                || at > observe_at
+            {
+                return Err("conformance vector is invalid");
+            }
+            previous_at = Some(at);
+        }
+        let expected_state_is_coherent = if case.expected.row_exists {
+            if case.expected.quarantined {
+                case.expected.consecutive_exhaustions > 0
+                    && case.expected.quarantined_at.is_some()
+                    && case.expected.failure_class.is_some()
+                    && case.expected.reason.is_some()
+            } else {
+                case.expected.consecutive_exhaustions == 0
+                    && case.expected.quarantined_at.is_none()
+                    && case.expected.failure_class.is_none()
+                    && case.expected.reason.is_none()
+            }
+        } else {
+            case.expected.consecutive_exhaustions == 0
+                && !case.expected.quarantined
+                && case.expected.quarantined_at.is_none()
+                && case.expected.failure_class.is_none()
+                && case.expected.reason.is_none()
+        };
+        let repeated_exhaustion_replaces_evidence = match case.scenario {
+            RetryQuarantineRecoveryScenario::RepeatedExhaustion => {
+                case.exhaustions.windows(2).next().is_some_and(|pair| {
+                    pair[0].failure_class != pair[1].failure_class
+                        && pair[0].reason != pair[1].reason
+                })
+            }
+            _ => true,
+        };
+        let expected_scheduler_counts = match case.scenario {
+            RetryQuarantineRecoveryScenario::FirstExhaustion
+            | RetryQuarantineRecoveryScenario::RepeatedExhaustion => (0, 0),
+            RetryQuarantineRecoveryScenario::ExplicitRelease
+            | RetryQuarantineRecoveryScenario::ReleaseWithoutQuarantine => (1, 1),
+        };
+        if !valid_case_id(&case.case_id)
+            || !case_ids.insert(&case.case_id)
+            || !scenarios.insert(case.scenario)
+            || observe_at != expected_observe_at
+            || !case
+                .scenario
+                .matches_input(case.exhaustions.len(), release_at.is_some())
+            || release_at.is_some_and(|release| {
+                release <= fixture_created_at
+                    || previous_at.is_some_and(|last_exhaustion| release <= last_exhaustion)
+                    || release > observe_at
+            })
+            || !repeated_exhaustion_replaces_evidence
+            || !expected_state_is_coherent
+            || case.expected.release_changed
+                != (case.scenario == RetryQuarantineRecoveryScenario::ExplicitRelease)
+            || (case.expected.planned_count, case.expected.claimed_count)
+                != expected_scheduler_counts
+        {
+            return Err("conformance vector is invalid");
+        }
+    }
+    if scenarios.len() != RetryQuarantineRecoveryScenario::COUNT {
+        return Err("conformance vector is invalid");
+    }
+
+    let mut passed_cases = 0;
+    for (case_index, case) in vectors.cases.iter().enumerate() {
+        passed_cases += usize::from(retry_quarantine_recovery_case_matches(case_index, case)?);
+    }
+    Ok(passed_cases == vectors.cases.len())
+}
+
+fn retry_quarantine_recovery_case_matches(
+    case_index: usize,
+    case: &RetryQuarantineRecoveryVectorCase,
+) -> Result<bool, &'static str> {
+    let conn = command_conformance_connection()?;
+    conn.execute_batch(super::leadership::AUTOMATION_SCHEDULER_AUTHORITY_SCHEMA_SQL)
+        .map_err(|_| "conformance suite execution failed")?;
+    let automation_id = format!("retry-quarantine-{case_index}");
+    let definition = super::definition::RoutineDefinition::from_json(&json!({
+        "schemaVersion": 1,
+        "id": automation_id,
+        "name": "Retry quarantine conformance",
+        "status": "ACTIVE",
+        "rrule": "FREQ=DAILY;BYHOUR=9",
+        "timezone": "utc",
+        "misfire": "latest",
+        "overlap": "forbid",
+        "timeoutMinutes": 30,
+        "runtime": "coven-code",
+        "cwd": "/tmp",
+        "prompt": "Run the retry quarantine conformance probe.",
+        "tags": []
+    }))
+    .map_err(|_| "conformance suite execution failed")?;
+    super::store::insert_definition(&conn, &definition)
+        .map_err(|_| "conformance suite execution failed")?;
+    conn.execute(
+        "UPDATE automation_definitions
+         SET created_at = ?1,
+             updated_at = ?1
+         WHERE id = ?2",
+        params![RETRY_QUARANTINE_FIXTURE_CREATED_AT, &automation_id],
+    )
+    .map_err(|_| "conformance suite execution failed")?;
+
+    for exhaustion in &case.exhaustions {
+        super::runs::record_retry_exhaustion(
+            &conn,
+            &automation_id,
+            exhaustion.failure_class.as_str(),
+            &exhaustion.reason,
+            canonical_timestamp(&exhaustion.at).ok_or("conformance vector is invalid")?,
+        )
+        .map_err(|_| "conformance suite execution failed")?;
+    }
+    let release_changed = match case.release_at.as_deref() {
+        Some(release_at) => super::runs::clear_retry_quarantine(
+            &conn,
+            &automation_id,
+            canonical_timestamp(release_at).ok_or("conformance vector is invalid")?,
+        )
+        .map_err(|_| "conformance suite execution failed")?,
+        None => false,
+    };
+    let quarantined = super::runs::is_retry_quarantined(&conn, &automation_id)
+        .map_err(|_| "conformance suite execution failed")?;
+    let row = conn
+        .query_row(
+            "SELECT consecutive_exhaustions, quarantined_at, failure_class, reason
+             FROM automation_retry_state
+             WHERE automation_id = ?1",
+            [&automation_id],
+            |row| {
+                Ok((
+                    row.get::<_, u32>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|_| "conformance suite execution failed")?;
+    let observe_at =
+        canonical_timestamp(&case.observe_at).ok_or("conformance vector is invalid")?;
+    let scheduler_home = tempfile::tempdir().map_err(|_| "conformance suite execution failed")?;
+    crate::daemon::ensure_private_coven_home(scheduler_home.path())
+        .map_err(|_| "conformance suite execution failed")?;
+    let leadership =
+        super::leadership::SchedulerLeadership::acquire(scheduler_home.path(), &conn, observe_at)
+            .map_err(|_| "conformance suite execution failed")?;
+    let tick =
+        super::occurrences::tick_with_scheduler_fence(&conn, observe_at, &leadership.fence())
+            .map_err(|_| "conformance suite execution failed")?;
+    let row_exists = row.is_some();
+    let observed = row.unwrap_or((0, None, None, None));
+
+    Ok(row_exists == case.expected.row_exists
+        && observed.0 == case.expected.consecutive_exhaustions
+        && quarantined == case.expected.quarantined
+        && observed.1 == case.expected.quarantined_at
+        && observed.2 == case.expected.failure_class
+        && observed.3 == case.expected.reason
+        && release_changed == case.expected.release_changed
+        && tick.planned.len() == case.expected.planned_count
+        && tick.claimed.len() == case.expected.claimed_count)
 }
 
 fn evaluate_misfire_latest_planning(vector: &Value) -> Result<bool, &'static str> {

--- a/crates/coven-cli/src/automations/conformance_target_tests.rs
+++ b/crates/coven-cli/src/automations/conformance_target_tests.rs
@@ -33,6 +33,9 @@ const OVERLAP_FORBID_CLAIMING_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/overlap-forbid-claiming.vectors.json");
 const RETRY_BACKOFF_TIMING_VECTORS: &str =
     include_str!("../../../../conformance/automations/runner/retry-backoff-timing.vectors.json");
+const RETRY_QUARANTINE_RECOVERY_VECTORS: &str = include_str!(
+    "../../../../conformance/automations/runner/retry-quarantine-recovery.vectors.json"
+);
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -104,7 +107,8 @@ fn capability_advertises_the_native_structural_suites() {
                         MISFIRE_LATEST_PLANNING_SUITE,
                         OCCURRENCE_LEASE_RECOVERY_SUITE,
                         OVERLAP_FORBID_CLAIMING_SUITE,
-                        "retry-backoff-timing"
+                        "retry-backoff-timing",
+                        "retry-quarantine-recovery"
                     ]
                 }
             ]
@@ -407,6 +411,95 @@ fn retry_backoff_timing_suite_requires_scheduler_profile() {
     let vectors: Value = serde_json::from_str(RETRY_BACKOFF_TIMING_VECTORS).unwrap();
     assert_eq!(
         evaluate(&request_for("retry-backoff-timing", vectors)).unwrap_err(),
+        "conformance suite is unsupported"
+    );
+}
+
+#[test]
+fn retry_quarantine_recovery_suite_executes_the_checked_in_vectors() {
+    let vectors: Value = serde_json::from_str(RETRY_QUARANTINE_RECOVERY_VECTORS).unwrap();
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        "retry-quarantine-recovery",
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Passed);
+    assert_eq!(response.evidence.as_ref().unwrap()["executedCases"], 4);
+    assert_eq!(response.evidence.as_ref().unwrap()["passedCases"], 4);
+}
+
+#[test]
+fn retry_quarantine_recovery_suite_fails_closed_on_an_expectation_mismatch() {
+    let mut vectors: Value = serde_json::from_str(RETRY_QUARANTINE_RECOVERY_VECTORS).unwrap();
+    vectors["cases"][0]["expected"]["reason"] = json!("different failure");
+
+    let response = evaluate(&request_for_profile(
+        "scheduler_reliability",
+        "retry-quarantine-recovery",
+        vectors,
+    ))
+    .unwrap();
+
+    assert_eq!(response.status, TargetSuiteStatus::Failed);
+    assert_eq!(response.evidence, None);
+}
+
+#[test]
+fn retry_quarantine_recovery_suite_rejects_invalid_vector_shapes() {
+    let invalid_mutations: [fn(&mut Value); 13] = [
+        |vectors| vectors["schemaVersion"] = json!("unsupported"),
+        |vectors| vectors["cases"][0]["caseId"] = json!("-bad-case-id"),
+        |vectors| vectors["cases"][1]["caseId"] = vectors["cases"][0]["caseId"].clone(),
+        |vectors| vectors["cases"][1]["scenario"] = vectors["cases"][0]["scenario"].clone(),
+        |vectors| vectors["cases"][0]["exhaustions"][0]["at"] = json!("not-a-time"),
+        |vectors| vectors["cases"][0]["exhaustions"][0]["failureClass"] = json!("unknown"),
+        |vectors| vectors["cases"][0]["exhaustions"][0]["reason"] = json!(""),
+        |vectors| {
+            vectors["cases"][1]["exhaustions"][1]["failureClass"] =
+                vectors["cases"][1]["exhaustions"][0]["failureClass"].clone()
+        },
+        |vectors| {
+            vectors["cases"][1]["exhaustions"][1]["reason"] =
+                vectors["cases"][1]["exhaustions"][0]["reason"].clone()
+        },
+        |vectors| vectors["cases"][0]["releaseAt"] = json!("2026-09-02T08:45:00.000Z"),
+        |vectors| {
+            vectors["cases"][2]["expected"]["quarantinedAt"] = json!("2026-09-02T08:30:00.000Z")
+        },
+        |vectors| {
+            vectors["cases"][3]["observeAt"] = json!("2026-09-01T08:50:00.000Z");
+            vectors["cases"][3]["expected"]["plannedCount"] = json!(0);
+            vectors["cases"][3]["expected"]["claimedCount"] = json!(0);
+        },
+        |vectors| {
+            vectors["cases"][3]["observeAt"] = json!("2026-09-02T08:50:00.000Z");
+            vectors["cases"][3]["expected"]["plannedCount"] = json!(0);
+            vectors["cases"][3]["expected"]["claimedCount"] = json!(0);
+        },
+    ];
+
+    for mutate in invalid_mutations {
+        let mut vectors: Value = serde_json::from_str(RETRY_QUARANTINE_RECOVERY_VECTORS).unwrap();
+        mutate(&mut vectors);
+        assert_eq!(
+            evaluate(&request_for_profile(
+                "scheduler_reliability",
+                "retry-quarantine-recovery",
+                vectors,
+            ))
+            .unwrap_err(),
+            "conformance vector is invalid"
+        );
+    }
+}
+
+#[test]
+fn retry_quarantine_recovery_suite_requires_scheduler_profile() {
+    let vectors: Value = serde_json::from_str(RETRY_QUARANTINE_RECOVERY_VECTORS).unwrap();
+    assert_eq!(
+        evaluate(&request_for("retry-quarantine-recovery", vectors)).unwrap_err(),
         "conformance suite is unsupported"
     );
 }

--- a/crates/coven-cli/tests/automations_conformance.rs
+++ b/crates/coven-cli/tests/automations_conformance.rs
@@ -30,6 +30,8 @@ const OVERLAP_FORBID_CLAIMING_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/overlap-forbid-claiming.vectors.json");
 const RETRY_BACKOFF_TIMING_VECTORS: &str =
     include_str!("../../../conformance/automations/runner/retry-backoff-timing.vectors.json");
+const RETRY_QUARANTINE_RECOVERY_VECTORS: &str =
+    include_str!("../../../conformance/automations/runner/retry-quarantine-recovery.vectors.json");
 const OCCURRENCE_FENCE_UNIQUENESS_VECTORS: &str = include_str!(
     "../../../conformance/automations/runner/occurrence-fence-uniqueness.vectors.json"
 );
@@ -122,7 +124,8 @@ fn native_target_capability_is_stateless_and_machine_readable() -> anyhow::Resul
                         "misfire-latest-planning",
                         "occurrence-lease-recovery",
                         "overlap-forbid-claiming",
-                        "retry-backoff-timing"
+                        "retry-backoff-timing",
+                        "retry-quarantine-recovery"
                     ]
                 }
             ]
@@ -333,6 +336,47 @@ fn native_target_evaluates_checked_in_retry_backoff_timing_vectors() -> anyhow::
     assert_eq!(response["status"], "passed");
     assert_eq!(response["evidence"]["executedCases"], 5);
     assert_eq!(response["evidence"]["passedCases"], 5);
+    assert!(!coven_home.exists());
+    Ok(())
+}
+
+#[test]
+fn native_target_evaluates_checked_in_retry_quarantine_recovery_vectors() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("must-not-be-created");
+    let vectors: Value = serde_json::from_str(RETRY_QUARANTINE_RECOVERY_VECTORS)?;
+    let request = json!({
+        "schemaVersion": "coven.automations.conformance-suite-request.v1",
+        "profile": "scheduler_reliability",
+        "suiteId": "retry-quarantine-recovery",
+        "protocolArtifact": {
+            "bundleSchemaVersion": "coven.automations.bundle.v1",
+            "sourceCommit": "1111111111111111111111111111111111111111",
+            "bundleSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "contractContentSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "fileCount": 19
+        },
+        "subjectArtifact": {
+            "artifactId": "coven-cli",
+            "artifactVersion": "0.1.0",
+            "platform": {"os": "linux", "arch": "x86_64"},
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "vector": vectors
+    });
+
+    let output = run_target(&coven_home, "evaluate", Some(&request))?;
+
+    assert!(
+        output.status.success(),
+        "evaluate command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["suiteId"], "retry-quarantine-recovery");
+    assert_eq!(response["status"], "passed");
+    assert_eq!(response["evidence"]["executedCases"], 4);
+    assert_eq!(response["evidence"]["passedCases"], 4);
     assert!(!coven_home.exists());
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add portable retry exhaustion, quarantine, and explicit recovery vectors
- execute them through the production retry-state ledger and fenced scheduler authority
- fail closed on vacuous timing, scheduler-count, and repeated-evidence vectors
- advertise and document the sixth native scheduler reliability suite

## Readiness
- Scope: native Coven Automations conformance for #858
- Authority boundary: retry and scheduling behavior remains in Rust; the runner receives aggregate evidence only
- Compatibility: additive capability; existing suites and profiles are unchanged
- Validation: full Rust workspace fmt/clippy/tests, runner tests, secret scan, and staged privacy guard passed locally

Refs #858